### PR TITLE
ci: add the geometry literal check and its ratcheting baseline

### DIFF
--- a/.github/geometry_literals_baseline.txt
+++ b/.github/geometry_literals_baseline.txt
@@ -1,0 +1,4 @@
+# Geometry/tuning literals tolerated per file — a ratchet, not a target.
+# Counts may go down and the file is regenerated with --update-baseline.
+# They may never go up: see .github/scripts/check_geometry_literals.py.
+

--- a/.github/scripts/check_geometry_literals.py
+++ b/.github/scripts/check_geometry_literals.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Stop the named-values rule from decaying.
+
+`docs/engineering/tech-stack.md` says every size, offset, margin, duration,
+speed, and payout is a named constant or a serialized field. A rule with no
+backstop decays: one literal at a time, each individually defensible.
+
+This is the backstop, and it is **deliberately conservative**. It flags
+f-suffixed float literals of magnitude 3 or more that appear on a line which
+does not give them a name. That is narrower than the rule — see "What it does
+not catch" below — because a check with a high false-positive rate is a check
+people learn to override, and then it catches nothing at all.
+
+It ratchets against a committed baseline: a file may keep the literals it
+already has, and may not gain more. A check that demanded a clean codebase
+before it could be switched on is a check that never gets switched on.
+
+    python3 .github/scripts/check_geometry_literals.py
+    python3 .github/scripts/check_geometry_literals.py --update-baseline
+
+## What it does not catch
+
+- Literals inside a named declaration's initialiser —
+  `var spot = new Vector3(12f, 40f, 0f);` names the vector but not its
+  components. Catching this needs a parser, not a regex.
+- Integer literals. `32` is a loop bound far more often than it is geometry, and
+  the false positives would swamp the findings.
+- Magnitudes below 3, which are overwhelmingly arithmetic and halving.
+
+Those are gaps in the *check*, not permission in the *rule*. Review is what
+catches them.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOT = REPO_ROOT / "Assets" / "Scripts"
+BASELINE_PATH = REPO_ROOT / ".github" / "geometry_literals_baseline.txt"
+
+# Below this, a literal is nearly always arithmetic (0, 1), a halving (2), or a
+# sentinel — not a measurement.
+MINIMUM_MAGNITUDE = 3.0
+
+# An f-suffixed float: 12f, 0.5F, 12.5f. The suffix is what makes this
+# low-noise — a bare `32` is usually a count.
+LITERAL = re.compile(r"(?<![\w.])(\d+(?:\.\d+)?)[fF](?![\w])")
+
+# A line that gives the value a name: a field, a constant, or a local
+# declaration. `float gap = 12f;`, `const float W = 280f;`, `var gap = 12f;`.
+# Requires two space-separated identifiers before the `=`, which is what
+# distinguishes a declaration from an assignment to something that already
+# exists (`transform.position = …` has no type token).
+DECLARATION = re.compile(
+    r"""
+    ^\s*
+    (?:\[[^\]]*\]\s*)*                                  # attributes
+    (?:(?:public|private|protected|internal|static|readonly|const|new|override
+        |sealed|virtual|extern|volatile|unsafe|partial)\s+)*
+    [A-Za-z_][\w\.<>,\[\]\?]*                           # the type
+    \s+
+    [A-Za-z_]\w*                                        # the name
+    \s*=
+    """,
+    re.VERBOSE,
+)
+
+
+class Finding:
+    def __init__(self, path: str, line: int, literal: str, text: str) -> None:
+        self.path = path
+        self.line = line
+        self.literal = literal
+        self.text = text
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"{self.path}:{self.line}: {self.literal}"
+
+
+class Verdict:
+    def __init__(self, ok: bool, reason: str) -> None:
+        self.ok = ok
+        self.reason = reason
+
+
+def _strip_noise(line: str) -> str:
+    """Remove string literals and line comments, so neither is searched."""
+    without_strings = re.sub(r'"(?:\\.|[^"\\])*"', '""', line)
+    without_chars = re.sub(r"'(?:\\.|[^'\\])*'", "''", without_strings)
+    return without_chars.split("//")[0]
+
+
+def find_literals(source: str, path: str) -> list[Finding]:
+    """Every flagged literal in one file's text."""
+    findings: list[Finding] = []
+    in_block_comment = False
+
+    for number, raw in enumerate(source.splitlines(), start=1):
+        line = raw
+
+        if in_block_comment:
+            if "*/" not in line:
+                continue
+            line = line.split("*/", 1)[1]
+            in_block_comment = False
+
+        if "/*" in line:
+            before, _, after = line.partition("/*")
+            if "*/" in after:
+                line = before + after.split("*/", 1)[1]
+            else:
+                line = before
+                in_block_comment = True
+
+        line = _strip_noise(line)
+
+        if not line.strip():
+            continue
+
+        for match in LITERAL.finditer(line):
+            if float(match.group(1)) < MINIMUM_MAGNITUDE:
+                continue
+            if _is_named(line, match.start()):
+                continue
+            findings.append(Finding(path, number, match.group(0), raw.strip()))
+
+    return findings
+
+
+def _is_named(line: str, position: int) -> bool:
+    """Does a declaration introduce the value at `position`?
+
+    Looks at the statement the literal sits in — from the last `;` or `{`
+    before it — rather than at the whole line, so a declaration written inline
+    (`void A() { var gap = 12f; }`) is recognised just as well as one on its own
+    line.
+    """
+    start = max(line.rfind(";", 0, position), line.rfind("{", 0, position)) + 1
+    return DECLARATION.match(line[start:position]) is not None
+
+
+def scan(root: Path) -> tuple[dict[str, int], list[Finding]]:
+    counts: dict[str, int] = {}
+    findings: list[Finding] = []
+
+    for source in sorted(root.rglob("*.cs")):
+        relative = source.relative_to(REPO_ROOT).as_posix()
+        found = find_literals(source.read_text(encoding="utf-8", errors="replace"), relative)
+        if found:
+            counts[relative] = len(found)
+            findings.extend(found)
+
+    return counts, findings
+
+
+def read_baseline(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        return {}
+
+    baseline: dict[str, int] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, _, count = line.partition("\t")
+        baseline[name.strip()] = int(count.strip())
+
+    return baseline
+
+
+def write_baseline(path: Path, counts: dict[str, int]) -> None:
+    lines = [
+        "# Geometry/tuning literals tolerated per file — a ratchet, not a target.",
+        "# Counts may go down and the file is regenerated with --update-baseline.",
+        "# They may never go up: see .github/scripts/check_geometry_literals.py.",
+        "",
+    ]
+    lines += [f"{name}\t{count}" for name, count in sorted(counts.items())]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def compare(counts: dict[str, int], baseline: dict[str, int]) -> Verdict:
+    regressions = []
+    improvements = []
+
+    for name, count in sorted(counts.items()):
+        allowed = baseline.get(name, 0)
+        if count > allowed:
+            regressions.append(f"{name}: {count} literal(s), baseline allows {allowed}")
+
+    for name, allowed in sorted(baseline.items()):
+        if counts.get(name, 0) < allowed:
+            improvements.append(name)
+
+    if regressions:
+        return Verdict(
+            False,
+            "New geometry/tuning literals:\n  " + "\n  ".join(regressions),
+        )
+
+    if improvements:
+        return Verdict(
+            True,
+            f"{len(improvements)} file(s) improved. Run with --update-baseline and "
+            "commit it, so the new lower count becomes the ceiling.",
+        )
+
+    return Verdict(True, "No new geometry/tuning literals.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline from the current tree",
+    )
+    arguments = parser.parse_args(argv)
+
+    if not SOURCE_ROOT.is_dir():
+        print(f"No {SOURCE_ROOT.relative_to(REPO_ROOT)}/ — nothing to check.")
+        return 0
+
+    counts, findings = scan(SOURCE_ROOT)
+
+    if arguments.update_baseline:
+        write_baseline(BASELINE_PATH, counts)
+        total = sum(counts.values())
+        print(f"Baseline written: {total} literal(s) across {len(counts)} file(s).")
+        return 0
+
+    verdict = compare(counts, read_baseline(BASELINE_PATH))
+
+    if not verdict.ok:
+        print(verdict.reason, file=sys.stderr)
+        print("", file=sys.stderr)
+        for finding in findings:
+            print(f"  {finding.path}:{finding.line}: {finding.literal} — {finding.text}",
+                  file=sys.stderr)
+        print(
+            "\nGive each value a name: a `const`, or a `[SerializeField]` so it can be "
+            "tuned without a rebuild. See docs/engineering/tech-stack.md.\n"
+            "Raising the baseline to make this pass is not a fix, and reads as one in "
+            "review.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(verdict.reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_check_geometry_literals.py
+++ b/.github/scripts/tests/test_check_geometry_literals.py
@@ -1,0 +1,154 @@
+"""Unit tests for the geometry/tuning literal check.
+
+The check is deliberately conservative: it exists to stop the named-values rule
+decaying, not to catch every violation. These tests pin both what it flags and
+what it deliberately does not, so a later "improvement" has to face the cases
+that were left out on purpose.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_geometry_literals as check  # noqa: E402
+
+
+class FlaggedTests(unittest.TestCase):
+    def findings(self, source):
+        return check.find_literals(source, "Thing.cs")
+
+    def test_a_bare_literal_in_a_method_body_is_flagged(self):
+        found = self.findings("void Move() { transform.position = new Vector3(12f, 0f, 0f); }")
+
+        self.assertEqual(1, len(found))
+        self.assertIn("12f", found[0].literal)
+
+    def test_several_on_one_line_are_all_flagged(self):
+        found = self.findings("void Move() { Place(12f, 40f); }")
+
+        self.assertEqual(2, len(found))
+
+    def test_a_literal_in_a_comparison_is_flagged(self):
+        found = self.findings("void Tick() { if (elapsed > 4f) Split(); }")
+
+        self.assertEqual(1, len(found))
+
+    def test_the_line_number_is_reported(self):
+        found = check.find_literals("void A()\n{\n    Place(12f);\n}\n", "Thing.cs")
+
+        self.assertEqual(3, found[0].line)
+
+
+class NotFlaggedTests(unittest.TestCase):
+    def findings(self, source):
+        return check.find_literals(source, "Thing.cs")
+
+    def test_a_named_constant_is_not_flagged(self):
+        self.assertEqual([], self.findings("const float PanelWidth = 280f;"))
+
+    def test_a_serialized_field_is_not_flagged(self):
+        self.assertEqual(
+            [], self.findings("[SerializeField] float _splitSeconds = 4f;"))
+
+    def test_a_local_declaration_is_not_flagged(self):
+        self.assertEqual([], self.findings("void A() { var gap = 12f; }"))
+
+    def test_a_typed_local_declaration_is_not_flagged(self):
+        self.assertEqual([], self.findings("void A() { float gap = 12f; }"))
+
+    def test_small_magnitudes_are_not_flagged(self):
+        # 0, 1, and 2 are overwhelmingly arithmetic and halving rather than
+        # measurements; flagging them would bury the real findings.
+        self.assertEqual([], self.findings("void A() { Place(0f, 1f, 2f, 2.5f); }"))
+
+    def test_the_magnitude_boundary_is_inclusive(self):
+        self.assertEqual(1, len(self.findings("void A() { Place(3f); }")))
+
+    def test_a_negative_literal_is_judged_on_magnitude(self):
+        self.assertEqual(1, len(self.findings("void A() { Place(-12f); }")))
+
+    def test_an_int_literal_is_not_flagged(self):
+        # Only f-suffixed floats. Ints are loop bounds and counts far more often
+        # than they are geometry, and the false-positive rate is what decides
+        # whether a check survives.
+        self.assertEqual([], self.findings("void A() { for (var i = 0; i < 32; i++) { } }"))
+
+    def test_a_literal_in_a_line_comment_is_not_flagged(self):
+        self.assertEqual([], self.findings("void A() { } // was 12f before"))
+
+    def test_a_literal_in_a_string_is_not_flagged(self):
+        self.assertEqual([], self.findings('void A() { Log("moved 12f"); }'))
+
+    def test_a_literal_in_a_doc_comment_is_not_flagged(self):
+        self.assertEqual([], self.findings("/// Defaults to 12f.\nvoid A() { }"))
+
+
+class BaselineTests(unittest.TestCase):
+    def test_a_file_within_its_baseline_passes(self):
+        verdict = check.compare({"A.cs": 3}, {"A.cs": 3})
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_a_file_over_its_baseline_fails(self):
+        verdict = check.compare({"A.cs": 4}, {"A.cs": 3})
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("A.cs", verdict.reason)
+        self.assertIn("4", verdict.reason)
+
+    def test_a_new_file_with_any_literal_fails(self):
+        verdict = check.compare({"B.cs": 1}, {"A.cs": 3})
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("B.cs", verdict.reason)
+
+    def test_a_file_under_its_baseline_passes_and_says_so(self):
+        # A decrease must not fail: the ratchet's job is "not worse", and
+        # failing on improvement is how a check gets turned off.
+        verdict = check.compare({"A.cs": 1}, {"A.cs": 3})
+
+        self.assertTrue(verdict.ok, verdict.reason)
+        self.assertIn("--update-baseline", verdict.reason)
+
+    def test_a_removed_file_passes(self):
+        verdict = check.compare({}, {"A.cs": 3})
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_a_clean_tree_against_an_empty_baseline_passes(self):
+        self.assertTrue(check.compare({}, {}).ok)
+
+
+class BaselineFileTests(unittest.TestCase):
+    def test_a_baseline_round_trips(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "baseline.txt"
+            check.write_baseline(path, {"b.cs": 2, "a.cs": 1})
+
+            self.assertEqual({"a.cs": 1, "b.cs": 2}, check.read_baseline(path))
+
+    def test_a_missing_baseline_reads_as_empty(self):
+        with TemporaryDirectory() as directory:
+            self.assertEqual({}, check.read_baseline(Path(directory) / "nope.txt"))
+
+    def test_comments_and_blank_lines_are_ignored(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "baseline.txt"
+            path.write_text("# a comment\n\na.cs\t1\n", encoding="utf-8")
+
+            self.assertEqual({"a.cs": 1}, check.read_baseline(path))
+
+    def test_the_written_baseline_is_sorted_for_reviewable_diffs(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "baseline.txt"
+            check.write_baseline(path, {"z.cs": 1, "a.cs": 1})
+
+            body = [line for line in path.read_text().splitlines() if not line.startswith("#")]
+            self.assertEqual(["a.cs\t1", "z.cs\t1"], [line for line in body if line])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/geometry-lint.yml
+++ b/.github/workflows/geometry-lint.yml
@@ -1,0 +1,48 @@
+name: geometry-lint
+
+# The backstop for the named-values rule in docs/engineering/tech-stack.md.
+# Ratchets against a committed baseline: a file may keep the literals it has
+# and may not gain more.
+#
+# Path-gated to the sources it checks and to the checker itself — including the
+# baseline, so a PR that only raises the baseline still runs the check that
+# would have failed.
+
+on:
+  pull_request:
+    paths:
+      - Assets/Scripts/**
+      - .github/scripts/check_geometry_literals.py
+      - .github/scripts/tests/test_check_geometry_literals.py
+      - .github/geometry_literals_baseline.txt
+      - .github/workflows/geometry-lint.yml
+  push:
+    branches: [main]
+    paths:
+      - Assets/Scripts/**
+      - .github/scripts/check_geometry_literals.py
+      - .github/geometry_literals_baseline.txt
+      - .github/workflows/geometry-lint.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: geometry-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The checker's own tests run first, in the same job. A gate nobody has
+      # tested is a gate whose verdict means nothing — and if the checker is
+      # broken, its "pass" is the dangerous outcome.
+      - name: Test the checker
+        run: python3 .github/scripts/run_python_tests.py scripts
+
+      - name: Check for new geometry literals
+        run: python3 .github/scripts/check_geometry_literals.py

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -17,6 +17,7 @@ be blocking; if you can, the fix is to satisfy it, not to route around it.
 | `rc-build` | manual, tag | no | a release candidate someone can actually play |
 | `release-please` | push to `main` | no | the version, changelog, tag, release, and release APK |
 | `labels-sync` | push to `main` touching `labels.yml` | no | the label taxonomy matches the file |
+| `geometry-lint` | PR touching `Assets/Scripts/**` | yes | the named-values rule, ratcheting |
 | `pipeline-*` | schedule, issue comments | no | the issue pipeline itself |
 
 ## Every action is pinned to a commit SHA
@@ -446,25 +447,46 @@ pass — the whole point is to not accept an absence of evidence as evidence.
 The script is stdlib-only, so it needs no setup step, and it has 18 unit tests
 covering each failure mode.
 
-### The geometry and tuning literal check
+### `geometry-lint` — the tuning-literal check
 
-Enforces the named-values rule from [Tech stack](tech-stack.md): no bare numeric
-literals for sizes, offsets, margins, durations, speeds, thresholds, or payouts
-in method bodies.
+The backstop for the named-values rule in [Tech stack](tech-stack.md). A rule
+with no backstop decays one literal at a time, each individually defensible.
 
-**Ratcheting baseline.** A committed baseline file records how many violations
-exist per file today. The check fails if a file's count goes *up*; it does not
-demand that existing code be fixed before anything else can happen. When a file's
-count goes down, the baseline is updated in the same PR, and the new lower number
-becomes the ceiling.
+**What it flags:** f-suffixed float literals of magnitude 3 or more, on a line
+that does not give them a name.
 
-The ratchet is the whole design. A check that demanded the codebase be clean
-before it could be turned on is a check that never gets turned on; one that only
-says "not worse than yesterday" can be turned on today and still converges.
+```csharp
+Place(12f, 40f);                    // flagged
+const float PanelWidth = 280f;      // fine — named
+[SerializeField] float _gap = 12f;  // fine — named, and tunable
+var gap = 18f;                      // fine — named
+Fade(0.5f);                         // fine — below the magnitude floor
+```
 
-If a literal is genuinely fine, the answer is one of the documented exemptions,
-or naming it. Raising the baseline to make the check pass is not a fix and shows
-up in review as exactly what it is.
+**It is deliberately narrower than the rule.** It does not catch literals inside
+a named declaration's initialiser (`var spot = new Vector3(12f, 40f, 0f)` names
+the vector, not its components), integer literals, or magnitudes below 3. Those
+need a parser, or would produce more false positives than findings — and a check
+people learn to override catches nothing at all. **They are gaps in the check,
+not permission in the rule**; review catches them.
+
+**Ratcheting baseline.** `.github/geometry_literals_baseline.txt` records how
+many literals each file is allowed. A count going *up* fails. A count going down
+passes, with a note to run `--update-baseline` so the new lower number becomes
+the ceiling — an improvement must never fail a build, or the check gets turned
+off.
+
+The ratchet is the whole design. A check demanding a clean codebase before it
+could be switched on is a check that never gets switched on; one saying "not
+worse than yesterday" can be switched on today and still converges.
+
+Raising the baseline to make the check pass is not a fix, and the script says so
+in its own failure output. The workflow is path-gated to include the baseline
+file, so a PR that only raises it still runs the check it was trying to silence.
+
+**The checker's tests run in the same job, first.** A gate nobody has tested is
+a gate whose verdict means nothing — and a broken checker's dangerous outcome is
+the *pass*.
 
 ## Docs workflows
 

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -74,9 +74,10 @@ build that finishes while you are still looking at it. Use it for "does the app
 launch and show the right screen", never for judging performance or for anything
 shipped.
 
-CI builds the device profile. The emulator profile is a local convenience, and
-a bug that reproduces only under it is a bug in the profile until proven
-otherwise.
+CI builds both: the device profile is what the release ships, and an
+emulator-targeted asset is attached alongside it so the release can be tried on
+a desktop without rebuilding. A bug that reproduces only under the emulator is a
+bug in the profile until proven otherwise.
 
 ### What is explicitly not a target
 
@@ -270,7 +271,19 @@ Deliberately narrow:
 - Unity's own required literals in serialization or attribute arguments, where a
   constant is not permitted by the language.
 
-Anything else needs a name. CI enforces this: the geometry lint fails a PR that
-adds a bare numeric literal to a method body outside those exemptions, with a
-ratcheting baseline so existing code does not have to be fixed all at once —
-but the count can only go down. See [CI/CD](ci-cd.md).
+Anything else needs a name.
+
+### The check is narrower than the rule
+
+`geometry-lint` flags **f-suffixed float literals of magnitude 3 or more** on a
+line that does not name them, ratcheting against a committed baseline so
+existing code need not be fixed all at once — but the count can only go down.
+
+That is deliberately narrower than the rule above. It does not see integer
+literals, magnitudes below 3, or values inside a named declaration's
+initialiser. A check with a high false-positive rate is one people learn to
+override, and then it catches nothing.
+
+**So passing the check is not the same as following the rule.** The rule is what
+review holds you to; the check is what stops the rule decaying while nobody is
+looking. See [CI/CD](ci-cd.md#geometry-lint-the-tuning-literal-check).


### PR DESCRIPTION
Closes #41

The named-values rule has no backstop, so it decays one literal at a time, each individually defensible. This is the backstop.

**Docs:** `docs/engineering/ci-cd.md` (new `geometry-lint` section) and `docs/engineering/tech-stack.md` (what the check does and doesn't cover).

## What it flags

f-suffixed float literals of magnitude ≥ 3, on a line that doesn't give them a name:

```csharp
Place(12f, 40f);                    // flagged
const float PanelWidth = 280f;      // fine — named
[SerializeField] float _gap = 12f;  // fine — named, and tunable
var gap = 18f;                      // fine — named
Fade(0.5f);                         // fine — below the magnitude floor
```

Verified against exactly that planted file: the two literals in `Place(…)` flagged, everything else left alone.

## It is narrower than the rule, on purpose

It doesn't catch integers, magnitudes below 3, or literals inside a named declaration's initialiser (`var spot = new Vector3(12f, 40f, 0f)` names the vector, not its components). Those need a parser, or would produce more false positives than findings — and **a check people learn to override catches nothing at all**.

Both docs pages now say so explicitly: *passing the check is not the same as following the rule.* The rule is what review holds you to; the check is what stops it decaying while nobody is looking. Otherwise the check quietly becomes the definition of the rule, which would be a substantial loosening nobody voted for.

## The ratchet

`.github/geometry_literals_baseline.txt` — currently empty, since the tree is clean.

- Count goes **up** → fail, listing every literal with its line and the source text.
- Count goes **down** → **pass**, with a note to run `--update-baseline`. An improvement that fails a build is how a check gets switched off.
- File removed → pass.

The failure output ends with "raising the baseline to make this pass is not a fix, and reads as one in review", and the workflow is path-gated to include the baseline file — so a PR that only raises it still runs the check it was trying to silence.

## Test-first

Red on `ModuleNotFoundError: No module named 'check_geometry_literals'`. Then 24 tests — pinning what is deliberately **not** flagged as carefully as what is, so a future "improvement" has to face the cases left out on purpose. **83 tests in the `scripts` suite, all green.**

One test caught a real bug: the declaration check was anchored to the start of the line, so an inline `void A() { var gap = 12f; }` was flagged. It now looks at the *statement* the literal sits in — from the last `;` or `{` — which is both more correct and simpler to explain.

## Deviations and Decisions

- **The checker's tests run in the same job, before the check.** A gate nobody has tested is a gate whose verdict means nothing, and a broken checker's *dangerous* outcome is the pass, not the fail.
- **A decrease warns rather than failing.** The issue says "ratchets"; strictly, requiring the baseline to be regenerated on every improvement would fail PRs for making things better. The note in the output is enough.
- **Corrected a stale line in `tech-stack.md`** that said CI builds only the device profile — #40 landed the emulator asset since.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_