### PR TITLE
feat(pipeline): add the gatekeeper's per-issue snapshot builder

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Turn an `issue_comment` webhook payload into the snapshot the parser reads.
+
+All the I/O and all the payload-shape guesswork lives here, so
+`parse_commands.py` stays pure and testable. The parser should never have to
+know what GitHub's JSON looks like.
+
+The snapshot:
+
+    {
+      "issue":   {number, labels, body, milestone, blockers, is_dashboard},
+      "comment": {id, body, author, watermarked}
+    }
+
+Returns **None** when the event should not be acted on at all.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import re
+
+DASHBOARD_LABEL = "dashboard"
+WATERMARK = "eyes"
+
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def _labels(issue: dict) -> list[str]:
+    return [label.get("name", "") for label in (issue.get("labels") or [])]
+
+
+def _text_blockers(body: str | None) -> set[int]:
+    return {int(number) for number in TEXT_BLOCKER.findall(body or "")}
+
+
+def _native_blockers(api, issue_number: int) -> set[int]:
+    """Native blocked-by edges, or nothing if the lookup fails.
+
+    A failed dependency lookup must not lose the whole event: the command is
+    probably `/park`, which does not care. The gates that *do* care see the
+    smaller list and refuse, which is the safe direction.
+    """
+    try:
+        edges = api("GET", f"/issues/{issue_number}/dependencies/blocked_by") or []
+    except Exception:  # noqa: BLE001 - any failure means "unknown"
+        return set()
+
+    return {edge["number"] for edge in edges if isinstance(edge.get("number"), int)}
+
+
+def _is_watermarked(api, comment_id: int, bot_login: str) -> bool:
+    """Has the gatekeeper already claimed this comment?
+
+    Only its **own** 👀 counts. A human reacting out of interest must not
+    silence a command.
+    """
+    try:
+        reactions = api("GET", f"/issues/comments/{comment_id}/reactions") or []
+    except Exception:  # noqa: BLE001
+        # Unknown is not "unclaimed": re-applying a command is worse than
+        # skipping one, and the sweep will pick it up next time.
+        return True
+
+    return any(
+        reaction.get("content") == WATERMARK
+        and (reaction.get("user") or {}).get("login", "").lower() == bot_login.lower()
+        for reaction in reactions
+    )
+
+
+def build(event: dict, api, owner: str, bot_login: str = "github-actions[bot]") -> dict | None:
+    """The snapshot for one comment event, or None if it should be ignored."""
+    issue = (event or {}).get("issue") or {}
+    comment = (event or {}).get("comment") or {}
+
+    if not comment or not issue.get("number"):
+        return None
+
+    # Defence in depth. The workflow filters these too, but a snapshot the
+    # parser *could* act on is one it eventually will.
+    if issue.get("pull_request"):
+        return None
+
+    user = comment.get("user") or {}
+    if user.get("type") == "Bot":
+        return None
+
+    labels = _labels(issue)
+
+    return {
+        "issue": {
+            "number": issue["number"],
+            "labels": labels,
+            "body": issue.get("body") or "",
+            "milestone": (issue.get("milestone") or {}).get("title"),
+            "blockers": sorted(
+                _text_blockers(issue.get("body")) | _native_blockers(api, issue["number"])),
+            "is_dashboard": DASHBOARD_LABEL in labels,
+        },
+        "comment": {
+            "id": comment.get("id"),
+            "body": comment.get("body") or "",
+            "author": user.get("login", ""),
+            "watermarked": _is_watermarked(api, comment.get("id"), bot_login),
+        },
+        "owner": owner,
+    }

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fetch_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fetch_comment_event.py
@@ -1,0 +1,134 @@
+"""Tests for the per-issue snapshot builder."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import fetch_comment_event as fetcher  # noqa: E402
+
+
+def payload(body="/approve", author="derekwinters", bot=False, is_pr=False, number=10):
+    issue = {"number": number, "labels": [{"name": "pending-approval"}],
+             "body": "Blocked by #20", "milestone": {"title": "v0.0.1"}}
+    if is_pr:
+        issue["pull_request"] = {"url": "..."}
+    return {
+        "issue": issue,
+        "comment": {"id": 555, "body": body,
+                    "user": {"login": author, "type": "Bot" if bot else "User"}},
+    }
+
+
+class FakeApi:
+    def __init__(self, blocked_by=(), reactions=()):
+        self.blocked_by = list(blocked_by)
+        self.reactions = list(reactions)
+
+    def __call__(self, method, path, payload=None):
+        if "dependencies/blocked_by" in path:
+            return self.blocked_by
+        if "reactions" in path:
+            return self.reactions
+        return {}
+
+
+class SkipTests(unittest.TestCase):
+    def test_a_pull_request_comment_is_skipped(self):
+        # Defence in depth: the workflow filters these too, but a snapshot the
+        # parser could act on is one it eventually will.
+        self.assertIsNone(fetcher.build(payload(is_pr=True), FakeApi(), owner="derekwinters"))
+
+    def test_a_bot_comment_is_skipped(self):
+        self.assertIsNone(fetcher.build(payload(bot=True), FakeApi(), owner="derekwinters"))
+
+    def test_the_gatekeeper_s_own_ack_is_skipped(self):
+        # Otherwise its own reply could be parsed as a command.
+        event = payload(body="/approve", author="github-actions[bot]", bot=True)
+
+        self.assertIsNone(fetcher.build(event, FakeApi(), owner="derekwinters"))
+
+
+class SnapshotTests(unittest.TestCase):
+    def snapshot(self, **kwargs):
+        api = kwargs.pop("api", FakeApi())
+        return fetcher.build(payload(**kwargs), api, owner="derekwinters")
+
+    def test_it_carries_the_issue_basics(self):
+        snapshot = self.snapshot()
+
+        self.assertEqual(10, snapshot["issue"]["number"])
+        self.assertEqual(["pending-approval"], snapshot["issue"]["labels"])
+        self.assertEqual("v0.0.1", snapshot["issue"]["milestone"])
+
+    def test_it_carries_the_comment_under_consideration(self):
+        snapshot = self.snapshot(body="/approve")
+
+        self.assertEqual("/approve", snapshot["comment"]["body"])
+        self.assertEqual(555, snapshot["comment"]["id"])
+
+    def test_blockers_union_text_and_native(self):
+        api = FakeApi(blocked_by=[{"number": 21}])
+
+        snapshot = self.snapshot(api=api)
+
+        self.assertEqual([20, 21], sorted(snapshot["issue"]["blockers"]))
+
+    def test_the_watermark_is_read_from_the_comment_s_reactions(self):
+        api = FakeApi(reactions=[{"content": "eyes", "user": {"login": "github-actions[bot]"}}])
+
+        self.assertTrue(self.snapshot(api=api)["comment"]["watermarked"])
+
+    def test_someone_else_s_eyes_reaction_is_not_the_watermark(self):
+        # A human reacting 👀 out of interest must not silence a command.
+        api = FakeApi(reactions=[{"content": "eyes", "user": {"login": "derekwinters"}}])
+
+        self.assertFalse(self.snapshot(api=api)["comment"]["watermarked"])
+
+    def test_the_dashboard_issue_is_recognised(self):
+        event = payload()
+        event["issue"]["labels"] = [{"name": "dashboard"}]
+
+        snapshot = fetcher.build(event, FakeApi(), owner="derekwinters")
+
+        self.assertTrue(snapshot["issue"]["is_dashboard"])
+
+
+class ToleranceTests(unittest.TestCase):
+    def test_a_payload_with_no_milestone_does_not_throw(self):
+        event = payload()
+        event["issue"]["milestone"] = None
+
+        self.assertIsNone(fetcher.build(event, FakeApi(), owner="derekwinters")["issue"]["milestone"])
+
+    def test_a_payload_with_no_body_does_not_throw(self):
+        event = payload()
+        event["issue"]["body"] = None
+
+        self.assertEqual([], fetcher.build(event, FakeApi(), owner="derekwinters")["issue"]["blockers"])
+
+    def test_a_payload_with_no_labels_does_not_throw(self):
+        event = payload()
+        del event["issue"]["labels"]
+
+        self.assertEqual([], fetcher.build(event, FakeApi(), owner="derekwinters")["issue"]["labels"])
+
+    def test_a_payload_with_no_comment_is_skipped_rather_than_throwing(self):
+        self.assertIsNone(fetcher.build({"issue": {"number": 1}}, FakeApi(), owner="d"))
+
+    def test_a_failing_blockers_fetch_does_not_lose_the_snapshot(self):
+        # A command should still be honoured when the dependency lookup fails;
+        # the gates that need blockers see an empty list and say so.
+        def explode(method, path, payload=None):
+            if "dependencies" in path:
+                raise RuntimeError("the API is down")
+            return []
+
+        snapshot = fetcher.build(payload(), explode, owner="derekwinters")
+
+        self.assertEqual([20], snapshot["issue"]["blockers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -156,6 +156,29 @@ account**, and it skips any comment that already has one.
 
 To make the gatekeeper reconsider a comment, remove its 👀.
 
+**Only the gatekeeper's own 👀 counts.** A human reacting out of interest must
+not silence a command, so the watermark check matches on the reacting account.
+And if the reactions cannot be read at all, the comment is treated as *already
+claimed* — re-applying a command is worse than skipping one, and the sweep picks
+it up next time.
+
+### The snapshot
+
+`fetch_comment_event.py` turns the raw webhook payload into what the parser
+reads: the issue's number, labels, body, milestone, blockers (text ∪ native),
+whether it is the dashboard, and the comment itself. All the payload-shape
+guesswork lives there so the parser never has to know what GitHub's JSON looks
+like.
+
+It returns nothing at all for a comment on a pull request or from a bot —
+defence in depth, since the workflow filters those too, but a snapshot the
+parser *could* act on is one it eventually will.
+
+It also tolerates a partial payload rather than throwing. A failed
+dependency lookup in particular does not lose the event: the command is
+probably `/park`, which does not care, and the gates that *do* care see a
+smaller blocker list and refuse — which is the safe direction.
+
 ## The approval gates
 
 Both gates **refuse and explain**. Neither ever fixes the problem itself.


### PR DESCRIPTION
Closes #57

Turns a raw `issue_comment` payload into the snapshot the parser reads. All the I/O and all the payload-shape guesswork lives here, so `parse_commands.py` stays pure — the parser should never have to know what GitHub's JSON looks like.

**Docs:** `docs/engineering/issue-pipeline.md` — added the snapshot section and the watermark-ownership rule.

## What it builds

Issue number, labels, body, milestone, blockers (text ∪ native), whether it's the dashboard, plus the comment itself and whether it's already watermarked.

## What it refuses to build

Returns **`None`** for a comment on a pull request or from a bot. Defence in depth — the workflow filters those too — but a snapshot the parser *could* act on is one it eventually will. The bot filter matters more than it looks: the gatekeeper's own ack is the comment most likely to contain a command.

## Two decisions about the watermark

- **Only the gatekeeper's own 👀 counts.** A human reacting out of interest must not silence a command. Tested both ways.
- **If the reactions can't be read, the comment is treated as already claimed.** Unknown resolves toward *skip*, because re-applying a command is worse than skipping one and the sweep picks it up next time.

## Tolerating partial payloads

No milestone, no body, no labels, no comment — none of them throw. The one worth calling out: **a failed dependency lookup doesn't lose the event.** The command is probably `/park`, which doesn't care; and the gates that *do* care see a smaller blocker list and refuse, which is the safe direction.

**95 tests** in the gatekeeper suite. Written first, red on `ModuleNotFoundError`.

## Deviations and Decisions

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_