### PR TITLE
ci: add the docs reconciliation gate

### DIFF
--- a/.github/scripts/docs_reconciliation_gate.py
+++ b/.github/scripts/docs_reconciliation_gate.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""The docs reconciliation gate.
+
+`/docs` is the design contract. A contract that lags the code by three PRs is
+not a contract, so a PR that changes code changes the docs in the same PR — or
+says, with the `skip-docs` label, that it deliberately did not.
+
+The rule is only real if CI enforces it. This is the decision function:
+
+    docs changed                        → pass
+    code only, `skip-docs` label        → pass
+    code only, no label                 → fail
+    the release PR                      → pass, always
+
+Usage:
+    python3 .github/scripts/docs_reconciliation_gate.py \\
+        --changed-files changed.txt --pr 123 --head-ref "$HEAD_REF"
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import PurePosixPath
+
+SKIP_LABEL = "skip-docs"
+
+# The release PR is exempt. It cannot reconcile docs — it contains only the
+# version bump and the changelog release-please generated — and it cannot label
+# itself, because nobody is driving it. Matched two ways so a change to either
+# does not silently start failing every release.
+RELEASE_BRANCH_PREFIX = "release-please--branches--"
+RELEASE_LABEL = "autorelease: pending"
+
+# Paths whose change counts as documenting the change.
+DOCS_DIRECTORIES = ("docs/",)
+DOCS_FILES = ("CLAUDE.md", "README.md", "mkdocs.yml")
+
+# A label applied moments after a PR opens would otherwise produce a failing run
+# that is already wrong by the time anyone reads it — and a red tick nobody
+# should act on is worse than a slow one. Poll the *live* labels for a short
+# window before failing.
+GRACE_POLL_SECONDS = 10
+GRACE_POLL_ATTEMPTS = 6
+
+
+class Verdict:
+    def __init__(self, ok: bool, reason: str) -> None:
+        self.ok = ok
+        self.reason = reason
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Verdict(ok={self.ok!r}, reason={self.reason!r})"
+
+
+def is_docs(path: str) -> bool:
+    """Does changing this path count as documenting a change?
+
+    Deliberately not "any markdown file". A `SKILL.md` is documentation of a
+    skill, but it is also the skill's behaviour — changing it changes what an
+    agent does, so it does not excuse the docs.
+    """
+    normalised = PurePosixPath(path).as_posix()
+    return normalised in DOCS_FILES or normalised.startswith(DOCS_DIRECTORIES)
+
+
+def is_release_pull_request(labels: list[str], head_ref: str) -> bool:
+    return head_ref.startswith(RELEASE_BRANCH_PREFIX) or RELEASE_LABEL in labels
+
+
+def decide(changed_files: list[str], labels: list[str], head_ref: str) -> Verdict:
+    """The gate's verdict, from a snapshot. Pure."""
+    if is_release_pull_request(labels, head_ref):
+        return Verdict(True, "The release PR is exempt from the docs gate.")
+
+    if not changed_files:
+        return Verdict(True, "Nothing changed.")
+
+    documented = [path for path in changed_files if is_docs(path)]
+    if documented:
+        return Verdict(True, f"Docs changed: {', '.join(sorted(documented)[:5])}.")
+
+    if SKIP_LABEL in labels:
+        return Verdict(
+            True,
+            f"No docs changed, but the `{SKIP_LABEL}` label says that is deliberate. "
+            "Justify it in the PR's Deviations and Decisions section.",
+        )
+
+    return Verdict(
+        False,
+        "This PR changes code and no documentation.\n\n"
+        "  /docs is the design contract, and a contract that lags the code is not one.\n"
+        "  Either update the page this change affects, or add the "
+        f"`{SKIP_LABEL}` label and say\n"
+        "  why in the PR's `## Deviations and Decisions` section.\n\n"
+        "  Adding the label re-runs this check; you do not need to push anything.",
+    )
+
+
+def decide_with_grace(
+    changed_files: list[str],
+    labels: list[str],
+    head_ref: str,
+    fetch_labels,
+    sleep=time.sleep,
+) -> Verdict:
+    """`decide`, but re-reading live labels before reporting a failure.
+
+    A passing PR never waits. Only a would-be failure polls, because the label
+    that fixes it is one click away and often arrives seconds after the PR is
+    opened.
+    """
+    verdict = decide(changed_files, labels, head_ref)
+    if verdict.ok:
+        return verdict
+
+    for attempt in range(GRACE_POLL_ATTEMPTS):
+        sleep(GRACE_POLL_SECONDS)
+
+        try:
+            live = fetch_labels()
+        except Exception as error:  # noqa: BLE001 - any failure means "unknown"
+            # Unknown is not permission. A gate that passes when it cannot read
+            # the labels is a gate an outage switches off.
+            print(f"Could not read the PR's labels ({error}); retrying.", file=sys.stderr)
+            continue
+
+        verdict = decide(changed_files, live, head_ref)
+        if verdict.ok:
+            return Verdict(
+                True,
+                f"{verdict.reason} (Seen {(attempt + 1) * GRACE_POLL_SECONDS}s after the "
+                "run started, within the grace window.)",
+            )
+
+    return verdict
+
+
+def fetch_labels_from_github(repository: str, pull_number: int):
+    """Live labels for a PR, via the `gh` CLI already present on the runner."""
+
+    def fetch() -> list[str]:
+        completed = subprocess.run(
+            ["gh", "api", f"repos/{repository}/pulls/{pull_number}", "--jq", "[.labels[].name]"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(completed.stdout or "[]")
+
+    return fetch
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changed-files", required=True, help="file with one path per line")
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="owner/repo; defaults to $GITHUB_REPOSITORY",
+    )
+    parser.add_argument(
+        "--labels",
+        default="",
+        help="comma-separated labels from the event payload",
+    )
+    arguments = parser.parse_args(argv)
+
+    with open(arguments.changed_files, encoding="utf-8") as handle:
+        changed = [line.strip() for line in handle if line.strip()]
+
+    labels = [label.strip() for label in arguments.labels.split(",") if label.strip()]
+
+    verdict = decide_with_grace(
+        changed,
+        labels,
+        arguments.head_ref,
+        fetch_labels=fetch_labels_from_github(arguments.repository, arguments.pr),
+    )
+
+    print(verdict.reason, file=sys.stdout if verdict.ok else sys.stderr)
+    return 0 if verdict.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_docs_reconciliation_gate.py
+++ b/.github/scripts/tests/test_docs_reconciliation_gate.py
@@ -1,0 +1,157 @@
+"""Decision-matrix tests for the docs reconciliation gate."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import docs_reconciliation_gate as gate  # noqa: E402
+
+FEATURE_BRANCH = "claude/some-work"
+RELEASE_BRANCH = "release-please--branches--main"
+
+
+class DecisionMatrixTests(unittest.TestCase):
+    def decide(self, paths, labels=(), head_ref=FEATURE_BRANCH):
+        return gate.decide(list(paths), list(labels), head_ref)
+
+    def test_a_docs_change_passes(self):
+        verdict = self.decide(["Assets/Scripts/Core/Pond.cs", "docs/specs/frogs.md"])
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_a_docs_only_change_passes(self):
+        self.assertTrue(self.decide(["docs/engineering/testing.md"]).ok)
+
+    def test_code_only_with_skip_docs_passes(self):
+        verdict = self.decide(["Assets/Scripts/Core/Pond.cs"], labels=["skip-docs"])
+
+        self.assertTrue(verdict.ok, verdict.reason)
+        self.assertIn("skip-docs", verdict.reason)
+
+    def test_code_only_without_either_fails(self):
+        verdict = self.decide(["Assets/Scripts/Core/Pond.cs"])
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("skip-docs", verdict.reason)
+
+    def test_an_unrelated_label_does_not_exempt(self):
+        self.assertFalse(self.decide(["Assets/Scripts/Core/Pond.cs"], labels=["area:build"]).ok)
+
+    def test_a_pr_that_changes_nothing_passes(self):
+        self.assertTrue(self.decide([]).ok)
+
+
+class WhatCountsAsDocsTests(unittest.TestCase):
+    def assertCounts(self, path):
+        self.assertTrue(gate.is_docs(path), f"{path} should count as docs")
+
+    def assertDoesNotCount(self, path):
+        self.assertFalse(gate.is_docs(path), f"{path} should not count as docs")
+
+    def test_the_docs_tree_counts(self):
+        self.assertCounts("docs/engineering/ci-cd.md")
+
+    def test_the_root_rules_file_counts(self):
+        # CLAUDE.md is where an agent reads the rules; a change there is a
+        # documentation change by any useful definition.
+        self.assertCounts("CLAUDE.md")
+
+    def test_the_readme_counts(self):
+        self.assertCounts("README.md")
+
+    def test_the_site_config_counts(self):
+        self.assertCounts("mkdocs.yml")
+
+    def test_source_does_not_count(self):
+        self.assertDoesNotCount("Assets/Scripts/Core/Pond.cs")
+
+    def test_a_workflow_does_not_count(self):
+        self.assertDoesNotCount(".github/workflows/ci-tests.yml")
+
+    def test_a_skill_does_not_count(self):
+        # A SKILL.md is documentation of a skill, but it is also the skill's
+        # behaviour — changing it changes what an agent does, so it does not
+        # excuse the docs.
+        self.assertDoesNotCount(".claude/skills/release-flow/SKILL.md")
+
+    def test_a_markdown_file_outside_docs_does_not_count(self):
+        self.assertDoesNotCount("Assets/Scripts/Core/notes.md")
+
+
+class ReleasePullRequestTests(unittest.TestCase):
+    def test_the_release_branch_is_exempt(self):
+        verdict = gate.decide(["VERSION", "CHANGELOG.md"], [], RELEASE_BRANCH)
+
+        self.assertTrue(verdict.ok, verdict.reason)
+        self.assertIn("release", verdict.reason.lower())
+
+    def test_the_autorelease_label_is_exempt(self):
+        # Belt and braces: if the branch naming ever changes, the label still
+        # exempts it. A release PR can neither reconcile docs nor label itself.
+        verdict = gate.decide(["VERSION"], ["autorelease: pending"], "some-other-branch")
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_a_feature_branch_named_similarly_is_not_exempt(self):
+        verdict = gate.decide(["Assets/Scripts/Core/Pond.cs"], [], "my-release-please-notes")
+
+        self.assertFalse(verdict.ok)
+
+
+class GracePollTests(unittest.TestCase):
+    def test_a_pass_returns_immediately_without_polling(self):
+        polls = []
+
+        verdict = gate.decide_with_grace(
+            ["docs/x.md"], ["nothing"], FEATURE_BRANCH,
+            fetch_labels=lambda: polls.append(1) or [],
+            sleep=lambda seconds: None)
+
+        self.assertTrue(verdict.ok)
+        self.assertEqual([], polls, "a passing PR must not wait")
+
+    def test_a_label_landing_during_the_window_is_observed(self):
+        # The point of the whole mechanism: no failing run is produced when the
+        # label arrives moments after the PR opens.
+        responses = [[], [], ["skip-docs"]]
+
+        verdict = gate.decide_with_grace(
+            ["Assets/Scripts/Core/Pond.cs"], [], FEATURE_BRANCH,
+            fetch_labels=lambda: responses.pop(0),
+            sleep=lambda seconds: None)
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_it_gives_up_after_the_window_and_fails(self):
+        slept = []
+
+        verdict = gate.decide_with_grace(
+            ["Assets/Scripts/Core/Pond.cs"], [], FEATURE_BRANCH,
+            fetch_labels=lambda: [],
+            sleep=slept.append)
+
+        self.assertFalse(verdict.ok)
+        self.assertEqual(gate.GRACE_POLL_ATTEMPTS, len(slept))
+        self.assertTrue(all(delay == gate.GRACE_POLL_SECONDS for delay in slept))
+
+    def test_a_fetch_failure_does_not_pass_the_gate(self):
+        def explode():
+            raise RuntimeError("the API is down")
+
+        verdict = gate.decide_with_grace(
+            ["Assets/Scripts/Core/Pond.cs"], [], FEATURE_BRANCH,
+            fetch_labels=explode,
+            sleep=lambda seconds: None)
+
+        self.assertFalse(verdict.ok)
+
+    def test_the_grace_window_is_a_named_constant(self):
+        self.assertIsInstance(gate.GRACE_POLL_SECONDS, (int, float))
+        self.assertIsInstance(gate.GRACE_POLL_ATTEMPTS, int)
+        self.assertGreater(gate.GRACE_POLL_ATTEMPTS, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,14 @@ Every PR body carries a `**Docs:**` line stating what happened:
 **Docs:** None — no behaviour the docs describe was changed.
 ```
 
-CI enforces the line's presence. The `skip-docs` label is the escape hatch for
-the genuinely doc-irrelevant PR, and using it is a decision you justify in
+**CI enforces the docs change, not the line.** A PR that touches code and
+nothing under `docs/` fails the reconciliation gate. The `skip-docs` label is
+the escape hatch for the genuinely doc-irrelevant PR — adding it re-runs the
+check — and using it is a decision you justify in
 `## Deviations and Decisions`.
+
+The line is still required, because the gate can only see *that* a docs file
+changed. Only you can say what changed in it.
 
 → [`docs/engineering/ci-cd.md`](docs/engineering/ci-cd.md)
 

--- a/docs/engineering/agent-workflow.md
+++ b/docs/engineering/agent-workflow.md
@@ -83,7 +83,9 @@ arrive.
 8. **Open the PR**, with:
    - a **Conventional Commit title** — it becomes the squash commit;
    - the **plain-English lead** (below);
-   - a **`**Docs:**` line**, always, `None` included;
+   - a **`**Docs:**` line**, always, `None` included. CI checks that a docs
+     file changed; the line is how a reader learns *what* changed in it, which
+     the gate cannot see ([CI/CD](ci-cd.md#the-reconciliation-gate-always-on));
    - a **closing keyword** — `Closes #12` — in the body, not just a mention.
      The pipeline reads issue state from GitHub, so an issue left open after its
      work merged is an issue that gets handed out again;
@@ -190,7 +192,7 @@ better.
 | | Answers | Doesn't answer |
 | --- | --- | --- |
 | The diff | what the text now says | what it said before, or why |
-| `**Docs:**` line | which pages changed | what changed in them |
+| `**Docs:**` line | which pages changed, and what changed in them | why the old rule was wrong |
 | Deviations and Decisions | where you departed from the issue | a change the issue *asked* for |
 | **How the spec is changing** | old rule → new rule, and why | — |
 

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -504,28 +504,55 @@ Never edit `gh-pages` by hand.
 
 ### The reconciliation gate — always on
 
-**Every PR must state what happened to the docs.** The gate checks the PR body
-for a `**Docs:**` line:
+**A PR that changes code changes the docs, in the same PR.** `/docs` is the
+design contract, and a contract that lags the code by three PRs is not one.
 
-```text
-**Docs:** docs/specs/frogs.md — updated the splitting rule to cap at 32.
-**Docs:** None — no behaviour the docs describe was changed.
-```
+`.github/scripts/docs_reconciliation_gate.py` decides:
 
-It is deliberately a *statement* requirement rather than a diff requirement. A
-check that demanded a docs change whenever code changed would be wrong most of
-the time and would train everyone to make token docs edits. A check that
-requires you to say "None" makes the author spend three seconds actually
-considering it, which is the behaviour we want.
+| PR | Verdict |
+| --- | --- |
+| touches anything under `docs/`, or `CLAUDE.md`, `README.md`, `mkdocs.yml` | pass |
+| code only, carrying `skip-docs` | pass |
+| code only, no label | **fail** |
+| the release PR | pass, always |
+| changes nothing | pass |
 
-The gate is **always on** — it does not skip based on which files changed,
+The gate is **always on**. It does not skip based on which files changed,
 because "this PR obviously doesn't affect the docs" is exactly the judgement it
 exists to make someone write down.
 
+#### What counts as documentation
+
+Not "any markdown file". A `SKILL.md` is documentation *of* a skill, but it is
+also the skill's behaviour — changing it changes what an agent does, so it does
+not excuse the docs. Neither does a `.md` file sitting next to some source.
+
+#### The release PR is exempt
+
+It contains the version bump and the changelog release-please generated, and
+nothing else. It cannot reconcile docs, and there is nobody driving it to apply
+a label. Matched **both** by its head branch and by its `autorelease: pending`
+label, so a change to either does not silently start failing every release.
+
+#### The grace poll
+
+A `skip-docs` label applied moments after the PR opens would otherwise produce a
+failing run that is already wrong by the time anyone reads it — and a red tick
+nobody should act on is worse than a slow one.
+
+So a would-be failure re-reads the PR's **live** labels for up to a minute
+(`GRACE_POLL_ATTEMPTS` × `GRACE_POLL_SECONDS`) before reporting. A label landing
+inside that window is observed by the same run: **no failing run is produced at
+all.** A passing PR never waits.
+
+If the label API cannot be read, the gate keeps failing. Unknown is not
+permission — a gate that passes when it cannot see the labels is a gate an
+outage switches off.
+
 #### The `skip-docs` escape hatch
 
-The `skip-docs` label bypasses the gate, for the genuinely doc-irrelevant PR —
-a dependency bump, a CI fix, a typo in a comment.
+For the genuinely doc-irrelevant PR — a dependency bump, a CI fix, a typo in a
+comment. Adding the label re-runs the check, so nothing needs pushing.
 
 Using it is a decision, so it goes in the PR's `## Deviations and Decisions`
 section with a reason. A `skip-docs` label with no justification is a review


### PR DESCRIPTION
Closes #42

The docs-reconciliation rule is only real if CI enforces it. This is the gate's decision function; #43 wires it into a workflow.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the reconciliation-gate section; `CLAUDE.md` and `docs/engineering/agent-workflow.md` corrected to match.

## The decision matrix

| PR | Verdict |
| --- | --- |
| touches `docs/**`, `CLAUDE.md`, `README.md`, `mkdocs.yml` | pass |
| code only, carrying `skip-docs` | pass |
| code only, no label | **fail** |
| the release PR | pass, always |
| changes nothing | pass |

**What counts as documentation is deliberately not "any markdown file".** A `SKILL.md` is documentation *of* a skill, but it's also the skill's behaviour — changing it changes what an agent does, so it doesn't excuse the docs. There's a test pinning that.

**The release PR is exempt** because it can do neither thing the gate asks for: it contains only release-please's version bump and changelog, and nobody is driving it to apply a label. Matched by **both** its head branch and its `autorelease: pending` label, so a change to either doesn't silently start failing every release.

## The grace poll

A `skip-docs` label applied moments after a PR opens would otherwise produce a failing run that's already wrong by the time anyone reads it — and a red tick nobody should act on is worse than a slow one.

So a would-be failure re-reads the PR's **live** labels for up to a minute before reporting. A label landing inside that window is observed by the same run: **no failing run is produced at all.** A passing PR never polls.

If the labels can't be read, the gate keeps failing. Unknown is not permission — a gate that passes when it can't see the labels is a gate an outage switches off. Both behaviours have tests.

## Test-first

Red on `ModuleNotFoundError: No module named 'docs_reconciliation_gate'`. Then 21 tests covering the matrix, what counts as docs, the release exemption (including that a branch merely *named* like one isn't exempt), and all four grace-poll behaviours. **105 tests in the `scripts` suite, all green.**

## How the spec is changing

> **Previously** `ci-cd.md` described the gate as a **statement** requirement: it checked the PR body for a `**Docs:**` line, and I argued there that a diff requirement "would be wrong most of the time and would train everyone to make token docs edits". **From this change** it is a **file** requirement — a code-only PR fails unless it carries `skip-docs`.
>
> This issue specifies that behaviour, and **the issue was treated as authoritative over the doc**, per `CLAUDE.md`. It's also the stronger rule: a `**Docs:**` line saying "None" is one keystroke and no thought, whereas `skip-docs` is a deliberate act that shows up in the PR's label list and has to be justified in Deviations and Decisions.

The `**Docs:**` line stays as a PR convention, because the gate can only see *that* a docs file changed — only the author can say *what* changed in it. `CLAUDE.md` rule 9 and the agent-workflow page no longer claim CI enforces the line, since that would now be false.

## Deviations and Decisions

- **Included `CLAUDE.md`, `README.md`, and `mkdocs.yml`** as documentation alongside `docs/**`. `CLAUDE.md` is where an agent reads the rules; a change there is a documentation change by any useful definition, and excluding it would force `skip-docs` onto PRs that are pure documentation.
- **The grace poll is 6 × 10s.** Long enough for a human to notice a red check and click a label, short enough not to hold a PR up. Both are named constants with a test asserting they're named constants, since a magic number here is exactly the thing the geometry check exists to complain about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_