### PR TITLE
ci: add the Core and EditMode test workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,127 @@
+name: ci-tests
+
+# The required test check. Two suites, deliberately separate:
+#
+#   core     — plain NUnit via dotnet test. No editor, no licence, seconds.
+#   editmode — a headless Unity editor. Minutes, and needs a licence.
+#
+# Path-gated, because most changes in this repo are docs, skills, and
+# workflows, and running a containerised editor for a typo helps nobody.
+#
+# NOTE for branch protection (#80): a path-gated workflow does not report at
+# all on PRs that miss its paths. If `ci-tests` is marked *required*, those PRs
+# block forever waiting for a check that will never run. Require the individual
+# jobs only if you also add an always-running guard job, or leave this
+# non-required and rely on review. See docs/engineering/ci-cd.md.
+
+on:
+  pull_request:
+    paths:
+      - Assets/**
+      - Tests/**
+      - ProjectSettings/**
+      - Packages/**
+      - .github/workflows/ci-tests.yml
+      - .github/scripts/verify_editmode_results.py
+  push:
+    branches: [main]
+    paths:
+      - Assets/**
+      - Tests/**
+      - ProjectSettings/**
+      - Packages/**
+      - .github/workflows/ci-tests.yml
+      - .github/scripts/verify_editmode_results.py
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: Core (NUnit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 8.0.x
+
+      # Cheap, and it fails for a reason the test output would not explain:
+      # game logic that has grown a dependency on the engine.
+      - name: Core is engine-free
+        run: python3 .github/scripts/check_core_isolation.py
+
+      - name: Run the Core suite
+        run: dotnet test Tests/Core/Frogs.Core.Tests.csproj --verbosity normal
+
+  editmode:
+    name: EditMode (Unity)
+    runs-on: ubuntu-latest
+    steps:
+      # Before anything expensive. A missing licence must fail the job loudly:
+      # a required check that goes green because the suite never ran is worse
+      # than no check at all.
+      - name: Require the Unity licence
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -z "$UNITY_LICENSE" ]; then
+            echo "::error::The UNITY_LICENSE secret is not set, so the EditMode suite" \
+                 "cannot run. This job fails rather than skipping — see issue #82."
+            exit 1
+          fi
+          echo "UNITY_LICENSE is present."
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+
+      # Unity's Library/ is expensive to rebuild and safe to reuse for the same
+      # project state.
+      - name: Cache Unity's Library
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: Library
+          key: Library-editmode-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: Library-editmode-
+
+      # continue-on-error, because the exit code is not the verdict: Unity
+      # exits nonzero from a teardown crash after a fully green run. The gate
+      # below decides. See docs/engineering/ci-cd.md.
+      - name: Run the EditMode suite
+        id: tests
+        continue-on-error: true
+        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          unityVersion: 6000.0.81f1
+          testMode: EditMode
+          artifactsPath: artifacts
+          customParameters: -nographics
+          checkName: EditMode results
+
+      - name: Verify the results
+        env:
+          UNITY_EXIT_CODE: ${{ steps.tests.outputs.exitCode || '0' }}
+        run: |
+          python3 .github/scripts/verify_editmode_results.py \
+            --results artifacts/editmode-results.xml \
+            --exit-code "$UNITY_EXIT_CODE"
+
+      # Uploaded even on failure — a red EditMode run is the one you most want
+      # the XML for, and it is gone with the runner otherwise.
+      - name: Upload the results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: editmode-results
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -86,6 +86,7 @@ repository.
 | `actions/setup-python` | `5fda3b95a4ea91299a34e894583c3862153e4b97` | docs, pipeline, scripts |
 | `actions/setup-dotnet` | `a98b56852c35b8e3190ac28c8c2271da59106c68` | the Core suite |
 | `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | APKs, test results |
+| `actions/cache` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | Unity's `Library/` |
 | `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | the release attach step |
 | `googleapis/release-please-action` | `45996ed1f6d02564a971a2fa1b5860e934307cf7` | `release-please` |
 | `game-ci/unity-builder` | `d829bfc901f2347c8fe18898f06712b66916ef42` | APK builds |
@@ -250,13 +251,54 @@ python3 .github/scripts/run_python_tests.py scripts
 
 ### `ci-tests` — the two suites
 
-Runs both, always, in one workflow:
+Two jobs, deliberately separate because they cost wildly different amounts:
 
-1. **Core** — plain NUnit via `dotnet test`. No editor, no licence, seconds.
-2. **EditMode** — Unity Test Framework, headless, in a GameCI container with the
-   Unity licence from the `UNITY_LICENSE` secret.
+| Job | Runs | Needs |
+| --- | --- | --- |
+| **Core (NUnit)** | `dotnet test` on `Tests/Core` | nothing — seconds |
+| **EditMode (Unity)** | headless Unity via GameCI | a licence, and minutes |
 
 See [Testing](testing.md) for what belongs in each.
+
+The Core job also runs `check_core_isolation.py` first. It costs nothing and it
+fails for a reason the test output would never explain: game logic that has
+grown a dependency on the engine.
+
+#### A missing licence fails, it does not skip
+
+The EditMode job's **first** step, before any checkout or container pull,
+asserts that `UNITY_LICENSE` is set — and fails the job if it isn't.
+
+Skipping would be the friendlier behaviour and the wrong one. A required check
+that goes green because the suite never ran is worse than no check at all: it
+reports "tested" on a PR nothing tested, and nobody looks twice at a green tick.
+
+Until the secret exists (#82), this job is red on every PR that touches the
+Unity project. That is the intended behaviour, and it is visible rather than
+quiet.
+
+#### Path-gating, and what it means for branch protection
+
+The workflow only runs when `Assets/`, `Tests/`, `ProjectSettings/`,
+`Packages/`, or its own files change. Most changes here are docs, skills, and
+workflows, and pulling a containerised editor to check a typo helps nobody.
+
+!!! warning "Path-gated workflows and required checks don't mix"
+    A path-gated workflow does not report *at all* on a PR that misses its
+    paths — it is not skipped, it is absent. If `ci-tests` is marked **required**
+    in branch protection, every docs-only PR blocks forever waiting for a check
+    that will never run.
+
+    When configuring branch protection (#80), either leave `ci-tests`
+    non-required, or add an always-running guard job that reports the required
+    name and the real jobs depend on. Don't mark the path-gated jobs required
+    and hope.
+
+#### Why the runner step is `continue-on-error`
+
+Because the exit code is not the verdict — see below. The runner is allowed to
+fail; the gate step decides, and the results XML is uploaded as an artifact
+either way, since a red run is the one you most want the XML for.
 
 #### The results-XML verdict rule
 


### PR DESCRIPTION
Closes #37

The test check. Two jobs, split because they cost wildly different amounts: Core runs `dotnet test` in seconds with no editor at all; EditMode pulls a containerised Unity and needs a licence.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the `ci-tests` section and added the path-gating warning.

## What's here

- **Core (NUnit)** — `check_core_isolation.py` then `dotnet test Tests/Core/…`. The isolation check goes first because it's free and it fails for a reason the test output would never explain: game logic that has grown a dependency on the engine.
- **EditMode (Unity)** — GameCI test runner, `-nographics`, with `Library/` cached against `manifest.json` + `ProjectVersion.txt`.
- The runner step is **`continue-on-error`**, and `verify_editmode_results.py` (#36) gives the verdict. Results are uploaded `if: always()` — a red run is the one you most want the XML for, and it's gone with the runner otherwise.
- Path-gated to `Assets/`, `Tests/`, `ProjectSettings/`, `Packages/`, and its own files.
- Every `uses:` SHA-pinned; `actions/cache` resolved with `resolve_action_pin.sh` and added to the pin table.

## A missing licence fails — it does not skip

The EditMode job's **first** step, before any checkout or container pull, asserts `UNITY_LICENSE` is set and fails the job if it isn't.

Skipping would be friendlier and wrong. A required check that goes green because the suite never ran reports "tested" on a PR that nothing tested, and nobody looks twice at a green tick.

**So expect this job to be red** on any PR touching the Unity project until #82 (the `UNITY_LICENSE` secret) and #104 (the generated `ProjectSettings/`) land. That's the specified behaviour — visible rather than quiet — and it's an external blocker rather than something the workflow can fix. Path-gating keeps it off the docs and skills PRs that make up most of this milestone.

## Deviations and Decisions

- **Added `actions/cache`** to the pinned-actions table. Not on the checklist, but a Unity job that rebuilds `Library/` from scratch every run turns a two-minute check into a ten-minute one, and this is the check people will be waiting on.
- **Documented a trap rather than pre-solving it:** a path-gated workflow is *absent*, not skipped, on PRs that miss its paths — so marking `ci-tests` required in branch protection would block every docs-only PR forever. #80 (branch protection) is Derek's and hasn't been configured yet, so the docs now carry the warning and the two ways out. Building an always-running guard job now would be machinery for a configuration that doesn't exist.
- **`--verbosity normal` on `dotnet test`** so a failure shows which test and what it expected in the log, rather than needing an artifact download for a suite that takes two seconds to run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_