### PR TITLE
feat(pipeline): add the gatekeeper's deterministic command parser

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -64,6 +64,13 @@
       "ported_at": "v0.0.1",
       "diverged": true,
       "notes": "Adds the FROZEN marker check from this repo's conventions, and refuses to close a milestone with open issues."
+    },
+    {
+      "name": "pipeline-gatekeeper",
+      "ported_from": "derekwinters/lucas-doggiehood",
+      "ported_at": "v0.0.1",
+      "diverged": true,
+      "notes": "Vocabulary and refusal reason codes follow issues #53-#61; the bad-actor gate and idempotency are enforced inside the parser."
     }
   ]
 }

--- a/.claude/skills/pipeline-gatekeeper/parse_commands.py
+++ b/.claude/skills/pipeline-gatekeeper/parse_commands.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Turn an issue comment into a list of pipeline actions.
+
+**Deterministic, and the only thing that decides what a comment means.** Not a
+model. The gatekeeper can label issues, fire scheduled routines, and queue work
+for an agent that writes code — so the component deciding whether to do any of
+that is a parser with a fixed vocabulary, and the worst a confused model can do
+is *suggest* something.
+
+Two of the pipeline's safety properties live here, in the parser rather than
+downstream, because a check the caller has to remember is a check that gets
+forgotten:
+
+- **The bad-actor gate.** Only the repository owner's comments are honoured.
+- **Idempotency.** A comment already carrying the 👀 watermark is never
+  re-applied.
+
+Pure: data in, actions out. No GitHub I/O, no network, no subprocess — see
+`test_the_module_imports_nothing_that_talks_to_github`.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+# The vocabulary. Nothing here closes an issue, edits a body, or merges a PR:
+# those have GitHub buttons, and a command set that can do irreversible things
+# will eventually do one by accident.
+COMMANDS = (
+    "admit",      # bring an issue into the pipeline
+    "approve",    # the triaged plan is right — queue it for work
+    "revise",     # the plan is not right; re-triage with these notes
+    "redo",       # the built work is not right; queue it again
+    "propose",    # ask triage to produce a plan
+    "park",       # set aside deliberately
+    "unpark",     # bring it back
+    "milestone",  # set the milestone, by title
+    "focus",      # set the pipeline's focus milestone
+    "cap",        # set the max concurrent in-progress issues
+)
+
+# Only meaningful on the one dashboard issue: they configure the pipeline, not
+# an issue.
+DASHBOARD_ONLY = {"focus", "cap"}
+
+# Epics are containers; their children are the work. An admitted or approved
+# epic is one the builder would try to build. Parking or re-milestoning a whole
+# epic is still reasonable, so the exclusion is per command rather than blanket.
+EPIC_EXCLUDED = {"admit", "approve", "revise", "redo", "propose"}
+EPIC_LABEL = "type:epic"
+
+COMMAND_LINE = re.compile(r"^\s{0,3}/([A-Za-z][\w-]*)\s*(.*?)\s*$")
+FENCE = re.compile(r"^\s*(```|~~~)")
+
+
+class Action:
+    """A recognised command, with its argument."""
+
+    def __init__(self, command: str, argument: str = "") -> None:
+        self.command = command
+        self.argument = argument
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Action({self.command!r}, {self.argument!r})"
+
+
+class Skip:
+    """A command that was recognised as a command and not acted on."""
+
+    def __init__(self, reason: str, detail: str, command: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        self.command = command
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Skip({self.reason!r}, {self.detail!r})"
+
+
+class Context:
+    """Everything about the issue the parser needs, and nothing else."""
+
+    def __init__(self, owner: str, labels=None, is_dashboard: bool = False) -> None:
+        self.owner = owner
+        self.labels = list(labels or [])
+        self.is_dashboard = is_dashboard
+
+    @property
+    def is_epic(self) -> bool:
+        return EPIC_LABEL in self.labels
+
+
+class Outcome:
+    def __init__(self, actions: list[Action], skips: list[Skip], acknowledge: bool) -> None:
+        self.actions = actions
+        self.skips = skips
+        self._acknowledge = acknowledge
+
+    @property
+    def should_acknowledge(self) -> bool:
+        """Should the gatekeeper react to or reply to this comment?
+
+        False for a comment from anyone but the owner — even a reaction would
+        let a stranger make the bot act on their comment, which is a smaller
+        hole of the same shape as obeying it.
+        """
+        return self._acknowledge
+
+
+def _command_lines(body: str):
+    """Lines that look like commands, skipping fenced code blocks.
+
+    A command inside a fence is documentation. Without this, writing up the
+    vocabulary in a comment would execute it.
+    """
+    in_fence = False
+
+    for line in (body or "").splitlines():
+        if FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        match = COMMAND_LINE.match(line)
+        if match:
+            yield match.group(1), match.group(2)
+
+
+def parse(comment: dict, context: Context) -> Outcome:
+    """The actions a comment asks for, and the ones deliberately not taken."""
+    author = (comment.get("author") or "").lower()
+
+    # The bad-actor gate, first. Checked against the configured owner login —
+    # not "is a collaborator", because access is granted for reasons that have
+    # nothing to do with driving the pipeline.
+    if author != (context.owner or "").lower():
+        found = list(_command_lines(comment.get("body", "")))
+        skips = [Skip("not-owner", f"/{name} from {comment.get('author')}", name)
+                 for name, _ in found if name in COMMANDS]
+        return Outcome([], skips, acknowledge=False)
+
+    # Idempotency. The watermark is on the comment, so it survives workflow
+    # re-runs, sweeps, and redelivered webhooks alike.
+    if comment.get("watermarked"):
+        found = [name for name, _ in _command_lines(comment.get("body", "")) if name in COMMANDS]
+        skips = [Skip("already-applied", f"/{name} was applied on an earlier run", name)
+                 for name in found]
+        return Outcome([], skips, acknowledge=False)
+
+    actions: list[Action] = []
+    skips: list[Skip] = []
+
+    for name, argument in _command_lines(comment.get("body", "")):
+        if name not in COMMANDS:
+            suggestion = difflib.get_close_matches(name, COMMANDS, n=1, cutoff=0.6)
+            hint = f" Did you mean /{suggestion[0]}?" if suggestion else ""
+            skips.append(Skip("unknown-command", f"/{name} is not a command.{hint}", name))
+            continue
+
+        if name in DASHBOARD_ONLY and not context.is_dashboard:
+            skips.append(Skip(
+                "not-dashboard",
+                f"/{name} configures the pipeline, so it only applies on the dashboard issue.",
+                name))
+            continue
+
+        if name in EPIC_EXCLUDED and context.is_epic:
+            skips.append(Skip(
+                "epic-excluded",
+                f"/{name} does not apply to a `{EPIC_LABEL}`. Epics are containers — "
+                "their children are the work.",
+                name))
+            continue
+
+        if name == "cap" and not _is_positive_integer(argument):
+            skips.append(Skip(
+                "cap-invalid",
+                f"/cap needs a positive whole number, got '{argument}'.",
+                name))
+            continue
+
+        actions.append(Action(name, argument))
+
+    return Outcome(actions, skips, acknowledge=bool(actions or skips))
+
+
+def _is_positive_integer(value: str) -> bool:
+    return value.isdigit() and int(value) > 0

--- a/.claude/skills/pipeline-gatekeeper/tests/test_parse_commands.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_parse_commands.py
@@ -1,0 +1,221 @@
+"""Tests for the deterministic command parser.
+
+This is where the bad-actor gate and idempotency live, so the tests lean on the
+cases where the parser must refuse.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import parse_commands as parser  # noqa: E402
+
+OWNER = "derekwinters"
+
+
+def comment(body, author=OWNER, watermarked=False, comment_id=1):
+    return {"id": comment_id, "body": body, "author": author, "watermarked": watermarked}
+
+
+def context(labels=(), is_dashboard=False):
+    return parser.Context(owner=OWNER, labels=list(labels), is_dashboard=is_dashboard)
+
+
+def parse(body, **kwargs):
+    author = kwargs.pop("author", OWNER)
+    watermarked = kwargs.pop("watermarked", False)
+    return parser.parse(comment(body, author, watermarked), context(**kwargs))
+
+
+class VocabularyTests(unittest.TestCase):
+    def test_every_command_parses(self):
+        for body, expected in (
+            ("/admit", "admit"),
+            ("/approve", "approve"),
+            ("/revise needs a smaller scope", "revise"),
+            ("/redo", "redo"),
+            ("/propose", "propose"),
+            ("/park", "park"),
+            ("/unpark", "unpark"),
+            ("/milestone v0.1", "milestone"),
+        ):
+            result = parse(body)
+            self.assertEqual([expected], [a.command for a in result.actions], body)
+
+    def test_dashboard_commands_parse_on_the_dashboard(self):
+        for body, expected in (("/focus v0.1", "focus"), ("/cap 2", "cap")):
+            result = parse(body, is_dashboard=True)
+            self.assertEqual([expected], [a.command for a in result.actions], body)
+
+    def test_an_argument_is_captured(self):
+        result = parse("/revise the scope is too big, split it")
+
+        self.assertEqual("the scope is too big, split it", result.actions[0].argument)
+
+    def test_a_command_with_no_argument_has_an_empty_one(self):
+        self.assertEqual("", parse("/approve").actions[0].argument)
+
+
+class ProseTests(unittest.TestCase):
+    def test_prose_around_a_command_is_ignored(self):
+        result = parse("Looks good to me.\n\n/approve\n\nThanks!")
+
+        self.assertEqual(["approve"], [a.command for a in result.actions])
+
+    def test_several_commands_apply_in_order(self):
+        result = parse("/milestone v0.1\n/approve")
+
+        self.assertEqual(["milestone", "approve"], [a.command for a in result.actions])
+
+    def test_a_command_must_start_its_line(self):
+        # "see /approve for details" is a mention, not an instruction.
+        self.assertEqual([], parse("see /approve for details").actions)
+
+    def test_a_command_inside_a_code_fence_is_ignored(self):
+        # Otherwise documenting the vocabulary would execute it.
+        body = "Here is how it works:\n\n```\n/approve\n```\n"
+
+        self.assertEqual([], parse(body).actions)
+
+    def test_a_comment_with_no_commands_yields_nothing(self):
+        result = parse("This looks reasonable, I'll think about it.")
+
+        self.assertEqual([], result.actions)
+        self.assertEqual([], result.skips)
+
+
+class BadActorGateTests(unittest.TestCase):
+    def test_a_command_from_anyone_else_is_dropped(self):
+        result = parse("/approve", author="a-stranger")
+
+        self.assertEqual([], result.actions)
+        self.assertEqual(["not-owner"], [s.reason for s in result.skips])
+
+    def test_the_drop_is_silent(self):
+        # No reply and no reaction: replying would let a stranger make the bot
+        # post, which is a smaller hole of the same shape.
+        result = parse("/approve", author="a-stranger")
+
+        self.assertFalse(result.should_acknowledge)
+
+    def test_the_check_is_the_login_not_an_association(self):
+        # Write access is granted for reasons unrelated to driving a pipeline.
+        result = parser.parse(
+            {"id": 1, "body": "/approve", "author": "a-collaborator",
+             "watermarked": False, "author_association": "COLLABORATOR"},
+            context())
+
+        self.assertEqual([], result.actions)
+
+    def test_the_owner_check_is_case_insensitive(self):
+        # GitHub logins are case-insensitive; "DerekWinters" is the same person.
+        result = parse("/approve", author="DerekWinters")
+
+        self.assertEqual(["approve"], [a.command for a in result.actions])
+
+
+class IdempotencyTests(unittest.TestCase):
+    def test_a_watermarked_comment_is_never_re_applied(self):
+        result = parse("/approve", watermarked=True)
+
+        self.assertEqual([], result.actions)
+        self.assertEqual(["already-applied"], [s.reason for s in result.skips])
+
+    def test_a_watermarked_comment_from_a_stranger_is_still_dropped(self):
+        result = parse("/approve", author="a-stranger", watermarked=True)
+
+        self.assertEqual([], result.actions)
+
+
+class UnknownCommandTests(unittest.TestCase):
+    def test_an_unknown_command_is_skipped_not_guessed(self):
+        result = parse("/aprove")
+
+        self.assertEqual([], result.actions)
+        self.assertEqual(["unknown-command"], [s.reason for s in result.skips])
+
+    def test_the_skip_names_the_closest_match(self):
+        result = parse("/aprove")
+
+        self.assertIn("/approve", result.skips[0].detail)
+
+    def test_a_nonsense_command_still_skips_cleanly(self):
+        result = parse("/xyzzy")
+
+        self.assertEqual(["unknown-command"], [s.reason for s in result.skips])
+
+
+class CapTests(unittest.TestCase):
+    def test_cap_is_rejected_off_the_dashboard(self):
+        result = parse("/cap 2")
+
+        self.assertEqual([], result.actions)
+        self.assertEqual(["not-dashboard"], [s.reason for s in result.skips])
+
+    def test_focus_is_rejected_off_the_dashboard(self):
+        self.assertEqual(["not-dashboard"], [s.reason for s in parse("/focus v0.1").skips])
+
+    def test_a_non_numeric_cap_is_rejected(self):
+        result = parse("/cap lots", is_dashboard=True)
+
+        self.assertEqual(["cap-invalid"], [s.reason for s in result.skips])
+
+    def test_a_zero_or_negative_cap_is_rejected(self):
+        for value in ("0", "-1"):
+            result = parse(f"/cap {value}", is_dashboard=True)
+            self.assertEqual(["cap-invalid"], [s.reason for s in result.skips], value)
+
+    def test_a_valid_cap_carries_the_number(self):
+        result = parse("/cap 3", is_dashboard=True)
+
+        self.assertEqual("3", result.actions[0].argument)
+
+
+class EpicTests(unittest.TestCase):
+    def test_admit_is_refused_on_an_epic(self):
+        # Epics are containers. Their children are the work, and an admitted
+        # epic is one the builder would try to build.
+        result = parse("/admit", labels=["type:epic"])
+
+        self.assertEqual([], result.actions)
+        self.assertEqual(["epic-excluded"], [s.reason for s in result.skips])
+
+    def test_approve_is_refused_on_an_epic(self):
+        self.assertEqual(["epic-excluded"], [s.reason for s in parse("/approve", labels=["type:epic"]).skips])
+
+    def test_park_is_allowed_on_an_epic(self):
+        # Parking a whole epic is a reasonable thing to want.
+        result = parse("/park", labels=["type:epic"])
+
+        self.assertEqual(["park"], [a.command for a in result.actions])
+
+    def test_milestone_is_allowed_on_an_epic(self):
+        result = parse("/milestone v0.1", labels=["type:epic"])
+
+        self.assertEqual(["milestone"], [a.command for a in result.actions])
+
+
+class NoIoTests(unittest.TestCase):
+    def test_the_module_imports_nothing_that_can_reach_the_network(self):
+        # Data in, actions out. The parser is the safety boundary, and a
+        # boundary that can also act is not one. Checked against the import
+        # statements rather than the whole file, so prose about I/O in a
+        # docstring does not trip it.
+        import ast
+
+        source = Path(parser.__file__).read_text()
+        imported = set()
+
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+
+        self.assertEqual(set(), imported & {"urllib", "http", "socket", "subprocess", "requests"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -72,20 +72,45 @@ explain yourself in the same comment.
 
 | Command | Effect |
 | --- | --- |
-| `/approve` | `pending-approval` → `ready-for-work`. Subject to both approval gates. |
-| `/park [reason]` | any state → `parked`. The reason is recorded in the ack. |
-| `/unpark` | `parked` → `ai-triage`, so it gets re-triaged against current reality. |
-| `/retriage` | any state → `ai-triage`. Use after answering a `needs-clarification`. |
-| `/block #N` | record a native blocked-by relationship on issue N. |
-| `/unblock #N` | remove it. |
-| `/milestone <title>` | set the issue's milestone by title. |
-| `/focus <title>` | set the pipeline's focus milestone. Dashboard issue only. |
-| `/cap <n>` | set the max concurrent `in-progress` issues. Dashboard issue only. |
-| `/help` | reply with this vocabulary. Works anywhere. |
+| `/admit` | bring an issue into the pipeline — it becomes `ai-triage`. |
+| `/propose` | ask triage to produce a plan for it. |
+| `/approve` | the plan is right → `ready-for-work`. Subject to both approval gates. |
+| `/revise <notes>` | the plan is not right → back to `ai-triage`, with the notes. |
+| `/redo` | the built work is not right → queue it again. |
+| `/park` | set aside deliberately. |
+| `/unpark` | bring it back. |
+| `/milestone <title>` | set the issue's milestone, by title. |
+| `/focus <title>` | set the pipeline's focus milestone. **Dashboard issue only.** |
+| `/cap <n>` | set the max concurrent `in-progress` issues. **Dashboard issue only.** |
 
 Deliberately absent: anything that closes an issue, edits a body, or merges a
 PR. Those have perfectly good GitHub buttons, and a command vocabulary that can
 do irreversible things is a vocabulary that will eventually do one by accident.
+
+### Where each command is refused
+
+The parser refuses rather than guessing, and every refusal carries a reason
+code so the ack can say which rule applied:
+
+| Reason | When |
+| --- | --- |
+| `not-owner` | the comment is from anyone but the owner — dropped **silently** |
+| `already-applied` | the comment already carries the 👀 watermark |
+| `unknown-command` | `/aprove` — never guessed at; the reply names the closest match |
+| `not-dashboard` | `/focus` or `/cap` on an ordinary issue |
+| `cap-invalid` | `/cap lots`, `/cap 0`, `/cap -1` |
+| `epic-excluded` | `/admit`, `/propose`, `/approve`, `/revise`, `/redo` on a `type:epic` |
+
+**Epics are containers**, so the five commands that would put one in the
+builder's path are refused on them — their children are the work. `/park` and
+`/milestone` still apply to a whole epic, because both are reasonable things to
+want.
+
+Two parsing rules worth knowing:
+
+- **A command must start its line.** "see /approve for details" is a mention.
+- **A command inside a code fence is ignored**, or writing up this table in a
+  comment would execute it.
 
 ### Unknown commands
 


### PR DESCRIPTION
Closes #53

The first piece of the gatekeeper: the thing that decides what a comment means. It's a parser with a fixed vocabulary, never a model — the gatekeeper can label issues, fire routines, and queue work for an agent that writes code, so the worst a confused model should be able to do is *suggest* something.

**Docs:** `docs/engineering/issue-pipeline.md` — replaced the commands table and added the refusal-reasons table.

## Both safety properties live in the parser

Not downstream, because a check the caller has to remember is a check that gets forgotten.

- **The bad-actor gate** — only the owner's comments are honoured, checked against the configured login rather than "is a collaborator" (access is granted for reasons unrelated to driving a pipeline). Everything else is dropped **silently**: `should_acknowledge` is false, because even a reaction would let a stranger make the bot act on their comment.
- **Idempotency** — a comment carrying the 👀 watermark yields no actions, ever.

## It refuses rather than guessing

Every refusal carries a reason code, so the ack can say which rule applied: `not-owner`, `already-applied`, `unknown-command` (with the closest match named — `/aprove` does *not* approve), `not-dashboard`, `cap-invalid`, `epic-excluded`.

**Epics are containers**, so the five commands that would put one in the builder's path are refused on them, while `/park` and `/milestone` still work — parking a whole epic is a reasonable thing to want, and a blanket exclusion would have made it impossible.

Two parsing rules the tests pin:
- **A command must start its line** — "see /approve for details" is a mention.
- **A command inside a code fence is ignored**, or writing up the vocabulary in a comment would execute it.

## Test-first, and one failure was worth keeping

Red on `ModuleNotFoundError`. Then 28 tests, of which one failed for a good reason: `test_the_module_imports_nothing_that_talks_to_github` grepped the source for `"subprocess"` and matched **the module's own docstring** saying it doesn't use one. A test that fails on prose is a test that will be deleted the next time it's inconvenient, so it now walks the AST's import statements instead.

## How the spec is changing

> **Previously** `issue-pipeline.md` listed a vocabulary I wrote in #21: `/retriage`, `/block`, `/unblock`, `/help` alongside approve/park/unpark/milestone/focus/cap. **From this change** it is the one this issue specifies: `/admit`, `/propose`, `/approve`, `/revise <notes>`, `/redo`, `/park`, `/unpark`, `/milestone`, `/focus`, `/cap`.
>
> The issue is authoritative over the page I wrote, per `CLAUDE.md`. It's also a better fit: `/revise` and `/redo` distinguish "the plan is wrong" from "the built work is wrong", which the single `/retriage` conflated — and those need different responses from the pipeline.

## Deviations and Decisions

- **`/block` and `/unblock` are gone** from the vocabulary, since this issue's list doesn't include them. Recording a blocker is still cheap — it's the `issue-blockers` skill (#51) — so nothing is lost except a second way to do it from a comment.
- **The semantics of `/admit`, `/propose`, `/revise`, and `/redo` are my reading**, since the issue names them without defining their transitions. I've written the reading into the docs table so it's reviewable rather than implicit: admit → in the pipeline; propose → ask triage for a plan; revise → the plan is wrong, re-triage with notes; redo → the built work is wrong, queue it again. **This is the one thing here worth a second look** — if any of those four should mean something else, say so and it's a small change to the table in #58 (where the label moves are actually applied).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_