### PR TITLE
feat(skills): bring over the issue-blockers skill

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -50,6 +50,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Reference only; defers to docs/engineering/tech-stack.md rather than restating the rule, so the two cannot drift."
+    },
+    {
+      "name": "issue-blockers",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Adds an audit subcommand that finds prose blockers with no native relationship; keeps 'Depends on:' as soft ordering."
     }
   ]
 }

--- a/.claude/skills/issue-blockers/SKILL.md
+++ b/.claude/skills/issue-blockers/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: issue-blockers
+description: Read and write native GitHub blocked-by relationships between issues. Use when an issue cannot start until another is done, when a prose "Blocked by #N" needs converting, or when checking what is blocking an issue.
+---
+
+# issue-blockers
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+python3 .claude/skills/issue-blockers/set_blocker.py list   --issue 28
+python3 .claude/skills/issue-blockers/set_blocker.py add    --issue 28 --blocked-by 82
+python3 .claude/skills/issue-blockers/set_blocker.py remove --issue 28 --blocked-by 82
+python3 .claude/skills/issue-blockers/set_blocker.py audit  --issue 28
+```
+
+## Prose blockers are not allowed
+
+**`Blocked by #42` written in an issue body is not a blocker.** It is a sentence.
+
+Everything that acts on blockers reads the *native* dependency graph: the
+nightly builder computing its ready queue, the dashboard's blocked section, and
+the sweep that wakes an issue when its blocker closes. None of them read prose.
+An issue "blocked" in a sentence is an issue the builder walks straight into and
+starts.
+
+So when you discover a dependency — even on an issue that is not yours — record
+it natively, there and then. `audit` finds the ones already written as prose:
+
+```text
+#42 is named as a blocker in the body but has no native relationship.
+Run: set_blocker.py add --issue 28 --blocked-by 42
+```
+
+### `Depends on:` is different, and stays prose
+
+`Depends on: #42` is **soft ordering** — "this will go better afterwards" — and
+it has no native form on purpose.
+
+Converting one into a native blocker turns a preference into a hard gate the
+builder refuses to pass, which is how a queue deadlocks on an issue that could
+have been worked at any time. `audit` deliberately ignores `Depends on:` lines,
+and there is a test pinning that.
+
+| In the body | Means | Native? |
+| --- | --- | --- |
+| `Blocked by #42` | cannot start until #42 is done | **yes** — convert it |
+| `Depends on: #42` | easier after #42, but not blocked | no — leave it |
+
+## The trap: the write API takes an id, not a number
+
+`GET .../dependencies/blocked_by` returns issues with their `number`. The
+**write** endpoints take `issue_id` — the internal ten-digit identifier, not the
+number everyone reads and writes:
+
+```http
+POST /repos/:owner/:repo/issues/28/dependencies/blocked_by
+{"issue_id": 5098389812}      ✅   the internal id of issue #82
+{"issue_id": 82}              ❌   either a 422, or a link to a random issue
+```
+
+`resolve_issue_id` does the lookup, and **refuses to fall back to the issue
+number** if it cannot — a wrong id here does not fail, it creates a
+relationship pointing at whatever issue happens to have that internal id.
+
+## Verified
+
+Against this repo: `list --issue 28` reports `#82 [open] Derek: add the
+UNITY_LICENSE repository secret`, which is the real relationship on that issue,
+and `list --issue 53` reports no blockers.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py issue-blockers
+```
+
+13 tests. The API is injected as a callable, so every path — including that the
+issue *number* is never sent as the id — is asserted without a network call.

--- a/.claude/skills/issue-blockers/set_blocker.py
+++ b/.claude/skills/issue-blockers/set_blocker.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Read and write **native** GitHub blocked-by relationships.
+
+A blocker written as prose — `Blocked by #42` in an issue body — is invisible to
+everything that matters. The nightly builder computes its ready queue from the
+real dependency graph, the dashboard's blocked section reads the same graph, and
+the revisit sweep watches it to know when to wake an issue up. None of them read
+prose. An issue "blocked" in a sentence is an issue the builder walks straight
+into.
+
+    python3 set_blocker.py list   --issue 28
+    python3 set_blocker.py add    --issue 28 --blocked-by 82
+    python3 set_blocker.py remove --issue 28 --blocked-by 82
+    python3 set_blocker.py audit  --issue 28
+
+Stdlib only. Needs GITHUB_TOKEN and GITHUB_REPOSITORY.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+# "Blocked by #42", "blocked by: #42". Deliberately NOT "Depends on: #42" —
+# that is soft ordering with no native form, and converting it would turn a
+# preference into a hard gate the builder refuses to pass.
+PROSE_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+class BlockerError(Exception):
+    """Something the caller has to fix, not a transport failure."""
+
+
+def github_api(token: str, repository: str, api_url: str = "https://api.github.com"):
+    """A callable(method, path, payload) -> parsed JSON."""
+
+    def call(method: str, path: str, payload: dict | None = None):
+        url = f"{api_url}/repos/{repository}{path}"
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(url, data=data, method=method)
+        request.add_header("Authorization", f"Bearer {token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+
+        with urllib.request.urlopen(request) as response:
+            body = response.read()
+
+        return json.loads(body) if body else None
+
+    return call
+
+
+def resolve_issue_id(api, issue_number: int) -> int:
+    """The internal numeric id for an issue number.
+
+    **This is the trap the whole module exists around.** The dependencies write
+    API takes `issue_id` — the internal identifier, a ten-digit number — not the
+    issue number everyone reads and writes. Passing the number produces either a
+    422 or, worse, a relationship pointing at whatever issue happens to have
+    that internal id.
+    """
+    issue = api("GET", f"/issues/{issue_number}") or {}
+    issue_id = issue.get("id")
+
+    if not isinstance(issue_id, int):
+        raise BlockerError(
+            f"Could not read the internal id of issue #{issue_number}. Refusing to "
+            "fall back to the issue number: that is a different identifier and would "
+            "silently point at the wrong issue."
+        )
+
+    return issue_id
+
+
+def list_blockers(api, issue_number: int) -> list[dict]:
+    """The issues blocking this one, as returned by the API."""
+    return api("GET", f"/issues/{issue_number}/dependencies/blocked_by") or []
+
+
+def add_blocker(api, blocked: int, blocked_by: int):
+    if blocked == blocked_by:
+        raise BlockerError(f"Issue #{blocked} cannot block itself.")
+
+    issue_id = resolve_issue_id(api, blocked_by)
+    return api("POST", f"/issues/{blocked}/dependencies/blocked_by", {"issue_id": issue_id})
+
+
+def remove_blocker(api, blocked: int, blocked_by: int):
+    issue_id = resolve_issue_id(api, blocked_by)
+    return api("DELETE", f"/issues/{blocked}/dependencies/blocked_by/{issue_id}")
+
+
+def prose_blockers(body: str) -> list[int]:
+    """Issue numbers named as blockers in prose — which is the wrong place."""
+    return [int(match) for match in PROSE_BLOCKER.findall(body or "")]
+
+
+def audit(api, issue_number: int) -> list[str]:
+    """Prose blockers that have no matching native relationship."""
+    issue = api("GET", f"/issues/{issue_number}") or {}
+    native = {blocker.get("number") for blocker in list_blockers(api, issue_number)}
+
+    return [
+        f"#{number} is named as a blocker in the body but has no native relationship. "
+        f"Run: set_blocker.py add --issue {issue_number} --blocked-by {number}"
+        for number in prose_blockers(issue.get("body") or "")
+        if number not in native
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("list", "add", "remove", "audit"))
+    parser.add_argument("--issue", type=int, required=True, help="the blocked issue")
+    parser.add_argument("--blocked-by", type=int, help="the blocking issue")
+    arguments = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repository:
+        sys.exit("GITHUB_TOKEN and GITHUB_REPOSITORY must both be set.")
+
+    api = github_api(token, repository)
+
+    try:
+        if arguments.command == "list":
+            blockers = list_blockers(api, arguments.issue)
+            if not blockers:
+                print(f"#{arguments.issue} is not blocked by anything.")
+            for blocker in blockers:
+                print(f"  #{blocker['number']} [{blocker['state']}] {blocker['title']}")
+            return 0
+
+        if arguments.command == "audit":
+            problems = audit(api, arguments.issue)
+            for problem in problems:
+                print(f"  {problem}", file=sys.stderr)
+            if not problems:
+                print(f"#{arguments.issue}: every blocker named in the body is native.")
+            return 1 if problems else 0
+
+        if not arguments.blocked_by:
+            sys.exit(f"--blocked-by is required for `{arguments.command}`.")
+
+        if arguments.command == "add":
+            add_blocker(api, arguments.issue, arguments.blocked_by)
+            print(f"#{arguments.issue} is now blocked by #{arguments.blocked_by}.")
+        else:
+            remove_blocker(api, arguments.issue, arguments.blocked_by)
+            print(f"#{arguments.issue} is no longer blocked by #{arguments.blocked_by}.")
+
+        return 0
+
+    except BlockerError as error:
+        sys.exit(str(error))
+    except urllib.error.HTTPError as error:
+        sys.exit(f"GitHub API {error.code}: {error.read().decode(errors='replace')}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/issue-blockers/tests/test_set_blocker.py
+++ b/.claude/skills/issue-blockers/tests/test_set_blocker.py
@@ -1,0 +1,113 @@
+"""Unit tests for the native blocked-by helper."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import set_blocker  # noqa: E402
+
+
+class FakeApi:
+    """Records calls and replays canned responses."""
+
+    def __init__(self, responses=None):
+        self.calls = []
+        self.responses = responses or {}
+
+    def __call__(self, method, path, payload=None):
+        self.calls.append((method, path, payload))
+        return self.responses.get((method, path), self.responses.get(path, []))
+
+
+class ResolveIdTests(unittest.TestCase):
+    def test_an_issue_number_resolves_to_its_numeric_id(self):
+        # The write API takes the internal id, not the number anyone can see.
+        # Getting this wrong is the whole trap.
+        api = FakeApi({"/issues/82": {"number": 82, "id": 5098389999}})
+
+        self.assertEqual(5098389999, set_blocker.resolve_issue_id(api, 82))
+
+    def test_a_missing_id_is_an_error_not_a_guess(self):
+        api = FakeApi({"/issues/82": {"number": 82}})
+
+        with self.assertRaises(set_blocker.BlockerError):
+            set_blocker.resolve_issue_id(api, 82)
+
+    def test_the_number_is_never_used_as_the_id(self):
+        api = FakeApi({"/issues/82": {"number": 82, "id": 5098389999}})
+
+        set_blocker.add_blocker(api, blocked=28, blocked_by=82)
+
+        method, path, payload = api.calls[-1]
+        self.assertEqual("POST", method)
+        self.assertEqual({"issue_id": 5098389999}, payload)
+
+
+class ListTests(unittest.TestCase):
+    def test_it_lists_the_blocking_issue_numbers(self):
+        api = FakeApi({
+            "/issues/28/dependencies/blocked_by": [
+                {"number": 82, "title": "the secret", "state": "open", "id": 1},
+                {"number": 104, "title": "the settings", "state": "closed", "id": 2},
+            ]
+        })
+
+        blockers = set_blocker.list_blockers(api, 28)
+
+        self.assertEqual([82, 104], [b["number"] for b in blockers])
+
+    def test_no_blockers_is_an_empty_list_not_an_error(self):
+        self.assertEqual([], set_blocker.list_blockers(FakeApi(), 28))
+
+
+class AddTests(unittest.TestCase):
+    def test_it_posts_to_the_blocked_issue(self):
+        api = FakeApi({"/issues/82": {"id": 999}})
+
+        set_blocker.add_blocker(api, blocked=28, blocked_by=82)
+
+        method, path, _ = api.calls[-1]
+        self.assertEqual("POST", method)
+        self.assertEqual("/issues/28/dependencies/blocked_by", path)
+
+    def test_an_issue_cannot_block_itself(self):
+        with self.assertRaises(set_blocker.BlockerError):
+            set_blocker.add_blocker(FakeApi(), blocked=28, blocked_by=28)
+
+
+class RemoveTests(unittest.TestCase):
+    def test_it_deletes_by_numeric_id(self):
+        api = FakeApi({"/issues/82": {"id": 999}})
+
+        set_blocker.remove_blocker(api, blocked=28, blocked_by=82)
+
+        method, path, _ = api.calls[-1]
+        self.assertEqual("DELETE", method)
+        self.assertEqual("/issues/28/dependencies/blocked_by/999", path)
+
+
+class ProseDetectionTests(unittest.TestCase):
+    def test_a_blocked_by_line_in_a_body_is_found(self):
+        body = "Some context.\n\nBlocked by #42\n\n## Build checklist"
+
+        self.assertEqual([42], set_blocker.prose_blockers(body))
+
+    def test_it_is_case_insensitive_and_tolerates_a_colon(self):
+        self.assertEqual([42], set_blocker.prose_blockers("blocked by: #42"))
+
+    def test_several_are_all_found(self):
+        self.assertEqual([42, 43], set_blocker.prose_blockers("Blocked by #42\nBlocked by #43"))
+
+    def test_a_soft_depends_on_line_is_not_a_blocker(self):
+        # `Depends on:` is soft ordering with no native form. Converting it
+        # would turn a preference into a hard gate the builder refuses to pass.
+        self.assertEqual([], set_blocker.prose_blockers("Depends on: #42"))
+
+    def test_a_mention_in_ordinary_prose_is_not_a_blocker(self):
+        self.assertEqual([], set_blocker.prose_blockers("This is similar to #42 but simpler."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -325,6 +325,17 @@ The builder computes its ready queue from that graph. A dependency written as a
 sentence is a dependency it walks straight into. This is also why `/block` and
 `/unblock` exist as commands: recording one has to be as cheap as mentioning it.
 
+**`Depends on:` is not a blocker.** It is soft ordering — "this will go better
+afterwards" — and it deliberately has no native form. Converting one into a hard
+blocked-by turns a preference into a gate the builder refuses to pass, which is
+how a queue deadlocks on work that could have been done at any time.
+
+The `issue-blockers` skill is the write side, and its `audit` subcommand finds
+`Blocked by #N` lines that were never recorded natively. One trap it exists
+around: the dependencies **write** API takes the internal `issue_id`, not the
+issue number — and a wrong id does not fail, it links to whatever issue happens
+to have it.
+
 ### Development — the ready queue
 
 `select_queue.py` returns the issues to work, in the order to work them:


### PR DESCRIPTION
Closes #51

The write side for native blocked-by relationships, so a dependency someone notices actually reaches the things that act on dependencies.

**Docs:** `docs/engineering/issue-pipeline.md` — added the `Depends on:` distinction, the skill, and the `issue_id` trap.

## Prose blockers are not blockers

`Blocked by #42` in an issue body is a *sentence*. Everything that acts on blockers — the builder's ready queue, the dashboard's blocked section, the sweep that wakes an issue when its blocker closes — reads the **native graph**. An issue "blocked" in prose is one the builder walks straight into and starts.

So there's an `audit` subcommand that finds them and prints the fix:

```
#42 is named as a blocker in the body but has no native relationship.
Run: set_blocker.py add --issue 28 --blocked-by 42
```

## `Depends on:` stays prose, deliberately

It's **soft ordering** — "this will go better afterwards" — and has no native form on purpose. Converting one into a hard blocked-by turns a preference into a gate the builder *refuses to pass*, which is how a queue deadlocks on work that could have been done at any time. `audit` ignores those lines, and there's a test pinning it.

## The trap this module exists around

The read endpoint returns issues with their `number`. The **write** endpoints take `issue_id` — the internal ten-digit identifier:

```http
{"issue_id": 5098389812}   ✅  the internal id of issue #82
{"issue_id": 82}           ❌  a 422, or a link to a random issue
```

The second case is the dangerous one: a wrong id doesn't necessarily fail, it creates a relationship pointing at whatever issue happens to have that internal id. So `resolve_issue_id` **refuses to fall back** to the number, and one of the tests asserts specifically that the number is never sent as the id.

## Verified against real data

```
$ set_blocker.py list --issue 28
  #82 [open] Derek: add the `UNITY_LICENSE` repository secret

$ set_blocker.py list --issue 53
#53 is not blocked by anything.
```

That's the genuine relationship on #28. **13 tests**, written first (red on `ModuleNotFoundError`), with the API injected as a callable so every path is asserted with no network call.

## Deviations and Decisions

- **Added the `audit` subcommand**, beyond the checklist's add/remove/list. The issue's whole premise is that prose blockers are invisible — a tool that can only write native ones still leaves someone to *find* the prose ones by reading every body. `audit` is where the rule becomes enforceable, and it's what a future reconciler check would call.
- **`add` refuses self-blocking.** A one-line guard, but it's a typo away (`--issue 28 --blocked-by 28`) and the resulting issue is permanently unworkable in a way that's confusing to diagnose.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_