### PR TITLE
feat(pipeline): add the milestone-order gate

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/gates.py
+++ b/.claude/skills/pipeline-gatekeeper/gates.py
@@ -26,7 +26,10 @@ import re
 # what fixes a missing milestone, so gating it on having one would make the fix
 # impossible.
 GATES = {
-    "approve": ["milestone-presence"],
+    "approve": ["milestone-presence", "milestone-order"],
+    # Setting a milestone is the other way to create an inversion, so the order
+    # gate runs there too.
+    "milestone": ["milestone-order"],
 }
 
 VERSION_MILESTONE = re.compile(r"^v(\d+)\.(\d+)(?:\.(\d+))?$")
@@ -88,3 +91,72 @@ def milestone_present(issue: dict, comments=None) -> Verdict:
         "and approve again.",
         skip_reason="approve-no-milestone",
     )
+
+
+def _blocking_edges(issue: dict) -> list[dict]:
+    """Every open thing this issue waits on: hard blockers and soft ones.
+
+    Soft `Depends on:` gets the same refuse rule as a hard blocker. It does not
+    stop the builder selecting the issue, but the ordering problem is identical
+    — the thing it depends on is not scheduled to be built — and a refusal is
+    cheap while a stalled milestone is not.
+    """
+    edges = list(issue.get("blockers") or []) + list(issue.get("soft_dependencies") or [])
+    return [edge for edge in edges if (edge.get("state") or "open") == "open"]
+
+
+def milestone_order_ok(issue: dict, milestones=None) -> Verdict:
+    """No issue is scheduled earlier than something it waits on.
+
+    **Invariant:** for every open blocker edge A → B, `order(A) >= order(B)`,
+    and B must be scheduled.
+
+    Without this, an issue can sit in `v0.0.1` blocked by one in `v0.1`. The
+    builder correctly skips the dependent — but the blocker is not in the
+    focus milestone to be built either, so the work silently stalls while the
+    milestone reads "ready". Nothing else notices, because from every angle
+    each issue looks fine on its own.
+    """
+    subject_order = milestone_order(issue.get("milestone"))
+
+    if subject_order is None:
+        # An unscheduled or unordered subject is the presence gate's problem.
+        # Two gates reporting one mistake produces two acks for it.
+        return Verdict(True, "Not scheduled in a version milestone; nothing to order against.")
+
+    unscheduled = []
+    inverted = []
+
+    for edge in _blocking_edges(issue):
+        edge_order = milestone_order(edge.get("milestone"))
+
+        if edge_order is None:
+            unscheduled.append(edge)
+        elif edge_order > subject_order:
+            inverted.append(edge)
+
+    if unscheduled:
+        named = ", ".join(f"#{edge.get('number')}" for edge in unscheduled)
+        return Verdict(
+            False,
+            f"This is in **{issue['milestone']}**, but it waits on {named}, which "
+            "is not scheduled in a version milestone — so nothing will ever build it "
+            "and this issue would sit ready forever.\n\n"
+            "Give it a milestone at or before this one, then try again.",
+            skip_reason="blocker-unscheduled",
+        )
+
+    if inverted:
+        named = ", ".join(
+            f"#{edge.get('number')} ({edge.get('milestone')})" for edge in inverted)
+        return Verdict(
+            False,
+            f"This is in **{issue['milestone']}**, but it waits on {named} — later "
+            "milestones. The builder would skip this issue every night while the "
+            "milestone reads ready, and nothing would say why.\n\n"
+            "Move the blocker earlier, or move this issue later. **Nothing has been "
+            "changed here** — which way round is a planning decision.",
+            skip_reason="blocker-inversion",
+        )
+
+    return Verdict(True, "Everything this issue waits on is scheduled at or before it.")

