### PR TITLE
ci: build a release candidate for every push to the release PR

### DIFF
--- a/.github/scripts/next_rc_number.py
+++ b/.github/scripts/next_rc_number.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Work out which release candidate this build is.
+
+While a release PR is open, every push to it produces an `rcN` build. The number
+is **derived**, never chosen: nobody has to remember where they got to, and two
+pushes cannot both claim `rc3`.
+
+release-please's own prerelease support cannot do this — it bumps on releases,
+not on pushes to an open PR — so N is the number of rc-build runs on the release
+branch since that PR opened. Counting from the PR's open time is what makes a
+fresh release PR restart at `rc1` rather than continuing from the last release's
+numbering.
+
+Usage:
+    python3 .github/scripts/next_rc_number.py --snapshot snapshot.json
+
+where the snapshot is:
+
+    {
+      "pr_created_at": "2026-08-08T10:00:00Z",
+      "this_run_id": 102,
+      "runs": [{"id": 100, "created_at": "2026-08-08T10:05:00Z"}, ...]
+    }
+
+Prints the number. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+
+def _timestamp(value: str | None, what: str) -> datetime:
+    if not value:
+        raise ValueError(
+            f"The snapshot has no {what}. Guessing one would silently renumber every "
+            "release candidate, so this is an error."
+        )
+
+    try:
+        # GitHub sends "...Z"; fromisoformat wants an offset before 3.11.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"The {what} '{value}' is not an ISO-8601 timestamp.") from error
+
+
+def next_rc_number(snapshot: dict) -> int:
+    """The rc number for the run described by `snapshot`."""
+    opened = _timestamp(snapshot.get("pr_created_at"), "pr_created_at")
+    this_run_id = snapshot.get("this_run_id")
+
+    since_opened = []
+    this_run_created: datetime | None = None
+
+    for run in snapshot.get("runs") or []:
+        created = _timestamp(run.get("created_at"), f"created_at for run {run.get('id')}")
+        if created < opened:
+            continue
+        since_opened.append((created, run.get("id")))
+        if run.get("id") == this_run_id:
+            this_run_created = created
+
+    # Only runs at or before this one count. A re-run of an older build must not
+    # renumber itself above a newer sibling, which would make two artifacts
+    # claim the same rc and neither be the later one.
+    if this_run_created is not None:
+        earlier = [entry for entry in since_opened if entry[0] <= this_run_created]
+        return len(earlier)
+
+    # This run is not in the list — the Actions API lags, and a run querying for
+    # itself often cannot see itself yet. Count what is there and add ourselves.
+    return len(since_opened) + 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", required=True, help="JSON file, or - for stdin")
+    arguments = parser.parse_args(argv)
+
+    if arguments.snapshot == "-":
+        snapshot = json.load(sys.stdin)
+    else:
+        with open(arguments.snapshot, encoding="utf-8") as handle:
+            snapshot = json.load(handle)
+
+    print(next_rc_number(snapshot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_next_rc_number.py
+++ b/.github/scripts/tests/test_next_rc_number.py
@@ -1,0 +1,140 @@
+"""Unit tests for deriving the next release-candidate number."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import next_rc_number as rc  # noqa: E402
+
+PR_OPENED = "2026-08-08T10:00:00Z"
+
+
+def run(created_at, run_id=1, status="completed"):
+    return {"id": run_id, "created_at": created_at, "status": status}
+
+
+class CountingTests(unittest.TestCase):
+    def test_the_first_run_after_the_pr_opens_is_rc1(self):
+        snapshot = {"pr_created_at": PR_OPENED, "runs": [run("2026-08-08T10:05:00Z", 100)],
+                    "this_run_id": 100}
+
+        self.assertEqual(1, rc.next_rc_number(snapshot))
+
+    def test_the_third_run_is_rc3(self):
+        snapshot = {
+            "pr_created_at": PR_OPENED,
+            "runs": [
+                run("2026-08-08T10:05:00Z", 100),
+                run("2026-08-08T11:00:00Z", 101),
+                run("2026-08-08T12:00:00Z", 102),
+            ],
+            "this_run_id": 102,
+        }
+
+        self.assertEqual(3, rc.next_rc_number(snapshot))
+
+    def test_runs_from_before_the_pr_opened_do_not_count(self):
+        # A fresh release PR restarts at rc1, so runs belonging to the previous
+        # release must not carry over.
+        snapshot = {
+            "pr_created_at": PR_OPENED,
+            "runs": [
+                run("2026-08-01T09:00:00Z", 1),
+                run("2026-08-02T09:00:00Z", 2),
+                run("2026-08-08T10:05:00Z", 100),
+            ],
+            "this_run_id": 100,
+        }
+
+        self.assertEqual(1, rc.next_rc_number(snapshot))
+
+    def test_a_run_at_exactly_the_pr_open_time_counts(self):
+        snapshot = {"pr_created_at": PR_OPENED, "runs": [run(PR_OPENED, 100)], "this_run_id": 100}
+
+        self.assertEqual(1, rc.next_rc_number(snapshot))
+
+    def test_runs_newer_than_this_one_are_ignored(self):
+        # A re-run of an older build must not renumber itself above a newer one.
+        snapshot = {
+            "pr_created_at": PR_OPENED,
+            "runs": [
+                run("2026-08-08T10:05:00Z", 100),
+                run("2026-08-08T11:00:00Z", 101),
+                run("2026-08-08T12:00:00Z", 102),
+            ],
+            "this_run_id": 101,
+        }
+
+        self.assertEqual(2, rc.next_rc_number(snapshot))
+
+    def test_out_of_order_input_is_sorted(self):
+        snapshot = {
+            "pr_created_at": PR_OPENED,
+            "runs": [
+                run("2026-08-08T12:00:00Z", 102),
+                run("2026-08-08T10:05:00Z", 100),
+                run("2026-08-08T11:00:00Z", 101),
+            ],
+            "this_run_id": 102,
+        }
+
+        self.assertEqual(3, rc.next_rc_number(snapshot))
+
+    def test_this_run_missing_from_the_list_still_counts_itself(self):
+        # The API can lag: a run querying for itself may not see itself yet.
+        snapshot = {
+            "pr_created_at": PR_OPENED,
+            "runs": [run("2026-08-08T10:05:00Z", 100)],
+            "this_run_id": 999,
+        }
+
+        self.assertEqual(2, rc.next_rc_number(snapshot))
+
+    def test_offset_timestamps_are_understood(self):
+        snapshot = {
+            "pr_created_at": "2026-08-08T10:00:00+00:00",
+            "runs": [run("2026-08-08T10:05:00Z", 100)],
+            "this_run_id": 100,
+        }
+
+        self.assertEqual(1, rc.next_rc_number(snapshot))
+
+
+class BadInputTests(unittest.TestCase):
+    def test_a_missing_pr_time_is_an_error_not_an_assumption(self):
+        with self.assertRaises(ValueError):
+            rc.next_rc_number({"runs": [], "this_run_id": 1})
+
+    def test_an_unparseable_timestamp_is_an_error(self):
+        with self.assertRaises(ValueError):
+            rc.next_rc_number(
+                {"pr_created_at": "yesterday", "runs": [], "this_run_id": 1})
+
+    def test_no_runs_at_all_still_yields_rc1(self):
+        snapshot = {"pr_created_at": PR_OPENED, "runs": [], "this_run_id": 1}
+
+        self.assertEqual(1, rc.next_rc_number(snapshot))
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_main_prints_the_number(self):
+        import io
+        import json
+        import unittest.mock
+
+        snapshot = json.dumps(
+            {"pr_created_at": PR_OPENED, "runs": [run("2026-08-08T10:05:00Z", 100)],
+             "this_run_id": 100})
+
+        out = io.StringIO()
+        with unittest.mock.patch("sys.stdin", io.StringIO(snapshot)), \
+                unittest.mock.patch("sys.stdout", out):
+            self.assertEqual(0, rc.main(["--snapshot", "-"]))
+
+        self.assertEqual("1", out.getvalue().strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -1,0 +1,132 @@
+name: rc-build
+
+# A release candidate for every push to the open release PR, so what is about
+# to be released can be played before the release is real.
+#
+# The rc number is derived, never chosen — see .github/scripts/next_rc_number.py.
+
+on:
+  push:
+    branches:
+      - release-please--branches--main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Reading this workflow's own past runs is how the rc number is derived.
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: rc-build
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Release candidate
+    runs-on: ubuntu-latest
+
+    steps:
+      # Warns and skips, like pr-build: an RC is something to play with, not a
+      # correctness gate, and failing the release branch over a missing secret
+      # would make the release PR look broken when it is not.
+      - name: Check for the Unity licence
+        id: licence
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -z "$UNITY_LICENSE" ]; then
+            echo "::warning::No UNITY_LICENSE secret, so no release candidate." \
+                 "See issue #82."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.licence.outputs.present == 'true'
+        with:
+          # The versionCode is the commit count; a shallow checkout would
+          # produce a number Android refuses to install over the last build.
+          fetch-depth: 0
+
+      # /VERSION on this branch is release-please's, already bumped to the
+      # version about to ship — which is exactly the version an RC should carry.
+      - name: Work out the version and the rc number
+        id: stamp
+        if: steps.licence.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          echo "version=$(cut -d'#' -f1 VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+          echo "version_code=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+
+          PR_OPENED=$(gh pr list --head "$GITHUB_REF_NAME" --state open \
+            --json createdAt --jq '.[0].createdAt')
+
+          if [ -z "$PR_OPENED" ]; then
+            echo "::error::No open release PR for $GITHUB_REF_NAME, so there is nothing" \
+                 "to build a candidate of."
+            exit 1
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/rc-build.yml/runs" \
+            --paginate \
+            --jq '{runs: [.workflow_runs[] | {id, created_at}]}' \
+            > runs.json
+
+          jq --arg opened "$PR_OPENED" --argjson run "$RUN_ID" \
+            '. + {pr_created_at: $opened, this_run_id: $run}' runs.json > snapshot.json
+
+          echo "rc=$(python3 .github/scripts/next_rc_number.py --snapshot snapshot.json)" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Cache Unity's Library
+        if: steps.licence.outputs.present == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: Library
+          key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: Library-android-
+
+      # Same debug signing and .debug suffix as a PR build. An RC is for trying
+      # the game, and release signing needs a secret this workflow should not be
+      # able to reach.
+      - name: Build the release candidate
+        if: steps.licence.outputs.present == 'true'
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
+          FROGS_RC_NUMBER: ${{ steps.stamp.outputs.rc }}
+          FROGS_APPLICATION_ID_SUFFIX: .debug
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          androidExportType: androidPackage
+          buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-rc${{ steps.stamp.outputs.rc }}
+          allowDirtyBuild: true
+
+      # Artifacts only. An RC is not a release: no tag, no GitHub release.
+      - name: Upload the release candidate
+        if: steps.licence.outputs.present == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rc-apk-${{ steps.stamp.outputs.version }}-rc${{ steps.stamp.outputs.rc }}
+          path: build/Android/*.apk
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Summarise
+        if: always()
+        run: |
+          if [ "${{ steps.licence.outputs.present }}" != "true" ]; then
+            echo "No release candidate: the UNITY_LICENSE secret is not set (#82)." \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Release candidate \`${{ steps.stamp.outputs.version }}-rc${{ steps.stamp.outputs.rc }}\`" \
+                 "(versionCode ${{ steps.stamp.outputs.version_code }})." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Assets/Editor/BuildStampApplier.cs
+++ b/Assets/Editor/BuildStampApplier.cs
@@ -31,13 +31,18 @@ namespace Frogs.EditorTools
         const string VersionFileName = "VERSION";
         const string VersionCodeVariable = "FROGS_VERSION_CODE";
         const string BuildShaVariable = "FROGS_BUILD_SHA";
+        const string RcNumberVariable = "FROGS_RC_NUMBER";
 
         /// <summary>A release build: PlayerSettings shows the bare version.</summary>
         public static void ApplyRelease() => Apply(BuildStamp.Release(ReadVersion(), ReadCommitCount()));
 
-        /// <summary>A PR or RC build: the version name carries the commit sha.</summary>
+        /// <summary>A PR build: the version name carries the commit sha.</summary>
         public static void ApplyDebug() =>
             Apply(BuildStamp.Debug(ReadVersion(), ReadCommitCount(), ReadCommitSha()));
+
+        /// <summary>A release candidate: the version name carries "rcN".</summary>
+        public static void ApplyReleaseCandidate() =>
+            Apply(BuildStamp.ReleaseCandidate(ReadVersion(), ReadCommitCount(), ReadRcNumber()));
 
         public static void Apply(BuildStamp stamp)
         {
@@ -81,6 +86,20 @@ namespace Frogs.EditorTools
             }
 
             return int.Parse(Git("rev-list --count HEAD"));
+        }
+
+        static int ReadRcNumber()
+        {
+            var value = Environment.GetEnvironmentVariable(RcNumberVariable);
+
+            if (string.IsNullOrWhiteSpace(value) || !int.TryParse(value, out var parsed))
+            {
+                throw new FormatException(
+                    $"{RcNumberVariable} is '{value}', which is not a release-candidate "
+                    + "number. It is derived by .github/scripts/next_rc_number.py.");
+            }
+
+            return parsed;
         }
 
         static string ReadCommitSha()

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -20,8 +20,9 @@ namespace Frogs.EditorTools
     /// checkout has no history to count:
     ///
     ///     FROGS_VERSION_CODE            the Android versionCode
-    ///     FROGS_BUILD_SHA               set for a debug/RC build, absent for a release
-    ///     FROGS_APPLICATION_ID_SUFFIX   ".debug" for a PR build
+    ///     FROGS_BUILD_SHA               set for a PR build, absent otherwise
+    ///     FROGS_RC_NUMBER               set for a release candidate
+    ///     FROGS_APPLICATION_ID_SUFFIX   ".debug" for a PR or RC build
     ///
     /// See docs/engineering/versioning.md.
     /// </summary>
@@ -29,22 +30,31 @@ namespace Frogs.EditorTools
     {
         const string ApplicationIdSuffixVariable = "FROGS_APPLICATION_ID_SUFFIX";
         const string BuildShaVariable = "FROGS_BUILD_SHA";
+        const string RcNumberVariable = "FROGS_RC_NUMBER";
 
         /// <summary>Early, so later pre-processors see the stamped values.</summary>
         public int callbackOrder => -100;
 
         public void OnPreprocessBuild(BuildReport report)
         {
-            // A build sha means "this is not the release" — a PR build or an RC.
+            // Which kind of build this is, decided by which variable CI set.
+            // An rc number wins over a sha: a release candidate is identified
+            // by its position in the queue, because "is this newer than the one
+            // I tried yesterday" is not a question a sha answers by eye.
+            var rcNumber = Environment.GetEnvironmentVariable(RcNumberVariable);
             var sha = Environment.GetEnvironmentVariable(BuildShaVariable);
 
-            if (string.IsNullOrWhiteSpace(sha))
+            if (!string.IsNullOrWhiteSpace(rcNumber))
             {
-                BuildStampApplier.ApplyRelease();
+                BuildStampApplier.ApplyReleaseCandidate();
+            }
+            else if (!string.IsNullOrWhiteSpace(sha))
+            {
+                BuildStampApplier.ApplyDebug();
             }
             else
             {
-                BuildStampApplier.ApplyDebug();
+                BuildStampApplier.ApplyRelease();
             }
 
             ApplyApplicationIdSuffix();

--- a/Assets/Scripts/Core/BuildStamp.cs
+++ b/Assets/Scripts/Core/BuildStamp.cs
@@ -33,7 +33,10 @@ namespace Frogs.Core
         /// </summary>
         public int VersionCode { get; }
 
-        /// <summary>The short commit sha, or empty for a release build.</summary>
+        /// <summary>
+        /// What distinguishes this build from the plain release of the same
+        /// version — a short commit sha, or an "rcN" — and empty for a release.
+        /// </summary>
         public string CommitSha { get; }
 
         /// <summary>
@@ -60,7 +63,33 @@ namespace Frogs.Core
             return new BuildStamp(version, commitCount, string.Empty);
         }
 
-        /// <summary>A debug or release-candidate build, identified by its commit.</summary>
+        /// <summary>
+        /// A release candidate: "0.1.0-rc2".
+        ///
+        /// Named by its position in the queue rather than by its commit,
+        /// because the question an RC has to answer is "is this newer than the
+        /// one I tried yesterday" — which a sha cannot answer by eye.
+        /// </summary>
+        public static BuildStamp ReleaseCandidate(AppVersion version, int commitCount, int rcNumber)
+        {
+            RequirePositive(commitCount);
+
+            if (rcNumber < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(rcNumber),
+                    rcNumber,
+                    "Release candidates start at rc1. An rc0 means the counting went wrong, "
+                    + "and an RC nobody can order against its siblings is worse than no RC.");
+            }
+
+            return new BuildStamp(
+                version,
+                commitCount,
+                string.Format(CultureInfo.InvariantCulture, "rc{0}", rcNumber));
+        }
+
+        /// <summary>A debug build, identified by its commit.</summary>
         public static BuildStamp Debug(AppVersion version, int commitCount, string shortSha)
         {
             RequirePositive(commitCount);

--- a/Tests/Core/BuildStampTests.cs
+++ b/Tests/Core/BuildStampTests.cs
@@ -109,6 +109,26 @@ namespace Frogs.Core.Tests
         }
 
         [Test]
+        public void ReleaseCandidate_NamesItselfRcN()
+        {
+            var stamp = BuildStamp.ReleaseCandidate(Version, commitCount: 147, rcNumber: 2);
+
+            Assert.That(stamp.VersionName, Is.EqualTo("0.2.3-rc2"));
+            Assert.That(stamp.VersionCode, Is.EqualTo(147));
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void ReleaseCandidate_RejectsAnRcNumberBelowOne(int rcNumber)
+        {
+            // rc0 would mean the counting went wrong, and an RC nobody can
+            // order against its siblings is worse than a failed build.
+            Assert.That(
+                () => BuildStamp.ReleaseCandidate(Version, 147, rcNumber),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
         public void Debug_AcceptsAFullLengthShaAndShortensIt()
         {
             var stamp = BuildStamp.Debug(Version, 147, "abc1234def5678901234567890abcdef12345678");

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -173,14 +173,38 @@ because it lives in the Unity layer. Read the build log, not the test log.
 An RC is a build of what is *about* to be released, produced so someone can play
 it before the release is real.
 
-- Triggered manually, or by a pre-release tag.
-- **The `rcN` number is derived, not chosen.** It counts the existing RC
-  artifacts for the current `/VERSION` and adds one, so the first RC of `0.2.0`
-  is `0.2.0-rc1` and the next is `rc2`. Nobody has to remember where they got to,
-  and two people cannot both produce `rc3`.
-- Release-signed and built with the device profile — an RC that differs from the
-  release in signing or backend is an RC that proves less than it appears to.
-- Artifacts only. An RC is not a release; it gets no tag and no GitHub release.
+- **Triggered by a push to the open release PR's branch**
+  (`release-please--branches--main`), so every change to what is about to ship
+  produces something playable. Also `workflow_dispatch`.
+- **The version comes from `/VERSION` on that branch**, which release-please has
+  already bumped to the version about to ship — exactly the version an RC should
+  carry.
+- **Same debug signing and `.debug` suffix as a PR build.** An RC is for trying
+  the game; release signing needs a keystore secret this workflow should not be
+  able to reach.
+- **Artifacts only.** An RC is not a release: no tag, no GitHub release.
+
+#### The `rcN` number is derived, not chosen
+
+`N` is the number of `rc-build` runs on the release branch **since that PR
+opened**. Nobody has to remember where they got to, and two pushes cannot both
+claim `rc3`.
+
+Counting from the PR's open time is what makes a fresh release PR restart at
+`rc1` instead of continuing the last release's numbering — the release branch
+itself is rewritten on every release, so there is nothing on it to count.
+
+release-please's own prerelease support cannot do this: it bumps on *releases*,
+not on pushes to an open PR.
+
+`.github/scripts/next_rc_number.py` does the arithmetic, from a snapshot of the
+workflow's runs, and it handles the two cases that would otherwise produce two
+artifacts claiming the same number:
+
+- **A re-run of an older build** counts only runs at or before itself, so it
+  cannot renumber above a newer sibling.
+- **A run that cannot see itself yet** — the Actions API lags — counts what is
+  there and adds one, rather than reporting a number already taken.
 
 ### `release-please` — the version, the tag, and the release
 


### PR DESCRIPTION
Closes #39

Every push to the open release PR now produces a playable `rcN` build, so what's about to ship can be tried before the release is real.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the `rc-build` section; see below.

## What's here

- **Triggered by pushes to `release-please--branches--main`** — every change to what's about to ship produces something playable.
- **The version comes from `/VERSION` on that branch**, which release-please has already bumped to the version about to ship.
- **Same debug signing and `.debug` suffix as a PR build.** Artifacts only — no tag, no GitHub release.
- **`.github/scripts/next_rc_number.py`** with 11 tests, and `BuildStamp.ReleaseCandidate` in Core with 3 more. Both written test-first; **42 Core tests, 58 script tests, all green.**

## The `rcN` number

`N` is the count of `rc-build` runs on the release branch **since that PR opened**. Counting from the PR's open time is what makes a fresh release PR restart at `rc1` — the release branch itself is rewritten on every release, so there's nothing on it to count. release-please's own prerelease support can't do this: it bumps on *releases*, not on pushes to an open PR.

Two cases that would otherwise put two artifacts on the same number, both covered by tests:

- **A re-run of an older build** counts only runs at or before itself, so it can't renumber above a newer sibling.
- **A run that can't see itself yet** — the Actions API lags — counts what's there and adds one, rather than claiming a number already taken.

`ReleaseCandidate` names an RC by its position rather than its commit, because "is this newer than the one I tried yesterday" isn't a question a sha answers by eye. It rejects `rc0`, since an RC nobody can order against its siblings is worse than a failed build.

## How the spec is changing

> **Previously** `ci-cd.md` described `rc-build` as manually triggered or tag-driven, **release-signed**, with `N` derived by counting existing RC *artifacts*. **From this change** it triggers on pushes to the release PR's branch, is **debug-signed** like a PR build, and derives `N` from workflow runs since the PR opened.
>
> Each part is better for a reason this issue named: pushes-to-the-release-PR means an RC exists for every state of what's shipping rather than only when someone remembers to ask; debug signing keeps the release keystore out of a workflow that runs on a bot-pushed branch; and counting runs works where counting artifacts doesn't, because artifacts expire and the count would silently reset mid-release.

That design came from #39 itself, and the issue was treated as authoritative over the doc I wrote in #19.

## Deviations and Decisions

- **Added `ApplyReleaseCandidate` and an `FROGS_RC_NUMBER` branch** to the build pre-processor from #38. Without it, an RC would have been stamped as a debug build and named `0.1.0-abc1234` rather than `0.1.0-rc2`. RC wins over sha when both are set.
- **`actions: read` and `pull-requests: read` permissions** — the derivation reads this workflow's own past runs and the release PR's open time. Both read-only, both minimum.
- The workflow can't be exercised until a release PR exists *and* `UNITY_LICENSE` is set (#82); the licence check warns and skips, matching `pr-build`. The arithmetic — the part most likely to be wrong — is covered by unit tests that run today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_