### PR TITLE
ci: verify EditMode results from the XML, not the exit code

### DIFF
--- a/.github/scripts/tests/test_verify_editmode_results.py
+++ b/.github/scripts/tests/test_verify_editmode_results.py
@@ -1,0 +1,159 @@
+"""Unit tests for the EditMode results gate.
+
+The gate decides whether a Unity test run passed. Getting it wrong in the
+lenient direction means shipping on a red suite, so these tests lean on the
+failure cases.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import verify_editmode_results as gate  # noqa: E402
+
+
+def results_xml(total=3, passed=3, failed=0, inconclusive=0, skipped=0, result="Passed"):
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<test-run id="2" result="{result}" total="{total}" passed="{passed}" '
+        f'failed="{failed}" inconclusive="{inconclusive}" skipped="{skipped}" '
+        'asserts="3" duration="1.234">\n'
+        '  <test-suite type="Assembly" name="Frogs.Unity.EditModeTests" />\n'
+        "</test-run>\n"
+    )
+
+
+class GreenRunTests(unittest.TestCase):
+    def test_a_clean_run_passes(self):
+        verdict = gate.verify(results_xml(), exit_code=0)
+
+        self.assertTrue(verdict.ok, verdict.reason)
+        self.assertIn("3", verdict.reason)
+
+    def test_skipped_tests_do_not_fail_the_run(self):
+        verdict = gate.verify(results_xml(total=3, passed=2, skipped=1), exit_code=0)
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+
+class ZeroTestTests(unittest.TestCase):
+    def test_zero_tests_is_a_failure_however_green_it_looks(self):
+        # The most dangerous green there is: a licence problem, a missing
+        # assembly, or a filter that matched nothing all look like success.
+        verdict = gate.verify(results_xml(total=0, passed=0), exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("0 tests", verdict.reason)
+
+
+class RedRunTests(unittest.TestCase):
+    def test_a_failing_test_fails_the_gate(self):
+        verdict = gate.verify(results_xml(total=3, passed=2, failed=1, result="Failed"), exit_code=1)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("1 failed", verdict.reason)
+
+    def test_a_failing_test_fails_even_when_unity_exited_zero(self):
+        verdict = gate.verify(results_xml(total=3, passed=2, failed=1), exit_code=0)
+
+        self.assertFalse(verdict.ok)
+
+    def test_a_failing_test_fails_even_on_the_forgiven_exit_code(self):
+        # Forgiveness is about teardown, never about results.
+        verdict = gate.verify(
+            results_xml(total=3, passed=2, failed=1), exit_code=gate.DEFAULT_FORGIVEN_EXIT_CODE
+        )
+
+        self.assertFalse(verdict.ok)
+
+    def test_an_inconclusive_test_fails(self):
+        verdict = gate.verify(results_xml(total=3, passed=2, inconclusive=1), exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("inconclusive", verdict.reason)
+
+
+class TeardownForgivenessTests(unittest.TestCase):
+    def test_the_known_teardown_exit_code_is_forgiven_on_a_green_run(self):
+        verdict = gate.verify(results_xml(), exit_code=gate.DEFAULT_FORGIVEN_EXIT_CODE)
+
+        self.assertTrue(verdict.ok, verdict.reason)
+        self.assertIn("teardown", verdict.reason)
+
+    def test_any_other_nonzero_exit_code_still_fails(self):
+        verdict = gate.verify(results_xml(), exit_code=2)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("exit code 2", verdict.reason)
+
+    def test_an_extra_forgiven_code_can_be_supplied(self):
+        verdict = gate.verify(results_xml(), exit_code=134, forgiven=(134,))
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+
+class MissingOrBrokenResultsTests(unittest.TestCase):
+    def test_a_run_that_died_before_writing_results_fails(self):
+        verdict = gate.verify(None, exit_code=139)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("no results", verdict.reason.lower())
+
+    def test_a_missing_file_fails_rather_than_being_skipped(self):
+        with TemporaryDirectory() as directory:
+            verdict = gate.verify_file(Path(directory) / "nope.xml", exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("nope.xml", verdict.reason)
+
+    def test_unparseable_xml_fails(self):
+        verdict = gate.verify("<test-run total='3'", exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("could not be parsed", verdict.reason)
+
+    def test_the_wrong_root_element_fails(self):
+        verdict = gate.verify("<results total='3' passed='3' failed='0' />", exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("test-run", verdict.reason)
+
+    def test_missing_counts_fail_rather_than_defaulting_to_zero(self):
+        # A total that defaults to 0 would fail anyway, but a *failed* count
+        # defaulting to 0 would turn an unreadable file into a pass.
+        verdict = gate.verify('<test-run total="3" passed="3" />', exit_code=0)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("failed", verdict.reason)
+
+
+class FileAndCommandLineTests(unittest.TestCase):
+    def write(self, directory, contents):
+        path = Path(directory) / "results.xml"
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_verify_file_reads_and_passes(self):
+        with TemporaryDirectory() as directory:
+            path = self.write(directory, results_xml())
+
+            self.assertTrue(gate.verify_file(path, exit_code=0).ok)
+
+    def test_main_exits_zero_on_a_green_run(self):
+        with TemporaryDirectory() as directory:
+            path = self.write(directory, results_xml())
+
+            self.assertEqual(0, gate.main(["--results", str(path), "--exit-code", "0"]))
+
+    def test_main_exits_one_on_a_red_run(self):
+        with TemporaryDirectory() as directory:
+            path = self.write(directory, results_xml(total=3, passed=2, failed=1))
+
+            self.assertEqual(1, gate.main(["--results", str(path), "--exit-code", "0"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify_editmode_results.py
+++ b/.github/scripts/verify_editmode_results.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Decide whether a Unity EditMode run actually passed.
+
+The exit code alone cannot answer that, in both directions:
+
+  * **Falsely red.** Unity's editor sometimes dies during *teardown*, after a
+    fully green run has already written its results. Treating that as a failure
+    means a red PR with nothing wrong in it, and the fix everyone reaches for is
+    "re-run until it's green" — which trains people to re-run real failures too.
+
+  * **Falsely green.** The runner can exit 0 having run *zero* tests. A licence
+    problem, a missing assembly, or a filter that matched nothing all look like
+    success from the outside, and "0 tests passed" is the most dangerous green
+    there is.
+
+So the verdict comes from the results XML, and the exit code is forgiven in
+exactly one narrow case: a code known to come from teardown, on a run whose
+results say everything passed. Forgiveness is never about results.
+
+Usage:
+    python3 .github/scripts/verify_editmode_results.py \\
+        --results artifacts/editmode-results.xml --exit-code "$UNITY_EXIT_CODE"
+
+Stdlib only, so it runs in any job without a setup step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+# Unity on Linux segfaults during editor shutdown often enough to be a known
+# quantity; 139 is the shell's way of reporting SIGSEGV. It is forgiven ONLY
+# when the results are green.
+#
+# Adding a code here needs evidence — a run where the results XML is complete
+# and green and the editor still exited nonzero. Anything else is a real
+# failure being hidden.
+DEFAULT_FORGIVEN_EXIT_CODE = 139
+
+
+class Verdict:
+    def __init__(self, ok: bool, reason: str) -> None:
+        self.ok = ok
+        self.reason = reason
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Verdict(ok={self.ok!r}, reason={self.reason!r})"
+
+
+def _count(element: ElementTree.Element, name: str) -> int | None:
+    """An integer attribute, or None when it is absent or not a number.
+
+    None rather than 0 on purpose: a `failed` count defaulting to zero would
+    turn an unreadable results file into a pass.
+    """
+    raw = element.get(name)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def verify(
+    results: str | None,
+    exit_code: int,
+    forgiven: tuple[int, ...] = (DEFAULT_FORGIVEN_EXIT_CODE,),
+) -> Verdict:
+    """The verdict for one run, from its results XML and its exit code."""
+    if results is None:
+        return Verdict(
+            False,
+            f"The run produced no results (exit code {exit_code}). Unity died before "
+            "writing the XML, so there is nothing to trust — this is a failure, not a "
+            "teardown crash.",
+        )
+
+    try:
+        root = ElementTree.fromstring(results)
+    except ElementTree.ParseError as error:
+        return Verdict(False, f"The results XML could not be parsed: {error}.")
+
+    if root.tag != "test-run":
+        return Verdict(
+            False,
+            f"Expected a <test-run> document, found <{root.tag}>. This is not an NUnit "
+            "results file.",
+        )
+
+    total = _count(root, "total")
+    failed = _count(root, "failed")
+    inconclusive = _count(root, "inconclusive")
+
+    for name, value in (("total", total), ("failed", failed), ("inconclusive", inconclusive)):
+        if value is None:
+            return Verdict(
+                False,
+                f"The results XML has no readable '{name}' count, so the run cannot be "
+                "verified. Treating that as a pass is how an unreadable file becomes a "
+                "green build.",
+            )
+
+    if total == 0:
+        return Verdict(
+            False,
+            "The run reported 0 tests. That is not a pass — it usually means the licence "
+            "failed, an assembly did not compile, or a filter matched nothing.",
+        )
+
+    if failed:
+        return Verdict(False, f"{failed} failed of {total} tests.")
+
+    if inconclusive:
+        return Verdict(
+            False,
+            f"{inconclusive} of {total} tests were inconclusive. An inconclusive test is "
+            "one that did not answer the question it was asked.",
+        )
+
+    # Results are green from here on. Only now does the exit code matter.
+    if exit_code == 0:
+        return Verdict(True, f"All {total} tests passed.")
+
+    if exit_code in forgiven:
+        return Verdict(
+            True,
+            f"All {total} tests passed. Unity exited {exit_code} during teardown, which is "
+            "forgiven — the results were already written.",
+        )
+
+    return Verdict(
+        False,
+        f"All {total} tests passed, but Unity exited with exit code {exit_code}, which is "
+        f"not a known teardown code (forgiven: {', '.join(str(code) for code in forgiven)}). "
+        "Something went wrong after the tests ran; look at the log before forgiving it.",
+    )
+
+
+def verify_file(
+    path: Path,
+    exit_code: int,
+    forgiven: tuple[int, ...] = (DEFAULT_FORGIVEN_EXIT_CODE,),
+) -> Verdict:
+    if not path.is_file():
+        return Verdict(
+            False,
+            f"No results file at {path}. A missing results file is a failure: the gate "
+            "cannot tell a green run from one that never started.",
+        )
+
+    return verify(path.read_text(encoding="utf-8", errors="replace"), exit_code, forgiven)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", required=True, help="path to the NUnit results XML")
+    parser.add_argument("--exit-code", type=int, required=True, help="Unity's exit code")
+    parser.add_argument(
+        "--forgive",
+        type=int,
+        action="append",
+        default=[],
+        metavar="CODE",
+        help="an additional teardown exit code to forgive on a green run",
+    )
+    arguments = parser.parse_args(argv)
+
+    forgiven = tuple([DEFAULT_FORGIVEN_EXIT_CODE] + arguments.forgive)
+    verdict = verify_file(Path(arguments.results), arguments.exit_code, forgiven)
+
+    print(verdict.reason, file=sys.stdout if verdict.ok else sys.stderr)
+    return 0 if verdict.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -260,20 +260,46 @@ See [Testing](testing.md) for what belongs in each.
 
 #### The results-XML verdict rule
 
-**A green exit code is not a pass.** The Unity test runner has been known to
-exit 0 having run zero tests — a licence problem, a missing assembly, or a
-filter that matched nothing all look like success from the outside, and "0 tests
-passed" is the most dangerous green there is.
+**The exit code is not the verdict.** It is wrong in both directions:
 
-So the verdict comes from the results XML, not the exit code. A dedicated script
-parses it and fails the job unless:
+- **Falsely green.** The runner can exit 0 having run *zero* tests — a licence
+  problem, a missing assembly, or a filter that matched nothing all look like
+  success from the outside. "0 tests passed" is the most dangerous green there
+  is.
+- **Falsely red.** Unity's editor sometimes dies during *teardown*, after a
+  fully green run has written its results. Treating that as a failure produces a
+  red PR with nothing wrong in it, and the fix everyone reaches for is "re-run
+  until it's green" — which trains people to re-run real failures too.
 
-- the results file exists and parses;
-- the total number of tests run is **greater than zero**;
-- there are no failures, errors, or unexpected inconclusives.
+So `.github/scripts/verify_editmode_results.py` derives the verdict from the
+NUnit results XML. It passes only when:
+
+- the results file exists, parses, and is a `<test-run>` document;
+- `total` is **greater than zero**;
+- `failed` is zero, and nothing is inconclusive;
+- every count it needs is actually present — a missing `failed` attribute is a
+  failure, not a zero, because otherwise an unreadable file reads as a pass.
+
+Then, and only then, it looks at the exit code:
+
+| Exit code | Green results | Verdict |
+| --- | --- | --- |
+| `0` | yes | pass |
+| `139` (SIGSEGV in teardown) | yes | pass, and says so in the log |
+| anything else | yes | **fail** — something went wrong after the tests |
+| any, including `139` | no | **fail** |
+
+**Forgiveness is about teardown, never about results.** A failing test fails the
+gate whatever the exit code was. Adding a code to the forgiven list needs
+evidence — a run with complete, green results and a nonzero exit — and is done
+with `--forgive`, so it shows up in the workflow rather than being buried in the
+script.
 
 If the XML is missing, the job fails. "We couldn't tell" is a failure, not a
 pass — the whole point is to not accept an absence of evidence as evidence.
+
+The script is stdlib-only, so it needs no setup step, and it has 18 unit tests
+covering each failure mode.
 
 ### The geometry and tuning literal check
 


### PR DESCRIPTION
Closes #36

Unity's exit code can't be trusted to say whether the tests passed — it's wrong in both directions, and each direction has its own cost.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the results-XML verdict rule with the forgiveness table.

## Both failure modes

- **Falsely green.** The runner exits 0 having run *zero* tests when the licence fails, an assembly doesn't compile, or a filter matches nothing. "0 tests passed" is the most dangerous green there is.
- **Falsely red.** The editor sometimes dies during *teardown*, after a fully green run has already written its results. That produces a red PR with nothing wrong in it — and the fix everyone reaches for is "re-run until it's green", which trains people to re-run real failures too.

## What the gate requires

The verdict comes from the NUnit XML. It passes only when the file exists, parses, is a `<test-run>`, reports `total > 0`, and has no failures or inconclusives.

One detail worth calling out: **every count it needs must actually be present.** A missing `failed` attribute is a failure, not a zero — otherwise an unreadable results file reads as a pass, which is the same bug as trusting the exit code, one level down.

Only *then* does the exit code matter:

| Exit code | Green results | Verdict |
| --- | --- | --- |
| `0` | yes | pass |
| `139` (SIGSEGV in teardown) | yes | pass, and says so |
| anything else | yes | **fail** |
| any, including `139` | no | **fail** |

**Forgiveness is about teardown, never about results.** There's a test asserting that a failing test still fails the gate even on the forgiven exit code.

## Test-first

Red:
```
ERROR: tests.test_verify_editmode_results
ModuleNotFoundError: No module named 'verify_editmode_results'
```
Green: **18 tests for this script, 46 in the `scripts` suite, all passing.** Stdlib only, so it runs in any job with no setup step.

## Deviations and Decisions

- **The forgiven code is `139`.** The issue says "the known teardown exit code" without naming it, and Doggiehood's value wasn't readable from here. 139 is the shell's SIGSEGV, which is how Unity-on-Linux shutdown crashes surface. The safety property doesn't depend on getting that number right: forgiveness only ever applies to a run whose results are already green, so a wrong constant costs a false red (visible, annoying) rather than a false green (invisible, dangerous).
- **Extra codes go through `--forgive`, not the script.** If another teardown code shows up, it gets added in the workflow where it's visible in review, with the evidence in the PR — rather than growing a list in the script that nobody re-examines.
- **Kept `Verdict` local** rather than sharing the one in `release_flow.py`. Two small identical classes beat a shared utility module that couples a CI script to a skill; if a third appears, that's the time to extract it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_