### PR TITLE
feat(skills): bring over the release-flow skill

### DIFF
--- a/.claude/skills/release-flow/SKILL.md
+++ b/.claude/skills/release-flow/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: release-flow
+description: Drive a release-please release PR to a tagged, published release. Use when asked to cut, ship, or publish a release, when checking whether a release completed, or when the release PR looks stale or stuck.
+---
+
+# release-flow
+
+Merging the release PR **is** the release. This skill exists because two things
+go wrong every time, and both are silent.
+
+## The two gotchas
+
+### 1. The release PR can be stale
+
+release-please rewrites its PR on every push to `main`, but that run takes a
+minute and can fail. Merging a stale release PR ships a changelog and a version
+that **omit whatever landed after it was last written**.
+
+Nothing catches this afterwards. The release succeeds, the tag is created, the
+APK is attached — and the version is simply lower than it should have been, with
+commits missing from the changelog forever. Check before merging, every time.
+
+### 2. Check runs can be parked, waiting for a human
+
+A run in `action_required` or `waiting` is neither passing nor failing. It never
+finishes on its own. Merging past it means merging with the checks **not having
+run**, which from the merge button looks exactly like merging with them green.
+
+Derek approves them in the PR's Checks tab. **This skill never approves them** —
+approving a parked run on your own PR is the thing being parked is meant to
+prevent.
+
+## What this skill never does
+
+- **It never toggles the release PR's own state.** No labels, no title edits, no
+  closing and reopening, no pushing to `release-please--branches--main`.
+  release-please owns that branch and that PR; it recomputes them from scratch
+  on every run, so an edit is either undone or corrupts the next computation.
+- **It never approves parked check runs.**
+- **It never creates the tag or the release by hand.** Those are release-please's
+  output. If they are missing after a merge, that is a bug to investigate, not a
+  gap to fill in manually.
+
+The only mutating step in the whole flow is the squash-merge, and that is
+Derek's call.
+
+## The flow
+
+Each step gathers a snapshot with `gh` and hands it to `release_flow.py`, which
+is pure and offline.
+
+### 1. Find the release PR
+
+```bash
+gh pr list --state open --json number,title,headRefName,baseRefName,labels
+```
+
+It is the one whose head branch starts with `release-please--branches--`. Match
+on that, not on the title — the title is configurable and has already changed
+once.
+
+If there isn't one, there is nothing to release: every commit since the last
+release was a `docs:`/`chore:`/`ci:` that doesn't move the version.
+
+### 2. Confirm it regenerated
+
+```bash
+gh api repos/:owner/:repo/pulls/$PR --jq \
+  '{pull_request: {base: {sha: .base.sha}}}' > /tmp/s.json
+gh api repos/:owner/:repo/commits/main --jq '.sha' \
+  | xargs -I{} jq '. + {main_sha: "{}"}' /tmp/s.json > /tmp/snapshot.json
+
+python3 .claude/skills/release-flow/release_flow.py regenerated --snapshot /tmp/snapshot.json
+```
+
+If it fails, wait for the `release-please` workflow to finish and re-check.
+Don't merge, and don't "fix" the PR.
+
+### 3. Check for parked runs
+
+```bash
+gh pr checks $PR --json name,state > /tmp/checks.json
+jq '{check_runs: [.[] | {name, status: .state}]}' /tmp/checks.json > /tmp/parked.json
+
+python3 .claude/skills/release-flow/release_flow.py parked --snapshot /tmp/parked.json
+```
+
+If it fails, **stop and tell Derek** which runs need approving. This is a halt,
+not a retry: nothing changes until a human clicks.
+
+### 4. Squash-merge, with the right title
+
+The title becomes the commit on `main`, so it has to be a valid Conventional
+Commit:
+
+```bash
+TITLE=$(python3 .claude/skills/release-flow/release_flow.py title --version 0.1.0)
+gh pr merge $PR --squash --subject "$TITLE"
+```
+
+Merging is Derek's decision. Ask, unless he has already said to go ahead.
+
+### 5. Verify all three artifacts appeared
+
+```bash
+python3 .claude/skills/release-flow/release_flow.py verify --snapshot /tmp/after.json
+```
+
+with a snapshot of:
+
+```json
+{
+  "version": "0.1.0",
+  "tags": ["v0.1.0"],
+  "releases": [{"tag_name": "v0.1.0", "draft": false}],
+  "pull_request_labels": ["autorelease: tagged"]
+}
+```
+
+All three, because each can happen without the others:
+
+- **the `v0.1.0` tag** — from `gh api repos/:owner/:repo/tags`;
+- **a published (not draft) GitHub Release** — a tag with no release is a
+  release nobody can download;
+- **`autorelease: tagged`** on the merged PR — without it release-please thinks
+  the release never happened and will try again.
+
+Then check the release has its APK attached. If not, the manual backfill
+workflow exists for exactly that.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_skill_tests.py release-flow
+```
+
+Every check in `release_flow.py` is a pure function over a snapshot dict, so the
+tests need no network and no fixtures.

--- a/.claude/skills/release-flow/release_flow.py
+++ b/.claude/skills/release-flow/release_flow.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Checks for driving a release-please release to a tagged, released state.
+
+Every function here is pure: it takes a snapshot of GitHub state and returns a
+verdict. Nothing in this file talks to the network, and nothing in it mutates
+anything — gathering the snapshot is the caller's job (see SKILL.md), and
+mutating the release PR is release-please's.
+
+Usage:
+
+    python3 release_flow.py regenerated --snapshot snapshot.json
+    python3 release_flow.py parked      --snapshot snapshot.json
+    python3 release_flow.py verify      --snapshot snapshot.json
+    python3 release_flow.py title       --version 0.1.0
+
+`--snapshot -` reads from stdin. Each check exits 0 when it passes and 1 when
+it does not, printing a one-line reason either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+RELEASE_BRANCH_PREFIX = "release-please--branches--"
+PENDING_LABEL = "autorelease: pending"
+TAGGED_LABEL = "autorelease: tagged"
+
+# A check run that GitHub is holding until someone with write access approves it
+# — the state a first-time or fork contributor's workflow run sits in.
+PARKED_STATES = {"action_required", "waiting", "queued_pending_approval"}
+
+
+class Verdict:
+    """A pass/fail with a reason a human can act on."""
+
+    def __init__(self, ok: bool, reason: str) -> None:
+        self.ok = ok
+        self.reason = reason
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Verdict)
+            and self.ok == other.ok
+            and self.reason == other.reason
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Verdict(ok={self.ok!r}, reason={self.reason!r})"
+
+
+def find_release_pr(pull_requests: list[dict]) -> dict | None:
+    """The open release PR, or None.
+
+    Matched on the head branch rather than the title, because the title is
+    configurable and has changed once already.
+    """
+    for pull_request in pull_requests:
+        head_ref = (pull_request.get("head") or {}).get("ref", "")
+        if head_ref.startswith(RELEASE_BRANCH_PREFIX):
+            return pull_request
+    return None
+
+
+def check_regenerated(snapshot: dict) -> Verdict:
+    """Gotcha 1: is the release PR up to date with main?
+
+    release-please rewrites its PR on every push to main, but the run takes a
+    minute and can fail. Merging a stale release PR ships a changelog and a
+    version that silently omit whatever landed after it was last written — and
+    nothing downstream notices, because the release itself succeeds.
+    """
+    pull_request = snapshot.get("pull_request")
+    if not pull_request:
+        return Verdict(False, "No open release PR — release-please has nothing to release.")
+
+    main_sha = snapshot.get("main_sha")
+    if not main_sha:
+        return Verdict(False, "Snapshot has no main_sha, so staleness cannot be checked.")
+
+    base_sha = (pull_request.get("base") or {}).get("sha")
+    if not base_sha:
+        return Verdict(False, "Snapshot has no pull_request.base.sha.")
+
+    if base_sha != main_sha:
+        return Verdict(
+            False,
+            f"The release PR is based on {base_sha[:7]} but main is at {main_sha[:7]}. "
+            "Wait for release-please to rewrite it, or re-run the workflow.",
+        )
+
+    return Verdict(True, f"The release PR is current with main at {main_sha[:7]}.")
+
+
+def check_parked_runs(snapshot: dict) -> Verdict:
+    """Gotcha 2: are any of the PR's checks waiting on a human?
+
+    A parked run is not a failure and not a success — it simply never finishes.
+    Merging past it means merging without the checks having run at all, which
+    looks identical to merging with them green.
+
+    The owner approves them in the GitHub UI. This never approves them itself:
+    approving your own parked run defeats the point of it being parked.
+    """
+    parked = [
+        run
+        for run in snapshot.get("check_runs") or []
+        if run.get("status") in PARKED_STATES or run.get("conclusion") in PARKED_STATES
+    ]
+
+    if parked:
+        names = ", ".join(sorted(run.get("name", "?") for run in parked))
+        return Verdict(
+            False,
+            f"{len(parked)} check run(s) waiting for approval: {names}. "
+            "Ask Derek to approve them in the PR's Checks tab, then re-run this.",
+        )
+
+    return Verdict(True, "No check runs are waiting for approval.")
+
+
+def squash_title(version: str) -> str:
+    """The squash-merge subject for a release PR."""
+    return f"chore(main): release {version}"
+
+
+def check_released(snapshot: dict) -> Verdict:
+    """After the merge: did the tag, the release, and the label all appear?
+
+    All three, because each can happen without the others. A tag with no
+    release is a release nobody can download; a release with no
+    `autorelease: tagged` label is one release-please will try to make again.
+    """
+    version = snapshot.get("version")
+    if not version:
+        return Verdict(False, "Snapshot has no version to verify.")
+
+    tag = f"v{version}"
+    missing = []
+
+    if tag not in set(snapshot.get("tags") or []):
+        missing.append(f"the {tag} tag")
+
+    releases = snapshot.get("releases") or []
+    published = [
+        release
+        for release in releases
+        if release.get("tag_name") == tag and not release.get("draft", False)
+    ]
+    if not published:
+        drafted = any(release.get("tag_name") == tag for release in releases)
+        missing.append(f"a published GitHub Release for {tag}" + (" (found a draft)" if drafted else ""))
+
+    labels = set(snapshot.get("pull_request_labels") or [])
+    if TAGGED_LABEL not in labels:
+        missing.append(f"the `{TAGGED_LABEL}` label on the release PR")
+
+    if missing:
+        return Verdict(False, f"Release {tag} is incomplete — missing " + "; ".join(missing) + ".")
+
+    return Verdict(True, f"Release {tag} is tagged, published, and labelled.")
+
+
+def load_snapshot(path: str) -> dict:
+    if path == "-":
+        return json.load(sys.stdin)
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("regenerated", "check the release PR is current with main"),
+        ("parked", "check no check runs are waiting for approval"),
+        ("verify", "check the tag, release, and label all exist"),
+    ):
+        subcommand = subcommands.add_parser(name, help=help_text)
+        subcommand.add_argument("--snapshot", required=True, help="JSON file, or - for stdin")
+
+    title = subcommands.add_parser("title", help="print the squash-merge title")
+    title.add_argument("--version", required=True)
+
+    arguments = parser.parse_args(argv)
+
+    if arguments.command == "title":
+        print(squash_title(arguments.version))
+        return 0
+
+    check = {
+        "regenerated": check_regenerated,
+        "parked": check_parked_runs,
+        "verify": check_released,
+    }[arguments.command]
+
+    verdict = check(load_snapshot(arguments.snapshot))
+    print(verdict.reason, file=sys.stdout if verdict.ok else sys.stderr)
+    return 0 if verdict.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/release-flow/tests/test_release_flow.py
+++ b/.claude/skills/release-flow/tests/test_release_flow.py
@@ -1,0 +1,193 @@
+"""Unit tests for the release-flow checks.
+
+    python3 -m unittest discover -s .claude/skills -p 'test_*.py'
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import release_flow  # noqa: E402
+
+
+class FindReleasePrTests(unittest.TestCase):
+    def test_matches_on_the_release_branch_not_the_title(self):
+        pulls = [
+            {"number": 1, "title": "chore(main): release 0.1.0", "head": {"ref": "someones-branch"}},
+            {"number": 2, "title": "anything at all", "head": {"ref": "release-please--branches--main"}},
+        ]
+
+        self.assertEqual(2, release_flow.find_release_pr(pulls)["number"])
+
+    def test_returns_none_when_there_is_no_release_pr(self):
+        self.assertIsNone(release_flow.find_release_pr([{"head": {"ref": "main"}}]))
+
+    def test_tolerates_a_pull_request_with_no_head(self):
+        self.assertIsNone(release_flow.find_release_pr([{"number": 1}]))
+
+
+class RegeneratedTests(unittest.TestCase):
+    def snapshot(self, base_sha, main_sha):
+        return {"main_sha": main_sha, "pull_request": {"base": {"sha": base_sha}}}
+
+    def test_passes_when_the_pr_is_based_on_the_current_main(self):
+        verdict = release_flow.check_regenerated(self.snapshot("abc1234", "abc1234"))
+
+        self.assertTrue(verdict.ok)
+
+    def test_fails_when_main_has_moved_on(self):
+        verdict = release_flow.check_regenerated(self.snapshot("abc1234", "def5678"))
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("abc1234", verdict.reason)
+        self.assertIn("def5678", verdict.reason)
+
+    def test_fails_when_there_is_no_release_pr(self):
+        verdict = release_flow.check_regenerated({"main_sha": "abc1234"})
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("No open release PR", verdict.reason)
+
+    def test_fails_rather_than_passing_when_the_snapshot_is_incomplete(self):
+        # An absent main_sha must not read as "nothing has changed".
+        verdict = release_flow.check_regenerated({"pull_request": {"base": {"sha": "abc1234"}}})
+
+        self.assertFalse(verdict.ok)
+
+
+class ParkedRunTests(unittest.TestCase):
+    def test_passes_when_every_run_has_finished(self):
+        snapshot = {
+            "check_runs": [
+                {"name": "ci-tests", "status": "completed", "conclusion": "success"},
+                {"name": "docs-test", "status": "completed", "conclusion": "success"},
+            ]
+        }
+
+        self.assertTrue(release_flow.check_parked_runs(snapshot).ok)
+
+    def test_passes_when_there_are_no_runs_at_all(self):
+        self.assertTrue(release_flow.check_parked_runs({}).ok)
+
+    def test_fails_on_a_run_awaiting_approval(self):
+        snapshot = {"check_runs": [{"name": "pr-build", "status": "action_required"}]}
+
+        verdict = release_flow.check_parked_runs(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("pr-build", verdict.reason)
+
+    def test_fails_when_the_parked_state_is_in_the_conclusion(self):
+        snapshot = {
+            "check_runs": [{"name": "pr-build", "status": "completed", "conclusion": "action_required"}]
+        }
+
+        self.assertFalse(release_flow.check_parked_runs(snapshot).ok)
+
+    def test_names_every_parked_run_so_none_is_a_surprise(self):
+        snapshot = {
+            "check_runs": [
+                {"name": "pr-build", "status": "waiting"},
+                {"name": "ci-tests", "status": "action_required"},
+                {"name": "docs-test", "status": "completed", "conclusion": "success"},
+            ]
+        }
+
+        verdict = release_flow.check_parked_runs(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("ci-tests", verdict.reason)
+        self.assertIn("pr-build", verdict.reason)
+        self.assertNotIn("docs-test", verdict.reason)
+
+    def test_a_failing_run_is_not_a_parked_run(self):
+        # Failures are CI's problem to report; this check is only about runs
+        # that will never finish on their own.
+        snapshot = {"check_runs": [{"name": "ci-tests", "status": "completed", "conclusion": "failure"}]}
+
+        self.assertTrue(release_flow.check_parked_runs(snapshot).ok)
+
+
+class SquashTitleTests(unittest.TestCase):
+    def test_uses_the_conventional_release_subject(self):
+        self.assertEqual("chore(main): release 0.1.0", release_flow.squash_title("0.1.0"))
+
+
+class ReleasedTests(unittest.TestCase):
+    def complete(self):
+        return {
+            "version": "0.1.0",
+            "tags": ["v0.0.1", "v0.1.0"],
+            "releases": [{"tag_name": "v0.1.0", "draft": False}],
+            "pull_request_labels": ["autorelease: tagged"],
+        }
+
+    def test_passes_when_tag_release_and_label_all_exist(self):
+        verdict = release_flow.check_released(self.complete())
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_fails_when_the_tag_is_missing(self):
+        snapshot = self.complete()
+        snapshot["tags"] = ["v0.0.1"]
+
+        verdict = release_flow.check_released(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("v0.1.0 tag", verdict.reason)
+
+    def test_fails_when_the_release_is_missing(self):
+        snapshot = self.complete()
+        snapshot["releases"] = []
+
+        verdict = release_flow.check_released(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("published GitHub Release", verdict.reason)
+
+    def test_a_draft_release_does_not_count_and_says_so(self):
+        snapshot = self.complete()
+        snapshot["releases"] = [{"tag_name": "v0.1.0", "draft": True}]
+
+        verdict = release_flow.check_released(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("found a draft", verdict.reason)
+
+    def test_fails_when_the_tagged_label_is_missing(self):
+        snapshot = self.complete()
+        snapshot["pull_request_labels"] = ["autorelease: pending"]
+
+        verdict = release_flow.check_released(snapshot)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("autorelease: tagged", verdict.reason)
+
+    def test_reports_every_missing_piece_at_once(self):
+        verdict = release_flow.check_released({"version": "0.1.0"})
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("v0.1.0 tag", verdict.reason)
+        self.assertIn("published GitHub Release", verdict.reason)
+        self.assertIn("autorelease: tagged", verdict.reason)
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_title_subcommand_exits_zero(self):
+        self.assertEqual(0, release_flow.main(["title", "--version", "0.2.0"]))
+
+    def test_a_failing_check_exits_one(self):
+        import io
+        import json
+        import unittest.mock
+
+        snapshot = json.dumps({"main_sha": "aaaaaaa", "pull_request": {"base": {"sha": "bbbbbbb"}}})
+
+        with unittest.mock.patch("sys.stdin", io.StringIO(snapshot)):
+            self.assertEqual(1, release_flow.main(["regenerated", "--snapshot", "-"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/run_skill_tests.py
+++ b/.github/scripts/run_skill_tests.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run every skill's unit tests.
+
+`python3 -m unittest discover` cannot find them on its own: discovery only
+recurses into directories whose names are valid Python identifiers, and
+`.claude` starts with a dot. So this walks `.claude/skills/*/tests/` itself,
+putting each skill's own directory on sys.path first so its scripts import by
+their plain module name.
+
+Usage:
+    python3 .github/scripts/run_skill_tests.py            # every skill
+    python3 .github/scripts/run_skill_tests.py release-flow pipeline-gatekeeper
+
+Exits non-zero if any test fails, or if a named skill has no tests — a skill
+whose tests silently stopped being run is worse than one with none.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
+
+
+def skill_directories(names: list[str]) -> list[Path]:
+    if names:
+        directories = []
+        for name in names:
+            directory = SKILLS_ROOT / name
+            if not directory.is_dir():
+                sys.exit(f"No skill named {name!r} under {SKILLS_ROOT.relative_to(REPO_ROOT)}/")
+            directories.append(directory)
+        return directories
+
+    return sorted(path for path in SKILLS_ROOT.glob("*") if path.is_dir())
+
+
+def main(argv: list[str]) -> int:
+    if not SKILLS_ROOT.is_dir():
+        print("No .claude/skills/ directory — nothing to test.")
+        return 0
+
+    requested = skill_directories(argv)
+    suite = unittest.TestSuite()
+    tested: list[str] = []
+
+    for directory in requested:
+        if not (directory / "tests").is_dir():
+            if argv:
+                sys.exit(f"{directory.name} has no tests/ directory.")
+            continue
+
+        # The skill's own directory, so `import release_flow` resolves to the
+        # script sitting next to the tests rather than to anything else on the
+        # path.
+        sys.path.insert(0, str(directory))
+        suite.addTests(unittest.defaultTestLoader.discover(
+            start_dir=str(directory), top_level_dir=str(directory)))
+        tested.append(directory.name)
+
+    if not tested:
+        print("No skill has a tests/ directory yet.")
+        return 0
+
+    print(f"Testing: {', '.join(tested)}")
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,15 @@ google-services.json
 [Oo]bj/
 
 # =============================================================================
+# Python
+# =============================================================================
+# Bytecode from the skill scripts and the .github/scripts helpers.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+
+# =============================================================================
 # Docs site
 # =============================================================================
 # `mkdocs build` output. The published site is built by CI from docs/, never

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -212,6 +212,29 @@ and runs on every push, with no editor and no network.
    creates the tag and the GitHub release, and triggers the release build, which
    attaches the APK.
 
+### Use the `release-flow` skill
+
+Two things go wrong at step 3 every time, and both are silent:
+
+- **The release PR can be stale.** release-please rewrites it on every push to
+  `main`, but that run takes a minute and can fail. Merging a stale one ships a
+  changelog and a version that omit whatever landed after it was last written —
+  and nothing catches it afterwards, because the release itself succeeds.
+- **Check runs can be parked** in `action_required`, waiting for a human. A
+  parked run never finishes on its own, so merging past it means merging with
+  the checks not having run — which from the merge button looks identical to
+  merging with them green.
+
+`.claude/skills/release-flow/` checks both before the merge, and afterwards
+verifies that all three artifacts appeared: the tag, a *published* release, and
+the `autorelease: tagged` label. Each can happen without the others — a tag with
+no release is a release nobody can download, and a missing label makes
+release-please try the same release again.
+
+The skill never edits the release PR, never approves a parked run, and never
+creates a tag by hand. release-please owns that branch and recomputes it from
+scratch on every run, so an edit is either undone or corrupts the next one.
+
 ## One issue → one PR → one squash commit → one changelog entry
 
 The chain is only as good as its narrowest link, and every link is enforced:


### PR DESCRIPTION
Closes #34

Two things go wrong at every release, and both are silent — so they get captured in a skill instead of being re-derived (or forgotten) each time.

**Docs:** `docs/engineering/versioning.md` — added the "Use the `release-flow` skill" section to the release flow.

## The two gotchas

**A stale release PR.** release-please rewrites it on every push to `main`, but that run takes a minute and can fail. Merging a stale one ships a changelog and a version that omit whatever landed after it was last written — and nothing catches it afterwards, because the release itself *succeeds*.

**A parked check run.** A run in `action_required` or `waiting` is neither passing nor failing; it never finishes on its own. Merging past it means merging with the checks not having run, which from the merge button looks identical to merging with them green.

## What's here

- **`release_flow.py`** — four pure functions over a GitHub state snapshot. No network, no mutation. `find_release_pr` matches on the **head branch** rather than the title, because the title is configurable and has already changed once (#115).
- **22 unit tests**, no fixtures and no mocking beyond one stdin patch.
- **`SKILL.md`** — the five-step flow with the `gh` commands to gather each snapshot, and an explicit **"what this skill never does"**: it doesn't touch the release PR's own state, doesn't approve parked runs, and doesn't create tags or releases by hand. release-please recomputes that branch from scratch on every run, so an edit is either undone or corrupts the next computation. The only mutating step in the flow is the squash-merge, and that's Derek's call.
- The `verify` check requires **all three** artifacts together — tag, *published* (not draft) release, and the `autorelease: tagged` label — because each can happen without the others. A tag with no release is a release nobody can download; a missing label makes release-please try the same release again. It reports every missing piece at once rather than one per run.

```
$ python3 .github/scripts/run_skill_tests.py release-flow
Ran 22 tests in 0.035s
OK
```

## Deviations and Decisions

- **Added `.github/scripts/run_skill_tests.py`**, beyond the issue's scope. `python3 -m unittest discover` finds nothing under `.claude/skills`: discovery only recurses into directories whose names are valid Python identifiers, and `.claude` starts with a dot. Without a runner, every one of the ~12 remaining skill issues would hit this and solve it differently. It also fails loudly if a *named* skill has no tests, since tests that silently stopped running are worse than none.
- **A parked run is distinguished from a failing one.** Failures are CI's job to report and the drive-to-green loop's job to fix; this check is only about runs that will never finish without a human. There's a test asserting a `failure` conclusion does *not* trip it.
- **Incomplete snapshots fail rather than pass.** A missing `main_sha` could plausibly read as "nothing has changed" — it reads as "can't tell", which is a failure. Tested.
- Added `__pycache__/` and friends to `.gitignore` — the first Python in the repo, so the first time it mattered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_