### PR TITLE
docs(specs): write the future-ideas parking lot

### DIFF
--- a/docs/specs/future-ideas.md
+++ b/docs/specs/future-ideas.md
@@ -1,8 +1,80 @@
 # Future ideas
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #15](https://github.com/derekwinters/connor-multiplying-frogs/issues/15).
+!!! danger "Everything on this page is out of scope"
+    Nothing here is being built. Nothing here is planned. An idea is on this
+    page precisely because we decided **not** to do it yet, and it stays out of
+    scope until it is **deliberately promoted** — which means someone opens an
+    issue for it, gives it a milestone, and it goes through triage like any
+    other work. Finding an idea here is not permission to build it.
 
-The parking lot: ideas worth keeping but not worth building yet.
+## What this page is for
+
+Good ideas turn up at the worst possible moments — mid-issue, mid-review, in the
+car. The temptation is to argue them into the current milestone, because the
+alternative feels like throwing them away.
+
+This page is the alternative. It costs one paragraph to park an idea and keeps
+the current milestone from growing a new goal every time someone has a good
+thought. "That's a future-ideas entry" is a complete answer, and it is not a no.
+
+It also protects the ideas. An idea that lives in a Slack message or a comment
+on a closed issue is an idea that is gone. An idea on this page is one Connor
+can scroll through later and pick from.
+
+## How to park an idea
+
+1. Add an entry under [The parking lot](#the-parking-lot), newest at the top.
+2. Give it a one-line summary anyone could understand, then two or three
+   sentences at most.
+3. Say **why it is parked** — too big, depends on something that doesn't exist,
+   needs a decision from Connor, or just not now. This is the important part; an
+   entry without it reads like an oversight six months later.
+4. Link its GitHub issue if one exists. Most entries will not have one, and that
+   is fine — an idea with no issue is exactly what this page is for.
+
+Keep entries short. If an idea needs a page to explain, it has outgrown the
+parking lot and wants a `type:question` issue instead.
+
+## How an idea leaves
+
+An idea is **promoted** by opening a real issue for it, putting it in a version
+milestone, and letting triage handle it from there. When that happens, move the
+entry to [Promoted](#promoted) with a link, rather than deleting it — the record
+of when something stopped being a someday-idea is worth keeping.
+
+An idea is **dropped** by moving it to [Dropped](#dropped) with a one-line
+reason. Deleting an entry outright loses the fact that we considered it, which
+is how the same idea gets re-argued a year later.
+
+### Entry format
+
+```markdown
+### A short, plain name for the idea
+
+What it is, in a sentence or two.
+
+**Why it's parked:** the reason it is not being built now.
+**Issue:** #123 — or "none yet".
+```
+
+## The parking lot
+
+*Nothing parked yet.*
+
+The game concept itself is still being settled by Derek and Connor in
+[issue #7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7),
+and `v0.0.1` is entirely infrastructure — build tooling, CI, the AI pipeline,
+and a Hello World app. There is not yet a game for an idea to be "out of scope"
+*of*.
+
+Expect this section to start filling up as soon as the concept lands: the first
+entries will be the things that come up during that conversation and get set
+aside.
+
+## Promoted
+
+*Nothing promoted yet.*
+
+## Dropped
+
+*Nothing dropped yet.*


### PR DESCRIPTION
Closes #15

Good ideas turn up mid-issue, mid-review, in the car. Without somewhere to put them they get argued into the current milestone, because the alternative feels like throwing them away. This page is that alternative — and "that's a future-ideas entry" becomes a complete answer that isn't a no.

**Docs:** `docs/specs/future-ideas.md` — new page.

## What's here

- **A danger admonition at the top** stating that nothing on the page is planned or being built, and that an idea only leaves by being **deliberately promoted** — a real issue, a milestone, normal triage. Finding an idea here is explicitly not permission to build it.
- **Why the page exists** — it costs a paragraph to park something, and it protects the idea too: an idea in a comment on a closed issue is gone; an idea here is one Connor can scroll through and pick from later.
- **How to park one** — short summary, and a required **why it's parked** line. An entry without that reads like an oversight six months later.
- **How one leaves** — promoted entries move to a `Promoted` section with their issue link, dropped ones to `Dropped` with a reason. Neither gets deleted, so the same idea doesn't get re-argued a year on.
- **Entry format** as a copyable template, including "**Issue:** none yet" as a normal answer.

Already in the `mkdocs.yml` nav from #8; `mkdocs build --strict` passes.

## Deviations and Decisions

- **The parking lot starts empty**, with a note saying why: the game concept is still being settled by Derek and Connor in #7, and `v0.0.1` is entirely infrastructure — there isn't yet a game for an idea to be out of scope *of*. Seeding it would have meant inventing mechanics, which `CLAUDE.md` rules out; those are Connor's to invent. The page's structure is the deliverable, and it's ready for the first entries the concept conversation throws off.
- Included empty `Promoted` and `Dropped` sections rather than adding them on first use, so the lifecycle is visible to anyone who reads the page once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_