### PR TITLE
feat(build): stamp the version into PlayerSettings at build time

### DIFF
--- a/Assets/Editor/BuildStampApplier.cs
+++ b/Assets/Editor/BuildStampApplier.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Frogs.Core;
+using UnityEditor;
+using UnityEditor.Build;
+using Debug = UnityEngine.Debug;
+
+namespace Frogs.EditorTools
+{
+    /// <summary>
+    /// Puts the version into PlayerSettings at build time, from /VERSION and the
+    /// commit history — never from a value typed into ProjectSettings.asset.
+    ///
+    /// This is the thin shell around <see cref="BuildStamp"/>: it reads files,
+    /// environment variables, and git, and hands the values to Core. The rules
+    /// about what a version name looks like and what makes a versionCode valid
+    /// live in Core, where the fast suite covers them.
+    ///
+    /// Headlessly:
+    ///
+    ///     Unity -batchmode -quit -projectPath . \
+    ///           -executeMethod Frogs.EditorTools.BuildStampApplier.ApplyRelease
+    ///
+    /// CI sets FROGS_VERSION_CODE and FROGS_BUILD_SHA rather than making this
+    /// shell out — a checkout with `fetch-depth: 1` has no history to count.
+    /// Locally, both fall back to git.
+    /// </summary>
+    public static class BuildStampApplier
+    {
+        const string VersionFileName = "VERSION";
+        const string VersionCodeVariable = "FROGS_VERSION_CODE";
+        const string BuildShaVariable = "FROGS_BUILD_SHA";
+
+        /// <summary>A release build: PlayerSettings shows the bare version.</summary>
+        public static void ApplyRelease() => Apply(BuildStamp.Release(ReadVersion(), ReadCommitCount()));
+
+        /// <summary>A PR or RC build: the version name carries the commit sha.</summary>
+        public static void ApplyDebug() =>
+            Apply(BuildStamp.Debug(ReadVersion(), ReadCommitCount(), ReadCommitSha()));
+
+        public static void Apply(BuildStamp stamp)
+        {
+            PlayerSettings.bundleVersion = stamp.VersionName;
+            PlayerSettings.Android.bundleVersionCode = stamp.VersionCode;
+
+            AssetDatabase.SaveAssets();
+            Debug.Log($"Build stamped {stamp.VersionName} (versionCode {stamp.VersionCode}).");
+        }
+
+        static AppVersion ReadVersion()
+        {
+            // Unity runs with the project root as the working directory, and
+            // /VERSION sits beside Assets/.
+            var path = Path.Combine(Directory.GetCurrentDirectory(), VersionFileName);
+
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException(
+                    $"No {VersionFileName} at {path}. It is the single source of the app's "
+                    + "version and the build cannot invent one.",
+                    path);
+            }
+
+            return AppVersion.ReadFrom(File.ReadAllText(path));
+        }
+
+        static int ReadCommitCount()
+        {
+            var fromEnvironment = Environment.GetEnvironmentVariable(VersionCodeVariable);
+
+            if (!string.IsNullOrWhiteSpace(fromEnvironment))
+            {
+                if (!int.TryParse(fromEnvironment, out var parsed))
+                {
+                    throw new FormatException(
+                        $"{VersionCodeVariable} is '{fromEnvironment}', which is not a number.");
+                }
+
+                return parsed;
+            }
+
+            return int.Parse(Git("rev-list --count HEAD"));
+        }
+
+        static string ReadCommitSha()
+        {
+            var fromEnvironment = Environment.GetEnvironmentVariable(BuildShaVariable);
+
+            return string.IsNullOrWhiteSpace(fromEnvironment)
+                ? Git("rev-parse --short=7 HEAD")
+                : fromEnvironment;
+        }
+
+        static string Git(string arguments)
+        {
+            var startInfo = new ProcessStartInfo("git", arguments)
+            {
+                WorkingDirectory = Directory.GetCurrentDirectory(),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using (var process = Process.Start(startInfo))
+            {
+                var output = process.StandardOutput.ReadToEnd().Trim();
+                var error = process.StandardError.ReadToEnd().Trim();
+                process.WaitForExit();
+
+                if (process.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"`git {arguments}` failed with exit code {process.ExitCode}: {error}. "
+                        + $"In CI, set {VersionCodeVariable} and {BuildShaVariable} instead — a "
+                        + "shallow checkout has no history to count.");
+                }
+
+                return output;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/AppVersion.cs
+++ b/Assets/Scripts/Core/AppVersion.cs
@@ -6,17 +6,17 @@ namespace Frogs.Core
     /// <summary>
     /// The app's version, as read from /VERSION.
     ///
-    /// Lives in Core rather than in an editor script so the parsing and the
-    /// versionCode derivation are covered by the fast NUnit suite. The Unity
-    /// side reads /VERSION and hands the string to <see cref="Parse"/>; it does
-    /// not do arithmetic on version numbers itself.
+    /// Lives in Core rather than in an editor script so the parsing is covered
+    /// by the fast NUnit suite. The Unity side reads the file and hands the
+    /// string to <see cref="Parse"/>; it does not pick versions apart itself.
+    ///
+    /// What a build calls itself — the display name and the Android
+    /// versionCode — is <see cref="BuildStamp"/>.
     ///
     /// See docs/engineering/versioning.md.
     /// </summary>
     public readonly struct AppVersion : IEquatable<AppVersion>
     {
-        const int MajorMultiplier = 10000;
-        const int MinorMultiplier = 100;
         const int ComponentCount = 3;
 
         public int Major { get; }
@@ -29,16 +29,6 @@ namespace Frogs.Core
             Minor = minor;
             Patch = patch;
         }
-
-        /// <summary>
-        /// Android's monotonically increasing build number, derived rather than
-        /// stored, so a rebuild of a tag produces an identical artifact rather
-        /// than a new number.
-        ///
-        /// The formula carries a constraint: minor and patch must each stay
-        /// below 100. See docs/engineering/versioning.md.
-        /// </summary>
-        public int AndroidVersionCode => (Major * MajorMultiplier) + (Minor * MinorMultiplier) + Patch;
 
         /// <summary>
         /// Reads the version out of the contents of /VERSION.

--- a/Assets/Scripts/Core/BuildStamp.cs
+++ b/Assets/Scripts/Core/BuildStamp.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Globalization;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// What a build calls itself: the version name Unity shows, and the integer
+    /// Android orders installs by.
+    ///
+    /// Lives in Core so the rules are covered by the fast NUnit suite. The
+    /// Unity build script reads /VERSION, the commit count, and the commit sha,
+    /// then asks this type what to put in PlayerSettings — it does not compose
+    /// version strings itself.
+    ///
+    /// See docs/engineering/versioning.md.
+    /// </summary>
+    public readonly struct BuildStamp
+    {
+        const int ShortShaLength = 7;
+
+        /// <summary>The semantic version, from /VERSION.</summary>
+        public AppVersion Version { get; }
+
+        /// <summary>
+        /// Android's versionCode: the number of commits on the release branch.
+        ///
+        /// Not derived from <see cref="Version"/>, deliberately. Android
+        /// refuses to install an APK whose code is not greater than the
+        /// installed one, and several builds share a version between releases —
+        /// every PR build of `0.2.3` would collide. A commit count increases
+        /// with every commit, is the same for everyone who builds that commit,
+        /// and owes nothing to CI run numbers.
+        /// </summary>
+        public int VersionCode { get; }
+
+        /// <summary>The short commit sha, or empty for a release build.</summary>
+        public string CommitSha { get; }
+
+        /// <summary>
+        /// What the app displays: "0.2.3" for a release, "0.2.3-abc1234" for a
+        /// build from a PR, so a phone with four test builds on it can say
+        /// which is which.
+        /// </summary>
+        public string VersionName =>
+            CommitSha.Length == 0
+                ? Version.ToString()
+                : string.Format(CultureInfo.InvariantCulture, "{0}-{1}", Version, CommitSha);
+
+        BuildStamp(AppVersion version, int versionCode, string commitSha)
+        {
+            Version = version;
+            VersionCode = versionCode;
+            CommitSha = commitSha;
+        }
+
+        /// <summary>A release build: bare version, no sha.</summary>
+        public static BuildStamp Release(AppVersion version, int commitCount)
+        {
+            RequirePositive(commitCount);
+            return new BuildStamp(version, commitCount, string.Empty);
+        }
+
+        /// <summary>A debug or release-candidate build, identified by its commit.</summary>
+        public static BuildStamp Debug(AppVersion version, int commitCount, string shortSha)
+        {
+            RequirePositive(commitCount);
+            return new BuildStamp(version, commitCount, RequireUsableSha(shortSha));
+        }
+
+        static void RequirePositive(int commitCount)
+        {
+            if (commitCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(commitCount),
+                    commitCount,
+                    "The Android versionCode must be positive — a build with a code of "
+                    + "zero or less cannot be installed over anything.");
+            }
+        }
+
+        static string RequireUsableSha(string shortSha)
+        {
+            if (string.IsNullOrWhiteSpace(shortSha))
+            {
+                throw new ArgumentException(
+                    "A debug build needs the commit sha in its version name, or nobody can "
+                    + "tell which of the builds on their phone is which.",
+                    nameof(shortSha));
+            }
+
+            var trimmed = shortSha.Trim();
+
+            if (trimmed.Length < ShortShaLength || !IsHex(trimmed))
+            {
+                throw new ArgumentException(
+                    $"'{shortSha}' is not a commit sha of at least {ShortShaLength} hex characters.",
+                    nameof(shortSha));
+            }
+
+            return trimmed.Substring(0, ShortShaLength).ToLowerInvariant();
+        }
+
+        static bool IsHex(string text)
+        {
+            foreach (var character in text)
+            {
+                var isHexDigit =
+                    (character >= '0' && character <= '9')
+                    || (character >= 'a' && character <= 'f')
+                    || (character >= 'A' && character <= 'F');
+
+                if (!isHexDigit)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Tests/Core/AppVersionTests.cs
+++ b/Tests/Core/AppVersionTests.cs
@@ -16,18 +16,6 @@ namespace Frogs.Core.Tests
             Assert.That(version.Patch, Is.EqualTo(3));
         }
 
-        // The formula is specified in docs/engineering/versioning.md. Android
-        // needs a monotonically increasing integer, and deriving it means a
-        // rebuild of a tag produces the same artifact rather than a new number.
-        [TestCase("0.0.1", 1)]
-        [TestCase("0.1.0", 100)]
-        [TestCase("0.2.3", 203)]
-        [TestCase("1.0.0", 10000)]
-        public void AndroidVersionCode_IsDerivedFromTheVersion(string text, int expected)
-        {
-            Assert.That(AppVersion.Parse(text).AndroidVersionCode, Is.EqualTo(expected));
-        }
-
         // /VERSION is read by the build. Malformed input has to fail loudly at
         // the point of reading, not silently become 0.0.0 in a shipped APK.
         [TestCase("")]

--- a/Tests/Core/BuildStampTests.cs
+++ b/Tests/Core/BuildStampTests.cs
@@ -1,0 +1,71 @@
+using System;
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    public sealed class BuildStampTests
+    {
+        static readonly AppVersion Version = AppVersion.Parse("0.2.3");
+
+        [Test]
+        public void Release_UsesTheBareVersionAsItsName()
+        {
+            var stamp = BuildStamp.Release(Version, commitCount: 147);
+
+            Assert.That(stamp.VersionName, Is.EqualTo("0.2.3"));
+            Assert.That(stamp.VersionCode, Is.EqualTo(147));
+        }
+
+        [Test]
+        public void Debug_AppendsTheShortShaToTheName()
+        {
+            var stamp = BuildStamp.Debug(Version, commitCount: 147, shortSha: "abc1234");
+
+            Assert.That(stamp.VersionName, Is.EqualTo("0.2.3-abc1234"));
+            Assert.That(stamp.VersionCode, Is.EqualTo(147));
+        }
+
+        // Android refuses to install an APK whose versionCode is not greater
+        // than the installed one, so a zero or negative code is a build that
+        // cannot be installed over anything — fail while we still know why.
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void Release_RejectsACommitCountThatIsNotPositive(int commitCount)
+        {
+            Assert.That(
+                () => BuildStamp.Release(Version, commitCount),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase(null)]
+        public void Debug_RejectsAMissingSha(string shortSha)
+        {
+            Assert.That(
+                () => BuildStamp.Debug(Version, 147, shortSha),
+                Throws.InstanceOf<ArgumentException>());
+        }
+
+        // "the one from Tuesday" is not an answer when there are four builds on
+        // the phone, so a debug stamp without a usable sha is worse than a
+        // failed build.
+        [TestCase("nothex!")]
+        [TestCase("abc")]
+        public void Debug_RejectsAShaThatIsNotUsable(string shortSha)
+        {
+            Assert.That(
+                () => BuildStamp.Debug(Version, 147, shortSha),
+                Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void Debug_AcceptsAFullLengthShaAndShortensIt()
+        {
+            var stamp = BuildStamp.Debug(Version, 147, "abc1234def5678901234567890abcdef12345678");
+
+            Assert.That(stamp.VersionName, Is.EqualTo("0.2.3-abc1234"));
+        }
+    }
+}

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -70,8 +70,8 @@ does it once, and is covered by the fast suite:
 
 ```csharp
 var version = AppVersion.ReadFrom(File.ReadAllText("VERSION"));
-version.Major;                // 0
-version.AndroidVersionCode;   // 1
+version.Major;      // 0
+version.ToString(); // "0.0.1"
 ```
 
 It throws `FormatException` on a file with only a marker and no version, and on
@@ -231,38 +231,62 @@ which is a changelog nobody reads and therefore a changelog nobody maintains.
 This is also why work-in-progress commits on a branch don't need to be
 Conventional Commits — they are squashed away. Only the PR title survives.
 
-## Android `versionCode`
+## What a build calls itself
 
-Android needs a monotonically increasing integer, separate from the display
-version. It is derived from `/VERSION` at build time — never stored, never
-hand-set:
+Two different things, from two different sources, both applied at build time and
+never stored in `ProjectSettings.asset`:
+
+| | Source | Example |
+| --- | --- | --- |
+| **Version name** (`PlayerSettings.bundleVersion`) | `/VERSION`, plus the commit sha on non-release builds | `0.2.3`, `0.2.3-abc1234` |
+| **`versionCode`** (Android) | `git rev-list --count main` | `147` |
+
+`Frogs.Core.BuildStamp` composes both and enforces the rules; the editor script
+`BuildStampApplier` reads the file, the environment, and git, and hands the
+values over. The split is the usual one — the arithmetic is in Core where the
+fast suite covers it, and the I/O is in the shell.
+
+### The version name
+
+`0.2.3` for a release. `0.2.3-abc1234` for anything built from a PR or as a
+release candidate, because a phone with four test builds on it needs to say
+which is which, and "the one from Tuesday" is not an answer.
+
+### `versionCode` is the commit count, not the version
 
 ```text
-versionCode = major * 10000 + minor * 100 + patch
+versionCode = git rev-list --count main
 ```
 
-| `/VERSION` | `versionCode` |
-| --- | --- |
-| `0.0.1` | 1 |
-| `0.1.0` | 100 |
-| `0.2.3` | 203 |
-| `1.0.0` | 10000 |
+Android orders installs by this integer and **refuses to install an APK whose
+code is not greater than the installed one.**
 
-The constraint the formula carries: **minor and patch must each stay below
-100.** With `feat:` bumping the minor, the minor is the component that moves
-fastest here, so `0.99.0` → `0.100.0` is the case that would break
-monotonicity. That is a long way off, and the answer when it approaches is to
-go to 1.0 rather than to widen the formula.
+Deriving it from the semantic version does not survive that rule. Several builds
+share a version between releases — every PR build of `0.2.3` would produce the
+same code, so installing today's test build over yesterday's would fail, and
+the two would be indistinguishable to the system. The commit count moves with
+every commit, which is exactly the granularity the constraint needs.
 
-Two properties this buys:
+What it buys:
 
-- **Reproducible.** The same `/VERSION` always yields the same `versionCode`, so
-  a rebuild of a tag produces an identical artifact rather than a new number.
-- **Legible.** `versionCode` 203 is `0.2.3`, readable by eye, which matters when
-  someone reports a bug from a phone showing only the code.
+- **Monotonic between releases, not just across them.** Every commit gets a
+  higher number than its parent.
+- **Reproducible.** The same commit always yields the same count, for everyone.
+  A rebuild of a tag produces the same code rather than a new one.
+- **Independent of CI.** No run numbers, no counters in workflow state, nothing
+  that resets when a workflow is renamed or a repository is migrated.
 
-A build counter appended to the low digits would allow multiple builds per
-version, and is deliberately not used: two APKs with the same version and
-different code is exactly the ambiguity this is meant to prevent. RC builds are
-identified by their artifact name and the commit they were built from, not by a
-different `versionCode`.
+The cost is legibility: `147` doesn't tell you the version at a glance the way a
+derived number would. That's the right trade — the version *name* is what a
+human reads, and it's on the same screen.
+
+### It is never hand-set
+
+`ProjectSettings.asset`'s version fields are not edited, ever — not by a person,
+not by a tool. They are overwritten at build time from the values above. A
+number typed into that file is a number that disagrees with `/VERSION` on the
+first release after someone forgets it.
+
+CI passes `FROGS_VERSION_CODE` and `FROGS_BUILD_SHA` rather than letting the
+editor shell out to git, because a checkout with `fetch-depth: 1` has no history
+to count. Locally both fall back to git, and a failure says so.


### PR DESCRIPTION
Closes #33

A build now works out what to call itself instead of being told: the version name comes from `/VERSION`, the Android `versionCode` from the commit count, and both are written into `PlayerSettings` at build time rather than typed into `ProjectSettings.asset`.

**Docs:** `docs/engineering/versioning.md` — replaced the `versionCode` section; see below.

## What's here

- **`Frogs.Core.BuildStamp`** — composes the version name (`0.2.3` for a release, `0.2.3-abc1234` for a PR or RC build) and carries the validation: a `versionCode` must be positive, and a debug build must have a usable sha of at least 7 hex characters. A full-length sha is shortened rather than rejected.
- **`Assets/Editor/BuildStampApplier.cs`** — the shell: reads `/VERSION`, the environment, and git, then hands values to Core and writes `bundleVersion` and `bundleVersionCode`. `ApplyRelease` / `ApplyDebug` are callable via `-executeMethod`.
- CI passes **`FROGS_VERSION_CODE`** and **`FROGS_BUILD_SHA`** instead of letting the editor shell out — a checkout with `fetch-depth: 1` has no history to count. Locally both fall back to git, and the failure message says exactly that.

Test-first. Red:
```
Tests/Core/BuildStampTests.cs(14,25): error CS0103: The name 'BuildStamp' does not exist in the current context
```
Green: **28 passed, 0 failed, 53 ms.** `check_core_isolation.py` passes — the arithmetic and rules are in Core, the file/env/git I/O is in the shell.

## How the spec is changing

> **Previously** (`versioning.md`, from #18) the Android `versionCode` was derived from the semantic version: `major * 10000 + minor * 100 + patch`, so `0.2.3` → `203`. **From this change** it is `git rev-list --count main`.
>
> The derived formula doesn't survive Android's install rule. Android refuses to install an APK whose `versionCode` isn't greater than the installed one — and several builds share a version between releases, so *every* PR build of `0.2.3` would produce `203`. Installing today's test build over yesterday's would fail outright, and the two would be indistinguishable to the system. Since the whole point of the PR build (#38) is Connor trying a change on his phone, that's the case that matters most.
>
> A commit count moves with every commit, which is the granularity the constraint actually needs; it's reproducible for the same commit; and it owes nothing to CI run numbers that reset when a workflow is renamed. The cost is legibility — `147` doesn't tell you the version at a glance — and that's the right trade, because the version *name* is what a human reads and it's on the same screen.

This came from #33, which specifies the commit-count derivation and its rationale. **The issue was treated as authoritative over the docs**, per `CLAUDE.md`: Derek's instruction in the issue wins, and the doc changes in the same PR.

## Deviations and Decisions

- **Removed `AppVersion.AndroidVersionCode` and its tests** rather than leaving them unused. Two contradicting derivations of the same number in one tree is precisely the drift #32 exists to prevent, and the dead one would eventually get called.
- **`versionCode` uses `HEAD`, not literally `main`, in the git fallback.** On `main` they're identical; on a branch, counting `main` would give every commit of that branch the same code, which reintroduces the collision this change fixes. CI passes the value explicitly anyway.
- **Validation lives in Core, not the editor script.** The issue asked for coverage "where the logic is testable in Core" — putting the rules there rather than the I/O means all six failure modes are covered by the fast suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_