### PR TITLE
build: extend .gitignore for a Unity project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,57 @@
-# Gradle files
+# =============================================================================
+# Unity
+# =============================================================================
+# Everything Unity regenerates from Assets/ + ProjectSettings/ + Packages/.
+# A fresh clone opened in the Editor rebuilds all of it; committing any of it
+# only produces conflicts. Leading slashes anchor these to the repo root so a
+# folder an artist names "Logs" inside Assets/ is not swallowed by accident.
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
+/[Ll]ogs/
+/[Uu]serSettings/
+/[Mm]emoryCaptures/
+
+# Unity's package manager cache and the recorder's output.
+/[Aa]ssets/[Aa]ssetStoreTools*
+/[Rr]ecordings/
+
+# Generated solution and project files. The IDE rewrites these from the
+# .asmdef files every time it regenerates, so they are pure churn.
+*.csproj
+*.sln
+*.unityproj
+*.pidb
+*.booproj
+*.svd
+*.suo
+*.user
+*.userprefs
+*.tmp
+.vs/
+.vscode/
+.consulo/
+
+# Crash dumps and build artifacts Unity leaves behind.
+sysinfo.txt
+*.stackdump
+crashlytics-build.properties
+/[Aa]ssets/[Ss]treamingAssets/aa.meta
+/[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# IMPORTANT: .meta files are NOT ignored. Unity stores every asset's GUID,
+# import settings, and the references other assets make to it in the sibling
+# .meta file. Dropping one re-imports the asset under a fresh GUID and detaches
+# every reference to it — the classic "all my prefabs lost their sprites"
+# breakage. If you ever add a broad ignore above, re-check it with:
+#     git check-ignore -v Assets/Art/frog.png.meta
+# which must print nothing.
+
+# =============================================================================
+# Gradle / Android — the exported build
+# =============================================================================
 .gradle/
 build/
 
@@ -32,3 +85,12 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# =============================================================================
+# OS and editor cruft
+# =============================================================================
+.DS_Store
+Thumbs.db
+desktop.ini
+*~
+*.swp


### PR DESCRIPTION
Closes #6

The committed `.gitignore` was the stock Android Studio/Gradle one, so the first Unity checkout would have tried to commit `Library/` and the `.csproj` files the IDE rewrites on every regeneration.

**Docs:** None — repo config, no behaviour the docs describe changed.

## What's here

- **Unity's generated directories** — `Library/`, `Temp/`, `Obj/`, `Build/`, `Builds/`, `Logs/`, `UserSettings/`, `MemoryCaptures/`, plus the recorder output and Addressables' streaming-assets cache.
- **Generated solution/project files** — `*.csproj`, `*.sln`, `*.unityproj`, `*.pidb`, `*.booproj`, and the IDE sidecars that come with them.
- **Crash and build artifacts** — `sysinfo.txt`, `*.stackdump`, `crashlytics-build.properties`.
- **The existing Android/Gradle and keystore entries**, kept intact for the exported build and moved under their own heading.

## `.meta` files are not ignored — verified

`git check-ignore -v` against the paths that matter:

| Path | Result |
| --- | --- |
| `Assets/Art/frog.png.meta` | not ignored ✅ |
| `Assets/Scripts/Core.asmdef.meta` | not ignored ✅ |
| `ProjectSettings/ProjectSettings.asset` | not ignored ✅ |
| `Packages/manifest.json` | not ignored ✅ |
| `Library/…`, `Temp/…`, `Logs/…`, `UserSettings/…`, `Build/…` | ignored ✅ |
| `Frogs.csproj`, `Frogs.sln`, `sysinfo.txt` | ignored ✅ |

There's a comment at the ignore site recording *why* `.meta` must stay tracked — a dropped `.meta` re-imports its asset under a fresh GUID and detaches every reference to it, which is the "all my prefabs lost their sprites" failure — along with the `git check-ignore` command to re-verify after any future broad pattern.

## Deviations and Decisions

- Anchored the Unity directories with a leading `/` and the `[Ll]` case variants (`/[Ll]ibrary/`). Unanchored `Logs/` would also ignore `Assets/Logs/`, which is a plausible thing for an artist to create; verified `Assets/Logs/level.txt` stays tracked.
- Grouped the file under `Unity` / `Gradle-Android` / `OS and editor cruft` headings and added the usual OS cruft (`.DS_Store`, `Thumbs.db`, swap files). Not on the checklist, but they're the entries that otherwise get added one at a time in unrelated PRs.
- Ignored `.vs/` and `.vscode/` as pure per-developer state. If we later want shared editor settings committed, that's a deliberate un-ignore rather than something to leave open by default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_