### PR TITLE
test(core): guard against /VERSION and the release-please manifest drifting

### DIFF
--- a/Tests/Core/VersionDriftTests.cs
+++ b/Tests/Core/VersionDriftTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// /VERSION and release-please's manifest are two files holding the same
+    /// number, and nothing in release-please notices when they stop agreeing:
+    /// a missing or damaged x-release-please-version marker leaves /VERSION
+    /// behind while the manifest advances, releases keep shipping, and the
+    /// first symptom is a build reporting a version from three releases ago.
+    ///
+    /// This runs in the ordinary Core suite, in milliseconds, on every push.
+    /// </summary>
+    public sealed class VersionDriftTests
+    {
+        const string VersionFileName = "VERSION";
+        const string ManifestPath = ".github/release-please/manifest.json";
+        const string ManifestKey = ".";
+
+        static string RepoRoot => FindRepoRoot();
+
+        [Test]
+        public void VersionFile_IsBareSemverOnceTheMarkerIsStripped()
+        {
+            var contents = File.ReadAllText(Path.Combine(RepoRoot, VersionFileName));
+
+            Assert.That(
+                () => AppVersion.ReadFrom(contents),
+                Throws.Nothing,
+                $"/VERSION should be `0.0.1 # x-release-please-version`, but is: {contents.Trim()}");
+        }
+
+        [Test]
+        public void VersionFile_StillCarriesTheReleasePleaseMarker()
+        {
+            var contents = File.ReadAllText(Path.Combine(RepoRoot, VersionFileName));
+
+            // Without the marker release-please stops rewriting the file, and
+            // it stops silently — this is the drift's usual cause, so it is
+            // worth failing on directly rather than only on the symptom.
+            Assert.That(
+                contents,
+                Does.Contain("x-release-please-version"),
+                "/VERSION has lost its marker, so release-please will no longer update it.");
+        }
+
+        [Test]
+        public void VersionFile_AgreesWithTheReleasePleaseManifest()
+        {
+            var versionFile = AppVersion.ReadFrom(
+                File.ReadAllText(Path.Combine(RepoRoot, VersionFileName)));
+            var manifest = ReadManifestVersion();
+
+            Assert.That(
+                versionFile,
+                Is.EqualTo(manifest),
+                $"/VERSION says {versionFile} and {ManifestPath} says {manifest}. "
+                + "One of them was hand-edited, or the marker in /VERSION is broken.");
+        }
+
+        static AppVersion ReadManifestVersion()
+        {
+            var path = Path.Combine(RepoRoot, ManifestPath);
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+            if (!document.RootElement.TryGetProperty(ManifestKey, out var element))
+            {
+                Assert.Fail($"{ManifestPath} has no \"{ManifestKey}\" entry.");
+            }
+
+            return AppVersion.Parse(element.GetString());
+        }
+
+        /// <summary>
+        /// Walks up from the test binary. The suite runs from
+        /// Tests/Core/bin/&lt;config&gt;/&lt;tfm&gt;/, and hard-coding that many
+        /// "../" is a test that breaks when someone changes the target
+        /// framework.
+        /// </summary>
+        static string FindRepoRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory is not null)
+            {
+                var looksLikeRoot =
+                    File.Exists(Path.Combine(directory.FullName, VersionFileName))
+                    && Directory.Exists(Path.Combine(directory.FullName, ".github"));
+
+                if (looksLikeRoot)
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException(
+                $"No repository root above {AppContext.BaseDirectory} — "
+                + $"looked for a directory containing both {VersionFileName} and .github/.");
+        }
+    }
+}

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -181,12 +181,26 @@ manifest-file: .github/release-please/manifest.json
 
 ### The guard test
 
-A Core test asserts that `/VERSION` and
-`.github/release-please/manifest.json` agree.
-It is a plain NUnit test, so it runs in seconds on every push, and it catches
-the whole class of "the marker was removed", "someone hand-edited one of them",
-and "a merge resolved the conflict wrongly" failures at the point they are
-introduced rather than at the next release.
+`/VERSION` and `.github/release-please/manifest.json` hold the same number in
+two places, and **nothing in release-please notices when they stop agreeing.**
+A damaged marker leaves `/VERSION` behind while the manifest advances; releases
+keep shipping; the first symptom is a build reporting a version from three
+releases ago.
+
+`Tests/Core/VersionDriftTests.cs` closes that hole with three assertions:
+
+| Assertion | Catches |
+| --- | --- |
+| `/VERSION` parses as bare semver once `#…` is stripped | a hand-edit, a bad merge resolution |
+| `/VERSION` still contains `x-release-please-version` | the marker being removed — the usual *cause* |
+| `/VERSION` equals the manifest's `"."` entry | the drift itself |
+
+The middle one earns its place by failing on the cause rather than waiting for
+the symptom: the run that removes the marker fails, instead of the release two
+months later.
+
+It is a plain NUnit test in the ordinary Core suite, so it costs milliseconds
+and runs on every push, with no editor and no network.
 
 ### The release flow
 


### PR DESCRIPTION
Closes #32

`/VERSION` and `.github/release-please/manifest.json` hold the same number in two places, and **nothing in release-please notices when they stop agreeing.** A damaged marker leaves `/VERSION` behind while the manifest advances, releases keep shipping, and the first symptom is a build reporting a version from three releases ago. This closes that hole for the cost of a few milliseconds per push.

**Docs:** `docs/engineering/versioning.md` — expanded the guard-test section with what each assertion catches.

## Three assertions

| Assertion | Catches |
| --- | --- |
| `/VERSION` parses as bare semver once `#…` is stripped | a hand-edit, a bad merge resolution |
| `/VERSION` still contains `x-release-please-version` | the marker being removed — the usual **cause** |
| `/VERSION` equals the manifest's `"."` entry | the drift itself |

The middle one is the one I'd argue for: it fails on the *cause* rather than waiting for the symptom, so the run that removes the marker goes red instead of a release two months later.

## Test-first, shown red against both drift cases

**Manifest advanced, `/VERSION` left behind** (manifest set to `0.3.0`):
```
  Failed VersionFile_AgreesWithTheReleasePleaseManifest [44 ms]
     /VERSION says 0.0.1 and .github/release-please/manifest.json says 0.3.0.
     One of them was hand-edited, or the marker in /VERSION is broken.
Failed!  - Failed: 1, Passed: 21, Total: 22
```

**Marker stripped** (`/VERSION` reduced to `0.0.1`):
```
  Failed VersionFile_StillCarriesTheReleasePleaseMarker [42 ms]
     /VERSION has lost its marker, so release-please will no longer update it.
Failed!  - Failed: 1, Passed: 21, Total: 22
```

Both restored → **`Passed! - Failed: 0, Passed: 22, Total: 22, Duration: 42 ms`**, running as part of the ordinary Core suite with no editor and no network.

The failure messages name both values and the two likely causes, because a drift failure is one you hit months later with no memory of the setup.

## Deviations and Decisions

- **Added a third assertion** beyond the two the checklist asked for — the marker-presence check. The two required ones catch drift *after* it happens; this one catches the change that causes it, in the PR that makes it.
- **The repo root is found by walking up** from the test binary looking for a directory containing both `VERSION` and `.github/`, rather than counting `../` segments. Hard-coding the depth makes the test break when someone changes the target framework or build configuration, which is a confusing failure with nothing to do with versions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_