### PR TITLE
feat(skills): bring over the run-tests skill

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -5,7 +5,7 @@
     "",
     "The skills in .claude/skills/ are the source of truth in this repository.",
     "They were hand-ported and then diverged to fit this game, so a sync from",
-    "upstream would revert local work — which is exactly why the upstream",
+    "upstream would revert local work \u2014 which is exactly why the upstream",
     "project disabled its own sync. See docs/engineering/issue-pipeline.md."
   ],
   "sync": "disabled",
@@ -22,6 +22,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Rewritten around this repo's release-please config paths and the pull-request-title-pattern set in .github/release-please/config.json."
+    },
+    {
+      "name": "run-tests",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Commands resolved to this repo's Core suite and CI scripts; records the EditMode CI-only limitation as a non-deviation."
     }
   ]
 }

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: run-tests
+description: Run the Multiplying Frogs test suites and report the result. Use during a red-green loop, before committing, before opening a PR, or whenever asked whether the tests pass.
+---
+
+# run-tests
+
+Run the suites the same way every time, and report the result the same way
+every time. Improvising a command per session is how "the tests pass" comes to
+mean four different things.
+
+## The Core suite
+
+This is the one you run constantly.
+
+```bash
+dotnet test Tests/Core/Frogs.Core.Tests.csproj
+```
+
+No editor, no licence, no display, no container — a couple of seconds. Fast
+enough to run on every save, which is the whole point: a red-green loop you can
+run mid-thought is one you actually use.
+
+One fixture, while you are in a loop:
+
+```bash
+dotnet test Tests/Core/Frogs.Core.Tests.csproj --filter FullyQualifiedName~AppVersion
+```
+
+### Reading the output
+
+The line that matters is the last one:
+
+```text
+Passed!  - Failed: 0, Passed: 42, Skipped: 0, Total: 42, Duration: 57 ms
+Failed!  - Failed: 3, Passed: 8,  Skipped: 0, Total: 11, Duration: 68 ms
+```
+
+- **`Failed: 0` and `Total > 0`** is a pass. Check both. A run that compiled
+  nothing and executed nothing also says `Failed: 0`.
+- **A build error is a red suite**, not a broken command. `error CS0103: The
+  name 'AppVersion' does not exist` during a red phase is *exactly right* — it
+  is what "the type does not exist yet" looks like.
+- **Read the failure message, not just the count.** In a red phase you are
+  checking that it failed for the reason you intended.
+
+## The EditMode suite cannot run here
+
+**Agent environments have no Unity editor and no licence.** `Assets/Tests/EditMode`
+cannot be executed locally. This is a fact about the environment, not a
+shortcoming of the change.
+
+The flow:
+
+1. Run the Core suite. This one is never blocked, so "I couldn't run the tests"
+   is never true of it.
+2. Write the EditMode tests the change needs, and say in the PR that they were
+   written but not executed locally.
+3. Push. CI runs both.
+4. **Watch CI.** If EditMode goes red, that is yours, exactly as if you had seen
+   it fail locally.
+
+**Do not report this as a deviation.** It is the expected, documented flow —
+see
+[testing.md](../../../docs/engineering/testing.md#this-is-not-a-reportable-deviation).
+
+## The other checks
+
+Not tests, but they fail PRs, and they all run here in seconds:
+
+```bash
+python3 .github/scripts/check_core_isolation.py     # Core has no Unity dependency
+python3 .github/scripts/check_geometry_literals.py  # no new bare tuning literals
+python3 .github/scripts/run_python_tests.py         # the skills and CI scripts
+mkdocs build --strict                               # the docs site
+```
+
+Run the ones the change could affect. Run all of them if unsure — the whole set
+is faster than opening the CI page.
+
+## Report format
+
+Same shape every time, so it can be skimmed:
+
+```text
+Core:      42 passed, 0 failed (57 ms)
+Isolation: pass
+Geometry:  pass
+Scripts:   105 passed
+Docs:      built
+EditMode:  not run — no editor in this environment; CI will run it
+```
+
+When something is red, add the failing test's name and what it said:
+
+```text
+Core:      39 passed, 3 failed
+  Parse_RejectsAnythingThatIsNotThreeNumbers("0.2")
+    Expected: <System.FormatException>
+```
+
+One failure with its message beats a hundred lines of pasted output. If several
+failed for the same reason, say so once and give the count.

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -67,6 +67,14 @@ dotnet test Tests/Core/Frogs.Core.Tests.csproj
 dotnet test Tests/Core/Frogs.Core.Tests.csproj --filter FullyQualifiedName~AppVersion
 ```
 
+The `run-tests` skill wraps both, along with the non-test checks that also fail
+a PR, and fixes a report format — so "the tests pass" means the same thing every
+time it is said.
+
+One thing worth knowing when reading the output: **check `Total > 0` as well as
+`Failed: 0`.** A run that compiled nothing and executed nothing also reports
+zero failures.
+
 `Frogs.Core.Tests.csproj` compiles `Assets/Scripts/Core/**/*.cs` directly rather
 than referencing a built assembly. Unity owns that build and regenerates its
 `.csproj` on every import, so there is no stable project to reference — and


### PR DESCRIPTION
Closes #47

Improvising a test command per session is how "the tests pass" comes to mean four different things. This fixes the commands, how to read them, and the shape of the report.

**Docs:** `docs/engineering/testing.md` — pointed at the skill and added the `Total > 0` reading note.

## What's here

- **The Core suite command**, plus the `--filter` form for a tight red-green loop.
- **How to read the output**, with two things worth knowing:
  - **Check `Total > 0` as well as `Failed: 0`.** A run that compiled nothing and executed nothing also reports zero failures — the same class of dangerous green that `verify_editmode_results.py` exists to catch, one level down.
  - **A build error during a red phase is the suite working.** `error CS0103: The name 'AppVersion' does not exist` is exactly what "the type doesn't exist yet" looks like, not a broken command to go fix.
- **The EditMode limitation** stated explicitly, with the four-step flow ending in *watch CI*, and that it is **not** a reportable deviation — pointing at `testing.md` rather than keeping a second copy of the reasoning that would drift.
- **The other checks** that also fail a PR — isolation, geometry, script tests, docs build.
- **A fixed report format**, with the rule that one failure with its message beats a hundred lines of pasted output.

## Deviations and Decisions

- **Included the non-test checks** (isolation, geometry, `run_python_tests`, `mkdocs build --strict`). The issue only asks for the suites, but the skill triggers "before committing", and at that moment the honest question is "will CI go green", not "did NUnit pass". Leaving them out would make the skill's answer confidently incomplete.
- **No script.** Unlike `release-flow`, there's no logic here to test — it's four commands and how to read them. A wrapper script would add a thing to maintain between the agent and `dotnet test`, and would hide the output the skill is trying to teach people to read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_