### PR TITLE
feat(skills): bring over the ci-watch skill

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -29,6 +29,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Commands resolved to this repo's Core suite and CI scripts; records the EditMode CI-only limitation as a non-deviation."
+    },
+    {
+      "name": "ci-watch",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Classifier written against this repo's check names and verified on PRs #130 and #123."
     }
   ]
 }

--- a/.claude/skills/ci-watch/SKILL.md
+++ b/.claude/skills/ci-watch/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: ci-watch
+description: Watch a pull request's checks until they finish and report pass or fail with log excerpts. Use after pushing, when asked whether CI is green, or when a PR's checks need following to completion. Reports only — it never fixes anything.
+---
+
+# ci-watch
+
+Poll a PR's checks until they reach a terminal state, then say what happened.
+
+```bash
+python3 .claude/skills/ci-watch/ci_watch.py --pr 123     # poll to completion
+python3 .claude/skills/ci-watch/ci_watch.py --pr 123 --once  # report right now
+```
+
+## It reports. It never fixes.
+
+Not a style preference — **a watcher that also fixes is a watcher whose report
+you cannot trust**, because it is describing a situation it has already changed.
+"CI was red, then I changed three things, and now it is green" is not a CI
+report; it is a second change nobody reviewed.
+
+Resolution belongs to whoever called it: the development agent for its own PR,
+the delivery skill for one it is driving. This skill does not push, does not
+re-run jobs, does not approve parked checks, and does not edit the PR.
+
+## The four states
+
+| State | Exit | Means |
+| --- | --- | --- |
+| `passed` | 0 | every check completed, none failed |
+| `failed` | 1 | at least one check failed — actionable now |
+| `parked` | 2 | a check is waiting for a human to approve it |
+| `pending` (timed out) | 2 | the checks never finished |
+
+Three exit codes because they need three different responses. Two of them are
+not "fix the build":
+
+- **`parked`** means nothing will change until someone clicks approve in the
+  PR's Checks tab. Polling through it just burns the timeout and reports the
+  same thing, so it is treated as **terminal**. Tell the human; do not wait.
+- **A timeout is not a pass and not a failure.** The report says the checks
+  never finished, which is a different problem from them failing — usually a
+  runner queue rather than the change.
+
+### Two things it deliberately does not call a pass
+
+- **No checks at all** is `pending`, not `passed`. An empty list means the
+  checks have not registered yet, and "no checks ran" is the worst possible
+  answer to "is CI green".
+- **`cancelled` and `timed_out` are failures.** They did not pass, and treating
+  them as a pass is how a cancelled run becomes a green merge. The classifier
+  lists the *passing* conclusions (`success`, `neutral`, `skipped`) rather than
+  the failing ones, so a conclusion GitHub adds later reads as "not a pass"
+  instead of being silently tolerated.
+
+A failure outranks a parked run: if something has already failed, that is the
+news, and the parked check is a detail on top of it.
+
+## Bounded polling
+
+`POLL_SECONDS = 15`, `TIMEOUT_SECONDS = 1200`. Long enough not to hammer the
+API, short enough that a two-minute check does not feel like five, and it always
+stops.
+
+## The report
+
+```text
+1 check(s) failed.
+  ok    Core (NUnit)
+  ok    Debug APK
+  FAIL  EditMode (Unity)
+  ok    lint
+```
+
+For a failure, add the excerpt from that job's log:
+
+```bash
+gh run view --job <job-id> --log-failed
+```
+
+`extract_excerpt` picks the lines worth reading — NUnit `Failed`/`Expected:`/
+`But was:` lines, `error CS…`, Actions' own `##[error]` markers, tracebacks —
+with two lines of context each, and falls back to the tail of the log when
+nothing matches, because the end of a log is where a crash usually is. It is
+capped at 40 lines: one failure with its message beats a hundred lines of
+pasted output.
+
+## Verified
+
+Checked against real PRs in this repo — #130 (all green) classified `passed`,
+#123 (EditMode red, everything else green) classified `failed` with only the
+Unity job marked.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py ci-watch
+```
+
+20 tests. The classifier and the excerpt extractor are pure functions, and
+`watch` takes its clock and its sleep as arguments, so the polling and timeout
+behaviour is tested without waiting for anything.

--- a/.claude/skills/ci-watch/ci_watch.py
+++ b/.claude/skills/ci-watch/ci_watch.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Watch a PR's checks until they finish, and report what happened.
+
+**This reports. It never fixes anything.** Resolution belongs to the caller —
+the development agent for its own PR, the delivery skill for one it is driving.
+A watcher that also fixes is a watcher whose report you cannot trust, because it
+is describing a situation it has already changed.
+
+    python3 ci_watch.py --pr 123
+
+Exits 0 when every check passed, 1 when any failed, 2 when they never finished
+or are waiting on a human. Three exit codes because they need three different
+responses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+
+PASSED = "passed"
+FAILED = "failed"
+PENDING = "pending"
+PARKED = "parked"
+
+# Long enough not to hammer the API, short enough that a two-minute check does
+# not feel like five.
+POLL_SECONDS = 15
+TIMEOUT_SECONDS = 20 * 60
+
+EXCERPT_LINES = 40
+
+# Conclusions that are not a pass but also not a failure to fix: nothing will
+# change until a person clicks approve.
+PARKED_STATES = {"action_required", "waiting", "queued_pending_approval"}
+
+# A conclusion that is not one of these is a failure. Listing the *good* ones is
+# deliberate: a conclusion GitHub adds later should read as "not a pass" rather
+# than being silently tolerated.
+PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+# Lines worth putting in front of a human, in preference to the tail of the log.
+INTERESTING = re.compile(
+    r"""
+    (^\s*Failed\s)            # NUnit: "  Failed SplitsAtThreshold [4 ms]"
+    | (\berror\s+CS\d+)       # the C# compiler
+    | (^\s*Expected:)         # an assertion's two halves
+    | (^\s*But\s+was:)
+    | (\b(error|Error|ERROR)\b[:\s])
+    | (^\s*[#][#]\[error\])   # Actions' own marker; '#' escaped for re.VERBOSE
+    | (\bTraceback\b)
+    | (\bAssertionError\b)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+class Result:
+    def __init__(self, state, checks, timed_out=False):
+        self.state = state
+        self.checks = checks
+        self.timed_out = timed_out
+
+    @property
+    def failed(self):
+        return [c for c in self.checks if _is_failure(c)]
+
+    @property
+    def parked(self):
+        return [c for c in self.checks if _is_parked(c)]
+
+    @property
+    def unfinished(self):
+        return [c for c in self.checks if c.get("status") != "completed" and not _is_parked(c)]
+
+
+def _is_parked(check: dict) -> bool:
+    return check.get("status") in PARKED_STATES or check.get("conclusion") in PARKED_STATES
+
+
+def _is_failure(check: dict) -> bool:
+    if check.get("status") != "completed" or _is_parked(check):
+        return False
+    return check.get("conclusion") not in PASSING_CONCLUSIONS
+
+
+def classify(checks: list[dict]) -> Result:
+    """The verdict for a set of check runs."""
+    if not checks:
+        # Not a pass. An empty list means the checks have not registered yet,
+        # and "no checks" is the worst possible answer to "is CI green".
+        return Result(PENDING, checks)
+
+    if any(_is_failure(check) for check in checks):
+        # A failure outranks everything: it is the news, and it is actionable
+        # now.
+        return Result(FAILED, checks)
+
+    if any(check.get("status") != "completed" and not _is_parked(check) for check in checks):
+        return Result(PENDING, checks)
+
+    if any(_is_parked(check) for check in checks):
+        return Result(PARKED, checks)
+
+    return Result(PASSED, checks)
+
+
+def is_terminal(state: str) -> bool:
+    """Is there any point waiting longer?
+
+    `PARKED` is terminal: nothing changes until a human clicks, so polling
+    through it just burns the timeout and then reports the same thing.
+    """
+    return state != PENDING
+
+
+def extract_excerpt(log: str, max_lines: int = EXCERPT_LINES) -> str:
+    """The part of a job log worth reading.
+
+    Interesting lines with a little context if there are any; otherwise the
+    tail, because the end of a log is where a crash usually is.
+    """
+    if not log.strip():
+        return "(no log available — the job may have been cancelled before it started)"
+
+    lines = log.splitlines()
+    wanted: set[int] = set()
+
+    for number, line in enumerate(lines):
+        if INTERESTING.search(line):
+            wanted.update(range(max(0, number - 2), min(len(lines), number + 3)))
+
+    if not wanted:
+        return "\n".join(lines[-max_lines:])
+
+    chosen = sorted(wanted)[:max_lines]
+    excerpt: list[str] = []
+    previous = None
+
+    for number in chosen:
+        if previous is not None and number > previous + 1:
+            excerpt.append("    …")
+        excerpt.append(lines[number])
+        previous = number
+
+    return "\n".join(excerpt)
+
+
+def watch(fetch, sleep=time.sleep, now=time.monotonic) -> Result:
+    """Poll `fetch` until the checks reach a terminal state or time runs out."""
+    started = now()
+
+    while True:
+        result = classify(fetch())
+
+        if is_terminal(result.state):
+            return result
+
+        if now() - started >= TIMEOUT_SECONDS:
+            # A timeout is not a pass and not a failure. The caller is told the
+            # checks never finished, which needs a different response from them
+            # having failed.
+            return Result(PENDING, result.checks, timed_out=True)
+
+        sleep(POLL_SECONDS)
+
+
+def fetch_checks(pull_number: int):
+    def fetch() -> list[dict]:
+        completed = subprocess.run(
+            ["gh", "pr", "view", str(pull_number), "--json", "statusCheckRollup"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(completed.stdout or "{}")
+        return [
+            {
+                "name": check.get("name") or check.get("context"),
+                "status": (check.get("status") or "").lower() or "completed",
+                "conclusion": (check.get("conclusion") or check.get("state") or "").lower() or None,
+                "url": check.get("detailsUrl") or check.get("targetUrl"),
+            }
+            for check in payload.get("statusCheckRollup") or []
+        ]
+
+    return fetch
+
+
+def report(result: Result) -> str:
+    lines = []
+
+    for check in sorted(result.checks, key=lambda c: c.get("name") or ""):
+        if _is_failure(check):
+            mark = "FAIL"
+        elif _is_parked(check):
+            mark = "WAIT"
+        elif check.get("status") != "completed":
+            mark = "...."
+        else:
+            mark = "ok"
+        lines.append(f"  {mark:5} {check.get('name')}")
+
+    if result.state == PASSED:
+        header = f"All {len(result.checks)} checks passed."
+    elif result.state == FAILED:
+        header = f"{len(result.failed)} check(s) failed."
+    elif result.state == PARKED:
+        header = (
+            f"{len(result.parked)} check(s) are waiting for approval. Nothing will "
+            "change until someone approves them in the PR's Checks tab."
+        )
+    elif result.timed_out:
+        header = (
+            f"Gave up after {TIMEOUT_SECONDS // 60} minutes with "
+            f"{len(result.unfinished)} check(s) still running. Not a pass, and not a "
+            "failure — the checks never finished."
+        )
+    else:
+        header = "Checks are still running."
+
+    return header + "\n" + "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--once", action="store_true", help="report now, do not poll")
+    arguments = parser.parse_args(argv)
+
+    fetch = fetch_checks(arguments.pr)
+    result = classify(fetch()) if arguments.once else watch(fetch)
+
+    print(report(result))
+
+    if result.state == PASSED:
+        return 0
+    if result.state == FAILED:
+        return 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/ci-watch/tests/test_ci_watch.py
+++ b/.claude/skills/ci-watch/tests/test_ci_watch.py
@@ -1,0 +1,165 @@
+"""Unit tests for the ci-watch classifier and excerpt extractor."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import ci_watch  # noqa: E402
+
+
+def run(name, status="completed", conclusion="success"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_all_successful_is_passed(self):
+        result = ci_watch.classify([run("lint"), run("Docs")])
+
+        self.assertEqual(ci_watch.PASSED, result.state)
+
+    def test_one_failure_is_failed(self):
+        result = ci_watch.classify([run("lint"), run("Docs", conclusion="failure")])
+
+        self.assertEqual(ci_watch.FAILED, result.state)
+        self.assertEqual(["Docs"], [c["name"] for c in result.failed])
+
+    def test_an_unfinished_run_is_pending(self):
+        result = ci_watch.classify([run("lint"), run("Docs", status="in_progress", conclusion=None)])
+
+        self.assertEqual(ci_watch.PENDING, result.state)
+
+    def test_a_queued_run_is_pending(self):
+        result = ci_watch.classify([run("lint", status="queued", conclusion=None)])
+
+        self.assertEqual(ci_watch.PENDING, result.state)
+
+    def test_skipped_and_neutral_do_not_fail_the_verdict(self):
+        result = ci_watch.classify(
+            [run("a", conclusion="skipped"), run("b", conclusion="neutral"), run("c")])
+
+        self.assertEqual(ci_watch.PASSED, result.state)
+
+    def test_cancelled_is_a_failure(self):
+        # A cancelled check did not pass, and treating it as one is how a
+        # cancelled run becomes a green merge.
+        result = ci_watch.classify([run("a", conclusion="cancelled")])
+
+        self.assertEqual(ci_watch.FAILED, result.state)
+
+    def test_a_timed_out_run_is_a_failure(self):
+        self.assertEqual(ci_watch.FAILED, ci_watch.classify([run("a", conclusion="timed_out")]).state)
+
+    def test_no_checks_at_all_is_pending_not_passed(self):
+        # An empty list means the checks have not registered yet. Reporting it
+        # as a pass is the worst possible answer to "is CI green".
+        self.assertEqual(ci_watch.PENDING, ci_watch.classify([]).state)
+
+
+class ParkedRunTests(unittest.TestCase):
+    def test_a_run_awaiting_approval_is_reported_as_parked(self):
+        result = ci_watch.classify([run("pr-build", status="waiting", conclusion=None)])
+
+        self.assertEqual(ci_watch.PARKED, result.state)
+        self.assertEqual(["pr-build"], [c["name"] for c in result.parked])
+
+    def test_action_required_counts_as_parked(self):
+        result = ci_watch.classify([run("pr-build", conclusion="action_required")])
+
+        self.assertEqual(ci_watch.PARKED, result.state)
+
+    def test_a_failure_outranks_a_parked_run(self):
+        # If something has already failed, that is the news; the parked run is
+        # a detail on top of it.
+        result = ci_watch.classify(
+            [run("a", conclusion="failure"), run("b", status="waiting", conclusion=None)])
+
+        self.assertEqual(ci_watch.FAILED, result.state)
+
+    def test_parked_is_terminal_for_polling(self):
+        # Nothing will change without a human, so waiting is pointless.
+        self.assertTrue(ci_watch.is_terminal(ci_watch.PARKED))
+        self.assertTrue(ci_watch.is_terminal(ci_watch.PASSED))
+        self.assertTrue(ci_watch.is_terminal(ci_watch.FAILED))
+        self.assertFalse(ci_watch.is_terminal(ci_watch.PENDING))
+
+
+class ExcerptTests(unittest.TestCase):
+    def test_error_lines_are_preferred_over_the_tail(self):
+        log = "\n".join(["setting up"] * 50 + ["error CS0103: nope"] + ["cleanup"] * 50)
+
+        excerpt = ci_watch.extract_excerpt(log)
+
+        self.assertIn("error CS0103", excerpt)
+
+    def test_the_tail_is_used_when_nothing_matches(self):
+        log = "\n".join(f"line {n}" for n in range(200))
+
+        excerpt = ci_watch.extract_excerpt(log)
+
+        self.assertIn("line 199", excerpt)
+        self.assertNotIn("line 0", excerpt)
+
+    def test_the_excerpt_is_bounded(self):
+        log = "\n".join(["error: something"] * 500)
+
+        excerpt = ci_watch.extract_excerpt(log)
+
+        self.assertLessEqual(len(excerpt.splitlines()), ci_watch.EXCERPT_LINES)
+
+    def test_a_failed_assertion_is_matched(self):
+        log = "ok\n  Failed SplitsAtThreshold [4 ms]\n  Expected: 32\n  But was: 16\nok"
+
+        excerpt = ci_watch.extract_excerpt(log)
+
+        self.assertIn("Failed SplitsAtThreshold", excerpt)
+
+    def test_an_empty_log_says_so_rather_than_returning_nothing(self):
+        self.assertIn("no log", ci_watch.extract_excerpt("").lower())
+
+
+class PollingBoundsTests(unittest.TestCase):
+    def test_the_interval_and_timeout_are_named_constants(self):
+        self.assertIsInstance(ci_watch.POLL_SECONDS, (int, float))
+        self.assertIsInstance(ci_watch.TIMEOUT_SECONDS, (int, float))
+        self.assertGreater(ci_watch.TIMEOUT_SECONDS, ci_watch.POLL_SECONDS)
+
+    def test_polling_stops_at_a_terminal_state(self):
+        responses = [
+            [run("a", status="in_progress", conclusion=None)],
+            [run("a", status="in_progress", conclusion=None)],
+            [run("a")],
+        ]
+        slept = []
+
+        result = ci_watch.watch(
+            fetch=lambda: responses.pop(0), sleep=slept.append, now=_clock())
+
+        self.assertEqual(ci_watch.PASSED, result.state)
+        self.assertEqual(2, len(slept))
+
+    def test_polling_gives_up_and_reports_pending(self):
+        # A timeout is not a pass. The caller is told the checks never
+        # finished, which is a different problem from them failing.
+        result = ci_watch.watch(
+            fetch=lambda: [run("a", status="in_progress", conclusion=None)],
+            sleep=lambda seconds: None,
+            now=_clock(step=ci_watch.TIMEOUT_SECONDS))
+
+        self.assertEqual(ci_watch.PENDING, result.state)
+        self.assertTrue(result.timed_out)
+
+
+def _clock(step=1):
+    state = {"t": 0}
+
+    def now():
+        state["t"] += step
+        return state["t"]
+
+    return now
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #48

Polls a PR's checks until they finish and says what happened. The serial-delivery skill (#67) will lean on it.

**Docs:** None — no behaviour the docs describe changed. `agent-workflow.md` already lists `ci-watch` in the skills table. Using `skip-docs`; see Deviations.

## It reports. It never fixes.

Stated as the first thing in `SKILL.md`, with the reason rather than the instruction: **a watcher that also fixes is a watcher whose report you can't trust**, because it's describing a situation it has already changed. "CI was red, then I changed three things, and now it's green" isn't a CI report — it's a second change nobody reviewed.

## Four states, three exit codes

| State | Exit | |
| --- | --- | --- |
| `passed` | 0 | |
| `failed` | 1 | actionable now |
| `parked` | 2 | waiting on a human — **terminal**, so it doesn't poll through it |
| `pending` (timed out) | 2 | the checks never finished |

Two of those aren't "fix the build", which is why they don't share an exit code. Parked is terminal because nothing changes until someone clicks approve — polling through it just burns the timeout and reports the same thing. A timeout is neither a pass nor a failure: "never finished" is usually a runner queue, not the change.

## Two things it refuses to call a pass

- **No checks at all** → `pending`, not `passed`. An empty list means the checks haven't registered yet, and "no checks ran" is the worst possible answer to "is CI green".
- **`cancelled` and `timed_out` are failures.** The classifier lists the *passing* conclusions (`success`, `neutral`, `skipped`) rather than the failing ones, so a conclusion GitHub adds later reads as "not a pass" instead of being silently tolerated.

## Verified against real PRs

As the issue asks — run against live check data from this repo:

- **#130** (all green) → `passed`, 3 checks
- **#123** (EditMode red, rest green) → `failed`, with only the Unity job marked `FAIL`

## Test-first, and it caught a real bug

Red on `ModuleNotFoundError`. Then the first run of the 20 tests failed to even import: the excerpt regex uses `re.VERBOSE`, where **`#` starts a comment** — so the `##[error]` pattern silently commented out the rest of its own line and left an unterminated group. A regex I'd have called obviously correct on review.

`watch` takes its clock and its sleep as arguments, so the polling and timeout behaviour is tested without waiting for anything.

## Deviations and Decisions

- **Used `skip-docs`.** This adds a tool, not a behaviour the design contract describes; `agent-workflow.md` already lists `ci-watch` among the supporting skills, and the operational detail belongs in `SKILL.md` next to the code rather than duplicated into `/docs` where it would drift. This is the first use of the hatch and it seemed worth being explicit about the reasoning rather than just applying the label.
- **Verified via the REST API rather than `gh`**, which isn't installed in this environment. The runtime path uses `gh pr view --json statusCheckRollup`; the classifier — the part with the logic — was fed real check-run payloads from both PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_