### PR TITLE
ci: run the docs build and reconciliation gate on every PR

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,0 +1,95 @@
+name: docs-test
+
+# Runs on EVERY pull request, with no path filter — deliberately.
+#
+# A path-gated workflow is *absent* on PRs that miss its paths, not skipped, so
+# it can never report on them. This one has to report on code-only PRs, because
+# a code-only PR is exactly what the reconciliation gate exists to catch. It is
+# also therefore safe to mark required in branch protection, unlike ci-tests.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The gate's own tests, on every PR. A gate nobody has tested is a gate whose
+  # verdict means nothing — and the dangerous outcome of a broken gate is the
+  # pass, which is also the quiet one.
+  gate-tests:
+    name: Gate tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Test the CI scripts
+        run: python3 .github/scripts/run_python_tests.py scripts
+
+  build:
+    name: Docs
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      # The gate re-reads the PR's live labels during its grace window.
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Both sides of the PR, so the changed-file list can be computed.
+          fetch-depth: 0
+
+      - name: Work out what changed
+        id: changed
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" > changed-files.txt
+          echo "Changed files:"
+          sed 's/^/  /' changed-files.txt
+
+          if grep -qE '^(docs/|CLAUDE\.md$|README\.md$|mkdocs\.yml$)' changed-files.txt; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.changed.outputs.docs == 'true' || github.event_name != 'pull_request'
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      # Strict: a broken nav entry, a dead internal link, or a page missing from
+      # the nav is a failure rather than a warning. No deploy — publishing is
+      # docs-publish's job, from main.
+      - name: Build the docs site
+        if: steps.changed.outputs.docs == 'true' || github.event_name != 'pull_request'
+        run: |
+          python3 -m pip install --quiet -r docs/requirements.txt
+          mkdocs build --strict
+
+      - name: Check the docs were reconciled
+        if: github.event_name == 'pull_request' && steps.changed.outputs.docs != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 .github/scripts/docs_reconciliation_gate.py \
+            --changed-files changed-files.txt \
+            --pr "${{ github.event.pull_request.number }}" \
+            --head-ref "${{ github.event.pull_request.head.ref }}" \
+            --labels "${{ join(github.event.pull_request.labels.*.name, ',') }}"

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -492,9 +492,29 @@ the *pass*.
 
 ### `docs-test`
 
-Builds the site with `mkdocs build --strict`, so a broken nav entry, a dead
-internal link, or a page that isn't in the nav fails the PR rather than shipping
-a broken site.
+Two jobs, on **every** pull request with no path filter.
+
+| Job | Does |
+| --- | --- |
+| `gate-tests` | runs the CI scripts' own unit tests |
+| `Docs` | builds the site if docs changed; runs the reconciliation gate if they didn't |
+
+**No path filter, deliberately.** A path-gated workflow is *absent* on PRs that
+miss its paths rather than skipped, so it can never report on them — and a
+code-only PR is exactly what the reconciliation gate exists to catch. It is
+therefore also the one workflow here that is safe to mark required in branch
+protection.
+
+When docs changed, it builds with `mkdocs build --strict`, so a broken nav
+entry, a dead internal link, or a page missing from the nav fails the PR rather
+than shipping a broken site. No deploy — publishing is `docs-publish`'s job.
+
+When they didn't, it runs the gate below. `pull-requests: read` is granted for
+the gate's live-label fetch, and nothing more.
+
+`gate-tests` runs on every PR because a gate nobody has tested is a gate whose
+verdict means nothing — and a broken gate's dangerous outcome is the *pass*,
+which is also the quiet one.
 
 ### `docs-publish`
 


### PR DESCRIPTION
Closes #43

Wires the gate from #42 into CI, and builds the docs site strictly when they change.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the `docs-test` section with the two jobs and the no-path-filter reasoning.

## What's here

Two jobs, on **every** pull request:

| Job | Does |
| --- | --- |
| `gate-tests` | runs the CI scripts' unit tests (105 of them) |
| `Docs` | builds the site if docs changed; runs the reconciliation gate if they didn't |

## No path filter, deliberately

A path-gated workflow is **absent** on PRs that miss its paths, not skipped — so it can never report on them. And a code-only PR is exactly what the reconciliation gate exists to catch, so gating this one by path would switch it off precisely when it matters.

That also makes it the one workflow here that's safe to mark **required** in branch protection (#80), unlike `ci-tests` and `geometry-lint`. Noted in the docs.

## The two paths

- **Docs changed** → `mkdocs build --strict`. A broken nav entry, dead internal link, or page missing from the nav fails the PR rather than shipping a broken site. No deploy; publishing is `docs-publish`'s job (#44).
- **Docs unchanged** → the gate, with `pull-requests: read` for its live-label fetch and nothing more.

`gate-tests` runs on every PR because a gate nobody has tested is a gate whose verdict means nothing — and a broken gate's dangerous outcome is the *pass*, which is also the quiet one.

## Note on this PR

This is the first PR the gate will judge. It touches `docs/engineering/ci-cd.md`, so it should take the docs-changed path and build the site — which is the more useful of the two to see exercised first, since it proves the strict build works on a clean runner rather than just locally.

## Deviations and Decisions

- **Also builds on push to `main`.** Not on the checklist. The strict build is the only thing that catches a broken site, and a PR that merges green can still land on a `main` whose site doesn't build if two PRs touch the nav concurrently.
- **`fetch-depth: 0` and an explicit `git diff base...head`** rather than an action to list changed files. It's two lines of shell and avoids a third-party action in the workflow that guards the docs — `ci-cd.md` sets the bar at "no reasonable way to do this with `run:`".
- **Python is only set up when the site is actually built**, so the gate path stays a few seconds rather than a minute. The gate is stdlib-only precisely so it can run on the runner's system Python.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_