### PR TITLE
feat(labels): add the area/type/pipeline label taxonomy as code

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,99 @@
+# Label taxonomy for connor-multiplying-frogs.
+#
+# This file is the source of truth. `.github/scripts/sync_labels.py` applies it
+# to the repository (create/update by name, then delete anything under `delete:`).
+# Run it via the `labels-sync` workflow, or locally:
+#
+#     GITHUB_TOKEN=... GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs \
+#       python .github/scripts/sync_labels.py
+#
+# Every label needs a distinct colour and a one-line description. The same list
+# is documented for humans in docs/intro/conventions.md — keep the two in step.
+
+labels:
+  # ---------------------------------------------------------------- area:*
+  # Which part of the game an issue touches. Exactly one per issue.
+  - name: "area:gameplay"
+    color: "1D76DB"
+    description: "Frog behaviour, multiplying rules, scoring, and game feel"
+  - name: "area:art"
+    color: "B392F0"
+    description: "Sprites, animation, palettes, and visual assets"
+  - name: "area:audio"
+    color: "8E44AD"
+    description: "Music, sound effects, and audio mixing"
+  - name: "area:ui"
+    color: "5319E7"
+    description: "Menus, HUD, layout, and on-screen controls"
+  - name: "area:story"
+    color: "D93F0B"
+    description: "Narrative, level themes, and world-building"
+  - name: "area:build"
+    color: "546E7A"
+    description: "Unity project config, CI, packaging, and releases"
+  - name: "area:ai"
+    color: "006B75"
+    description: "Claude skills, agents, and the issue pipeline itself"
+
+  # ---------------------------------------------------------------- type:*
+  # What kind of work the issue is. Exactly one per issue.
+  - name: "type:epic"
+    color: "3E4B9E"
+    description: "A milestone-sized parent that gets split into tasks"
+  - name: "type:task"
+    color: "C2E0C6"
+    description: "A single self-contained unit of buildable work"
+  - name: "type:question"
+    color: "CC317C"
+    description: "A decision to make before work can be specified"
+  - name: "type:bug"
+    color: "D73A4A"
+    description: "Something built already behaves incorrectly"
+  - name: "type:wireframe"
+    color: "F9D0C4"
+    description: "A UI layout to agree on before any UI code is written"
+
+  # ------------------------------------------------------- pipeline state
+  # The AI issue pipeline's state machine. Exactly one per open issue.
+  - name: "ai-triage"
+    color: "FBCA04"
+    description: "Queued for automated triage; the pipeline owns it next"
+  - name: "pending-approval"
+    color: "E99695"
+    description: "Triaged and waiting on a human /approve comment"
+  - name: "needs-clarification"
+    color: "F29513"
+    description: "Blocked on an answer from a human before it can proceed"
+  - name: "ready-for-work"
+    color: "0E8A16"
+    description: "Approved and eligible for the nightly builder to pick up"
+  - name: "in-progress"
+    color: "2188FF"
+    description: "An agent is actively building this issue right now"
+  - name: "parked"
+    color: "BFBFBF"
+    description: "Deliberately set aside; the pipeline will not pick it up"
+  - name: "dashboard"
+    color: "FEF2C0"
+    description: "The single live pipeline dashboard issue"
+
+  # -------------------------------------------------- CI escape hatches
+  - name: "skip-docs"
+    color: "EDEDED"
+    description: "Exempt this PR from the docs reconciliation gate"
+
+# GitHub's stock labels. Decision (issue #1): delete the six that duplicate the
+# type:* taxonomy, and keep duplicate/invalid/wontfix because they are useful as
+# close reasons and collide with nothing above.
+delete:
+  - "bug"
+  - "documentation"
+  - "enhancement"
+  - "good first issue"
+  - "help wanted"
+  - "question"
+
+keep:
+  - "duplicate"
+  - "invalid"
+  - "wontfix"

