### PR TITLE
ci: add the release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,68 @@
+name: release-please
+
+# Maintains the release PR on every push to main, and — when that PR is merged —
+# creates the tag and the GitHub release.
+#
+# Merging the release PR *is* the release. See docs/engineering/versioning.md.
+#
+# The APK is attached from inside this workflow (#40) rather than from a
+# separate workflow triggered by the `release` event: a release created with
+# GITHUB_TOKEN does not fire `release` events, so a listener workflow would
+# silently never run and the release would sit there with no artifact.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One at a time. Two concurrent runs would both try to rewrite the release
+# branch, and the loser leaves a half-written release PR behind. Never cancel a
+# run in progress — cancelling one mid-tag is how a tag exists without a
+# release.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Create the tag, the release, and the commit on the release branch.
+      contents: write
+      # Open and update the release PR.
+      pull-requests: write
+
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created || steps.release.outputs['.--release_created'] }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.release.outputs['.--tag_name'] }}
+      version: ${{ steps.release.outputs.version || steps.release.outputs['.--version'] }}
+
+    steps:
+      - id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          # Non-default paths — the repo root is crowded enough. See
+          # docs/engineering/versioning.md.
+          config-file: .github/release-please/config.json
+          manifest-file: .github/release-please/manifest.json
+          target-branch: main
+
+      # release-please's outputs are top-level for a single package and
+      # path-prefixed ('.--release_created') in manifest mode, and which you get
+      # has changed between versions. Reading both above costs nothing and means
+      # a version bump cannot silently turn every downstream `if:` false —
+      # which would look exactly like "there was nothing to release".
+      - name: Summarise
+        env:
+          RELEASE_CREATED: ${{ steps.release.outputs.release_created || steps.release.outputs['.--release_created'] }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name || steps.release.outputs['.--tag_name'] }}
+        run: |
+          if [ "$RELEASE_CREATED" = "true" ]; then
+            echo "Released $TAG_NAME." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No release this run — the release PR was updated instead." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -153,11 +153,46 @@ it before the release is real.
   release in signing or backend is an RC that proves less than it appears to.
 - Artifacts only. An RC is not a release; it gets no tag and no GitHub release.
 
+### `release-please` — the version, the tag, and the release
+
+Runs on every push to `main`, plus `workflow_dispatch`. Two outcomes:
+
+- **Usually**: it rewrites the open release PR with the pending changelog and
+  the next version, and stops. The PR title is `chore(main): release X.Y.Z`.
+- **When that PR merges**: it applies the version bump, creates the tag and the
+  GitHub release, and sets `release_created: true`.
+
+Downstream jobs gate on the workflow's outputs:
+
+| Output | Is |
+| --- | --- |
+| `release_created` | `true` only on the run that created a release |
+| `tag_name` | e.g. `v0.2.0` |
+| `version` | e.g. `0.2.0` |
+
+Two details worth knowing if you touch it:
+
+- **It reads each output twice** — `release_created` and `.--release_created`.
+  release-please emits top-level outputs for a single package and path-prefixed
+  ones in manifest mode, and which you get has changed across versions. Reading
+  both costs nothing, and means a version bump can't silently turn every
+  downstream `if:` false — which looks identical to "there was nothing to
+  release".
+- **`cancel-in-progress: false`.** Two concurrent runs would both rewrite the
+  release branch; cancelling one mid-tag is how a tag ends up existing without
+  a release.
+
+Permissions are `contents: write` (the tag, the release, the release branch) and
+`pull-requests: write` (the release PR), granted on the job rather than the
+workflow. It also needs **"Allow GitHub Actions to create and approve pull
+requests"** enabled on the repository, without which it fails on its first
+attempt to open the PR.
+
 ### Release builds
 
-Handled inside `release-please.yml` rather than by a separate workflow that
-listens for the release — see [Versioning](versioning.md) for the release flow.
-Merging the release PR creates the tag and the release, and the same run then:
+The APK is attached from inside `release-please.yml` rather than by a separate
+workflow that listens for the release — see [Versioning](versioning.md) for the
+release flow. On the run where `release_created` is true, it also:
 
 - Builds the release APK, signed with the release keystore, device profile
   (ARM64, IL2CPP).


### PR DESCRIPTION
Closes #31

release-please now runs. On every push to `main` it rewrites the open release PR with the pending changelog and next version; when that PR merges, the same workflow applies the bump and creates the tag and GitHub release.

**Docs:** `docs/engineering/ci-cd.md` — new `release-please` section with the outputs table and the two implementation details worth knowing.

## What's here

- **Runs on push to `main`** (plus `workflow_dispatch`), pointing at `.github/release-please/config.json` and `.github/release-please/manifest.json`.
- **Outputs `release_created`, `tag_name`, `version`** as job outputs, for #40's APK attach to gate on.
- **Minimum permissions**: workflow-level `contents: read`; the job gets `contents: write` (tag, release, release branch) and `pull-requests: write` (the release PR) and nothing else.
- **`concurrency: cancel-in-progress: false`** — two concurrent runs would both rewrite the release branch, and cancelling one mid-tag is how a tag ends up existing without a release.
- **A step summary** saying which of the two things happened, so the run list is readable without opening logs.
- **`googleapis/release-please-action` pinned** to `45996ed1…` (v5.0.0), per #84.

## The double-read on outputs

Each output is read as both `release_created` and `.--release_created`:

```yaml
release_created: ${{ steps.release.outputs.release_created || steps.release.outputs['.--release_created'] }}
```

release-please emits top-level outputs for a single package and path-prefixed ones in manifest mode, and which you get has moved across versions. Costs nothing to read both, and the failure it prevents is nasty: if the shape changes, every downstream `if: release_created == 'true'` goes false and the run looks exactly like a normal "nothing to release" — a release with no APK, and no error anywhere.

## What happens when this merges

The first run opens a release PR titled `chore(main): release 0.1.0` — 0.1.0 rather than 0.0.1 because the `feat:` commits in this milestone bump the minor under the plain-semver policy from #30. That PR will accumulate the rest of v0.0.1's work and sit there until Derek merges it. It shouldn't be merged yet: #40 hasn't landed, so a release created now would have no APK attached.

Requires **"Allow GitHub Actions to create and approve pull requests"** (#79, closed) and `googleapis/release-please-action` being permitted by the Actions policy (#110).

## Deviations and Decisions

- **The "first run opens a well-formed release PR" checklist item can't be verified before merge** — the workflow only runs on push to `main`. It's the first thing to check after merging; if the PR title isn't `chore(main): release X.Y.Z`, that's a config bug in #30 and I'll fix it.
- Added `version` alongside the two required outputs. #40 needs the bare version for the APK filename, and deriving it by stripping `v` from `tag_name` in a shell step is a second place to get it wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_