### PR TITLE
docs(specs): create the UI specs section

### DIFF
--- a/docs/specs/ui/index.md
+++ b/docs/specs/ui/index.md
@@ -1,8 +1,104 @@
 # UI specs
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #23](https://github.com/derekwinters/connor-multiplying-frogs/issues/23).
+**These pages are the layout contract.** One page per screen, saying what is on
+it, how it is arranged, and the named constants that define its geometry. Code
+is built from these pages; it does not decide them.
 
-Wireframes and screen specs, one page per screen.
+How a page here comes to exist — the wireframe loop, what counts as structure,
+and when an implementation is allowed to start — is in
+[UI design process](../../engineering/ui-design-process.md). Read that first if
+you are about to open a wireframe issue.
+
+## Screens
+
+*No screens specified yet.* The game concept is still being settled in
+[issue #7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7),
+and every screen page arrives through its own `Wireframe:` issue.
+
+## Shared components
+
+Reusable atomic pieces — a primary button, the score readout, a confirm dialog —
+are specified once in [Shared components](shared-components.md) and
+**referenced** by screen pages, never re-specified in them.
+
+The reason is drift. Three screens that each describe "the primary button" will,
+within a month, describe three subtly different buttons, and no one edit fixes
+all of them. One page, three references, one edit.
+
+## The per-screen page template
+
+Every screen page carries these sections, in this order. Sections that don't
+apply are written as "None" rather than omitted — an omitted section reads as an
+oversight, and the whole point of a template is that a reader knows where to
+look.
+
+### 1. Title and one-line purpose
+
+What the screen is for, in a sentence, in words Connor would use.
+
+### 2. Invariants
+
+Things that must always be true of this screen, stated as
+`**Invariant:** …` lines so they can be quoted in a PR and asserted in a test.
+
+```markdown
+**Invariant:** the pause screen never covers the score readout.
+**Invariant:** every destructive action confirms before it acts.
+```
+
+### 3. Regions
+
+The screen broken into its named areas, top to bottom. A region is a box with a
+name and a job — `header`, `playfield`, `controls`. Naming them is what lets
+everything else say *where* without re-describing the layout each time.
+
+| Region | Job |
+| --- | --- |
+| `header` | score and pause button |
+| `playfield` | the pond; everything interactive |
+| `controls` | the two action buttons |
+
+### 4. Anchors
+
+How each region is positioned and what it is pinned to — which edge, which safe
+area, what happens when the screen is taller or shorter than the mockup.
+
+Anchors are the section people skip and then regret. A phone is not one size;
+a layout that only says "the button is 40 dp from the bottom" has not said
+whether that's from the screen edge or the safe area, and the answer is the
+difference between a reachable button and one under the gesture bar.
+
+### 5. Named constants
+
+The table that the code's constants come from. Every size, margin, spacing,
+radius, and duration on the screen, named and valued.
+
+| Element | Constant | Value |
+| --- | --- | --- |
+| Panel width | `PausePanelWidth` | 280 dp |
+| Gap between buttons | `PauseButtonSpacing` | 12 dp |
+
+Same names in the code. See
+[named constants are the origin](../../engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought).
+
+### 6. Elements
+
+Each interactive element: what it says, what it does, what state it can be in
+(disabled, pressed, hidden), and whether it confirms.
+
+### 7. Behaviour
+
+What happens on entry and exit, what the hardware back button does, what
+animates and for how long, and what the screen does to the simulation
+underneath it.
+
+### 8. Mockup
+
+A link to the 1:1 HTML mockup for this screen, in
+[`mockups/`](mockups/index.md).
+
+### 9. Open questions
+
+Anything deliberately not decided yet, with the issue that will decide it.
+"None" when there are none — an empty section is a claim that the spec is
+complete, which is worth making explicitly.

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -1,0 +1,43 @@
+# Mockups
+
+The committed 1:1 HTML mockups. Each is a static page sized to the target phone
+viewport, showing a screen's real elements at their real proportions.
+
+Open one on a phone. That is what it is for — a mockup judged on a laptop is a
+mockup judged at the wrong size, and size is most of what a wireframe decides.
+
+## Committed mockups
+
+| Screen | Mockup | Spec page |
+| --- | --- | --- |
+| *(none yet)* | | |
+
+Each row arrives with its screen's `Wireframe:` issue. See
+[UI design process](../../../engineering/ui-design-process.md).
+
+## What a mockup is, and is not
+
+**Is:** static HTML and CSS, one file, no build step, no framework, no
+JavaScript beyond nothing at all. A picture that happens to be made of divs.
+
+**Is not:** a prototype. No behaviour, no navigation between screens, no
+interactivity. The moment a mockup does something, people start judging what it
+does instead of how it looks, and it stops being cheap to change — which was the
+entire point.
+
+## Conventions
+
+- **One file per screen**, named for the screen: `pause-screen.html`.
+- **Sized to the target viewport** with a fixed-size container, so it renders at
+  1:1 rather than filling whatever window it opens in. State the device and
+  dimensions in a comment at the top of the file.
+- **Real proportions, real units.** The numbers in the mockup are the numbers in
+  the spec page's constants table. If they disagree, one of them is a bug.
+- **Placeholder content is honest** — the longest plausible score, not `0`; a
+  real-length label, not `Text`. A layout that only works with short strings is
+  a layout that breaks on the first real one.
+- **Self-contained.** Inline the CSS; no CDN links, no web fonts fetched at
+  view time. A mockup that needs the network is a mockup that doesn't open on
+  the sofa.
+- **Committed, not generated.** These are reviewed artifacts and they live in
+  git next to the spec they illustrate.

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -1,0 +1,67 @@
+# Shared components
+
+!!! note "Stub — fills in as components are specified"
+    No shared components exist yet. This page is the home they go in, and the
+    rule for when something belongs here.
+
+Reusable atomic pieces of UI, specified **once** and referenced by screen pages.
+
+A screen page says *"the confirm dialog ([shared](shared-components.md))
+appears"* and moves on. It does not restate the dialog's padding, its button
+order, or how it dismisses.
+
+## Why this page exists
+
+Three screens that each describe "the primary button" will, within a month,
+describe three subtly different buttons. Nobody will have decided they should
+differ — the descriptions were written on different days by people making
+reasonable choices. Then a change to the button means finding all three, and one
+gets missed.
+
+One page, three references, one edit.
+
+## When something belongs here
+
+A piece belongs here once **either** is true:
+
+- it appears on two or more screens; or
+- it is going to, and the second screen is already specified.
+
+Do not pre-emptively generalise a one-screen element. A component extracted
+before its second use is a component shaped by exactly one caller, and the
+second caller ends up working around it.
+
+Moving an element here later is cheap: cut its section out of the screen page,
+paste it here, and leave a reference behind.
+
+## The per-component template
+
+### 1. What it is
+
+One sentence, and where it is used — a list of the screen pages that reference
+it. That list is how you find out what a change to this page affects.
+
+### 2. Invariants
+
+`**Invariant:** …` lines. Shared components are where invariants earn the most:
+"every destructive action confirms" is one rule stated once, rather than a thing
+five screens each have to remember.
+
+### 3. Named constants
+
+The same constants table screen pages use. These are the code's constants.
+
+### 4. States
+
+Every state the component can be in — default, pressed, disabled, loading,
+error — and what it looks like in each. A component page that only describes the
+default state is a component that gets a different disabled style on every
+screen.
+
+### 5. Behaviour
+
+What it does when interacted with, what it emits, and what it never does.
+
+## Components
+
+*None yet.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,8 @@ nav:
       - Future ideas: specs/future-ideas.md
       - UI:
           - specs/ui/index.md
+          - Shared components: specs/ui/shared-components.md
+          - Mockups: specs/ui/mockups/index.md
   - Engineering:
       - engineering/index.md
       - Tech stack: engineering/tech-stack.md


### PR DESCRIPTION
Closes #23

The UI specs section needs its overview page and the per-screen template before any wireframe issue can be filed against it. #22 defined the *process*; this is the shape the artifacts take.

**Docs:** `docs/specs/ui/index.md`, `docs/specs/ui/mockups/index.md`, `docs/specs/ui/shared-components.md`.

## What's here

**`docs/specs/ui/index.md`** — these pages are the layout contract; code is built from them and doesn't decide them. Links the design-process page as the thing to read first. Then the **nine-section per-screen template**: purpose, invariants, regions, anchors, named constants, elements, behaviour, mockup, open questions. Two sections worth calling out:

- **Anchors** gets its own argument, because it's the section people skip and then regret — "40 dp from the bottom" hasn't said whether that's the screen edge or the safe area, and the answer is the difference between a reachable button and one under the gesture bar.
- Sections that don't apply are written as **"None"** rather than omitted, so an absent section reads as an oversight and the template keeps its promise that a reader knows where to look.

**`docs/specs/ui/mockups/index.md`** — the committed-mockups table (empty, one row per screen as they arrive) and the conventions: one file per screen, sized to the target viewport so it renders at 1:1 rather than filling the window, real units matching the spec's constants, self-contained with no CDN so it opens on the sofa, and **honest placeholder content** — the longest plausible score, not `0`. Plus the line that a mockup is a picture and not a prototype: the moment it does something, people judge what it does instead of how it looks, and it stops being cheap to change.

**`docs/specs/ui/shared-components.md`** — the stub, with the drift argument for why it exists (three screens each describing "the primary button" will describe three subtly different buttons within a month, and one edit won't fix all three), the two-caller rule for when something belongs here, the explicit warning against generalising before the second use, and a five-section per-component template that includes **States** — a component page describing only its default state is a component that gets a different disabled style on every screen.

Nav updated; `mkdocs build --strict` passes.

## Deviations and Decisions

- Made `shared-components.md` a real page with its template and inclusion rule rather than a bare stub. The checklist said "stub", and the components list *is* empty — but a page that doesn't say when something belongs on it won't get used, and the first screen spec is the moment that question gets asked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_