### PR TITLE
docs(pipeline): record skills provenance and keep this repo's skills isolated

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -1,0 +1,27 @@
+{
+  "$comment": [
+    "PROVENANCE ONLY. This file records where each skill was originally ported",
+    "from. Nothing reads it at runtime, and no workflow syncs against it.",
+    "",
+    "The skills in .claude/skills/ are the source of truth in this repository.",
+    "They were hand-ported and then diverged to fit this game, so a sync from",
+    "upstream would revert local work — which is exactly why the upstream",
+    "project disabled its own sync. See docs/engineering/issue-pipeline.md."
+  ],
+  "sync": "disabled",
+  "sync_reason": "Skills here are local and hand-maintained. A scheduled sync would overwrite local divergence with an upstream copy that does not know about this game.",
+  "upstream": {
+    "repository": "derekwinters/lucas-doggiehood",
+    "role": "historical source, not a live dependency",
+    "read_at_runtime": false
+  },
+  "skills": [
+    {
+      "name": "release-flow",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Rewritten around this repo's release-please config paths and the pull-request-title-pattern set in .github/release-please/config.json."
+    }
+  ]
+}

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -412,3 +412,46 @@ remembered, so nothing on it can be stale.
 The scripts inside them are ordinary Python with ordinary unit tests, run by the
 `pipeline-tests` workflow ([CI/CD](ci-cd.md#pipeline-workflows)). The pipeline is
 code, and a broken gatekeeper is a broken queue.
+
+## Skills here are local, and deliberately not synced
+
+**`.claude/skills/` is the source of truth in this repository.** Every skill was
+hand-ported from `derekwinters/lucas-doggiehood` and then diverged to fit this
+game — different release config, different milestones, a different label
+taxonomy.
+
+There is **no `skills-update` workflow**, no scheduled sync, and nothing here
+reads an upstream skills repository at runtime. No `AI_SKILLS_READ_TOKEN` secret
+is needed, and one should not be added.
+
+### Why not sync
+
+A sync would eventually revert local work. That is not a hypothetical: it is
+why the upstream project disabled its own sync. Once a skill has diverged —
+which it does the first time it mentions `.github/release-please/config.json`
+or `type:wireframe` — an upstream copy is not an update, it is a regression
+wearing an update's clothes. And it arrives on a schedule, so it lands when
+nobody is looking at it.
+
+### The manifest is a record, not a subscription
+
+`.claude/.skills-manifest.json` says where each skill came from and whether it
+has diverged, so a future reconciliation knows what was copied from where. It
+carries `"sync": "disabled"` and the reason, so nobody wires a workflow to it by
+assuming that a manifest implies a sync.
+
+Nothing reads it. It is documentation that happens to be JSON.
+
+### If a sync is ever wanted
+
+In this order, and not any other:
+
+1. **Reconcile the divergence first.** Diff every local skill against upstream
+   and decide, per difference, which side is right. A sync installed before
+   this step is a sync that silently makes those decisions by overwriting.
+2. Restore a `skills-update` workflow and its read token.
+3. Subscribe only the skills that genuinely have no local divergence, and record
+   in the manifest which those are.
+
+Steps 2 and 3 are an afternoon. Step 1 is the one that gets skipped, and it is
+the one that matters.


### PR DESCRIPTION
Closes #46

This one is mostly a decision written down: the skills in this repo are local and hand-maintained, and **no sync gets installed**.

**Docs:** `docs/engineering/issue-pipeline.md` — new "Skills here are local, and deliberately not synced" section.

## What's here

- **No `.github/workflows/skills-update.yml`** — the most important deliverable is the file that doesn't exist.
- **`.claude/.skills-manifest.json`** as a provenance record: where each skill came from, whether it has diverged, and why. Carries `"sync": "disabled"` with a one-line reason, so nobody wires a workflow to it on the assumption that a manifest implies a subscription. Nothing reads it — it's documentation that happens to be JSON.
- **The decision recorded** in `issue-pipeline.md`, with the reasoning and the re-enable path.
- **No `AI_SKILLS_READ_TOKEN`**, and nothing reading an upstream skills repo at runtime.

## Why not sync

A sync would eventually revert local work — and that isn't hypothetical, it's why the upstream project disabled its own. Once a skill has diverged, which it does the first time it mentions `.github/release-please/config.json` or `type:wireframe`, an upstream copy isn't an update; it's a regression wearing an update's clothes. And it arrives on a schedule, so it lands when nobody's looking at it.

## If a sync is ever wanted

The docs give the order, and the order is the point:

1. **Reconcile the divergence first** — diff every local skill against upstream and decide, per difference, which side is right.
2. Restore the workflow and its token.
3. Subscribe only the skills with genuinely no local divergence.

Steps 2 and 3 are an afternoon. Step 1 is the one that gets skipped, and it's the one that matters — a sync installed before it silently makes all those decisions by overwriting.

## Deviations and Decisions

- **The manifest lists only `release-flow`**, the one skill that exists so far. Each of #47–#52 and #53–#73 adds its own entry as it lands, which keeps the record accurate rather than aspirational.
- **Recorded the upstream as `derekwinters/lucas-doggiehood`** rather than `derekwinters/ai-skills`. The issue mentions both; the port issues all name Doggiehood as the source, so that's what the provenance says. If skills actually came via an `ai-skills` bundle, the manifest is one line to correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_