### PR TITLE
ci: attach the release APKs from inside the release-please run

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,165 @@
+name: release-build
+
+# Builds the release APKs and attaches them to a GitHub release.
+#
+# Called two ways, and the distinction matters:
+#
+#   workflow_call      from release-please.yml, in the same run that created
+#                      the release. This is the normal path.
+#   workflow_dispatch  the manual backfill, for a release whose attach step
+#                      failed or was never run.
+#
+# Why not `on: release: published`? GitHub deliberately suppresses workflow
+# runs from events initiated by GITHUB_TOKEN, to stop workflows triggering
+# themselves forever. release-please creates the release with that token, so a
+# release-triggered workflow silently never fires — no error, no run, just a
+# release with no APK on it. Hence the call from inside the run that made it.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: The release tag to build and attach to, e.g. v0.1.0
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag to build and attach to, e.g. v0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-build-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-attach:
+    name: Release APKs for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Upload assets onto the release.
+      contents: write
+
+    steps:
+      # Same graceful-skip contract as pr-build and rc-build: a missing licence
+      # warns rather than failing. A release without its APK is a gap to
+      # backfill — this workflow is the backfill — not a reason to mark a
+      # completed release as failed.
+      - name: Check for the Unity licence
+        id: licence
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -z "$UNITY_LICENSE" ]; then
+            echo "::warning::No UNITY_LICENSE secret, so ${{ inputs.tag }} gets no APK." \
+                 "See issue #82. Re-run this workflow once the secret exists."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The tag, not a branch: the release must be built from exactly what was
+      # released, and full depth because the versionCode is the commit count.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.licence.outputs.present == 'true'
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Work out the build stamp
+        id: stamp
+        if: steps.licence.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          VERSION=$(cut -d'#' -f1 VERSION | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_code=$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+
+          # The tag and /VERSION at that tag must agree. If they do not, the
+          # release is mislabelled and attaching an APK to it would make the
+          # mislabelling permanent.
+          if [ "v$VERSION" != "${{ inputs.tag }}" ]; then
+            echo "::error::${{ inputs.tag }} was tagged, but /VERSION at that tag says" \
+                 "$VERSION. Refusing to attach an APK to a mislabelled release."
+            exit 1
+          fi
+
+      - name: Cache Unity's Library
+        if: steps.licence.outputs.present == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: Library
+          key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: Library-android-
+
+      # No FROGS_BUILD_SHA and no FROGS_RC_NUMBER: this is the release, so the
+      # version name is bare. No applicationId suffix either — this is the app.
+      - name: Build the device APK
+        if: steps.licence.outputs.present == 'true'
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
+          FROGS_ANDROID_PROFILE: device
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          androidExportType: androidPackage
+          buildsPath: build/device
+          buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}
+          allowDirtyBuild: true
+
+      # Its own build path, so the two APKs cannot be confused with each other —
+      # they have the same version and differ only in architecture, which is not
+      # visible from a filename in a shared directory.
+      - name: Build the emulator APK
+        if: steps.licence.outputs.present == 'true'
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
+          FROGS_ANDROID_PROFILE: emulator
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          androidExportType: androidPackage
+          buildsPath: build/emulator
+          buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-emulator
+          allowDirtyBuild: true
+
+      - name: Attach the APKs to the release
+        if: steps.licence.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assets=(build/device/*.apk build/emulator/*.apk)
+
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::Neither build produced an APK, so there is nothing to attach."
+            exit 1
+          fi
+
+          # --clobber so a backfill re-run replaces the asset instead of failing
+          # on "already exists" — the whole point of the backfill is re-running.
+          gh release upload "$TAG" "${assets[@]}" --clobber
+
+          echo "Attached to $TAG:" >> "$GITHUB_STEP_SUMMARY"
+          for asset in "${assets[@]}"; do
+            echo "- \`$(basename "$asset")\`" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Summarise a skip
+        if: steps.licence.outputs.present != 'true'
+        run: |
+          echo "No APKs attached to ${{ inputs.tag }}: the UNITY_LICENSE secret is not" \
+               "set (#82). Re-run this workflow with the tag once it exists." \
+               >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,3 +66,21 @@ jobs:
           else
             echo "No release this run — the release PR was updated instead." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # The APK is built and attached from inside this run, not by a workflow
+  # listening for `release: published`. GitHub suppresses workflow runs from
+  # events initiated by GITHUB_TOKEN, so a release-triggered workflow would
+  # silently never fire and every release would sit there with no APK.
+  #
+  # A local `./` reference is pinned by construction: it resolves to this
+  # workflow file's own commit, which is stricter than a SHA someone has to
+  # remember to update. See docs/engineering/ci-cd.md.
+  build-and-attach:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release-build.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+    secrets: inherit

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -23,6 +23,7 @@ namespace Frogs.EditorTools
     ///     FROGS_BUILD_SHA               set for a PR build, absent otherwise
     ///     FROGS_RC_NUMBER               set for a release candidate
     ///     FROGS_APPLICATION_ID_SUFFIX   ".debug" for a PR or RC build
+    ///     FROGS_ANDROID_PROFILE         "device" or "emulator"
     ///
     /// See docs/engineering/versioning.md.
     /// </summary>
@@ -31,6 +32,7 @@ namespace Frogs.EditorTools
         const string ApplicationIdSuffixVariable = "FROGS_APPLICATION_ID_SUFFIX";
         const string BuildShaVariable = "FROGS_BUILD_SHA";
         const string RcNumberVariable = "FROGS_RC_NUMBER";
+        const string AndroidProfileVariable = "FROGS_ANDROID_PROFILE";
 
         /// <summary>Early, so later pre-processors see the stamped values.</summary>
         public int callbackOrder => -100;
@@ -58,6 +60,50 @@ namespace Frogs.EditorTools
             }
 
             ApplyApplicationIdSuffix();
+            ApplyAndroidProfile();
+        }
+
+        /// <summary>
+        /// The device/emulator split from docs/engineering/tech-stack.md.
+        ///
+        /// Left alone when unset, so a build that does not ask for a profile
+        /// gets whatever the project is configured with — the editor's own
+        /// Build button keeps working.
+        /// </summary>
+        static void ApplyAndroidProfile()
+        {
+            var profile = Environment.GetEnvironmentVariable(AndroidProfileVariable);
+
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return;
+            }
+
+            switch (profile.Trim().ToLowerInvariant())
+            {
+                case "device":
+                    PlayerSettings.Android.targetArchitectures = AndroidArchitecture.ARM64;
+                    PlayerSettings.SetScriptingBackend(
+                        NamedBuildTarget.Android, ScriptingImplementation.IL2CPP);
+                    break;
+
+                case "emulator":
+                    // x86_64 and Mono. IL2CPP cross-compiling to x86_64 is slow
+                    // and buys nothing for a smoke test — this profile trades
+                    // fidelity for a build that finishes while you are still
+                    // looking at it.
+                    PlayerSettings.Android.targetArchitectures = AndroidArchitecture.X86_64;
+                    PlayerSettings.SetScriptingBackend(
+                        NamedBuildTarget.Android, ScriptingImplementation.Mono2x);
+                    break;
+
+                default:
+                    throw new ArgumentException(
+                        $"{AndroidProfileVariable} is '{profile}'. It must be 'device' or "
+                        + "'emulator'; guessing would silently ship the wrong architecture.");
+            }
+
+            Debug.Log($"Android build profile: {profile}.");
         }
 
         static void ApplyApplicationIdSuffix()

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -75,8 +75,13 @@ jobs:
 ```
 
 A reusable workflow runs with the caller's permissions, so it is the same
-exposure as an action — and the same rule, including for workflows in this
-repository.
+exposure as an action — and the same rule.
+
+**Workflows in this repository are referenced by local path** —
+`uses: ./.github/workflows/release-build.yml` — which is pinned by
+construction: it resolves to the calling workflow's own commit. That is
+stricter than a SHA, because there is no pin anyone has to remember to update
+and no way for the two to drift apart.
 
 ### The actions this project uses
 
@@ -243,24 +248,70 @@ attempt to open the PR.
 
 ### Release builds
 
-The APK is attached from inside `release-please.yml` rather than by a separate
-workflow that listens for the release — see [Versioning](versioning.md) for the
-release flow. On the run where `release_created` is true, it also:
+#### Why not `on: release: published`
 
-- Builds the release APK, signed with the release keystore, device profile
-  (ARM64, IL2CPP).
-- **Attaches it to the GitHub release**, so the tag and the artifact are one
-  thing. A release whose APK lives in an expiring workflow artifact is a release
-  you cannot re-install in six months.
-- **Attaches an emulator-targeted asset** as well — x86_64, Mono — so the
-  release can be run on a desktop emulator without rebuilding. Clearly named as
-  the emulator asset; it is for trying the game, not for judging it.
+Because it would never run.
 
-Keeping this inside `release-please.yml` avoids the failure mode where a
-separate release-triggered workflow doesn't fire (a `GITHUB_TOKEN`-created
-release does not trigger `release` events) and the release sits there with no
-APK. A manual backfill workflow exists for the case where the attach step
-itself fails.
+**GitHub deliberately suppresses workflow runs from events initiated by
+`GITHUB_TOKEN`.** The rule exists to stop workflows triggering themselves
+forever, and it is unconditional: it does not warn, and it does not appear
+anywhere in the Actions UI. release-please creates the release with that token,
+so a workflow listening for `release: published` simply never fires. Every
+release would sit there with no APK, and the only symptom would be the absence
+of a run nobody was watching for.
+
+So the build is called **from inside the run that created the release**, gated
+on `release_created`. The token that made the release is the token in the job,
+and no event is involved.
+
+The usual workaround — a personal access token or a GitHub App, so the event is
+attributed to something other than `GITHUB_TOKEN` — is a credential to store,
+rotate, and scope. Calling the workflow directly needs none of that.
+
+#### `release-build.yml`
+
+One reusable workflow, called two ways:
+
+| Called by | When |
+| --- | --- |
+| `release-please.yml` (`workflow_call`) | in the run that created the release — the normal path |
+| a human (`workflow_dispatch`, with a `tag` input) | the backfill, when the attach failed or never ran |
+
+Both paths run the same steps, so the backfill cannot drift from the thing it
+backfills. `gh release upload --clobber` means re-running it replaces the asset
+rather than failing on "already exists", which is the entire point of a
+backfill.
+
+It refuses to attach anything if `/VERSION` at the tag disagrees with the tag
+name — attaching an APK to a mislabelled release makes the mislabelling
+permanent.
+
+#### Two APKs, in two build paths
+
+| Asset | Profile | For |
+| --- | --- | --- |
+| `multiplying-frogs-0.2.0.apk` | ARM64, IL2CPP | the phone |
+| `multiplying-frogs-0.2.0-emulator.apk` | x86_64, Mono | a desktop emulator |
+
+They are built into `build/device/` and `build/emulator/` rather than a shared
+directory. The two have the same version and differ only in architecture, which
+is not visible from a filename sitting next to another filename — separate
+paths make it impossible for the wrong one to be picked up by a glob.
+
+The profile is applied by `BuildStampPreprocessor` from `FROGS_ANDROID_PROFILE`,
+and an unrecognised value fails the build rather than defaulting: guessing here
+ships the wrong architecture, which looks fine until someone installs it.
+
+Both are **attached to the GitHub release** rather than left as workflow
+artifacts, so the tag and the thing you install are one object. A release whose
+APK lives in an expiring artifact is a release you cannot re-install in six
+months, which defeats the point of tagging it.
+
+The emulator asset is for *trying* the game on a desktop, not for judging it —
+see [Tech stack](tech-stack.md#two-build-profiles).
+
+Neither build carries a `.debug` suffix or a sha in its version name. This is
+the app.
 
 ## Correctness workflows
 


### PR DESCRIPTION
Closes #40

A release now ships with its APKs attached, built in the same run that created it.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the release-builds section with the token/no-recursion reasoning, and clarified the local-path rule for reusable workflows.

## Why not `on: release: published`

Because it would never run. **GitHub suppresses workflow runs from events initiated by `GITHUB_TOKEN`** — unconditionally, to stop workflows triggering themselves forever. It doesn't warn, and nothing appears in the Actions UI. release-please creates the release with that token, so a release-triggered workflow simply never fires: every release sits there with no APK, and the only symptom is the *absence* of a run nobody was watching for.

So `release-please.yml` calls `release-build.yml` directly, gated on `release_created`. The usual workaround — a PAT or GitHub App so the event is attributed to something else — is a credential to store, rotate, and scope. Calling the workflow needs none.

## What's here

- **`build-and-attach` job in `release-please.yml`**, gated on `release_created == 'true'`, passing `tag_name` through.
- **`release-build.yml`** — one reusable workflow, two entry points: `workflow_call` from the release run, and `workflow_dispatch` with a `tag` input for the backfill. Same steps both ways, so the backfill can't drift from the thing it backfills.
  - Checks out the **tag**, full depth.
  - `gh release upload --clobber`, because re-running *is* the point of a backfill and "already exists" would defeat it.
  - **Refuses to attach** if `/VERSION` at the tag disagrees with the tag name — attaching an APK to a mislabelled release makes the mislabelling permanent.
- **Two APKs in two build paths** — `build/device/` (ARM64, IL2CPP) and `build/emulator/` (x86_64, Mono). They share a version and differ only in architecture, which isn't visible from a filename sitting next to another filename; separate paths make a wrong glob impossible.
- The profile comes from `FROGS_ANDROID_PROFILE` via the build pre-processor, and an unrecognised value **fails the build** rather than defaulting — guessing there ships the wrong architecture, which looks fine until someone installs it.
- Graceful licence skip on both paths, matching `pr-build` and `rc-build`.

## Deviations and Decisions

- **Made `release-build.yml` a reusable workflow rather than duplicating the build steps.** The issue asks for a job in `release-please.yml` *and* a standalone backfill; two copies of a build that only runs at release time is two copies that diverge unnoticed, since the backfill runs rarely enough that nobody would spot it.
- **Referenced it by local path** (`./.github/workflows/release-build.yml`) rather than `owner/repo/...@sha`. That's *stricter* than a SHA pin — it resolves to the calling workflow's own commit, so there's no pin to remember to update and no way for the two to drift. Updated the pinning doc to say so, since #84 phrased the rule in terms of SHAs.
- **Added the device/emulator profile switch** to the pre-processor. The emulator APK needs x86_64 + Mono, and `unity-builder` has no input for either; going through the pre-processor keeps it in the same place as the rest of the build configuration.
- **No release signing.** The issue doesn't ask for it and no keystore secret exists; adding one is its own decision with its own `Direct Involvement Needed` issue when Derek wants signed releases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_