### PR TITLE
docs(conventions): establish the milestone convention

### DIFF
--- a/docs/intro/conventions.md
+++ b/docs/intro/conventions.md
@@ -4,6 +4,80 @@ How this repo names, labels, and organises things. The AI issue pipeline reads
 these conventions as rules, not suggestions — an issue with the wrong labels is
 an issue the pipeline will route wrongly.
 
+## Milestones
+
+Milestones are how work is *planned*. Labels say what an issue is; the
+milestone says when we intend to do it.
+
+### Titles are versions, descriptions are scope
+
+A version milestone is titled with a bare version — `v0.0.1`, `v0.1`, `v1.0` —
+and nothing else. No dates, no theme in the title. The **description** carries
+the scope: a short heading plus a paragraph or two saying what shipping that
+version means and, just as usefully, what it does not include.
+
+Triage reads those descriptions to decide where a new issue belongs, so a
+milestone with an empty description is a milestone nothing can be routed into.
+Write the scope when you create the milestone, not later.
+
+### Milestones are planning labels, not the shipped version
+
+A milestone is decoupled from `/VERSION`. `/VERSION` is what the built app
+actually reports and is moved only by release-please, from conventional commits.
+A milestone titled `v0.1` is a statement of intent about a batch of work; it can
+be renamed, re-scoped, or have issues pulled out of it right up until it closes.
+Nothing in the build reads a milestone title. Don't try to keep the two in
+lockstep — they answer different questions.
+
+### Read milestones live, never from a list in the docs
+
+**This page deliberately does not list the current milestones.** Any list
+written here is a list that goes stale the first time someone adds a milestone,
+and a pipeline that trusts a stale list routes issues into milestones that no
+longer exist. Every skill, workflow, and script that needs to know the
+milestones queries the API for them:
+
+```bash
+gh api repos/:owner/:repo/milestones --paginate --jq '.[] | "\(.title): \(.description)"'
+```
+
+The live set is the truth. This page describes the *shape* of a milestone; the
+API says which ones there are.
+
+### Freezing a milestone to new intake
+
+When a version's scope is settled and you want triage to stop adding to it,
+freeze it — don't close it, because it still has open work:
+
+1. Prefix the milestone description with `**FROZEN — no new intake.**`
+2. Optionally set a due date, which signals the same thing to humans.
+
+Triage treats a description starting with `FROZEN` as ineligible when choosing a
+milestone for a new issue, and routes to the next open version instead. Existing
+issues in a frozen milestone keep moving through the pipeline normally.
+
+### A shipped version is a tag, not a lingering milestone
+
+When the last issue in a version milestone closes and the release goes out, the
+milestone **closes**. What survives the release is the git tag and the GitHub
+release that release-please created — those are the permanent record of what
+`v0.1` contained. A closed milestone is a historical planning artifact; a tag is
+the artifact you can check out and build.
+
+Never reopen a shipped milestone to hold follow-up work. Follow-up work is new
+work: it goes in the next open version milestone, or in
+`Direct Involvement Needed` if a human has to do it.
+
+### The non-version milestone
+
+`Direct Involvement Needed` is the one milestone with no version and no ship
+date. It holds work no agent can finish alone — anything needing repo-admin
+rights, a secret, an external account, a purchase, a device in hand, a Unity
+Editor session, or a taste call that is Connor's to make.
+
+It never closes. Issues leave it by a human doing them, or by being re-scoped
+into a version milestone once the human-only part is unblocked.
+
 ## Labels
 
 Labels are the pipeline's state machine. The list below is mirrored by


### PR DESCRIPTION
Closes #2

Triage has to route new issues somewhere, so the milestone model needs to be written down before the pipeline runs.

## What's here

A `## Milestones` section in `docs/intro/conventions.md` covering:

- **Titles are versions, descriptions are scope.** A bare `v0.1` in the title, the scope in the description — including what the version *doesn't* cover. A milestone with an empty description is one nothing can be routed into.
- **Milestones are planning labels, decoupled from `/VERSION`.** `/VERSION` is moved by release-please from conventional commits and is what the built app reports; a milestone is a statement of intent that can be re-scoped until it closes. Nothing in the build reads a milestone title.
- **Read milestones live.** The page deliberately contains no list of current milestones — a list here goes stale the moment someone adds one, and a pipeline trusting a stale list routes into milestones that don't exist. Includes the `gh api` one-liner skills should use instead.
- **Freezing.** Prefix the description with `**FROZEN — no new intake.**` to stop triage adding to a settled version without closing it; issues already in it keep moving.
- **A shipped version is a tag, not a lingering milestone.** The milestone closes at release; the tag and GitHub release are the permanent record. Follow-up work is new work and goes to the next open version.
- **The non-version milestone.** What belongs in `Direct Involvement Needed` and the two ways issues leave it.

## Done on the repo, not in the diff

`Direct Involvement Needed` had an empty description, so triage had nothing to match against — I gave it a scope description spelling out the human-only categories (admin rights, secrets, external accounts, purchases, a device in hand, a Unity Editor session, a taste call that's Connor's).

`v0.0.1` and `v0.1` both already carry scope descriptions from Derek, so I left those as written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_