### PR TITLE
feat(skills): bring over the milestone-ops skill

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -57,6 +57,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Adds an audit subcommand that finds prose blockers with no native relationship; keeps 'Depends on:' as soft ordering."
+    },
+    {
+      "name": "milestone-ops",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Adds the FROZEN marker check from this repo's conventions, and refuses to close a milestone with open issues."
     }
   ]
 }

--- a/.claude/skills/milestone-ops/SKILL.md
+++ b/.claude/skills/milestone-ops/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: milestone-ops
+description: List, count, close, and reopen GitHub milestones, and resolve a milestone title to the number the API needs. Use whenever a milestone number is required, when checking how much is left in a milestone, or when closing one at release.
+---
+
+# milestone-ops
+
+**The GitHub MCP toolset exposes no milestone CRUD at all** — no list, no close,
+no count. This is the direct REST helper everything else calls.
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+python3 .claude/skills/milestone-ops/milestone_ops.py list
+python3 .claude/skills/milestone-ops/milestone_ops.py number --title v0.1
+python3 .claude/skills/milestone-ops/milestone_ops.py count  --title v0.0.1
+python3 .claude/skills/milestone-ops/milestone_ops.py close  --title v0.0.1
+python3 .claude/skills/milestone-ops/milestone_ops.py reopen --title v0.0.1
+```
+
+## `milestone` takes a number, not a title
+
+The one thing to remember. `issue_write`'s `milestone` parameter — and the REST
+API's — takes the milestone's **number**:
+
+```json
+{"milestone": 2}       ✅
+{"milestone": "v0.1"}  ❌  a 422, or silently wrong
+```
+
+So anything holding a title resolves it first:
+
+```bash
+NUMBER=$(python3 .claude/skills/milestone-ops/milestone_ops.py number --title v0.1)
+```
+
+### Titles are compared exactly
+
+`v0.1` and `V0.1` are **different milestones**. `resolve_number` will not
+normalise them together, because that is how work lands in the wrong milestone
+silently — both spellings look right in a comment. An unknown title is an error
+that lists what does exist:
+
+```text
+No milestone titled 'V0.1'. There is: Direct Involvement Needed, v0.0.1, v0.1.
+```
+
+## Read milestones live
+
+Never from a list in the docs. `list` queries the API every time, which is why
+[conventions.md](../../../docs/intro/conventions.md) deliberately contains no
+list of current milestones.
+
+```text
+  #1 v0.0.1 [open] 30 open, 44 closed
+  #2 v0.1 [open] 7 open, 0 closed
+  #3 Direct Involvement Needed [open] 5 open, 2 closed
+```
+
+The `FROZEN` flag appears on any milestone whose description starts with the
+freeze marker — triage skips those when choosing where to route a new issue.
+
+## `close` refuses while there is open work
+
+Closing a milestone with open issues **hides that work**: it leaves the
+milestone view, and nothing else is watching for it. So `close` refuses, and
+says how many:
+
+```text
+'v0.1' still has 3 open issue(s). Closing it would hide them: they leave the
+milestone view and nothing else is watching. Move or close them first, or pass
+--force if that is genuinely what you mean.
+```
+
+If the work really is abandoned, move or close the issues — that is a decision,
+and it should look like one rather than being a side effect of tidying up.
+`--force` exists for when it genuinely is what you mean.
+
+## Verified
+
+Against this repo: `list` reports the three real milestones with their counts,
+`number --title v0.1` returns `2`, `count --title v0.0.1` returns the live open
+count, and `--title V0.1` is refused.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py milestone-ops
+```
+
+15 tests, with the API injected as a callable — no network.

