### PR TITLE
docs(engineering): write the UI design process page

### DIFF
--- a/docs/engineering/ui-design-process.md
+++ b/docs/engineering/ui-design-process.md
@@ -1,8 +1,188 @@
 # UI design process
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #22](https://github.com/derekwinters/connor-multiplying-frogs/issues/22).
+**No UI gets built without an approved wireframe. Not even graybox.**
 
-Wireframe before UI code, and what an agreed wireframe looks like.
+UI is the part of this game Connor has the strongest opinions about and the part
+that is most expensive to redo. A layout argued about as a picture costs an
+evening; the same argument had about working code costs the code.
+
+There is also a specific failure this prevents. An agent handed "add a pause
+screen" with no wireframe will produce *a* pause screen — a competent, tested,
+plausible one — and it will be somebody's idea of a pause screen rather than
+Connor's. Nothing in the test suite catches that, and by the time it's visible
+it's built.
+
+## What a wireframe is: a dual artifact
+
+Two files per screen, both under `docs/specs/ui/`, both required.
+
+### 1. The screen spec — `docs/specs/ui/<screen>.md`
+
+Structured text. What is on the screen, how it is arranged, what each element
+does, and — critically — the **named constants** that define its geometry.
+
+```markdown
+# Pause screen
+
+**Invariant:** the pause screen never covers the score readout.
+
+## Layout
+
+Vertical stack, centred, over a dimmed copy of the playfield.
+
+| Element | Constant | Value |
+| --- | --- | --- |
+| Panel width | `PausePanelWidth` | 280 dp |
+| Panel corner radius | `PausePanelCornerRadius` | 16 dp |
+| Gap between buttons | `PauseButtonSpacing` | 12 dp |
+| Backdrop dim | `PauseBackdropOpacity` | 0.6 |
+
+## Elements
+
+- **Resume** — returns to play. Primary; first in tab order.
+- **Restart** — confirms first (`RestartConfirmDelay`, 0 s — no delay, but the
+  confirm step is required).
+- **Quit to menu** — confirms first.
+
+## Behaviour
+
+- Opening pauses the simulation; nothing in Core advances.
+- Hardware back button resumes, it does not quit.
+```
+
+### 2. The mockup — `docs/specs/ui/mockups/<screen>.html`
+
+A **1:1 HTML mockup**: a static page sized to the target device, laying out the
+real elements at the real proportions.
+
+- 1:1 because "roughly this" is how a button ends up too small for an
+  eight-year-old's thumb. Sized to a real phone viewport, in the real units.
+- HTML because it opens in a browser on a phone. Connor can look at the actual
+  thing at the actual size, on the device he plays on, and say it's wrong.
+- Static. No behaviour, no framework, no build step. It is a picture that
+  happens to be made of divs.
+
+### Why both
+
+The spec is what the code is built from; the mockup is what the decision is made
+from. Neither substitutes:
+
+- A spec alone gets approved by someone who read the words and imagined a
+  different screen.
+- A mockup alone leaves every number to be re-guessed at implementation time,
+  and re-guessed differently.
+
+## The named constants are the origin, not an afterthought
+
+**The constants in the spec table are the same constants the code declares.**
+Same names, same values. The spec is where they are born.
+
+```csharp
+// Assets/Scripts/Unity/Views/PausePanelView.cs
+[SerializeField] float _pausePanelWidth = 280f;          // PausePanelWidth
+[SerializeField] float _pauseButtonSpacing = 12f;        // PauseButtonSpacing
+```
+
+This is the same rule as
+[named values](tech-stack.md#geometry-layout-and-tuning-values-are-named-variables),
+arriving one step earlier. The point is the direction of travel: the number is
+decided when the layout is agreed, and the code *receives* it. If the code
+invents a number the spec doesn't have, the layout was not fully agreed — go
+back and agree it, don't paper over it in an implementation PR.
+
+It also means "make the buttons further apart" is answerable in one place, by
+someone who doesn't read C#.
+
+Changing a constant after approval is a spec change: update the spec table and
+the mockup, and say so in the PR under
+[how the spec is changing](agent-workflow.md#how-the-spec-is-changing).
+
+## The loop
+
+**propose → review → approve → distill → implement → verify**
+
+1. **Propose.** Open a `type:wireframe` issue. Write the spec page and build the
+   mockup. Where there's a real choice, propose *two* mockups — comparing two
+   pictures is a much easier conversation than critiquing one.
+2. **Review.** Connor looks at the mockup, on a phone, at 1:1. Derek looks at
+   the spec. Feedback goes on the issue.
+3. **Approve.** The wireframe issue is **closed** by a human. Closing it is the
+   approval — there is no separate approved label to forget to apply.
+4. **Distill.** Fold the agreed decisions back into the spec page and mockup so
+   they describe what was agreed, not what was proposed. A spec page that
+   requires reading the issue thread to interpret has not been distilled.
+5. **Implement.** An implementation issue, blocked-by the wireframe issue, built
+   against the spec's constants.
+6. **Verify.** The PR shows the built screen against the mockup — a screenshot,
+   side by side. The check is "does it match the agreed picture", which is a
+   question anyone can answer.
+
+## The gate
+
+Before writing UI code, ask: **does an approved wireframe cover this?**
+
+### Stop and flag when it doesn't
+
+If the issue asks for UI structure and there's no approved wireframe:
+
+1. Stop. Do not sketch one in code "to be replaced later" — placeholder layout
+   is the code most likely to survive to release, because it works and nobody
+   goes back to it.
+2. Comment on the issue saying which screen needs a wireframe.
+3. Open the `type:wireframe` issue, and add a **blocked-by** relationship from
+   the implementation issue to it.
+4. Work something else.
+
+### What counts as structure
+
+Gated:
+
+- adding, removing, or moving an element;
+- changing sizes, spacing, or proportions;
+- changing what an element does, or the order things happen in;
+- a new screen, dialog, or overlay of any kind.
+
+### What isn't gated
+
+**Purely visual restyling** goes ahead without a wireframe: colours within the
+palette, a font weight, an icon swapped for a clearer one at the same size, a
+shadow, a transition's easing.
+
+The test is whether the change would alter the mockup's *layout*. If the mockup
+would still be an accurate picture of the screen afterwards, it's a restyle. If
+the mockup would now be wrong, it's structure — and the fix is to update the
+mockup, which is the wireframe loop.
+
+This carve-out is deliberate. A process that gates every pixel is a process
+people route around, and then it gates nothing.
+
+## Conventions
+
+### The `type:wireframe` label and the `Wireframe:` prefix
+
+Wireframe issues are labelled `type:wireframe` and titled with a `Wireframe:`
+prefix:
+
+```text
+Wireframe: pause screen
+Wireframe: level select
+```
+
+The label is what tooling filters on; the prefix is what a human scanning the
+issue list sees. Both, because they serve different readers.
+
+### How the blocker sweep treats a wireframe blocker
+
+The pipeline's [auto-revisit](issue-pipeline.md#auto-revisit-when-a-blocker-clears)
+returns an issue to triage once its blockers have closed. For a wireframe
+blocker that is exactly right — **closed is approved**, so an implementation
+issue blocked by a wireframe wakes up precisely when the wireframe is agreed.
+
+The carve-out runs the other way: **a `type:wireframe` issue is never itself
+auto-revisited.** Unblocking a wireframe doesn't make it agreeable; it still
+needs a person looking at a picture. Waking one automatically would produce an
+issue claiming to be ready that no agent can act on. They surface on the
+dashboard as waiting-on-a-human instead.
+
+So: wireframes are woken by people, and the things they block are woken by the
+wireframe closing.


### PR DESCRIPTION
Closes #22

No UI gets built without an approved wireframe — not even graybox. The page opens by naming the specific failure this prevents: an agent handed "add a pause screen" will produce a competent, tested, plausible pause screen, and it'll be somebody's idea of one rather than Connor's. Nothing in the test suite catches that, and by the time it's visible it's built.

**Docs:** `docs/engineering/ui-design-process.md` — new page.

## What's here

- **The dual artifact** — a per-screen spec page (`docs/specs/ui/<screen>.md`) with a worked example, and a **1:1 static HTML mockup** (`docs/specs/ui/mockups/<screen>.html`). 1:1 because "roughly this" is how a button ends up too small for an eight-year-old's thumb; HTML because it opens in a browser *on the phone*, so Connor can look at the real thing at real size and say it's wrong. Plus why neither substitutes: a spec alone gets approved by someone imagining a different screen, a mockup alone leaves every number to be re-guessed at implementation time.
- **Named constants are the origin** — the constants in the spec table are the same ones the code declares, same names, same values. It's the [named-values rule](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/tech-stack.md) arriving one step earlier, and the direction of travel is the point: if the code invents a number the spec doesn't have, the layout was never fully agreed. Also makes "move the buttons further apart" answerable by someone who doesn't read C#.
- **The loop** — propose → review → approve → distill → implement → verify. Closing the wireframe issue *is* the approval, so there's no separate label to forget. Proposing two mockups where there's a real choice, because comparing two pictures is a much easier conversation than critiquing one. Verify is a screenshot against the mockup, which is a question anyone can answer.
- **The gate** — stop and flag, with the explicit instruction not to sketch a layout in code "to be replaced later", since placeholder layout is the code most likely to survive to release. Lists what counts as structure and what doesn't.
- **Restyling isn't gated** — colours, weights, shadows, easing. The test: would the mockup still be an accurate picture afterwards? Called out as deliberate, because a process that gates every pixel gets routed around and then gates nothing.
- **Conventions** — the `type:wireframe` label (what tooling filters on) and the `Wireframe:` title prefix (what a human scanning the list sees), and how the blocker sweep treats wireframes in **both** directions: closed-is-approved means an implementation issue wakes exactly when its wireframe is agreed, while a wireframe is never itself auto-revisited because unblocking one doesn't make it agreeable.

`mkdocs build --strict` passes.

## Deviations and Decisions

- The worked spec example uses a pause screen with invented constants. It's illustrative formatting, not a spec for a real screen — the game concept isn't settled (#7) and inventing mechanics isn't mine to do. A format this specific needs an example, and an abstract one wouldn't show the constants table doing its job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_