### PR TITLE
fix(ci): put the version in the release PR title

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+  "pull-request-title-pattern": "chore(${branch}): release ${version}",
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,


### PR DESCRIPTION
The first real run of release-please (from #112) opened its release PR titled **`chore: release main`** — no version. #31's checklist specifies `chore(main): release X.Y.Z`, and I said in that PR I'd fix it if the first run came out wrong. It did, so here's the fix.

**Docs:** None — no behaviour the docs describe was changed; the release flow is unchanged.

## Why the version was missing

Manifest mode builds the combined release-PR title from the **group** pattern, not the per-package one. Its default is `chore: release ${branch}` — which is exactly the title we got, and it has no `${version}` in it at all. Setting only `pull-request-title-pattern` wouldn't have helped, so this sets both.

## Everything else about that run was correct

Worth recording, since it validates #29 and #30 end to end:

- It computed **0.1.0** from the conventional commits so far — the plain-semver policy from #30 working as documented (`feat:` bumps the minor even pre-1.0).
- Its diff touches exactly `VERSION`, `.github/release-please/manifest.json`, and `CHANGELOG.md`, so the `extra-files` generic updater and the `x-release-please-version` marker both work.
- **No stray `version.txt`** — #30 flagged that as a possible side effect of `release-type: simple` and said it'd be visible in the release PR if it happened. It didn't. That concern is closed.

## Deviations and Decisions

- **No closing keyword** — this completes a checklist item on #31, which is already closed. Reopening it to re-close it would be noise; the fix is small and its reason is here.
- **Set both patterns**, not just the group one. A future config change (`separate-pull-requests`, or a second package) would switch which one applies, and the two disagreeing would be a confusing title change nobody asked for.
- Verification is post-merge by nature: release-please retitles the open PR (#113) on the next push to `main`. I'll check it and follow up if `${version}` renders empty in the group context.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_