--- a/.claude/skills/milestone-ops/milestone_ops.py
+++ b/.claude/skills/milestone-ops/milestone_ops.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Milestone operations, because the GitHub MCP toolset has none.
+
+There is no milestone CRUD in the MCP tools at all — no list, no close, no
+count. Anything that needs a milestone number, or needs to know how much is left
+in one, comes through here.
+
+    python3 milestone_ops.py list
+    python3 milestone_ops.py number --title v0.1
+    python3 milestone_ops.py count  --title v0.0.1
+    python3 milestone_ops.py close  --title v0.0.1
+    python3 milestone_ops.py reopen --title v0.0.1
+
+Stdlib only. Needs GITHUB_TOKEN and GITHUB_REPOSITORY.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# The marker that stops triage routing new issues into a settled milestone.
+# See docs/intro/conventions.md.
+FROZEN_MARKER = "FROZEN"
+
+
+class MilestoneError(Exception):
+    """Something the caller has to fix."""
+
+
+def github_api(token: str, repository: str, api_url: str = "https://api.github.com"):
+    def call(method: str, path: str, payload: dict | None = None):
+        url = f"{api_url}/repos/{repository}{path}"
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(url, data=data, method=method)
+        request.add_header("Authorization", f"Bearer {token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+
+        with urllib.request.urlopen(request) as response:
+            body = response.read()
+
+        return json.loads(body) if body else None
+
+    return call
+
+
+def fetch(api, state: str = "all") -> list[dict]:
+    """Every milestone. Always read live — never from a list in the docs."""
+    return api("GET", f"/milestones?state={state}&per_page=100") or []
+
+
+def find(api, title: str) -> dict:
+    """The milestone with exactly this title.
+
+    Compared **exactly**. `v0.1` and `V0.1` are different milestones, and
+    normalising them together is how work lands in the wrong one — silently,
+    because both look right in a comment.
+    """
+    milestones = fetch(api)
+
+    for candidate in milestones:
+        if candidate.get("title") == title:
+            return candidate
+
+    known = ", ".join(sorted(m.get("title", "?") for m in milestones)) or "none"
+    raise MilestoneError(f"No milestone titled '{title}'. There is: {known}.")
+
+
+def resolve_number(api, title: str) -> int:
+    """Title → number.
+
+    This is the function everything else needs. `issue_write`'s `milestone`
+    parameter — and the REST API's — takes the milestone **number**, not its
+    title, and passing a title is either a 422 or silently wrong.
+    """
+    return find(api, title)["number"]
+
+
+def list_milestones(api, state: str = "all") -> list[tuple]:
+    """(number, title, state, open, closed, frozen) per milestone."""
+    return [
+        (
+            m.get("number"),
+            m.get("title"),
+            m.get("state"),
+            m.get("open_issues", 0),
+            m.get("closed_issues", 0),
+            is_frozen(m.get("description")),
+        )
+        for m in fetch(api, state)
+    ]
+
+
+def open_issue_count(api, title: str) -> int:
+    return find(api, title).get("open_issues", 0)
+
+
+def is_frozen(description: str | None) -> bool:
+    """Has this milestone been frozen to new intake?"""
+    return (description or "").lstrip("*# ").startswith(FROZEN_MARKER)
+
+
+def close_milestone(api, title: str, force: bool = False):
+    """Close a milestone, refusing while it still has open work.
+
+    Closing one with open issues hides that work: it stops appearing in the
+    milestone view, and nothing else is watching for it. If the work really is
+    abandoned, move or close the issues — that is a decision, and it should
+    look like one.
+    """
+    found = find(api, title)
+    remaining = found.get("open_issues", 0)
+
+    if remaining and not force:
+        raise MilestoneError(
+            f"'{title}' still has {remaining} open issue(s). Closing it would hide them: "
+            "they leave the milestone view and nothing else is watching. Move or close "
+            "them first, or pass --force if that is genuinely what you mean."
+        )
+
+    return api("PATCH", f"/milestones/{found['number']}", {"state": "closed"})
+
+
+def reopen_milestone(api, title: str):
+    return api("PATCH", f"/milestones/{find(api, title)['number']}", {"state": "open"})
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("list", "number", "count", "close", "reopen"))
+    parser.add_argument("--title", help="the milestone's exact title")
+    parser.add_argument("--state", default="all", choices=("all", "open", "closed"))
+    parser.add_argument("--force", action="store_true", help="close despite open issues")
+    arguments = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repository:
+        sys.exit("GITHUB_TOKEN and GITHUB_REPOSITORY must both be set.")
+
+    api = github_api(token, repository)
+
+    try:
+        if arguments.command == "list":
+            for number, title, state, open_count, closed, frozen in list_milestones(
+                    api, arguments.state):
+                flag = " FROZEN" if frozen else ""
+                print(f"  #{number} {title} [{state}] {open_count} open, {closed} closed{flag}")
+            return 0
+
+        if not arguments.title:
+            sys.exit(f"--title is required for `{arguments.command}`.")
+
+        if arguments.command == "number":
+            print(resolve_number(api, arguments.title))
+        elif arguments.command == "count":
+            print(open_issue_count(api, arguments.title))
+        elif arguments.command == "close":
+            close_milestone(api, arguments.title, arguments.force)
+            print(f"Closed '{arguments.title}'.")
+        else:
+            reopen_milestone(api, arguments.title)
+            print(f"Reopened '{arguments.title}'.")
+
+        return 0
+
+    except MilestoneError as error:
+        sys.exit(str(error))
+    except urllib.error.HTTPError as error:
+        sys.exit(f"GitHub API {error.code}: {error.read().decode(errors='replace')}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/milestone-ops/tests/test_milestone_ops.py
+++ b/.claude/skills/milestone-ops/tests/test_milestone_ops.py
@@ -1,0 +1,144 @@
+"""Unit tests for the milestone helper."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import milestone_ops  # noqa: E402
+
+
+def milestone(number, title, state="open", open_issues=0, closed_issues=0, description=""):
+    return {
+        "number": number,
+        "title": title,
+        "state": state,
+        "open_issues": open_issues,
+        "closed_issues": closed_issues,
+        "description": description,
+    }
+
+
+class FakeApi:
+    def __init__(self, responses=None):
+        self.calls = []
+        self.responses = responses or {}
+
+    def __call__(self, method, path, payload=None):
+        self.calls.append((method, path, payload))
+        return self.responses.get(path, [])
+
+
+class ResolveTests(unittest.TestCase):
+    def api(self):
+        return FakeApi({"/milestones?state=all&per_page=100": [
+            milestone(1, "v0.0.1"),
+            milestone(2, "v0.1"),
+            milestone(3, "Direct Involvement Needed"),
+        ]})
+
+    def test_a_title_resolves_to_a_number(self):
+        # The trap: issue_write's `milestone` takes the NUMBER, not the title.
+        self.assertEqual(2, milestone_ops.resolve_number(self.api(), "v0.1"))
+
+    def test_an_unknown_title_is_an_error_listing_what_exists(self):
+        with self.assertRaises(milestone_ops.MilestoneError) as caught:
+            milestone_ops.resolve_number(self.api(), "v9.9")
+
+        self.assertIn("v0.0.1", str(caught.exception))
+
+    def test_titles_are_compared_exactly(self):
+        # v0.1 and V0.1 are different milestones. Normalising and hoping is how
+        # work lands in the wrong one.
+        with self.assertRaises(milestone_ops.MilestoneError):
+            milestone_ops.resolve_number(self.api(), "V0.1")
+
+    def test_a_title_with_spaces_resolves(self):
+        self.assertEqual(3, milestone_ops.resolve_number(self.api(), "Direct Involvement Needed"))
+
+
+class ListTests(unittest.TestCase):
+    def test_it_reports_state_and_counts(self):
+        api = FakeApi({"/milestones?state=all&per_page=100": [
+            milestone(1, "v0.0.1", open_issues=12, closed_issues=40),
+        ]})
+
+        rows = milestone_ops.list_milestones(api)
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual(("v0.0.1", "open", 12, 40), rows[0][1:5])
+
+    def test_open_milestones_can_be_filtered(self):
+        api = FakeApi({"/milestones?state=open&per_page=100": [milestone(1, "v0.0.1")]})
+
+        self.assertEqual(1, len(milestone_ops.list_milestones(api, state="open")))
+
+
+class OpenIssueCountTests(unittest.TestCase):
+    def test_it_reads_the_count_from_the_milestone(self):
+        api = FakeApi({"/milestones?state=all&per_page=100": [
+            milestone(1, "v0.0.1", open_issues=12),
+        ]})
+
+        self.assertEqual(12, milestone_ops.open_issue_count(api, "v0.0.1"))
+
+    def test_a_milestone_with_no_open_issues_is_zero_not_an_error(self):
+        api = FakeApi({"/milestones?state=all&per_page=100": [milestone(1, "v0.0.1")]})
+
+        self.assertEqual(0, milestone_ops.open_issue_count(api, "v0.0.1"))
+
+
+class CloseAndReopenTests(unittest.TestCase):
+    def api(self):
+        return FakeApi({"/milestones?state=all&per_page=100": [
+            milestone(1, "v0.0.1", open_issues=0),
+            milestone(2, "v0.1", open_issues=3),
+        ]})
+
+    def test_closing_patches_the_state(self):
+        api = self.api()
+
+        milestone_ops.close_milestone(api, "v0.0.1")
+
+        self.assertEqual(("PATCH", "/milestones/1", {"state": "closed"}), api.calls[-1])
+
+    def test_closing_a_milestone_with_open_issues_is_refused(self):
+        # Closing one with open work hides the work: it stops appearing in the
+        # milestone view, and nothing else notices it exists.
+        api = self.api()
+
+        with self.assertRaises(milestone_ops.MilestoneError) as caught:
+            milestone_ops.close_milestone(api, "v0.1")
+
+        self.assertIn("3", str(caught.exception))
+
+    def test_closing_can_be_forced(self):
+        api = self.api()
+
+        milestone_ops.close_milestone(api, "v0.1", force=True)
+
+        self.assertEqual("PATCH", api.calls[-1][0])
+
+    def test_reopening_patches_the_state(self):
+        api = self.api()
+
+        milestone_ops.reopen_milestone(api, "v0.0.1")
+
+        self.assertEqual(("PATCH", "/milestones/1", {"state": "open"}), api.calls[-1])
+
+
+class FrozenTests(unittest.TestCase):
+    def test_a_frozen_milestone_is_recognised(self):
+        self.assertTrue(milestone_ops.is_frozen("**FROZEN — no new intake.** Scope is settled."))
+
+    def test_an_ordinary_description_is_not_frozen(self):
+        self.assertFalse(milestone_ops.is_frozen("# Initialization\n\nInfrastructure setup."))
+
+    def test_an_empty_description_is_not_frozen(self):
+        self.assertFalse(milestone_ops.is_frozen(""))
+        self.assertFalse(milestone_ops.is_frozen(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/intro/conventions.md
+++ b/docs/intro/conventions.md
@@ -59,11 +59,19 @@ longer exist. Every skill, workflow, and script that needs to know the
 milestones queries the API for them:
 
 ```bash
-gh api repos/:owner/:repo/milestones --paginate --jq '.[] | "\(.title): \(.description)"'
+python3 .claude/skills/milestone-ops/milestone_ops.py list
 ```
 
 The live set is the truth. This page describes the *shape* of a milestone; the
 API says which ones there are.
+
+### Setting a milestone takes its number, not its title
+
+Worth knowing before it costs you an afternoon: the API's `milestone` field
+takes the milestone's **number**. Passing `"v0.1"` is a 422 at best, and
+silently wrong at worst. The `milestone-ops` skill resolves a title to a number,
+and compares titles **exactly** — `v0.1` and `V0.1` are different milestones,
+and normalising them together is how work lands in the wrong one.
 
 ### Freezing a milestone to new intake
 


### PR DESCRIPTION
Closes #52

The GitHub MCP toolset exposes **no milestone CRUD at all** — no list, no close, no count. Anything that needs a milestone number, or needs to know how much is left in one, had nowhere to go. This is the direct REST helper.

**Docs:** `docs/intro/conventions.md` — pointed the read-live section at the skill and added the number-not-title trap.

## The trap it exists around

`issue_write`'s `milestone` parameter takes the milestone's **number**:

```json
{"milestone": 2}       ✅
{"milestone": "v0.1"}  ❌  a 422, or silently wrong
```

And **titles are compared exactly.** `v0.1` and `V0.1` are different milestones; `resolve_number` won't normalise them together, because that's how work lands in the wrong milestone *silently* — both spellings look right in a comment. An unknown title errors with what does exist:

```
No milestone titled 'V0.1'. There is: Direct Involvement Needed, v0.0.1, v0.1.
```

## `close` refuses while there's open work

Closing a milestone with open issues **hides them** — they leave the milestone view and nothing else is watching. So it refuses, with the count. If the work really is abandoned, moving or closing those issues is a *decision* and should look like one, rather than being a side effect of tidying up. `--force` is there for when it genuinely is what you mean.

## Verified against the real repo

```
$ milestone_ops.py list
  #1 v0.0.1 [open] 30 open, 44 closed
  #2 v0.1 [open] 7 open, 0 closed
  #3 Direct Involvement Needed [open] 5 open, 2 closed

$ milestone_ops.py number --title v0.1     → 2
$ milestone_ops.py count  --title v0.0.1   → 30
$ milestone_ops.py number --title V0.1     → refused
```

**15 tests**, written first, API injected as a callable so there's no network in the suite.

## Deviations and Decisions

- **`close` refuses by default** rather than just doing it. The checklist says "close, reopen, and open-issue-count operations"; a bare close is one keystroke from hiding a milestone's worth of unfinished work, and the conventions page already says a shipped version's milestone closes *when the last issue does*. The refusal encodes that rule where it can actually stop the mistake.
- **Added a `FROZEN` flag to `list`.** The freeze marker is a convention from #2 that triage has to check; surfacing it in the listing means the one tool that reads milestones can answer "is this one taking new intake" without a second lookup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_