### PR TITLE
feat(skills): bring over the scaffold-core skill

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -36,6 +36,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Classifier written against this repo's check names and verified on PRs #130 and #123."
+    },
+    {
+      "name": "scaffold-core",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Namespaces, folder layout, and the no-meta-for-Tests/Core rule follow this repo's tech-stack.md."
     }
   ]
 }

--- a/.claude/skills/scaffold-core/SKILL.md
+++ b/.claude/skills/scaffold-core/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: scaffold-core
+description: Create a new Core type and its failing test, following the project's namespaces, folder layout, and .meta conventions. Use before writing any Core logic, at the start of the red phase.
+---
+
+# scaffold-core
+
+```bash
+python3 .claude/skills/scaffold-core/scaffold.py Pond
+python3 .claude/skills/scaffold-core/scaffold.py SplitRule --subfolder Rules
+```
+
+## Run this before any logic exists
+
+The point is *where it leaves you*: an empty class and a test that fails. That
+is the start of the red phase, which is where a new type is supposed to begin.
+
+Scaffolding after writing the implementation gets you nothing — the layout is
+already decided by then, and the test you add afterwards is one written by
+someone who already knows the answer.
+
+## What it writes
+
+| File | |
+| --- | --- |
+| `Assets/Scripts/Core/<sub>/<Name>.cs` | the type, in `Frogs.Core[.<Sub>]` |
+| `Assets/Scripts/Core/<sub>/<Name>.cs.meta` | a pinned GUID |
+| `Tests/Core/<sub>/<Name>Tests.cs` | a test that **fails** |
+
+Namespaces and layout follow
+[tech-stack.md](../../../docs/engineering/tech-stack.md): a subfolder becomes a
+namespace segment, so `--subfolder Rules` gives `Frogs.Core.Rules` and
+`Frogs.Core.Tests.Rules`.
+
+### Three decisions worth knowing
+
+**The class is empty.** A class arriving with a plausible implementation in it
+is an invitation to skip the test that should have driven it — which is the one
+thing this skill exists to prevent.
+
+**The test calls `Assert.Fail`, not nothing.** An empty stub passes, and a
+passing suite right after scaffolding tells you nothing. Running the suite
+immediately after this must go red. The failure message says what to do next:
+
+```text
+Failed Pond_DoesTheThingTheIssueAskedFor
+  Write the first real test for Pond.
+```
+
+**The test file gets no `.meta`.** `Tests/Core` is outside `Assets/`, so Unity
+never sees it — a `.meta` there would be a file nothing reads. The *class* gets
+one, with a pinned GUID, so Unity does not invent an identity on first import.
+
+## It refuses rather than guessing
+
+- **A lowercase or dotted name is an error**, not something to correct. A
+  scaffolder that silently fixes what you asked for writes a file you then
+  cannot find.
+- **It never overwrites.** An existing file is a `FileExistsError` saying to
+  delete it first if that is really what you want.
+
+## After scaffolding
+
+1. Replace `Assert.Fail` with **one real behaviour**, named for the behaviour.
+2. Run the suite. **Watch it fail**, and check it failed for the reason you
+   meant.
+3. Write the smallest code that passes it.
+
+```bash
+dotnet test Tests/Core/Frogs.Core.Tests.csproj
+```
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py scaffold-core
+```
+
+23 tests. Everything that generates text is a pure function, and the writing is
+tested against a temporary directory.

--- a/.claude/skills/scaffold-core/scaffold.py
+++ b/.claude/skills/scaffold-core/scaffold.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Create a new Core type and its failing test.
+
+Run this **before** writing any logic. It leaves you at the *start* of the red
+phase: an empty class, and a test that fails.
+
+    python3 .claude/skills/scaffold-core/scaffold.py Pond
+    python3 .claude/skills/scaffold-core/scaffold.py Pond --subfolder Rules
+
+What it writes, following docs/engineering/tech-stack.md:
+
+    Assets/Scripts/Core/<sub>/<Name>.cs        the type, in Frogs.Core[.<Sub>]
+    Assets/Scripts/Core/<sub>/<Name>.cs.meta   a pinned GUID, so Unity does not
+                                               invent one on first import
+    Tests/Core/<sub>/<Name>Tests.cs            a test that fails
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import uuid
+from pathlib import Path
+
+CORE_ROOT = "Assets/Scripts/Core"
+TEST_ROOT = "Tests/Core"
+CORE_NAMESPACE = "Frogs.Core"
+TEST_NAMESPACE = "Frogs.Core.Tests"
+
+TYPE_NAME = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+
+
+def validate_type_name(name: str) -> str:
+    """A PascalCase C# identifier, or an error.
+
+    Deliberately does not "fix" a lowercase name: a scaffolder that silently
+    corrects what you asked for produces a file you then cannot find.
+    """
+    trimmed = (name or "").strip()
+
+    if not TYPE_NAME.match(trimmed):
+        raise ValueError(
+            f"'{name}' is not a usable type name. Use PascalCase with no dots or "
+            "spaces — `Pond`, `FrogColony`, `SplitRule`."
+        )
+
+    return trimmed
+
+
+def namespace_for(subfolder: str) -> str:
+    parts = [part for part in (subfolder or "").replace("\\", "/").split("/") if part]
+    return ".".join([CORE_NAMESPACE] + parts)
+
+
+def test_namespace_for(subfolder: str) -> str:
+    parts = [part for part in (subfolder or "").replace("\\", "/").split("/") if part]
+    return ".".join([TEST_NAMESPACE] + parts)
+
+
+def new_guid() -> str:
+    return uuid.uuid4().hex
+
+
+def meta_file(guid: str) -> str:
+    """The .meta for a C# file.
+
+    Modelled on the shape Unity writes for a script asset. The `guid` is the
+    part that matters — it is the asset's identity, and everything that
+    references the file references this rather than its path. See
+    docs/engineering/unity-serialization.md.
+    """
+    return (
+        "fileFormatVersion: 2\n"
+        f"guid: {guid}\n"
+        "MonoImporter:\n"
+        "  externalObjects: {}\n"
+        "  serializedVersion: 2\n"
+        "  defaultReferences: []\n"
+        "  executionOrder: 0\n"
+        "  icon: {instanceID: 0}\n"
+        "  userData:\n"
+        "  assetBundleName:\n"
+        "  assetBundleVariant:\n"
+    )
+
+
+def class_source(name: str, namespace: str) -> str:
+    """An empty type.
+
+    Empty on purpose. A class arriving with a plausible implementation already
+    in it is an invitation to skip writing the test that should have driven it,
+    which is the one thing this skill exists to prevent.
+    """
+    return (
+        f"namespace {namespace}\n"
+        "{\n"
+        f"    public sealed class {name}\n"
+        "    {\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def test_source(name: str, namespace: str, test_namespace: str) -> str:
+    """A test that fails.
+
+    Not an empty stub: running the suite straight after scaffolding must go
+    red, so the loop starts where it is supposed to. The failure message says
+    what to do next.
+    """
+    return (
+        "using NUnit.Framework;\n"
+        f"using {namespace};\n"
+        "\n"
+        f"namespace {test_namespace}\n"
+        "{\n"
+        f"    public sealed class {name}Tests\n"
+        "    {\n"
+        "        [Test]\n"
+        f"        public void {name}_DoesTheThingTheIssueAskedFor()\n"
+        "        {\n"
+        f"            // Replace this with one real behaviour of {name}, named for\n"
+        "            // the behaviour. Run it, watch it fail, and check it failed\n"
+        "            // for the reason you meant — then write the smallest code\n"
+        "            // that passes it.\n"
+        f"            Assert.Fail(\"Write the first real test for {name}.\");\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def scaffold(root: Path, name: str, subfolder: str = "") -> list[Path]:
+    """Write the three files. Returns their paths."""
+    name = validate_type_name(name)
+    relative = (subfolder or "").strip("/")
+
+    class_path = root / CORE_ROOT / relative / f"{name}.cs"
+    meta_path = class_path.with_name(f"{name}.cs.meta")
+    # Tests/Core is outside Assets/, so Unity never sees it — a .meta there
+    # would be a file nothing reads.
+    test_path = root / TEST_ROOT / relative / f"{name}Tests.cs"
+
+    for path in (class_path, meta_path, test_path):
+        if path.exists():
+            raise FileExistsError(
+                f"{path} already exists. Scaffolding over it would discard whatever "
+                "is in it; delete it first if that is what you want."
+            )
+
+    class_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+
+    class_path.write_text(class_source(name, namespace_for(relative)), encoding="utf-8")
+    meta_path.write_text(meta_file(new_guid()), encoding="utf-8")
+    test_path.write_text(
+        test_source(name, namespace_for(relative), test_namespace_for(relative)),
+        encoding="utf-8",
+    )
+
+    return [class_path, meta_path, test_path]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("name", help="the type name, PascalCase")
+    parser.add_argument("--subfolder", default="", help="under Assets/Scripts/Core/, e.g. Rules")
+    parser.add_argument("--root", default=".", help="the repository root")
+    arguments = parser.parse_args(argv)
+
+    try:
+        written = scaffold(Path(arguments.root).resolve(), arguments.name, arguments.subfolder)
+    except (ValueError, FileExistsError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    root = Path(arguments.root).resolve()
+    for path in written:
+        print(f"  {path.relative_to(root)}")
+
+    print(
+        "\nNow run the suite. It should be RED:\n"
+        "  dotnet test Tests/Core/Frogs.Core.Tests.csproj"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/scaffold-core/tests/test_scaffold.py
+++ b/.claude/skills/scaffold-core/tests/test_scaffold.py
@@ -1,0 +1,147 @@
+"""Unit tests for the Core scaffolder."""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scaffold  # noqa: E402
+
+
+class NameTests(unittest.TestCase):
+    def test_a_plain_name_is_accepted(self):
+        self.assertEqual("Pond", scaffold.validate_type_name("Pond"))
+
+    def test_whitespace_is_trimmed(self):
+        self.assertEqual("Pond", scaffold.validate_type_name("  Pond  "))
+
+    def test_a_lowercase_name_is_rejected(self):
+        # C# types are PascalCase, and a scaffolder that silently "fixes" the
+        # name produces a file whose name does not match what was asked for.
+        with self.assertRaises(ValueError):
+            scaffold.validate_type_name("pond")
+
+    def test_a_name_with_a_space_is_rejected(self):
+        with self.assertRaises(ValueError):
+            scaffold.validate_type_name("Frog Colony")
+
+    def test_a_name_with_a_dot_is_rejected(self):
+        with self.assertRaises(ValueError):
+            scaffold.validate_type_name("Frogs.Pond")
+
+    def test_an_empty_name_is_rejected(self):
+        with self.assertRaises(ValueError):
+            scaffold.validate_type_name("")
+
+
+class NamespaceTests(unittest.TestCase):
+    def test_the_root_namespace_for_no_subfolder(self):
+        self.assertEqual("Frogs.Core", scaffold.namespace_for(""))
+
+    def test_a_subfolder_becomes_a_namespace_segment(self):
+        self.assertEqual("Frogs.Core.Rules", scaffold.namespace_for("Rules"))
+
+    def test_nested_subfolders_nest_the_namespace(self):
+        self.assertEqual("Frogs.Core.Rules.Splitting", scaffold.namespace_for("Rules/Splitting"))
+
+    def test_the_test_namespace_mirrors_it(self):
+        self.assertEqual("Frogs.Core.Tests.Rules", scaffold.test_namespace_for("Rules"))
+
+
+class GuidTests(unittest.TestCase):
+    def test_a_guid_is_thirty_two_hex_characters(self):
+        guid = scaffold.new_guid()
+
+        self.assertEqual(32, len(guid))
+        self.assertTrue(all(character in "0123456789abcdef" for character in guid))
+
+    def test_guids_do_not_repeat(self):
+        # Two assets sharing a GUID is the one thing a .meta file must never do.
+        self.assertNotEqual(scaffold.new_guid(), scaffold.new_guid())
+
+    def test_a_meta_file_carries_the_guid(self):
+        meta = scaffold.meta_file("abc123")
+
+        self.assertIn("guid: abc123", meta)
+        self.assertIn("MonoImporter", meta)
+
+
+class GeneratedSourceTests(unittest.TestCase):
+    def test_the_class_is_in_the_right_namespace(self):
+        source = scaffold.class_source("Pond", "Frogs.Core.Rules")
+
+        self.assertIn("namespace Frogs.Core.Rules", source)
+        self.assertIn("public sealed class Pond", source)
+
+    def test_the_class_does_not_reference_unity(self):
+        source = scaffold.class_source("Pond", "Frogs.Core")
+
+        self.assertNotIn("UnityEngine", source)
+        self.assertNotIn("MonoBehaviour", source)
+
+    def test_the_class_body_is_empty_so_the_test_fails(self):
+        # The scaffolder leaves you at the START of the red phase. A class with
+        # a plausible implementation already in it is an invitation to skip
+        # writing the test that should have driven it.
+        source = scaffold.class_source("Pond", "Frogs.Core")
+
+        self.assertNotIn("return", source)
+
+
+class GeneratedTestTests(unittest.TestCase):
+    def source(self):
+        return scaffold.test_source("Pond", "Frogs.Core", "Frogs.Core.Tests")
+
+    def test_it_is_a_failing_test_not_an_empty_stub(self):
+        # The whole point: running the suite immediately after scaffolding must
+        # go red, so the red-green loop starts where it should.
+        source = self.source()
+
+        self.assertIn("Assert.Fail", source)
+
+    def test_it_names_the_type_under_test(self):
+        self.assertIn("PondTests", self.source())
+
+    def test_it_uses_the_test_namespace_and_imports_the_type(self):
+        source = self.source()
+
+        self.assertIn("namespace Frogs.Core.Tests", source)
+        self.assertIn("using Frogs.Core;", source)
+
+    def test_it_uses_nunit(self):
+        self.assertIn("using NUnit.Framework;", self.source())
+
+
+class WritingTests(unittest.TestCase):
+    def test_it_writes_four_files_in_the_right_places(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            written = scaffold.scaffold(root, "Pond", subfolder="Rules")
+
+            self.assertTrue((root / "Assets/Scripts/Core/Rules/Pond.cs").is_file())
+            self.assertTrue((root / "Assets/Scripts/Core/Rules/Pond.cs.meta").is_file())
+            self.assertTrue((root / "Tests/Core/Rules/PondTests.cs").is_file())
+            self.assertEqual(3, len(written))
+
+    def test_the_test_file_gets_no_meta(self):
+        # Tests/Core is outside Assets/, so Unity never sees it and a .meta
+        # there would be a file nothing reads.
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            scaffold.scaffold(root, "Pond")
+
+            self.assertFalse((root / "Tests/Core/PondTests.cs.meta").exists())
+
+    def test_it_refuses_to_overwrite(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            scaffold.scaffold(root, "Pond")
+
+            with self.assertRaises(FileExistsError):
+                scaffold.scaffold(root, "Pond")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -212,7 +212,16 @@ those, injected at build time ([Versioning](versioning.md)).
 
 ### Naming
 
+Use the `scaffold-core` skill to create a Core type; it applies all of this and
+leaves you with a failing test, which is where a new type should start.
+
+```bash
+python3 .claude/skills/scaffold-core/scaffold.py SplitRule --subfolder Rules
+```
+
 - Assemblies and their folders share a name: `Frogs.Core`, `Frogs.Unity`.
+- A subfolder under `Assets/Scripts/Core/` becomes a namespace segment:
+  `Rules/` is `Frogs.Core.Rules`, and its tests are `Frogs.Core.Tests.Rules`.
 - Core types are named for the game, not the engine — `Pond`, `FrogColony`,
   `SplitRule`. If a type name only makes sense to someone who knows Unity, it
   probably belongs in the shell.


### PR DESCRIPTION
Closes #49

Creates a new Core type, its `.meta`, and its test — and leaves you at the *start* of the red phase rather than somewhere writing the implementation first is easy.

**Docs:** `docs/engineering/tech-stack.md` — pointed the naming section at the skill and spelled out the subfolder → namespace rule.

## What it writes

| File | |
| --- | --- |
| `Assets/Scripts/Core/<sub>/<Name>.cs` | the type, in `Frogs.Core[.<Sub>]` |
| `Assets/Scripts/Core/<sub>/<Name>.cs.meta` | pinned GUID |
| `Tests/Core/<sub>/<Name>Tests.cs` | a test that **fails** |

## Three decisions, each pinned by a test

- **The class is empty.** A class arriving with a plausible implementation in it is an invitation to skip the test that should have driven it — the one thing this skill exists to prevent.
- **The test calls `Assert.Fail`, not nothing.** An empty stub *passes*, and a green suite immediately after scaffolding tells you nothing. The message says what to do next: `Write the first real test for Pond.`
- **The test file gets no `.meta`.** `Tests/Core` is outside `Assets/`, so Unity never sees it and a `.meta` there would be a file nothing reads. The class does get one, with a pinned GUID, so Unity doesn't invent an identity on first import.

It also **refuses rather than guessing**: a lowercase or dotted name is an error, not something to quietly correct (a scaffolder that fixes what you asked for writes a file you can't then find), and it never overwrites.

## Verified end to end

Scaffolded a real class and ran the suite:

```
$ python3 .claude/skills/scaffold-core/scaffold.py Pond --subfolder Rules
  Assets/Scripts/Core/Rules/Pond.cs
  Assets/Scripts/Core/Rules/Pond.cs.meta
  Tests/Core/Rules/PondTests.cs

$ dotnet test Tests/Core/Frogs.Core.Tests.csproj
  Failed Pond_DoesTheThingTheIssueAskedFor [37 ms]
Failed!  - Failed: 1, Passed: 42, Total: 43
```

Red on exactly the generated test, and the other 42 unaffected. **23 unit tests** for the scaffolder itself, written first.

## Deviations and Decisions

- **The scaffolded `Pond` was removed again**, so it isn't in this diff. Two reasons: it would leave a permanently failing test on `main`, and `Pond` is a game concept — inventing one isn't mine to do (`CLAUDE.md`). The verification is the run above; the suite is back to 42 passing.
- **`--subfolder` is optional and flat by default.** `Assets/Scripts/Core/` has no subfolders yet, and inventing a taxonomy (`Rules/`, `Frogs/`, `Model/`) before there's anything to sort would be designing the game's structure ahead of the game.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_