### PR TITLE
docs(engineering): write the issue-pipeline reference page

### DIFF
--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -1,8 +1,414 @@
 # Issue pipeline
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #21](https://github.com/derekwinters/connor-multiplying-frogs/issues/21).
+The AI issue-management pipeline: how an idea becomes a triaged issue, an
+approved issue, a queued issue, and a merged PR — mostly without anyone typing
+anything except `/approve`.
 
-The label state machine, the gatekeeper, and the nightly builder.
+Everything in the `pipeline-*` skills implements what this page describes. When
+the two disagree, this page is the specification and the code is the bug.
+
+## The model
+
+Four ideas, and the rest follows from them.
+
+**1. Labels are the state machine.** An issue's pipeline state is a label, not a
+field in a database somewhere, not a line in its body. GitHub is the store. That
+means the state is visible in the issues list, filterable, editable by hand in an
+emergency, and impossible to lose by dropping a file.
+
+**2. Comments are the owner's control surface.** Derek drives the pipeline by
+commenting `/approve`, `/park`, `/focus v0.1` on issues. No dashboard app, no
+CLI, no separate tool to log into. The place where the conversation about an
+issue already happens is the place where the decision about it is made.
+
+**3. A gatekeeper translates one into the other.** A deterministic script — not
+a model — reads comments, parses commands, and applies label changes. This is
+the whole safety story: the component that can change state is a parser with a
+fixed vocabulary, so the worst a confused language model can do is *suggest*
+something, never *do* it.
+
+**4. Only the owner's commands are honoured.** A command in a comment from
+anyone else is ignored. See [the bad-actor gate](#the-bad-actor-gate).
+
+## States
+
+Exactly one state label per open issue.
+
+| State | Meaning | Set by | Leaves when |
+| --- | --- | --- | --- |
+| *(none)* | brand new, not yet seen | issue creation | triage picks it up |
+| `ai-triage` | queued for automated triage | analysis, `/retriage` | triage finishes |
+| `pending-approval` | triaged; waiting on a human | triage | `/approve`, `/park` |
+| `needs-clarification` | triage could not proceed without an answer | triage | `/retriage` after the answer |
+| `ready-for-work` | approved and eligible for the builder | `/approve` | the builder picks it up |
+| `in-progress` | an agent is building it right now | the builder | its PR merges, or it fails |
+| `parked` | deliberately set aside | `/park` | `/unpark` |
+
+Plus `dashboard`, which is not a state — it marks the one live dashboard issue,
+which the pipeline never triages or works.
+
+**Invariant:** `ready-for-work` ⇒ the issue has a milestone. Enforced at the
+`/approve` gate and re-checked by the reconciler. See
+[Conventions](../intro/conventions.md#the-invariant-ready-for-work-has-a-milestone).
+
+**Invariant:** an issue has at most one state label. The gatekeeper *replaces*
+rather than adds; the reconciler flags any issue carrying two.
+
+### The normal path
+
+```text
+(new) → ai-triage → pending-approval → ready-for-work → in-progress → closed
+                            ↓                ↑
+                   needs-clarification ──────┘
+                            ↓
+                         parked → (unpark) → ai-triage
+```
+
+## Commands
+
+Every command is a line in an issue comment beginning with `/`. A comment may
+contain several; they apply in order. Text around them is ignored, so you can
+explain yourself in the same comment.
+
+| Command | Effect |
+| --- | --- |
+| `/approve` | `pending-approval` → `ready-for-work`. Subject to both approval gates. |
+| `/park [reason]` | any state → `parked`. The reason is recorded in the ack. |
+| `/unpark` | `parked` → `ai-triage`, so it gets re-triaged against current reality. |
+| `/retriage` | any state → `ai-triage`. Use after answering a `needs-clarification`. |
+| `/block #N` | record a native blocked-by relationship on issue N. |
+| `/unblock #N` | remove it. |
+| `/milestone <title>` | set the issue's milestone by title. |
+| `/focus <title>` | set the pipeline's focus milestone. Dashboard issue only. |
+| `/cap <n>` | set the max concurrent `in-progress` issues. Dashboard issue only. |
+| `/help` | reply with this vocabulary. Works anywhere. |
+
+Deliberately absent: anything that closes an issue, edits a body, or merges a
+PR. Those have perfectly good GitHub buttons, and a command vocabulary that can
+do irreversible things is a vocabulary that will eventually do one by accident.
+
+### Unknown commands
+
+A line starting with `/` that isn't in the table gets a 😕 reaction and a reply
+naming the closest match. It is never guessed at — `/aprove` does not approve.
+
+## The bad-actor gate
+
+**Commands are honoured only from the repository owner.** Everything else is
+read, recognised, and dropped.
+
+The pipeline can label, comment, fire scheduled routines, and queue work for an
+agent that writes code. That is not authority to hand to whoever can type in a
+comment box on a public repo.
+
+Two details that matter:
+
+- **Ignored means silent.** No reply, no reaction, no label change. Replying
+  would let a stranger make the bot post — a smaller hole than acting on the
+  command, but the same shape. The drop is recorded in the workflow log, which
+  is where you look if you expected something to happen and it didn't.
+- **Author association is not enough.** The check is against the configured
+  owner login, not "is a collaborator" or "has write access". Access can be
+  granted for a reason that has nothing to do with driving the pipeline.
+
+## Idempotency: the 👀 watermark
+
+Two things process comments — the `issue_comment` workflow and the periodic
+sweep — and neither can assume the other didn't get there first. Webhooks are
+also redelivered.
+
+So before acting on a comment, the gatekeeper adds a **👀 reaction from its own
+account**, and it skips any comment that already has one.
+
+- The watermark is **on the comment**, so it survives everything: workflow
+  re-runs, sweeps, redelivered webhooks, and the queue being rebuilt.
+- It is added **before** the actions are applied, not after. A crash mid-apply
+  leaves a claimed-but-unfinished comment, which is a stuck command someone can
+  see; the alternative — reacting afterwards — risks applying twice, which is a
+  state change nobody asked for. Prefer visible-and-stuck to silent-and-doubled.
+- It is a **claim**, so the outcome gets its own reaction: 🚀 applied, 😕
+  refused or not understood.
+
+To make the gatekeeper reconsider a comment, remove its 👀.
+
+## The approval gates
+
+Both gates **refuse and explain**. Neither ever fixes the problem itself.
+
+That posture is deliberate. Auto-correcting at an approval gate means the
+pipeline quietly decides something Derek was in the middle of deciding, and the
+first he hears of it is a build he didn't expect. A refusal costs one comment
+and ten seconds; a wrong auto-fix costs a milestone's worth of misordered work.
+
+### Gate 1: `/approve` requires a milestone
+
+**Invariant:** an issue cannot become `ready-for-work` without a milestone.
+
+Without one it is approved work no builder will ever select, because selection
+runs against the focus milestone. It leaves the queue silently, which is the
+worst way for work to disappear.
+
+The gatekeeper **refuses** and replies naming the open milestones and the
+`/milestone` command. It never picks one, not even when only one is open, and
+not even when the issue's siblings all sit in the same milestone.
+
+### Gate 2: milestone order
+
+**Invariant:** work is approved in milestone order. An issue in a later
+milestone cannot become `ready-for-work` while the focus milestone still has
+open work.
+
+Milestones are a plan. Approving `v0.2` work while `v0.1` still has twenty open
+issues is how a project ends up with three half-finished versions.
+
+The gatekeeper **refuses** and replies with the focus milestone, how many issues
+remain open in it, and the two ways forward: finish the focus milestone, or
+`/focus` the later one deliberately. It never bumps the issue's milestone, and
+never moves focus on its own.
+
+The escape hatch is `/focus`, which is a deliberate act, recorded on the
+dashboard, and visible to everyone.
+
+## Auto-revisit when a blocker clears
+
+An issue parked *because it was blocked* should not need a human to remember it.
+The sweep looks for issues whose recorded blockers have all closed, and returns
+them to `ai-triage` with a comment saying which blocker cleared.
+
+Conditions, all required:
+
+- the issue is `parked` or `needs-clarification`;
+- it has at least one native blocked-by relationship;
+- every blocking issue is closed;
+- it was not parked by an explicit `/park` with a reason unrelated to blocking —
+  a park the owner chose is a park the owner un-chooses.
+
+### The `type:wireframe` carve-out
+
+**`type:wireframe` issues are never auto-revisited.**
+
+Unblocking a wireframe doesn't make it agreeable. What a wireframe needs is a
+person looking at a picture and saying yes — usually Connor. Waking one up
+automatically produces an issue that says "ready" and isn't, and the pipeline
+would then hand it to a builder that has no wireframe to build against.
+
+They surface on the dashboard as waiting-on-a-human instead.
+
+## `/focus` and `/cap` live on the dashboard issue
+
+Both are stored as HTML-comment markers in the body of the dashboard issue:
+
+```html
+<!-- pipeline:focus=v0.0.1 -->
+<!-- pipeline:cap=1 -->
+```
+
+The dashboard issue is the one carrying the `dashboard` label. There is exactly
+one; the reconciler flags it if there are two or none.
+
+### Why markers, and why re-rendering beats hand-editing
+
+The dashboard body is **regenerated wholesale** on every render — every section
+is derived from live GitHub state. That is what makes it trustworthy: nothing on
+it can be stale, because nothing on it is remembered.
+
+Configuration can't work that way, so the renderer parses the markers out of the
+current body, and writes them back verbatim into the new one. The markers are
+the only part of the body that survives a render.
+
+Which gives the rule: **edit the markers, never the rendered sections.** A hand
+edit to a rendered section disappears at the next render, and — worse — looks
+like it worked until it does. Setting focus via `/focus` writes the marker,
+which is the same thing done in the place that keeps it.
+
+Markers rather than a config file in the repo because focus and cap are
+*operational* state that changes between merges. A PR to change which milestone
+is in focus is friction in exactly the wrong place.
+
+## Fetching live milestones
+
+Never hard-code a milestone list. Read it:
+
+```http
+GET /repos/{owner}/{repo}/milestones?state=open&per_page=100
+```
+
+### The gotcha: `milestone` takes a number
+
+When setting a milestone on an issue, the field takes the milestone's **number**,
+not its title:
+
+```http
+PATCH /repos/{owner}/{repo}/issues/{issue_number}
+{"milestone": 2}          ✅
+{"milestone": "v0.1"}     ❌ 422, or silently wrong
+```
+
+So anything accepting a title — `/milestone v0.1`, a triage decision — resolves
+title → number against the live list first, and refuses if the title doesn't
+match exactly one open milestone. Titles are compared literally: `v0.1` and
+`V0.1` are different milestones, and the fix is to type the real one rather than
+to normalise and hope.
+
+## Schedule
+
+| Runs | When | Does |
+| --- | --- | --- |
+| `gatekeeper-comment` workflow | on `issue_comment` created | parse and apply commands, immediately |
+| `gatekeeper-sweep` workflow | every 15 minutes | catch missed comments; auto-revisit cleared blockers |
+| `pipeline-analysis` routine | nightly, 02:00 UTC | triage everything untriaged |
+| reactive triage | fired on demand by the gatekeeper | triage one issue, now |
+| `pipeline-dev` routine | nightly, 03:00 UTC | build and work the ready queue |
+| `pipeline-reconcile` routine | nightly, 01:00 UTC | detect and fix drift |
+| `dashboard` workflow | hourly, and after each pipeline run | re-render the dashboard |
+
+Reconcile runs before analysis, which runs before development: fix the state,
+then triage against fixed state, then work against a triaged queue. A nightly
+order that ran them the other way would spend each night acting on yesterday's
+mistakes.
+
+### Reactive triage
+
+Waiting until 02:00 to triage an issue filed at 09:00 is a bad experience when
+the person who filed it is sitting right there. So the gatekeeper can **fire the
+triage routine immediately** for a single issue — on a new issue, or on
+`/retriage`.
+
+It needs a routine ID and a token with permission to fire it, both repository
+secrets. Without them the gatekeeper logs that it couldn't fire and carries on:
+the nightly run still picks the issue up, so a missing secret costs latency, not
+correctness. Never a hard failure.
+
+## What each stage does
+
+### Analysis — find what needs triage
+
+`select_triage.py` lists candidate issues: open, not the dashboard, and either
+carrying no state label or carrying `ai-triage`. It returns them oldest-first,
+with everything the triage stage needs already fetched, so the dispatcher can
+fan out without each triage run re-querying.
+
+The dispatcher (`pipeline-analysis`) is a thin loop over that list. It makes no
+decisions itself — the decisions are in `triage-issue`, one issue at a time,
+which keeps a bad triage contained to one issue instead of one batch.
+
+### Triage — one issue
+
+`triage-issue` reads an issue and produces:
+
+- an **`area:*` and `type:*` label**;
+- a **milestone proposal**, resolved against the live list;
+- a **build checklist** — the acceptance criteria, as checkboxes;
+- a **spec-pages line** naming what in `/docs` it touches;
+- **dependencies**, recorded natively (below);
+- a state: `pending-approval`, or `needs-clarification` with the specific
+  question that blocks it.
+
+It writes one comment containing its reasoning, so an `/approve` is a human
+agreeing with something they can read rather than rubber-stamping a label.
+
+**Re-fire repair.** Triage that runs twice on the same issue must not stack
+duplicate comments, duplicate checklists, or contradictory labels. Each triage
+comment carries a marker; a re-run finds its previous comment and **edits** it
+rather than adding another. `triage_repair.py` also detects the mess left by an
+older run that crashed mid-way — a label set without a comment, a comment
+without labels — and repairs it.
+
+### Recording dependencies
+
+Dependencies are **native GitHub relationships**, never prose:
+
+- *This is part of that* → a **sub-issue** of the parent epic.
+- *This can't start until that's done* → a **blocked-by** relationship.
+
+The builder computes its ready queue from that graph. A dependency written as a
+sentence is a dependency it walks straight into. This is also why `/block` and
+`/unblock` exist as commands: recording one has to be as cheap as mentioning it.
+
+### Development — the ready queue
+
+`select_queue.py` returns the issues to work, in the order to work them:
+
+**Eligibility** — all of:
+
+- `ready-for-work`;
+- in the focus milestone;
+- not blocked by an open issue;
+- not a `type:epic` (epics are containers; their children are the work);
+- has no open PR already referencing it.
+
+**Ordering** — a topological sort over the blocked-by graph, so an issue that
+unblocks others is worked before one that unblocks nothing. Ties break oldest
+first, so nothing starves. A cycle in the graph is reported, not resolved: a
+cycle is a triage mistake, and silently picking an entry point hides it.
+
+### Serial delegated delivery
+
+Issues are worked **one at a time**, each delegated to its own agent session.
+
+Serial because parallel agents on one repository fight: two branches touching
+`ProjectSettings.asset`, two release-please runs, two PRs renumbering the same
+things. The `cap` marker exists to raise this above 1 if that ever stops being
+true, and its default is 1.
+
+Delegated — a fresh session per issue — because context from the previous issue
+is a liability. The agent that just spent an hour on the audio system will find
+a way to make the next issue about audio.
+
+Each delegation is: mark `in-progress`, hand the issue to the development agent
+([Agent workflow](agent-workflow.md)), and let it open its own PR. The pipeline
+does not write code, and it does not merge PRs.
+
+### Reconciliation — drift
+
+Reality drifts: a PR merges without its closing keyword, someone hand-edits a
+label, a run crashes between two API calls. `reconcile.py` compares what the
+labels claim against what GitHub shows, and sorts each finding into
+**auto-fixable** or **flag-only**.
+
+**Auto-fixed** — mechanical, single correct answer, no judgement:
+
+- a closed issue still carrying a state label → remove it;
+- `in-progress` with no open PR and no recent activity → back to
+  `ready-for-work`;
+- an issue with two state labels where one was clearly just applied → keep the
+  newest;
+- a merged PR whose issue is still open, with a closing keyword that GitHub
+  missed → close the issue.
+
+**Flagged, never touched** — anything needing judgement:
+
+- `ready-for-work` with no milestone (the invariant is broken, but the fix is a
+  decision about which milestone);
+- an issue in the focus milestone blocked by one in a later milestone;
+- a dependency cycle;
+- two dashboard issues, or none.
+
+The split is the design. A reconciler that guesses is a reconciler you have to
+audit, and one you have to audit is one you turn off.
+
+### Dashboard
+
+`render_dashboard.py` rewrites the dashboard issue from live state: what is in
+focus, what is ready, what is in flight, what is blocked, what is waiting on a
+human, and what the reconciler flagged. Plus **unblocker stars** — the issues
+that would free the most other work, which are the ones worth approving next.
+
+Wholly regenerated every time, apart from the config markers. Nothing on it is
+remembered, so nothing on it can be stale.
+
+## Skills inventory
+
+| Skill | Owns |
+| --- | --- |
+| `pipeline-gatekeeper` | comment parsing, the gates, label application, acks, reactive fire |
+| `pipeline-analysis` | finding what needs triage and dispatching it |
+| `triage-issue` | triaging one issue, and repairing a re-fire |
+| `pipeline-dev` | the ready queue and serial delegated delivery |
+| `pipeline-reconcile` | drift detection, auto-fix, and flagging |
+| `pipeline-dashboard` | rendering the live dashboard issue |
+| `milestone-orchestration` | driving a milestone end to end across the above |
+
+The scripts inside them are ordinary Python with ordinary unit tests, run by the
+`pipeline-tests` workflow ([CI/CD](ci-cd.md#pipeline-workflows)). The pipeline is
+code, and a broken gatekeeper is a broken queue.


### PR DESCRIPTION
Closes #21

The reference page for the whole AI issue-management pipeline. Every `pipeline-*` skill issue (#53–#78) implements what's here, so it lands early and deliberately over-specifies: when the two disagree, this page is the spec and the code is the bug.

**Docs:** `docs/engineering/issue-pipeline.md` — new page.

## What's here

- **The model** — four ideas, with the safety argument stated plainly: the component that can change state is a *deterministic parser with a fixed vocabulary*, so the worst a confused language model can do is suggest something, never do it.
- **States and commands tables**, the normal-path diagram, and both label invariants (one state label; `ready-for-work` ⇒ has a milestone). Notes what's deliberately *absent* from the vocabulary — nothing that closes, edits a body, or merges, because a command set that can do irreversible things eventually does one by accident. Unknown commands get 😕 and a nearest-match reply, never a guess.
- **The bad-actor gate** — owner-only, with two details: ignored means *silent* (replying would still let a stranger make the bot post), and the check is against the owner login rather than write access, since access is granted for reasons unrelated to driving a pipeline.
- **The 👀 watermark** — on the comment so it survives re-runs, sweeps and redelivered webhooks, and added *before* apply rather than after. The tradeoff is written down: a crash mid-apply leaves a visible stuck command, which beats a silent double-apply.
- **Both approval gates**, stated as invariants with a **refuse-and-explain, never-auto-fix** posture and the cost argument for it — a refusal costs one comment; a wrong auto-fix costs a milestone of misordered work. Gate 1 never picks a milestone even when only one is open; gate 2 never bumps or moves focus, and `/focus` is the deliberate, recorded escape hatch.
- **Auto-revisit** with its four conditions and the **`type:wireframe` carve-out** — unblocking a wireframe doesn't make it agreeable; what it needs is Connor looking at a picture and saying yes.
- **`/focus` and `/cap` as markers** on the dashboard issue, with the reasoning: the body is regenerated wholesale so nothing on it can be stale, markers are the only part that survives, and a hand edit to a rendered section *looks like it worked* until the next render.
- **Live milestones** and the gotcha — `milestone` takes a **number**, not a title, so anything accepting a title resolves it first and refuses on an ambiguous or non-matching one rather than normalising and hoping.
- **The schedule table**, plus why reconcile → analysis → development is the right nightly order, and reactive triage degrading to *latency* rather than failure when its secrets are missing.
- **Stage behaviour** — analysis and why the dispatcher makes no decisions, triage's outputs and its re-fire repair via an edited marked comment, native dependency recording, queue eligibility and topological ordering (cycles reported, not resolved), serial delegated delivery and why both halves matter, reconciliation's auto-fix/flag split with the full list of each, and the dashboard.
- **Skills inventory** table.

`mkdocs build --strict` passes.

## Deviations and Decisions

- **I specified the command vocabulary rather than porting it.** Doggiehood's version wasn't readable from here, so the ten commands, the gate refusal wording, the reconciler's auto-fix/flag lists, and the marker syntax are all decided here. That's the right place to decide them — this page is what nine downstream issues build against, and deciding them in the first implementing PR would mean the other eight discover the conventions by reading code.
- **Set `cap` default to 1** and wrote down why serial is the default (parallel agents on one repo fight over `ProjectSettings.asset`, release-please, and PR ordering), so raising it later is a decision with a stated cost rather than a knob someone turns.
- Included the `/help` command, which the checklist didn't list. A command surface with no discoverable vocabulary is one people stop using.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_