### PR TITLE
ci: publish the docs site with mike

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,89 @@
+name: docs-publish
+
+# Publishes the docs site to GitHub Pages with mike, which keeps one built copy
+# per version in the gh-pages branch and adds the version selector in the
+# header.
+#
+# Never edit gh-pages by hand: mike rewrites it on every publish, so a hand edit
+# disappears at the next one — without warning, and after looking like it worked.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs-publish.yml
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialised, and never cancelled: two mike runs would both rewrite gh-pages,
+# and the loser leaves the published site in whatever state it got to.
+concurrency:
+  group: docs-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # mike commits the built site to the gh-pages branch.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # mike needs the gh-pages history to add a version to it rather than
+          # replace what is there.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install the docs toolchain
+        run: python3 -m pip install --quiet -r docs/requirements.txt
+
+      - name: Work out the version to publish under
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(cut -d'#' -f1 VERSION | tr -d '[:space:]')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::/VERSION is empty after stripping the marker comment."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # mike commits, so it needs an identity. The bot, because these commits
+      # are generated output rather than anyone's work.
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch the published site
+        run: git fetch origin gh-pages --depth=1 || echo "No gh-pages yet; mike will create it."
+
+      # --update-aliases so `latest` moves to this version rather than failing
+      # because it already points somewhere.
+      - name: Publish
+        run: |
+          mike deploy --push --update-aliases \
+            "${{ steps.version.outputs.version }}" latest
+          mike set-default --push latest
+
+      - name: Summarise
+        run: |
+          echo "Published docs for \`${{ steps.version.outputs.version }}\`, aliased \`latest\`." \
+            >> "$GITHUB_STEP_SUMMARY"
+          echo "https://derekwinters.github.io/connor-multiplying-frogs/" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -97,9 +97,9 @@ and no way for the two to drift apart.
 | `googleapis/release-please-action` | `45996ed1f6d02564a971a2fa1b5860e934307cf7` | `release-please` |
 | `game-ci/unity-builder` | `d829bfc901f2347c8fe18898f06712b66916ef42` | APK builds |
 | `game-ci/unity-test-runner` | `0ff419b913a3630032cbe0de48a0099b5a9f0ed9` | the EditMode suite |
-| `actions/configure-pages` | `45bfe0192ca1faeb007ade9deae92b16b8254a0d` | `docs-publish` |
-| `actions/upload-pages-artifact` | `fc324d3547104276b827a68afc52ff2a11cc49c9` | `docs-publish` |
-| `actions/deploy-pages` | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | `docs-publish` |
+
+`docs-publish` uses no Pages actions: `mike` commits the built site to
+`gh-pages` itself, which is also what makes the version selector work.
 
 **Adding an action that isn't on this list is a decision, not a detail.** Every
 one is third-party code running with a token; the bar is "there is no reasonable
@@ -518,9 +518,37 @@ which is also the quiet one.
 
 ### `docs-publish`
 
-Publishes the built site to GitHub Pages with `mike`, under the version alias
-for the release. See [Conventions](../intro/conventions.md#docs-versioning).
-Never edit `gh-pages` by hand.
+Publishes the site to GitHub Pages with [mike](https://github.com/jimporter/mike),
+which keeps one built copy per version in the `gh-pages` branch and drives the
+version selector in the header. See
+[Conventions](../intro/conventions.md#docs-versioning).
+
+- **Path-gated** to `docs/`, `mkdocs.yml`, and its own file, on pushes to
+  `main`, plus any `v*` tag and `workflow_dispatch`.
+- **The version comes from `/VERSION`**, marker stripped, so the docs are
+  labelled with the same number the app reports rather than a separate one to
+  keep in step.
+- **`latest` is an alias**, moved with `--update-aliases` on every publish, and
+  set as the default so the site root lands there.
+- **Serialised and never cancelled.** Two mike runs would both rewrite
+  `gh-pages`, and the loser leaves the published site in whatever state it got
+  to.
+
+**Never edit `gh-pages` by hand.** mike rewrites it on every publish, so a hand
+edit disappears at the next one — without warning, and after looking like it
+worked.
+
+#### Between releases, the current version's docs track `main`
+
+`/VERSION` only moves when a release goes out, so a docs change merged after
+`0.1.0` shipped republishes under `0.1.0`. The docs for a released version are
+therefore the *current* docs for that version, not a snapshot of what shipped
+with it.
+
+That is the right trade here: a fix to a confusing page should reach readers
+without waiting for a release. When `0.2.0` ships, `0.2.0` is created fresh and
+`0.1.0` stops moving — so history is preserved at the granularity of releases,
+which is the granularity anyone actually asks about.
 
 ### The reconciliation gate — always on
 


### PR DESCRIPTION
Closes #44

The docs site now publishes itself to GitHub Pages, versioned to match the app.

**Docs:** `docs/engineering/ci-cd.md` — rewrote the `docs-publish` section and corrected the pinned-actions table.

## What's here

- **Path-gated** to `docs/`, `mkdocs.yml`, and its own file, on pushes to `main` — plus any `v*` tag and `workflow_dispatch`.
- **The version comes from `/VERSION`**, marker stripped, so the docs carry the same number the app reports rather than a second one to keep in step.
- **`latest` is an alias**, moved with `--update-aliases` on every publish and set as the default, so the site root lands there.
- **Serialised and never cancelled** — two mike runs would both rewrite `gh-pages`, and the loser leaves the published site in whatever state it reached.

## No Pages actions

`mike` commits the built site to `gh-pages` itself, which is also what makes the version selector work — the `configure-pages`/`upload-pages-artifact`/`deploy-pages` route publishes a flat site with no version history. So those three are **removed from the pinned-actions table** rather than left as entries for actions nothing uses; #84's table is meant to be the real list.

## One consequence worth stating

`/VERSION` only moves when a release goes out, so a docs change merged after `0.1.0` shipped republishes under `0.1.0`. **A released version's docs are the *current* docs for that version, not a snapshot of what shipped with it.**

That's the right trade here — a fix to a confusing page should reach readers without waiting for a release — and history is still preserved at the granularity of releases, which is the granularity anyone actually asks about. It's documented rather than left as a surprise.

## Deviations and Decisions

- **Also triggers on `v*` tags**, which the checklist asks for, even though the tag and `main` carry the same `/VERSION` at that moment so the publish is usually a no-op. It's the belt to `main`'s braces: if a release lands without touching `docs/`, the path filter would skip the `main` push and the release would never publish its docs.
- **Kept `mike set-default --push latest` on every run** rather than making it a one-off. It's idempotent, and a conditional "only the first time" is a branch that eventually gets it wrong on a fresh `gh-pages`.
- Requires GitHub Pages to be serving from the `gh-pages` branch — #81, already closed. If the site 404s after this merges, that's the setting to check first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_