--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Apply .github/labels.yml to the repository's label set.
+
+Idempotent: labels are matched by name, created when missing, patched when the
+colour or description drifts, and left alone when they already agree. Labels
+listed under `delete:` are removed if they still exist; labels under `keep:`
+are documentation only and are never touched.
+
+Environment:
+    GITHUB_TOKEN       token with `issues: write` on the repository
+    GITHUB_REPOSITORY  owner/repo (set automatically inside Actions)
+    GITHUB_API_URL     defaults to https://api.github.com
+
+Usage:
+    python .github/scripts/sync_labels.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+LABELS_FILE = Path(__file__).resolve().parents[1] / "labels.yml"
+
+
+class GitHub:
+    def __init__(self, token: str, repo: str, api_url: str) -> None:
+        self._token = token
+        self._repo = repo
+        self._api_url = api_url.rstrip("/")
+
+    def _request(self, method: str, path: str, payload: dict | None = None) -> object:
+        url = f"{self._api_url}/repos/{self._repo}{path}"
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(url, data=data, method=method)
+        request.add_header("Authorization", f"Bearer {self._token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(request) as response:
+            body = response.read()
+        return json.loads(body) if body else None
+
+    def list_labels(self) -> list[dict]:
+        labels: list[dict] = []
+        page = 1
+        while True:
+            batch = self._request("GET", f"/labels?per_page=100&page={page}")
+            if not batch:
+                return labels
+            labels.extend(batch)
+            page += 1
+
+    def create_label(self, label: dict) -> None:
+        self._request("POST", "/labels", label)
+
+    def update_label(self, name: str, label: dict) -> None:
+        self._request("PATCH", f"/labels/{urllib.parse.quote(name)}", label)
+
+    def delete_label(self, name: str) -> None:
+        self._request("DELETE", f"/labels/{urllib.parse.quote(name)}")
+
+
+def load_spec() -> tuple[list[dict], list[str]]:
+    spec = yaml.safe_load(LABELS_FILE.read_text())
+    wanted = []
+    for entry in spec.get("labels") or []:
+        wanted.append(
+            {
+                "name": entry["name"],
+                "color": entry["color"].lstrip("#").lower(),
+                "description": entry.get("description", ""),
+            }
+        )
+    return wanted, list(spec.get("delete") or [])
+
+
+def check_spec(wanted: list[dict]) -> None:
+    """Fail loudly on the two mistakes a hand-edited taxonomy invites."""
+    problems = []
+    for field in ("name", "color"):
+        seen: dict[str, str] = {}
+        for label in wanted:
+            key = label[field]
+            if key in seen:
+                problems.append(f"duplicate {field} {key!r}: {seen[key]} and {label['name']}")
+            seen[key] = label["name"]
+    problems += [f"{l['name']}: missing description" for l in wanted if not l["description"]]
+    if problems:
+        sys.exit("labels.yml is invalid:\n  " + "\n  ".join(problems))
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv[1:]
+    wanted, doomed = load_spec()
+    check_spec(wanted)
+
+    if dry_run:
+        print(f"{len(wanted)} labels declared, {len(doomed)} marked for deletion; nothing applied")
+        return 0
+
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        sys.exit("GITHUB_TOKEN and GITHUB_REPOSITORY must both be set")
+
+    api = GitHub(token, repo, os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    existing = {label["name"]: label for label in api.list_labels()}
+
+    for label in wanted:
+        current = existing.get(label["name"])
+        if current is None:
+            api.create_label(label)
+            print(f"created  {label['name']}")
+        elif (
+            current.get("color", "").lower() != label["color"]
+            or (current.get("description") or "") != label["description"]
+        ):
+            api.update_label(label["name"], label)
+            print(f"updated  {label['name']}")
+        else:
+            print(f"ok       {label['name']}")
+
+    for name in doomed:
+        if name in existing:
+            api.delete_label(name)
+            print(f"deleted  {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.HTTPError as error:  # surface the API's own message
+        sys.exit(f"GitHub API {error.code}: {error.read().decode(errors='replace')}")

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,36 @@
+name: labels-sync
+
+# The label taxonomy is the pipeline's state machine, so it lives in git
+# (.github/labels.yml) and is applied from there rather than clicked into the
+# GitHub UI. Runs on every change to the taxonomy, and on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/scripts/sync_labels.py
+      - .github/workflows/labels-sync.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: labels-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Apply the label taxonomy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/sync_labels.py

--- a/docs/intro/conventions.md
+++ b/docs/intro/conventions.md
@@ -1,0 +1,87 @@
+# Conventions
+
+How this repo names, labels, and organises things. The AI issue pipeline reads
+these conventions as rules, not suggestions — an issue with the wrong labels is
+an issue the pipeline will route wrongly.
+
+## Labels
+
+Labels are the pipeline's state machine. The list below is mirrored by
+[`.github/labels.yml`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/.github/labels.yml),
+which is the machine-readable source of truth; the `labels-sync` workflow
+applies that file to the repo whenever it changes. **Edit `labels.yml` and this
+page together** — never the GitHub label UI, whose edits the next sync undoes.
+
+### `area:*` — what part of the game
+
+Exactly one per issue.
+
+| Label | Colour | Meaning |
+| --- | --- | --- |
+| `area:gameplay` | `#1D76DB` | Frog behaviour, multiplying rules, scoring, and game feel |
+| `area:art` | `#B392F0` | Sprites, animation, palettes, and visual assets |
+| `area:audio` | `#8E44AD` | Music, sound effects, and audio mixing |
+| `area:ui` | `#5319E7` | Menus, HUD, layout, and on-screen controls |
+| `area:story` | `#D93F0B` | Narrative, level themes, and world-building |
+| `area:build` | `#546E7A` | Unity project config, CI, packaging, and releases |
+| `area:ai` | `#006B75` | Claude skills, agents, and the issue pipeline itself |
+
+### `type:*` — what kind of work
+
+Exactly one per issue.
+
+| Label | Colour | Meaning |
+| --- | --- | --- |
+| `type:epic` | `#3E4B9E` | A milestone-sized parent that gets split into tasks |
+| `type:task` | `#C2E0C6` | A single self-contained unit of buildable work |
+| `type:question` | `#CC317C` | A decision to make before work can be specified |
+| `type:bug` | `#D73A4A` | Something built already behaves incorrectly |
+| `type:wireframe` | `#F9D0C4` | A UI layout to agree on before any UI code is written |
+
+### Pipeline state
+
+Exactly one per open issue. The pipeline moves an issue between these; humans
+change them only to override it.
+
+| Label | Colour | Meaning |
+| --- | --- | --- |
+| `ai-triage` | `#FBCA04` | Queued for automated triage; the pipeline owns it next |
+| `pending-approval` | `#E99695` | Triaged and waiting on a human `/approve` comment |
+| `needs-clarification` | `#F29513` | Blocked on an answer from a human before it can proceed |
+| `ready-for-work` | `#0E8A16` | Approved and eligible for the nightly builder to pick up |
+| `in-progress` | `#2188FF` | An agent is actively building this issue right now |
+| `parked` | `#BFBFBF` | Deliberately set aside; the pipeline will not pick it up |
+| `dashboard` | `#FEF2C0` | The single live pipeline dashboard issue |
+
+The normal path is `ai-triage` → `pending-approval` → `ready-for-work` →
+`in-progress` → closed. `needs-clarification` and `parked` are the two ways out
+of that path, and both need a human to get back on it.
+
+### CI escape hatches
+
+| Label | Colour | Meaning |
+| --- | --- | --- |
+| `skip-docs` | `#EDEDED` | Exempt this PR from the docs reconciliation gate |
+
+### GitHub's stock labels
+
+Deliberate decision, not an oversight:
+
+- **Deleted** — `bug`, `documentation`, `enhancement`, `good first issue`,
+  `help wanted`, and `question`. Each duplicates a `type:*` or `area:*` label,
+  and a label that means the same thing twice is a label the pipeline can
+  disagree with itself about.
+- **Kept** — `duplicate`, `invalid`, and `wontfix`. These describe why an issue
+  was closed rather than what it is, so they collide with nothing above.
+
+## Applying the taxonomy
+
+```bash
+# Preview: validates labels.yml (distinct names, distinct colours, every label
+# described) without touching the repo.
+python .github/scripts/sync_labels.py --dry-run
+
+# Apply, if you have a token with `issues: write`.
+GITHUB_TOKEN=... GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs \
+  python .github/scripts/sync_labels.py
+```


### PR DESCRIPTION
Closes #1

The AI issue pipeline treats labels as its state machine, so the whole set has to exist — and stay stable — before any of that tooling can run. Rather than clicking 20 labels into the GitHub UI where they can silently drift, the taxonomy lives in git and is applied from there.

## What's here

- **`.github/labels.yml`** — the source of truth. 7 `area:*`, 5 `type:*`, 7 pipeline state labels, and the `skip-docs` CI escape hatch. Every label has a distinct colour and a one-line description.
- **`.github/scripts/sync_labels.py`** — idempotent sync against the REST API. Creates what's missing, patches colour/description drift, leaves matching labels alone, and deletes the stock labels we've decided against. `--dry-run` validates the file (distinct names, distinct colours, no missing descriptions) without touching the repo.
- **`.github/workflows/labels-sync.yml`** — applies the file on any push to `main` that touches it, plus `workflow_dispatch`. Runs with `issues: write` only.
- **`docs/intro/conventions.md`** — the human-readable list, plus what each pipeline state means and how issues move between them.

## Stock labels — decided, not left by accident

Deleted the six that duplicate the taxonomy (`bug`, `documentation`, `enhancement`, `good first issue`, `help wanted`, `question`) — a label that means the same thing twice is a label the pipeline can disagree with itself about. Kept `duplicate`, `invalid`, and `wontfix`, which describe why an issue closed rather than what it is.

## Note

The labels themselves are created when this merges and `labels-sync` runs — I have no label-write access from here, so the workflow is how the taxonomy actually lands on the repo. `actions/checkout` is already SHA-pinned ahead of #84.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_