--- a/.claude/skills/pipeline-gatekeeper/tests/test_gate_milestone_order.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_gate_milestone_order.py
@@ -1,0 +1,159 @@
+"""Tests for the milestone-order gate.
+
+Invariant: for every open blocker edge A → B, milestone_order(A) >= 
+milestone_order(B), and B must be scheduled.
+
+It refuses and never auto-bumps, so a refusal leaving the issue completely
+untouched is asserted as hard as the refusal itself.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import gates  # noqa: E402
+
+
+def issue(number=10, milestone="v0.0.1", state="open", labels=(), blockers=()):
+    return {
+        "number": number,
+        "milestone": milestone,
+        "state": state,
+        "labels": list(labels),
+        "blockers": list(blockers),
+    }
+
+
+MILESTONES = ["v0.0.1", "v0.1", "v0.2", "Direct Involvement Needed"]
+
+
+class MilestoneOrderParsingTests(unittest.TestCase):
+    def test_a_version_title_is_ordered(self):
+        self.assertLess(gates.milestone_order("v0.0.1"), gates.milestone_order("v0.1"))
+
+    def test_a_patch_version_orders_within_its_minor(self):
+        self.assertLess(gates.milestone_order("v0.0.1"), gates.milestone_order("v0.0.2"))
+
+    def test_a_major_bump_orders_above_a_minor(self):
+        self.assertLess(gates.milestone_order("v0.9"), gates.milestone_order("v1.0"))
+
+    def test_a_non_version_title_is_unordered(self):
+        self.assertIsNone(gates.milestone_order("Direct Involvement Needed"))
+
+    def test_no_milestone_is_unordered(self):
+        self.assertIsNone(gates.milestone_order(None))
+
+
+class MilestoneOrderGateTests(unittest.TestCase):
+    def check(self, subject_milestone, blockers):
+        return gates.milestone_order_ok(
+            issue(milestone=subject_milestone, blockers=blockers), MILESTONES)
+
+    def blocker(self, number=20, milestone="v0.0.1", state="open", labels=()):
+        return {"number": number, "milestone": milestone, "state": state, "labels": list(labels)}
+
+    def test_a_blocker_in_an_earlier_milestone_is_fine(self):
+        verdict = self.check("v0.1", [self.blocker(milestone="v0.0.1")])
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_a_blocker_in_the_same_milestone_is_fine(self):
+        self.assertTrue(self.check("v0.1", [self.blocker(milestone="v0.1")]).ok)
+
+    def test_a_blocker_in_a_later_milestone_is_refused(self):
+        verdict = self.check("v0.0.1", [self.blocker(number=20, milestone="v0.1")])
+
+        self.assertFalse(verdict.ok)
+        self.assertEqual("blocker-inversion", verdict.skip_reason)
+        self.assertIn("#20", verdict.reason)
+
+    def test_an_unscheduled_blocker_is_refused(self):
+        verdict = self.check("v0.0.1", [self.blocker(number=20, milestone=None)])
+
+        self.assertFalse(verdict.ok)
+        self.assertEqual("blocker-unscheduled", verdict.skip_reason)
+
+    def test_a_blocker_in_an_unordered_milestone_is_refused(self):
+        # Direct Involvement Needed never ships, so a blocker parked there is
+        # one nothing will ever build.
+        verdict = self.check("v0.0.1",
+                             [self.blocker(number=20, milestone="Direct Involvement Needed")])
+
+        self.assertFalse(verdict.ok)
+        self.assertEqual("blocker-unscheduled", verdict.skip_reason)
+
+    def test_a_closed_blocker_is_ignored(self):
+        verdict = self.check("v0.0.1", [self.blocker(milestone="v0.2", state="closed")])
+
+        self.assertTrue(verdict.ok, verdict.reason)
+
+    def test_the_refusal_changes_nothing(self):
+        verdict = self.check("v0.0.1", [self.blocker(milestone="v0.1")])
+
+        self.assertEqual([], verdict.changes)
+
+    def test_it_never_bumps_the_milestone(self):
+        # Refuse, never auto-bump: moving the issue would quietly re-plan a
+        # milestone's worth of work.
+        verdict = self.check("v0.0.1", [self.blocker(milestone="v0.1")])
+
+        self.assertNotIn("milestone", str(verdict.changes))
+
+    def test_every_offending_blocker_is_named(self):
+        verdict = self.check("v0.0.1", [
+            self.blocker(number=20, milestone="v0.1"),
+            self.blocker(number=21, milestone="v0.2"),
+        ])
+
+        self.assertIn("#20", verdict.reason)
+        self.assertIn("#21", verdict.reason)
+
+    def test_no_blockers_passes(self):
+        self.assertTrue(self.check("v0.0.1", []).ok)
+
+    def test_an_unscheduled_subject_is_not_this_gate_s_problem(self):
+        # The presence gate handles that, and two gates reporting the same
+        # thing produces two acks for one mistake.
+        self.assertTrue(self.check(None, []).ok)
+
+
+class SoftDependencyTests(unittest.TestCase):
+    def test_a_soft_dependency_uses_the_same_refuse_rule(self):
+        subject = issue(milestone="v0.0.1")
+        subject["soft_dependencies"] = [
+            {"number": 30, "milestone": "v0.1", "state": "open", "labels": []}]
+
+        verdict = gates.milestone_order_ok(subject, MILESTONES)
+
+        self.assertFalse(verdict.ok)
+        self.assertIn("#30", verdict.reason)
+
+    def test_a_closed_soft_dependency_is_ignored(self):
+        subject = issue(milestone="v0.0.1")
+        subject["soft_dependencies"] = [
+            {"number": 30, "milestone": "v0.1", "state": "closed", "labels": []}]
+
+        self.assertTrue(gates.milestone_order_ok(subject, MILESTONES).ok)
+
+
+class CommandCoverageTests(unittest.TestCase):
+    def test_both_gates_run_on_approve(self):
+        self.assertEqual({"milestone-presence", "milestone-order"}, set(gates.gates_for("approve")))
+
+    def test_the_order_gate_runs_on_milestone(self):
+        # Setting a milestone is the other way to create an inversion.
+        self.assertIn("milestone-order", gates.gates_for("milestone"))
+
+    def test_the_presence_gate_does_not_run_on_milestone(self):
+        # /milestone is what fixes a missing milestone; gating it on having one
+        # would make the fix impossible.
+        self.assertNotIn("milestone-presence", gates.gates_for("milestone"))
+
+    def test_park_is_not_gated(self):
+        self.assertEqual([], gates.gates_for("park"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -190,20 +190,52 @@ impossible.
 
 ### Gate 2: milestone order
 
-**Invariant:** work is approved in milestone order. An issue in a later
-milestone cannot become `ready-for-work` while the focus milestone still has
-open work.
+**Invariant:** for every open blocker edge A → B, `order(A) ≥ order(B)`, and B
+must be scheduled.
 
-Milestones are a plan. Approving `v0.2` work while `v0.1` still has twenty open
-issues is how a project ends up with three half-finished versions.
+Without it, an issue can sit in `v0.0.1` blocked by one in `v0.1`. The builder
+correctly skips the dependent — but the blocker is not in the focus milestone to
+be built either, so **the work silently stalls while the milestone reads
+"ready"**. Nothing notices, because from every angle each issue looks fine on
+its own.
 
-The gatekeeper **refuses** and replies with the focus milestone, how many issues
-remain open in it, and the two ways forward: finish the focus milestone, or
-`/focus` the later one deliberately. It never bumps the issue's milestone, and
-never moves focus on its own.
+Two refusals:
 
-The escape hatch is `/focus`, which is a deliberate act, recorded on the
-dashboard, and visible to everyone.
+| Skip | When |
+| --- | --- |
+| `blocker-unscheduled` | the blocker has no milestone, or one with no version order |
+| `blocker-inversion` | the blocker is in a *later* milestone |
+
+Both name the offending issues, so the ack says which ones rather than that
+something is wrong.
+
+#### Milestone order comes from the title
+
+`vMAJOR.MINOR[.PATCH]` is ordered; anything else is **unordered**. That
+deliberately includes `Direct Involvement Needed` — it never ships, so a blocker
+parked there is one nothing will ever build, which is exactly the
+`blocker-unscheduled` case.
+
+Closed blockers are ignored: a resolved dependency constrains nothing.
+
+#### Soft `Depends on:` uses the same rule
+
+It does not stop the builder selecting the issue, but the ordering problem is
+identical — the thing it depends on is not scheduled — and a refusal is cheap
+while a stalled milestone is not.
+
+#### Refuse, never auto-bump
+
+A refusal leaves the issue **completely untouched**. Moving the blocker earlier
+and moving the subject later are both valid fixes, and which one is right is a
+planning decision about scope. The reply says so, and says that nothing was
+changed.
+
+#### It runs on `/milestone` too
+
+Setting a milestone is the other way to create an inversion. Gating only
+`/approve` would let `/milestone v0.0.1` quietly produce one, to be discovered
+at the next approval — or not at all, if the issue was already approved.
 
 ## Auto-revisit when a blocker clears
 


### PR DESCRIPTION
Closes #55

Stops an issue being scheduled *earlier* than something it waits on.

**Docs:** `docs/engineering/issue-pipeline.md` — rewrote Gate 2 with the invariant, both skip reasons, and the ordering rule.

## The failure it prevents

An issue sits in `v0.0.1`, blocked by one in `v0.1`. The builder correctly skips the dependent — but the blocker isn't in the focus milestone to be built either, so **the work silently stalls while the milestone reads "ready"**.

Nothing notices, because from every angle each issue looks fine on its own: the dependent is properly blocked, the blocker is properly scheduled, and the only thing wrong is the relationship between them.

**Invariant:** for every open blocker edge A → B, `order(A) ≥ order(B)`, and B must be scheduled.

## Two refusals, both naming names

| Skip | When |
| --- | --- |
| `blocker-unscheduled` | the blocker has no milestone, or one with no version order |
| `blocker-inversion` | the blocker is in a *later* milestone |

Order comes from the `vMAJOR.MINOR[.PATCH]` title. Anything else is **unordered** — which deliberately includes `Direct Involvement Needed`: it never ships, so a blocker parked there is one nothing will ever build. That's the same failure as an unscheduled blocker, so it gets the same skip rather than a special case.

Closed blockers are ignored, and soft `Depends on:` gets the same rule as a hard blocker — it doesn't stop selection, but the ordering problem is identical, and a refusal is cheap while a stalled milestone isn't.

## Refuse, never auto-bump

A refusal leaves the issue **completely untouched**, with a test asserting `changes == []`.

Moving the blocker earlier and moving the subject later are both valid fixes, and which one is right is a planning decision about scope — not something a gate should make at 3am. The reply says both options and says explicitly that nothing was changed.

## It runs on `/milestone` too

Setting a milestone is the other way to create an inversion. Gating only `/approve` would let `/milestone v0.0.1` quietly produce one, to be discovered at the next approval — or never, if the issue was already approved.

**59 tests** in the gatekeeper suite. Written first; the order tests were red against the missing function before this change.

## Deviations and Decisions

- **An unscheduled *subject* passes this gate**, rather than being a second refusal. The presence gate already reports that, and two gates reporting one mistake produces two acks for it. Tested.
- **`milestone_order_ok` takes a `milestones` argument it doesn't use.** Order is derived from the title, so the live list isn't needed — but the parameter keeps the call signature stable for a future rule that needs to know a milestone *exists* (as opposed to being well-named), and its absence would otherwise look like an oversight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_