### PR TITLE
ci: build a debug APK for every PR

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,120 @@
+name: pr-build
+
+# A debug APK for every PR, so "does it still build" is answered by a build
+# rather than by hope, and so Connor can try a change on his phone before it
+# merges.
+#
+# Distribution is the workflow artifact and nothing else — no store, no
+# distribution service, no link that outlives the PR. Artifacts expiring is
+# correct: a stale test build is worse than none.
+
+on:
+  pull_request:
+    paths:
+      - Assets/**
+      - ProjectSettings/**
+      - Packages/**
+      - VERSION
+      - .github/workflows/pr-build.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      # Unlike ci-tests, a missing licence WARNS and skips here. That job is a
+      # correctness gate — a green tick claiming the tests ran when they did not
+      # is a lie. This one is a convenience: no APK is an absent convenience,
+      # not a false claim, and failing every PR over it would train everyone to
+      # ignore a red check.
+      - name: Check for the Unity licence
+        id: licence
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -z "$UNITY_LICENSE" ]; then
+            echo "::warning::No UNITY_LICENSE secret, so no debug APK for this PR." \
+                 "See issue #82. Skipping rather than failing — this build is a" \
+                 "convenience, not a correctness gate."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.licence.outputs.present == 'true'
+        with:
+          # The versionCode is the commit count, so the whole history has to be
+          # here. A shallow checkout would silently produce a lower number than
+          # the last build, and Android refuses to install that.
+          fetch-depth: 0
+
+      - name: Work out the build stamp
+        id: stamp
+        if: steps.licence.outputs.present == 'true'
+        env:
+          # github.event.pull_request.head.sha, not github.sha: the latter is
+          # the merge commit, which is not a commit anyone can check out later.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          echo "version_code=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build_sha=$(git rev-parse --short=7 "$HEAD_SHA")" >> "$GITHUB_OUTPUT"
+          echo "version=$(cut -d'#' -f1 VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Unity's Library
+        if: steps.licence.outputs.present == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: Library
+          key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: Library-android-
+
+      # The version name, versionCode, and .debug suffix are applied by
+      # BuildStampPreprocessor from these variables — a build pre-processor, so
+      # no build can be produced without them. See docs/engineering/versioning.md.
+      - name: Build the debug APK
+        if: steps.licence.outputs.present == 'true'
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
+          FROGS_BUILD_SHA: ${{ steps.stamp.outputs.build_sha }}
+          FROGS_APPLICATION_ID_SUFFIX: .debug
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          androidExportType: androidPackage
+          # No keystore inputs, so Unity signs with the Android debug key. That
+          # is deliberate: the release keystore is a secret this workflow should
+          # not be able to reach from a PR branch.
+          buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-${{ steps.stamp.outputs.build_sha }}
+          allowDirtyBuild: true
+
+      - name: Upload the APK
+        if: steps.licence.outputs.present == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: debug-apk-${{ steps.stamp.outputs.version }}-${{ steps.stamp.outputs.build_sha }}
+          path: build/Android/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summarise
+        if: always()
+        run: |
+          if [ "${{ steps.licence.outputs.present }}" != "true" ]; then
+            echo "No debug APK: the UNITY_LICENSE secret is not set (#82)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Debug APK \`${{ steps.stamp.outputs.version }}-${{ steps.stamp.outputs.build_sha }}\`" \
+                 "(versionCode ${{ steps.stamp.outputs.version_code }}), installs alongside the" \
+                 "release build as \`.debug\`." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -1,0 +1,69 @@
+using System;
+using Frogs.Core;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using Debug = UnityEngine.Debug;
+
+namespace Frogs.EditorTools
+{
+    /// <summary>
+    /// Stamps every build with its version, before it builds.
+    ///
+    /// This runs as a build pre-processor rather than as a step CI remembers to
+    /// call, because a stamping step that can be forgotten will be — and a build
+    /// with the wrong version is one that cannot be identified afterwards. Local
+    /// builds, CI builds, and builds started from the editor all go through
+    /// here.
+    ///
+    /// CI sets the environment; nothing here reads git, because a shallow
+    /// checkout has no history to count:
+    ///
+    ///     FROGS_VERSION_CODE            the Android versionCode
+    ///     FROGS_BUILD_SHA               set for a debug/RC build, absent for a release
+    ///     FROGS_APPLICATION_ID_SUFFIX   ".debug" for a PR build
+    ///
+    /// See docs/engineering/versioning.md.
+    /// </summary>
+    public sealed class BuildStampPreprocessor : IPreprocessBuildWithReport
+    {
+        const string ApplicationIdSuffixVariable = "FROGS_APPLICATION_ID_SUFFIX";
+        const string BuildShaVariable = "FROGS_BUILD_SHA";
+
+        /// <summary>Early, so later pre-processors see the stamped values.</summary>
+        public int callbackOrder => -100;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            // A build sha means "this is not the release" — a PR build or an RC.
+            var sha = Environment.GetEnvironmentVariable(BuildShaVariable);
+
+            if (string.IsNullOrWhiteSpace(sha))
+            {
+                BuildStampApplier.ApplyRelease();
+            }
+            else
+            {
+                BuildStampApplier.ApplyDebug();
+            }
+
+            ApplyApplicationIdSuffix();
+        }
+
+        static void ApplyApplicationIdSuffix()
+        {
+            var suffix = Environment.GetEnvironmentVariable(ApplicationIdSuffixVariable);
+
+            if (string.IsNullOrWhiteSpace(suffix))
+            {
+                return;
+            }
+
+            var current = PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.Android);
+            var suffixed = BuildStamp.ApplicationIdWithSuffix(current, suffix);
+
+            PlayerSettings.SetApplicationIdentifier(NamedBuildTarget.Android, suffixed);
+            Debug.Log($"Application identifier for this build: {suffixed}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/BuildStamp.cs
+++ b/Assets/Scripts/Core/BuildStamp.cs
@@ -67,6 +67,72 @@ namespace Frogs.Core
             return new BuildStamp(version, commitCount, RequireUsableSha(shortSha));
         }
 
+        /// <summary>
+        /// The Android application identifier for a build, with its suffix
+        /// applied — ".debug" for a PR build, nothing for a release.
+        ///
+        /// A suffixed build installs *alongside* the release rather than
+        /// replacing it, so the game Connor plays survives someone testing a
+        /// change on the same phone.
+        ///
+        /// Idempotent: applying the same suffix twice leaves one, so a build
+        /// that stamps more than once cannot produce `...debug.debug`.
+        /// </summary>
+        public static string ApplicationIdWithSuffix(string applicationId, string suffix)
+        {
+            if (string.IsNullOrWhiteSpace(applicationId))
+            {
+                throw new ArgumentException(
+                    "A build needs an application identifier.", nameof(applicationId));
+            }
+
+            if (string.IsNullOrWhiteSpace(suffix))
+            {
+                return applicationId;
+            }
+
+            RequireUsableSuffix(suffix);
+
+            return applicationId.EndsWith(suffix, StringComparison.Ordinal)
+                ? applicationId
+                : applicationId + suffix;
+        }
+
+        static void RequireUsableSuffix(string suffix)
+        {
+            // Android package segments are lowercase letters, digits, and
+            // underscores, each introduced by a dot. A suffix that does not fit
+            // that produces an APK the device refuses to install, with an error
+            // that does not mention the identifier.
+            var valid = suffix.Length > 1 && suffix[0] == '.';
+
+            if (valid)
+            {
+                foreach (var character in suffix.Substring(1))
+                {
+                    var allowed =
+                        (character >= 'a' && character <= 'z')
+                        || (character >= '0' && character <= '9')
+                        || character == '_'
+                        || character == '.';
+
+                    if (!allowed)
+                    {
+                        valid = false;
+                        break;
+                    }
+                }
+            }
+
+            if (!valid)
+            {
+                throw new ArgumentException(
+                    $"'{suffix}' is not a usable applicationId suffix — it must start with a "
+                    + "dot and contain only lowercase letters, digits, and underscores.",
+                    nameof(suffix));
+            }
+        }
+
         static void RequirePositive(int commitCount)
         {
             if (commitCount <= 0)

--- a/Tests/Core/BuildStampTests.cs
+++ b/Tests/Core/BuildStampTests.cs
@@ -60,6 +60,54 @@ namespace Frogs.Core.Tests
                 Throws.InstanceOf<ArgumentException>());
         }
 
+        // A debug build has to install alongside the release build, so Connor
+        // keeps the game he plays and the build being tested at the same time.
+        [Test]
+        public void ApplicationIdWithSuffix_AppendsTheSuffix()
+        {
+            Assert.That(
+                BuildStamp.ApplicationIdWithSuffix("com.derekwinters.multiplyingfrogs", ".debug"),
+                Is.EqualTo("com.derekwinters.multiplyingfrogs.debug"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ApplicationIdWithSuffix_LeavesTheIdAloneWhenThereIsNoSuffix(string suffix)
+        {
+            Assert.That(
+                BuildStamp.ApplicationIdWithSuffix("com.derekwinters.multiplyingfrogs", suffix),
+                Is.EqualTo("com.derekwinters.multiplyingfrogs"));
+        }
+
+        [Test]
+        public void ApplicationIdWithSuffix_IsNotAppliedTwice()
+        {
+            var once = BuildStamp.ApplicationIdWithSuffix("com.frogs", ".debug");
+
+            Assert.That(BuildStamp.ApplicationIdWithSuffix(once, ".debug"), Is.EqualTo(once));
+        }
+
+        [TestCase("debug")]
+        [TestCase(".Debug")]
+        [TestCase(".deb ug")]
+        [TestCase(".")]
+        public void ApplicationIdWithSuffix_RejectsASuffixAndroidWouldNotAccept(string suffix)
+        {
+            Assert.That(
+                () => BuildStamp.ApplicationIdWithSuffix("com.frogs", suffix),
+                Throws.InstanceOf<ArgumentException>());
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void ApplicationIdWithSuffix_RejectsAMissingApplicationId(string applicationId)
+        {
+            Assert.That(
+                () => BuildStamp.ApplicationIdWithSuffix(applicationId, ".debug"),
+                Throws.InstanceOf<ArgumentException>());
+        }
+
         [Test]
         public void Debug_AcceptsAFullLengthShaAndShortensIt()
         {

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -13,7 +13,7 @@ be blocking; if you can, the fix is to satisfy it, not to route around it.
 | `pr-title-lint` | PR opened/edited | yes | the squash commit message, and therefore the changelog |
 | `ci-tests` | PR, push to `main` | yes | game logic and scene wiring |
 | `docs-test` | PR, push to `main` | yes | the docs site builds, and the docs match the change |
-| `pr-build` | PR | yes | the app still compiles into an installable APK |
+| `pr-build` | PR | no | the app still compiles into an installable APK |
 | `rc-build` | manual, tag | no | a release candidate someone can actually play |
 | `release-please` | push to `main` | no | the version, changelog, tag, release, and release APK |
 | `labels-sync` | push to `main` touching `labels.yml` | no | the label taxonomy matches the file |
@@ -136,6 +136,34 @@ by a build rather than by hope, and so Connor can try a change before it merges.
   Nothing is uploaded anywhere, no store, no distribution service, no link that
   outlives the PR. Artifacts expire and that is correct — a stale test build is
   worse than none.
+
+#### A missing licence warns and skips here
+
+The opposite of [`ci-tests`](#ci-tests-the-two-suites), deliberately.
+
+`ci-tests` is a **correctness gate**: a green tick claiming the tests ran when
+they did not is a lie, so a missing licence fails it. `pr-build` is a
+**convenience**: no APK is an absent convenience, not a false claim. Failing
+every PR over it would train everyone to ignore a red check, which costs more
+than the missing build.
+
+The workflow says so in a `::warning::` and in the step summary, so the absence
+is visible rather than silent.
+
+#### Two details that would be bugs if got wrong
+
+- **`fetch-depth: 0`.** The `versionCode` is the commit count, so the whole
+  history has to be present. A shallow checkout silently produces a *lower*
+  number than the previous build, and Android refuses to install that — with an
+  error that says nothing about depth.
+- **The sha comes from `pull_request.head.sha`, not `github.sha`.** The latter
+  is the ephemeral merge commit, which nobody can check out later; a version
+  name pointing at it identifies nothing.
+
+The version name, `versionCode`, and `.debug` suffix are all applied by
+`BuildStampPreprocessor`, a build pre-processor rather than a step CI remembers
+to call — a stamping step that can be forgotten will be, and a build with the
+wrong version cannot be identified afterwards.
 
 Red here almost always means a compile error the Core suite couldn't catch,
 because it lives in the Unity layer. Read the build log, not the test log.


### PR DESCRIPTION
Closes #38

Every PR that touches the Unity project now produces an installable debug APK. "Does it still build" gets answered by a build rather than by hope, and Connor gets something to try on his phone before a change merges.

**Docs:** `docs/engineering/ci-cd.md` — added the licence-handling contrast, the two gotchas, and corrected `pr-build` to non-blocking in the summary table.

## What's here

- **Debug signing** via Android's default debug key — no keystore inputs at all, so the release keystore secret isn't reachable from a PR branch.
- **The short commit sha in the version name** (`0.1.0-abc1234`), and a **`.debug` applicationId suffix** so a test build installs *alongside* the game Connor plays rather than replacing it.
- **Artifact-only distribution**, 14-day retention. No store, no distribution service, no link outliving the PR.
- Path-gated, `cancel-in-progress`, every `uses:` SHA-pinned.

## A missing licence warns and skips — the opposite of `ci-tests`

That looks inconsistent, so the docs now state the rule behind both:

- **`ci-tests` is a correctness gate.** A green tick claiming the tests ran when they didn't is a *lie*, so a missing licence fails it.
- **`pr-build` is a convenience.** No APK is an absent convenience, not a false claim — and failing every PR over it would train everyone to ignore a red check, which costs more than the missing build.

It's a `::warning::` plus a line in the step summary, so the absence is visible rather than silent.

## Two things that would have been silent bugs

- **`fetch-depth: 0`.** The `versionCode` is the commit count (#33), so the whole history has to be there. A shallow checkout silently produces a *lower* number than the previous build — and Android then refuses to install it, with an error that says nothing about checkout depth.
- **The sha comes from `pull_request.head.sha`, not `github.sha`.** The latter is the ephemeral merge commit, which nobody can check out later, so a version name pointing at it identifies nothing.

## Stamping can't be forgotten

Rather than a CI step that remembers to stamp, `BuildStampPreprocessor` implements `IPreprocessBuildWithReport` and runs before *every* build — CI, local, or started from the editor. A stamping step that can be forgotten will be, and a build with the wrong version can't be identified afterwards.

`BuildStamp.ApplicationIdWithSuffix` is in Core with tests, written first (red on `does not contain a definition for 'ApplicationIdWithSuffix'`), and is **idempotent** — a double stamp can't produce `...debug.debug`. It also rejects suffixes Android wouldn't accept, which otherwise produce an APK the device refuses with an error that never mentions the identifier. **39 Core tests passing.**

## Deviations and Decisions

- **Added the pre-processor rather than calling `BuildStampApplier` from the workflow.** `game-ci/unity-builder` uses its own build method, so there's no clean place to inject an `-executeMethod` call before it. The alternative was recomputing the version name in a shell step, which would put the composition rule in two places — exactly what `BuildStamp` exists to prevent.
- **`allowDirtyBuild: true`** — the pre-processor writes to `ProjectSettings.asset` during the build, which the builder would otherwise refuse as a dirty tree.
- This job will skip on every PR until `UNITY_LICENSE` (#82) and the generated `ProjectSettings/` (#104) exist. That's the designed behaviour, and it's why #28 (the Hello World APK) stays open behind it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_