### PR TITLE
feat(pipeline): add blocker auto-revisit to the gatekeeper

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/check_revisits.py
+++ b/.claude/skills/pipeline-gatekeeper/check_revisits.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Wake issues whose blockers have cleared.
+
+A **state-derived transition, not a command.** Nothing else would ever wake an
+issue set aside only because it was blocked: analysis acts on `ai-triage`, and
+the gatekeeper otherwise acts only on comments. Without this, the issue waits
+for a human to remember it — which is the same as waiting forever.
+
+Pure: a snapshot in, a list of revisits out. The sweep does the I/O.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import re
+
+# The state a blocked issue is parked in by triage.
+BLOCKED_LABEL = "needs-clarification"
+TRIAGE_LABEL = "ai-triage"
+
+WIREFRAME_LABEL = "type:wireframe"
+
+# An ordinary blocker is resolved once it is closed OR scheduled: it is going to
+# be built, and holding the dependent back until it closes costs a night for
+# nothing.
+SCHEDULED_LABELS = {"ready-for-work", "in-progress"}
+
+# Structured only. "This is similar to #42" is not a dependency, and treating it
+# as one would wake issues at random.
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+class Revisit:
+    def __init__(self, issue_number: int, cleared: list[int]) -> None:
+        self.issue_number = issue_number
+        self.cleared = cleared
+        self.add_labels = [TRIAGE_LABEL]
+        self.remove_labels = [BLOCKED_LABEL]
+
+    @property
+    def comment(self) -> str:
+        named = ", ".join(f"#{number}" for number in self.cleared)
+        return (
+            f"Everything this was waiting on has cleared ({named}), so it is back in "
+            f"the triage queue.\n\n"
+            f"_Automatic — nothing was decided here beyond that the blocker is done._"
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Revisit(#{self.issue_number}, cleared={self.cleared})"
+
+
+def blockers_of(issue: dict) -> list[int]:
+    """Every issue this one waits on — text lines **unioned** with native edges.
+
+    Union rather than either-or: an issue can have one recorded natively and
+    another still written in prose, and waking it when only half have cleared
+    is worse than not waking it at all.
+    """
+    from_text = {int(number) for number in TEXT_BLOCKER.findall(issue.get("body") or "")}
+    from_native = {int(number) for number in (issue.get("native_blockers") or [])}
+    return sorted(from_text | from_native)
+
+
+def is_resolved(blocker: dict) -> bool:
+    """Has this blocker stopped blocking?"""
+    if blocker.get("state") == "closed" or blocker.get("merged"):
+        return True
+
+    labels = set(blocker.get("labels") or [])
+
+    # The carve-out. A wireframe resolves ONLY when closed, because closing it
+    # is what "agreed" means — a wireframe marked ready-for-work is still a
+    # picture nobody has said yes to. Without this the sweep wakes the dependent
+    # every run and triage sets it aside again every run, forever.
+    if WIREFRAME_LABEL in labels:
+        return False
+
+    return bool(labels & SCHEDULED_LABELS)
+
+
+def find_revisits(issues: list[dict], snapshot: dict) -> list[Revisit]:
+    """Issues eligible to go back to triage, given the blockers' current state.
+
+    `snapshot` maps issue number → that issue's state. A blocker missing from it
+    is **not** treated as resolved: not knowing is not the same as knowing it is
+    done.
+    """
+    found: list[Revisit] = []
+
+    for issue in issues:
+        labels = set(issue.get("labels") or [])
+
+        # Only issues triage parked as blocked. A `parked` issue was set aside
+        # by a decision the owner made, and only the owner un-makes it.
+        if BLOCKED_LABEL not in labels:
+            continue
+
+        blockers = blockers_of(issue)
+        if not blockers:
+            continue
+
+        known = [snapshot.get(number) for number in blockers]
+        if any(blocker is None for blocker in known):
+            continue
+
+        if all(is_resolved(blocker) for blocker in known):
+            found.append(Revisit(issue["number"], blockers))
+
+    return found

--- a/.claude/skills/pipeline-gatekeeper/tests/test_check_revisits.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_check_revisits.py
@@ -1,0 +1,173 @@
+"""Tests for blocker auto-revisit.
+
+A state-derived transition, not a command: nothing else would ever wake an
+issue that was set aside only because it was blocked.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_revisits as revisits  # noqa: E402
+
+
+def issue(number=10, labels=("needs-clarification",), body="", native=(), blockers_state=None):
+    return {
+        "number": number,
+        "labels": list(labels),
+        "body": body,
+        "native_blockers": list(native),
+    }
+
+
+def blocker(number=20, state="open", labels=(), merged=False):
+    return {"number": number, "state": state, "labels": list(labels), "merged": merged}
+
+
+class NoBlockerTests(unittest.TestCase):
+    def test_an_issue_with_no_blockers_is_left_alone(self):
+        self.assertEqual([], revisits.find_revisits([issue()], {}))
+
+    def test_a_prose_only_mention_is_not_a_blocker(self):
+        # "similar to #42" is not a dependency.
+        subject = issue(body="This is similar to #42 but simpler.")
+
+        self.assertEqual([], revisits.find_revisits([subject], {42: blocker(42, "closed")}))
+
+
+class ResolutionTests(unittest.TestCase):
+    def revisit(self, blocker_state):
+        subject = issue(body="Blocked by #20")
+        return revisits.find_revisits([subject], {20: blocker_state})
+
+    def test_a_closed_blocker_resolves(self):
+        self.assertEqual(1, len(self.revisit(blocker(20, "closed"))))
+
+    def test_a_merged_blocker_resolves(self):
+        self.assertEqual(1, len(self.revisit(blocker(20, "closed", merged=True))))
+
+    def test_a_blocker_that_is_ready_for_work_resolves(self):
+        # It is scheduled and will be built; waiting for it to close would hold
+        # the dependent back for no benefit.
+        self.assertEqual(1, len(self.revisit(blocker(20, "open", ["ready-for-work"]))))
+
+    def test_a_blocker_that_is_in_progress_resolves(self):
+        self.assertEqual(1, len(self.revisit(blocker(20, "open", ["in-progress"]))))
+
+    def test_a_still_open_untouched_blocker_does_not(self):
+        self.assertEqual([], self.revisit(blocker(20, "open", ["pending-approval"])))
+
+    def test_an_unknown_blocker_does_not_resolve(self):
+        # Not in the snapshot means we cannot tell, and cannot-tell is not
+        # resolved.
+        subject = issue(body="Blocked by #99")
+
+        self.assertEqual([], revisits.find_revisits([subject], {}))
+
+
+class WireframeCarveOutTests(unittest.TestCase):
+    def test_a_wireframe_blocker_resolves_only_when_closed(self):
+        subject = issue(body="Blocked by #20")
+        ready = blocker(20, "open", ["type:wireframe", "ready-for-work"])
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: ready}))
+
+    def test_a_closed_wireframe_blocker_does_resolve(self):
+        subject = issue(body="Blocked by #20")
+        closed = blocker(20, "closed", ["type:wireframe"])
+
+        self.assertEqual(1, len(revisits.find_revisits([subject], {20: closed})))
+
+    def test_the_carve_out_stops_the_sweep_re_firing_forever(self):
+        # A wireframe marked ready-for-work is still not agreed. Without this,
+        # the sweep would wake the dependent every run, and triage would set it
+        # aside again every run.
+        subject = issue(body="Blocked by #20")
+        in_progress = blocker(20, "open", ["type:wireframe", "in-progress"])
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: in_progress}))
+
+
+class MultipleBlockerTests(unittest.TestCase):
+    def test_all_must_resolve(self):
+        subject = issue(body="Blocked by #20\nBlocked by #21")
+        snapshot = {20: blocker(20, "closed"), 21: blocker(21, "open", ["pending-approval"])}
+
+        self.assertEqual([], revisits.find_revisits([subject], snapshot))
+
+    def test_revisiting_once_every_one_resolves(self):
+        subject = issue(body="Blocked by #20\nBlocked by #21")
+        snapshot = {20: blocker(20, "closed"), 21: blocker(21, "closed")}
+
+        found = revisits.find_revisits([subject], snapshot)
+
+        self.assertEqual(1, len(found))
+        self.assertEqual([20, 21], sorted(found[0].cleared))
+
+
+class SourceUnionTests(unittest.TestCase):
+    def test_native_relationships_count(self):
+        subject = issue(native=[20])
+
+        self.assertEqual(1, len(revisits.find_revisits([subject], {20: blocker(20, "closed")})))
+
+    def test_text_and_native_are_unioned_not_either_or(self):
+        subject = issue(body="Blocked by #20", native=[21])
+        snapshot = {20: blocker(20, "closed"), 21: blocker(21, "open", ["pending-approval"])}
+
+        self.assertEqual([], revisits.find_revisits([subject], snapshot))
+
+    def test_the_same_blocker_from_both_sources_counts_once(self):
+        subject = issue(body="Blocked by #20", native=[20])
+
+        found = revisits.find_revisits([subject], {20: blocker(20, "closed")})
+
+        self.assertEqual([20], found[0].cleared)
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_a_parked_issue_is_left_alone(self):
+        # Parking is a decision the owner made. Only the owner un-makes it.
+        subject = issue(labels=["parked"], body="Blocked by #20")
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: blocker(20, "closed")}))
+
+    def test_a_pending_approval_issue_is_left_alone(self):
+        subject = issue(labels=["pending-approval"], body="Blocked by #20")
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: blocker(20, "closed")}))
+
+    def test_a_ready_issue_is_left_alone(self):
+        subject = issue(labels=["ready-for-work"], body="Blocked by #20")
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: blocker(20, "closed")}))
+
+
+class RevisitShapeTests(unittest.TestCase):
+    def test_it_adds_ai_triage_and_removes_needs_clarification(self):
+        subject = issue(body="Blocked by #20")
+
+        found = revisits.find_revisits([subject], {20: blocker(20, "closed")})[0]
+
+        self.assertEqual(["ai-triage"], found.add_labels)
+        self.assertEqual(["needs-clarification"], found.remove_labels)
+
+    def test_the_comment_names_the_cleared_blockers(self):
+        subject = issue(body="Blocked by #20")
+
+        found = revisits.find_revisits([subject], {20: blocker(20, "closed")})[0]
+
+        self.assertIn("#20", found.comment)
+
+    def test_the_comment_is_short(self):
+        subject = issue(body="Blocked by #20")
+
+        found = revisits.find_revisits([subject], {20: blocker(20, "closed")})[0]
+
+        self.assertLessEqual(len(found.comment.splitlines()), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -239,28 +239,54 @@ at the next approval — or not at all, if the issue was already approved.
 
 ## Auto-revisit when a blocker clears
 
-An issue parked *because it was blocked* should not need a human to remember it.
-The sweep looks for issues whose recorded blockers have all closed, and returns
-them to `ai-triage` with a comment saying which blocker cleared.
+An issue parked in `needs-clarification` **because it was blocked** has nothing
+to wake it. Analysis only acts on `ai-triage`, and the gatekeeper otherwise only
+acts on comments — so without this the issue waits for a human to remember it,
+which is the same as waiting forever.
 
-Conditions, all required:
+This is a **state-derived transition, not a command**. The sweep computes it.
 
-- the issue is `parked` or `needs-clarification`;
-- it has at least one native blocked-by relationship;
-- every blocking issue is closed;
-- it was not parked by an explicit `/park` with a reason unrelated to blocking —
-  a park the owner chose is a park the owner un-chooses.
+### What counts as a blocker
+
+Structured text lines (`Blocked by #42`) **unioned** with native GitHub
+relationships. Union rather than either-or: an issue can have one recorded
+natively and another still in prose, and waking it when only half have cleared
+is worse than not waking it at all.
+
+An unstructured mention — "this is similar to #42" — is not a dependency, and
+is deliberately not matched.
+
+### When a blocker resolves
+
+| Blocker state | Resolved? |
+| --- | --- |
+| closed, or merged | yes |
+| open, `ready-for-work` or `in-progress` | yes — it is scheduled and will be built |
+| open, anything else | no |
+| not in the snapshot | **no** — not knowing is not knowing it is done |
+
+An issue with several blockers is revisited **once every one** resolves.
 
 ### The `type:wireframe` carve-out
 
-**`type:wireframe` issues are never auto-revisited.**
+**A `type:wireframe` blocker resolves only when it is closed.** Being scheduled
+is not enough.
 
-Unblocking a wireframe doesn't make it agreeable. What a wireframe needs is a
-person looking at a picture and saying yes — usually Connor. Waking one up
-automatically produces an issue that says "ready" and isn't, and the pipeline
-would then hand it to a builder that has no wireframe to build against.
+Closing a wireframe issue is what "agreed" means, and a wireframe marked
+`ready-for-work` is still a picture nobody has said yes to. Without the
+carve-out the sweep wakes the dependent on every run and triage sets it aside
+again on every run — forever, and noisily.
 
-They surface on the dashboard as waiting-on-a-human instead.
+### What it never touches
+
+- **`parked` issues.** Parking is a decision the owner made; only the owner
+  un-makes it.
+- **Anything not in `needs-clarification`** — an issue already
+  `pending-approval` or `ready-for-work` is not waiting on a blocker.
+
+A revisit adds `ai-triage`, removes `needs-clarification`, and posts a short
+comment naming the cleared blockers — so the transition is visible in the
+thread rather than being a label that changed itself overnight.
 
 ## `/focus` and `/cap` live on the dashboard issue
 


### PR DESCRIPTION
Closes #56

An issue parked in `needs-clarification` *because it was blocked* has nothing to wake it — analysis acts only on `ai-triage`, and the gatekeeper otherwise acts only on comments. So it waits for a human to remember it, which is the same as waiting forever.

**Docs:** `docs/engineering/issue-pipeline.md` — rewrote the auto-revisit section with the resolution table and the carve-out's reasoning.

## What counts, and when it resolves

Blockers are structured text lines (`Blocked by #42`) **unioned** with native relationships — union rather than either-or, because an issue can have one recorded each way, and waking it when only half have cleared is worse than not waking it at all. An unstructured mention ("similar to #42") isn't a dependency and isn't matched.

| Blocker state | Resolved? |
| --- | --- |
| closed, or merged | yes |
| open, `ready-for-work` / `in-progress` | yes — it's scheduled and will be built |
| open, anything else | no |
| **not in the snapshot** | **no** — not knowing isn't knowing it's done |

Several blockers → revisited once **every** one resolves.

## The `type:wireframe` carve-out

**A wireframe blocker resolves only when closed.** Being scheduled isn't enough.

Closing a wireframe issue is what "agreed" *means*, and one marked `ready-for-work` is still a picture nobody has said yes to. Without the carve-out, the sweep wakes the dependent every run and triage sets it aside again every run — forever, and noisily. There's a test named for exactly that loop.

## No false triggers

Tested: no blocker, a still-open blocker, a prose-only mention, an unknown blocker, and a `parked` label are all left alone. Parking is a decision the owner made; only the owner un-makes it.

A revisit adds `ai-triage`, removes `needs-clarification`, and posts a short comment naming the cleared blockers — so the transition is visible in the thread rather than being a label that changed itself overnight.

**81 tests** in the gatekeeper suite. Written first, red on `ModuleNotFoundError`.

## Deviations and Decisions

- **A blocker missing from the snapshot blocks.** The issue says a blocker resolves when closed or scheduled; it doesn't say what to do about one that can't be found. Treating unknown as resolved would let a truncated or failed fetch wake every blocked issue at once, so it's the other way round — a sweep that does nothing is recoverable, one that wakes the queue isn't.
- **`is_resolved` checks the wireframe carve-out before the scheduled labels**, so the ordering can't be reversed by a later edit without a test going red.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_