### PR TITLE
feat: add /VERSION with the release-please marker

### DIFF
--- a/Assets/Scripts/Core/AppVersion.cs
+++ b/Assets/Scripts/Core/AppVersion.cs
@@ -41,6 +41,34 @@ namespace Frogs.Core
         public int AndroidVersionCode => (Major * MajorMultiplier) + (Minor * MinorMultiplier) + Patch;
 
         /// <summary>
+        /// Reads the version out of the contents of /VERSION.
+        ///
+        /// That file carries release-please's marker on the same line as the
+        /// version — `0.0.1 # x-release-please-version` — because the generic
+        /// updater only rewrites a line containing the marker. So every
+        /// consumer has to strip from '#' onward, and this is the one place
+        /// that does it.
+        /// </summary>
+        public static AppVersion ReadFrom(string fileContents)
+        {
+            if (fileContents is null)
+            {
+                throw new ArgumentNullException(nameof(fileContents));
+            }
+
+            var withoutComment = fileContents.Split('#')[0];
+            var trimmed = withoutComment.Trim();
+
+            if (trimmed.Length == 0)
+            {
+                throw new FormatException(
+                    "/VERSION has no version on it — expected `0.0.1 # x-release-please-version`.");
+            }
+
+            return Parse(trimmed);
+        }
+
+        /// <summary>
         /// Parses "major.minor.patch". Throws <see cref="FormatException"/> on
         /// anything else — /VERSION is read by the build, so a malformed value
         /// has to fail at the point of reading rather than silently become

--- a/Tests/Core/AppVersionTests.cs
+++ b/Tests/Core/AppVersionTests.cs
@@ -40,5 +40,30 @@ namespace Frogs.Core.Tests
         {
             Assert.That(() => AppVersion.Parse(text), Throws.TypeOf<FormatException>());
         }
+
+        // /VERSION carries the release-please marker on the same line as the
+        // version, so every consumer has to strip from '#' onward. Doing that
+        // in one place beats each caller reinventing it slightly differently.
+        [TestCase("0.0.1 # x-release-please-version", 0, 0, 1)]
+        [TestCase("1.2.3 # x-release-please-version", 1, 2, 3)]
+        [TestCase("0.4.0#x-release-please-version", 0, 4, 0)]
+        [TestCase("  0.5.6   # trailing whitespace and a comment  ", 0, 5, 6)]
+        [TestCase("0.7.8\n", 0, 7, 8)]
+        public void ReadFrom_StripsTheMarkerComment(string contents, int major, int minor, int patch)
+        {
+            var version = AppVersion.ReadFrom(contents);
+
+            Assert.That(version.Major, Is.EqualTo(major));
+            Assert.That(version.Minor, Is.EqualTo(minor));
+            Assert.That(version.Patch, Is.EqualTo(patch));
+        }
+
+        [TestCase("# x-release-please-version")]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ReadFrom_RejectsAFileWithNoVersionOnIt(string contents)
+        {
+            Assert.That(() => AppVersion.ReadFrom(contents), Throws.TypeOf<FormatException>());
+        }
     }
 }

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+0.0.1 # x-release-please-version

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -5,13 +5,11 @@ commit messages you were writing anyway.
 
 ## `/VERSION` is the source of truth
 
-A single file at the repo root holds the version the app reports:
+A single file at the repo root holds the version the app reports. It is one
+line:
 
 ```text
-# The app's version. Owned by release-please — never hand-edit.
-# x-release-please-start-version
-0.0.1
-# x-release-please-end-version
+0.0.1 # x-release-please-version
 ```
 
 Everything that needs a version reads it from here. Unity's
@@ -50,9 +48,9 @@ there is still exactly one source and Unity still gets what it needs. See
 ### The `x-release-please-version` marker
 
 release-please's generic updater does not guess where the version is in a file.
-It looks for the annotation — either inline on the same line, or as the
-`x-release-please-start-version` / `x-release-please-end-version` block used
-above — and replaces what it finds there.
+It rewrites **only lines containing the `x-release-please-version` annotation**,
+which is why the marker shares the line with the version rather than sitting
+above it.
 
 **Without the marker, nothing fails loudly.** release-please runs, opens its
 release PR, writes the changelog, tags the release — and leaves `/VERSION` at
@@ -60,6 +58,32 @@ its old value. You get a `v0.2.0` tag on a build that reports `0.1.0`, and the
 first sign of it is someone asking why the version on the title screen never
 changes. That is why the marker is a build-checklist item and why
 [a Core guard test](#the-guard-test) asserts the file and the manifest agree.
+
+### Every consumer strips from `#` onward
+
+The marker lives on the version's own line, so **the file's contents are not the
+version** — anything reading `/VERSION` has to cut the comment off first, then
+trim.
+
+Do not reimplement that per caller. `Frogs.Core.AppVersion.ReadFrom(contents)`
+does it once, and is covered by the fast suite:
+
+```csharp
+var version = AppVersion.ReadFrom(File.ReadAllText("VERSION"));
+version.Major;                // 0
+version.AndroidVersionCode;   // 1
+```
+
+It throws `FormatException` on a file with only a marker and no version, and on
+anything that isn't three non-negative numbers — a malformed `/VERSION` has to
+fail at the point of reading rather than silently become `0.0.0` in a shipped
+APK.
+
+For shell consumers, the equivalent is:
+
+```bash
+VERSION=$(cut -d'#' -f1 VERSION | tr -d '[:space:]')
+```
 
 ## Conventional Commits drive the bump
 


### PR DESCRIPTION
Closes #29

The app's version now has a home: one line at the repo root that release-please owns.

```text
0.0.1 # x-release-please-version
```

**Docs:** `docs/engineering/versioning.md` — corrected the marker form and added the strip-from-`#` rule for both C# and shell consumers.

## What's here

- **`/VERSION`** with the marker on the version's own line. That placement isn't cosmetic: release-please's generic updater rewrites *only* lines containing `x-release-please-version`. Without it nothing errors — releases just ship while the file quietly keeps saying `0.0.1`, and the first symptom is someone asking why the title screen's version never changes.
- **`AppVersion.ReadFrom(contents)`** in Core. Because the marker shares the line, the file's contents aren't the version — every consumer has to cut the comment and trim. Doing that once beats each caller reinventing it slightly differently.
- **`docs/engineering/versioning.md`** updated, including the shell equivalent: `cut -d'#' -f1 VERSION | tr -d '[:space:]'` (verified — yields `0.0.1`).

## Test-first

Red — `ReadFrom` didn't exist:
```
Tests/Core/AppVersionTests.cs(54,38): error CS0117: 'AppVersion' does not contain a definition for 'ReadFrom'
```
Green after implementing it: **19 passed, 0 failed, 34 ms.**

Cases cover the marker with and without spacing, extra whitespace, a trailing newline, and a file that has a marker but no version — which throws `FormatException` rather than silently becoming `0.0.0` in a shipped APK. `check_core_isolation.py` still passes; `mkdocs build --strict` passes.

## Deviations and Decisions

- **The versioning page previously specified the block-marker form** (`x-release-please-start-version` / `-end-version`), which I chose in #18 to keep the version alone on its line. This issue specifies the inline form, and it's the better call — one line, and the strip rule it forces is trivial and now centralised. Updated the page rather than leaving the two disagreeing; the issue's spec-pages line anticipated this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_