### PR TITLE
build: add .gitattributes marking binary game assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,142 @@
+# Binary assets, and why there is no Git LFS here.
+#
+# Two problems this file solves:
+#
+#   1. Git guesses at whether a file is text. When it guesses wrong on a .tga or
+#      a .fbx it EOL-normalizes the contents on checkout and silently corrupts
+#      the asset. Marking a path `binary` turns that off for good.
+#   2. `binary` also implies `-diff`, so `git diff` reports "Binary files
+#      differ" instead of dumping megabytes of noise into a review.
+#
+# Decision: no Git LFS. This is a small game built by a father and an
+# eight-year-old, with art measured in kilobytes. LFS adds a bandwidth quota, a
+# second thing that has to be installed before a clone works, a class of
+# "pointer file committed by mistake" failures, and CI checkouts that need an
+# extra step. Plain blobs cost nothing at this size. Revisit only if the repo
+# gets genuinely large — and revisiting means a migration, so decide before
+# committing anything big rather than after.
+
+# Everything not named below is normalized as text with LF in the repo. Working
+# copies get native line endings.
+* text=auto eol=lf
+
+# ---------------------------------------------------------------- images
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.bmp   binary
+*.tga   binary
+*.tif   binary
+*.tiff  binary
+*.exr   binary
+*.hdr   binary
+*.psd   binary
+*.ai    binary
+*.webp  binary
+*.ico   binary
+*.cur   binary
+*.svgz  binary
+
+# ------------------------------------------------------------- 3D models
+*.fbx   binary
+*.FBX   binary
+*.obj   binary
+*.blend binary
+*.blend1 binary
+*.glb   binary
+*.gltf  binary
+*.dae   binary
+*.3ds   binary
+*.max   binary
+*.ma    binary
+*.mb    binary
+*.c4d   binary
+*.abc   binary
+*.ply   binary
+*.stl   binary
+
+# ------------------------------------------------------------------ audio
+*.wav   binary
+*.mp3   binary
+*.ogg   binary
+*.aif   binary
+*.aiff  binary
+*.flac  binary
+*.m4a   binary
+*.aac   binary
+*.it    binary
+*.mod   binary
+*.s3m   binary
+*.xm    binary
+
+# ------------------------------------------------------------------ video
+*.mp4   binary
+*.mov   binary
+*.avi   binary
+*.webm  binary
+*.mkv   binary
+*.m4v   binary
+*.ogv   binary
+
+# ------------------------------------------------------------------ fonts
+*.ttf   binary
+*.otf   binary
+*.ttc   binary
+*.woff  binary
+*.woff2 binary
+*.eot   binary
+
+# --------------------------------------------------------------- archives
+*.zip   binary
+*.7z    binary
+*.gz    binary
+*.tgz   binary
+*.bz2   binary
+*.xz    binary
+*.rar   binary
+*.tar   binary
+
+# ------------------------------------------------- Unity binary artifacts
+# .unitypackage is a gzipped tar; the rest are Unity's own binary formats and
+# the native libraries a plugin drags in.
+*.unitypackage binary
+*.cubemap      binary
+*.a            binary
+*.so           binary
+*.dylib        binary
+*.dll          binary
+*.pdb          binary
+*.bundle       binary
+*.aar          binary
+*.jar          binary
+
+# -------------------------------------------------------- Android / build
+*.apk   binary
+*.aab   binary
+*.keystore binary
+*.jks   binary
+
+# ------------------------------------------------------------------- misc
+*.pdf   binary
+*.bin   binary
+*.dat   binary
+*.sqlite binary
+*.db    binary
+
+# ------------------------------------------------ Unity text-ish formats
+# These are YAML when Asset Serialization is set to Force Text (it is), so they
+# stay diffable — but they are generated, and a review that scrolls through a
+# .unity scene diff is a review that stops reading. Mark them generated so
+# GitHub collapses them by default; `git diff` still works when you want it.
+*.unity      text eol=lf linguist-generated=true
+*.prefab     text eol=lf linguist-generated=true
+*.asset      text eol=lf linguist-generated=true
+*.mat        text eol=lf linguist-generated=true
+*.anim       text eol=lf linguist-generated=true
+*.controller text eol=lf linguist-generated=true
+*.meta       text eol=lf linguist-generated=true
+
+# Shell scripts must keep LF even on a Windows checkout or they will not run.
+*.sh text eol=lf
+gradlew text eol=lf


### PR DESCRIPTION
Closes #5

Git guesses at which files are text. When it guesses wrong on a `.tga` or an `.fbx` it EOL-normalizes the contents on checkout and silently corrupts the asset — and in the meantime it line-diffs megabytes of binary into every review. This tells it not to guess.

**Docs:** None — repo config, no behaviour the docs describe changed.

## What's here

- **Images** — png, jpg, jpeg, gif, bmp, tga, tif, tiff, exr, hdr, psd, ai, plus webp/ico/cur/svgz.
- **3D models** — fbx (and `.FBX`, which case-sensitive filesystems treat as a different pattern), obj, blend, glb, gltf, plus the DCC formats an asset might arrive as.
- **Audio** — wav, mp3, ogg, aif, aiff, plus flac/m4a/aac and the tracker formats.
- **Video, fonts, archives** and the misc binaries — pdf, bin, dat, sqlite.
- **Unity and Android binaries** — `.unitypackage`, native libs, `.apk`/`.aab`, keystores.
- **A header comment recording the no-LFS decision** — plain blobs, because at this repo's size LFS only buys a bandwidth quota, a second install step before a clone works, and a class of "pointer file committed by mistake" failures. It also notes that revisiting means a migration, so the call gets made *before* something big is committed.

Verified with `git check-attr`: `.png`/`.wav`/`.fbx` resolve to `binary: set`, `diff: unset`; `.cs` is untouched.

## Deviations and Decisions

- Added `* text=auto eol=lf` as the default. Without a default the `binary` marks still work, but text files keep getting whatever the local `core.autocrlf` does, which is how a Windows checkout ends up committing CRLF into a C# file. Pinning LF in the repo makes the binary marks meaningful by contrast.
- Marked Unity's force-text YAML formats (`.unity`, `.prefab`, `.asset`, `.mat`, `.anim`, `.controller`, `.meta`) as `linguist-generated` rather than `binary`. They're genuinely text and staying diffable is worth keeping, but they're generated — collapsing them by default keeps a scene change from burying the actual review.
- Forced LF on `*.sh` and `gradlew` explicitly. They're covered by the default, but a CRLF shell script fails at runtime with an error that doesn't mention line endings, so it's worth being loud about.
- Extended each category past the issue's list (e.g. `.webp`, `.flac`, `.dylib`). The cost of a pattern that never matches is zero; the cost of a missing one is a corrupted asset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_