### PR TITLE
feat(pipeline): compute the gatekeeper's label merge, acks, and watermark

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/apply_actions.py
+++ b/.claude/skills/pipeline-gatekeeper/apply_actions.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Work out what a parsed action actually writes.
+
+The final label set, the acknowledgement, and whether to leave the 👀
+watermark. Pure — keeping it so is what makes the whole gatekeeper testable
+without a live repo.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+WATERMARK = "eyes"
+
+TRIAGE = "ai-triage"
+PENDING = "pending-approval"
+NEEDS_CLARIFICATION = "needs-clarification"
+READY = "ready-for-work"
+IN_PROGRESS = "in-progress"
+PARKED = "parked"
+
+# Exactly one of these is on an open issue at a time, so a state change
+# *replaces* rather than adds. Everything else — area:*, type:*, skip-docs — is
+# untouched, because a state change that dropped them would lose the whole
+# triage decision.
+STATE_LABELS = {TRIAGE, PENDING, NEEDS_CLARIFICATION, READY, IN_PROGRESS, PARKED}
+
+# What each command moves the issue to. Commands absent from this map change no
+# labels at all.
+MOVES = {
+    "admit": TRIAGE,
+    "propose": TRIAGE,
+    "revise": TRIAGE,
+    "unpark": TRIAGE,
+    "approve": READY,
+    "redo": READY,
+    "park": PARKED,
+}
+
+# What to say after each move, in terms of what happens next rather than what
+# label changed — the label is a means, and the reader wants the consequence.
+NEXT = {
+    TRIAGE: "the next triage run will pick it up",
+    READY: "the nightly builder can pick it up next",
+    PARKED: "the pipeline will leave it alone until `/unpark`",
+}
+
+# Refusals nobody is told about. Replying to a stranger would let them make the
+# bot post; replying to a replay would post the same ack twice.
+SILENT_SKIPS = {"not-owner", "already-applied"}
+
+
+class Plan:
+    def __init__(self, labels, milestone=None, focus=None, cap=None) -> None:
+        self.labels = labels
+        self.milestone = milestone
+        self.focus = focus
+        self.cap = cap
+
+
+def plan(current_labels, actions) -> Plan:
+    """The label set and settings after applying `actions` in order."""
+    labels = list(current_labels)
+    milestone = focus = cap = None
+
+    for act in actions:
+        if act.command in MOVES:
+            labels = [label for label in labels if label not in STATE_LABELS]
+            labels.append(MOVES[act.command])
+        elif act.command == "milestone":
+            milestone = act.argument
+        elif act.command == "focus":
+            focus = act.argument
+        elif act.command == "cap":
+            cap = int(act.argument)
+
+    return Plan(labels, milestone, focus, cap)
+
+
+def fires_triage(current_labels, new_labels) -> bool:
+    """Should reactive triage be fired?
+
+    **Only when `ai-triage` is newly present.** An idempotent re-add — a replay,
+    or a second `/admit` on an already-admitted issue — must not fire triage
+    again, or a stuck comment becomes a triage run every sweep.
+    """
+    return TRIAGE in set(new_labels) and TRIAGE not in set(current_labels)
+
+
+def acknowledgement(actions, skips) -> str:
+    """The comment to post, or "" for nothing."""
+    lines: list[str] = []
+
+    for act in actions:
+        if act.command in MOVES:
+            destination = MOVES[act.command]
+            lines.append(f"- `/{act.command}` → **{destination}**; {NEXT[destination]}.")
+        elif act.command == "milestone":
+            lines.append(f"- `/{act.command}` → milestone set to **{act.argument}**.")
+        elif act.command in ("focus", "cap"):
+            lines.append(f"- `/{act.command}` → **{act.argument}**, recorded on the dashboard.")
+
+    refusals = [skip for skip in skips if skip.reason not in SILENT_SKIPS]
+
+    for skip in refusals:
+        lines.append(f"- `/{skip.command}` was **not applied**. {skip.detail}")
+
+    if not lines:
+        return ""
+
+    if refusals:
+        lines.append("")
+        lines.append(
+            "Nothing was changed for the refused command(s) — not the labels, not the "
+            "milestone. Fix the reason and comment again.")
+
+    return "\n".join(lines)
+
+
+def should_watermark(actions, skips) -> bool:
+    """Leave the 👀 so this comment is never reconsidered.
+
+    A **refused** comment is watermarked too: it was considered, and without the
+    mark the sweep reconsiders it on every run, re-posting the same refusal.
+
+    A stranger's comment is not, because it was never claimed — reacting to it
+    would itself be letting them make the bot act.
+    """
+    if any(skip.reason == "not-owner" for skip in skips):
+        return False
+
+    return bool(actions or skips)

--- a/.claude/skills/pipeline-gatekeeper/tests/test_apply_actions.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_apply_actions.py
@@ -1,0 +1,172 @@
+"""Tests for label merging, acks, and the reaction watermark."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import apply_actions as apply  # noqa: E402
+import parse_commands as parser  # noqa: E402
+
+
+def action(command, argument=""):
+    return parser.Action(command, argument)
+
+
+class LabelMergeTests(unittest.TestCase):
+    def test_approve_moves_to_ready_for_work(self):
+        result = apply.plan(["pending-approval"], [action("approve")])
+
+        self.assertEqual({"ready-for-work"}, set(result.labels))
+
+    def test_unrelated_labels_are_never_clobbered(self):
+        # The label set carries area/type as well as state. A state change that
+        # dropped them would lose the triage decision entirely.
+        result = apply.plan(
+            ["pending-approval", "area:build", "type:task"], [action("approve")])
+
+        self.assertEqual({"ready-for-work", "area:build", "type:task"}, set(result.labels))
+
+    def test_only_one_state_label_survives(self):
+        result = apply.plan(["ai-triage", "pending-approval"], [action("approve")])
+
+        self.assertEqual({"ready-for-work"}, set(result.labels))
+
+    def test_park_replaces_whatever_state_was_there(self):
+        result = apply.plan(["ready-for-work"], [action("park")])
+
+        self.assertEqual({"parked"}, set(result.labels))
+
+    def test_unpark_returns_to_triage(self):
+        self.assertEqual({"ai-triage"}, set(apply.plan(["parked"], [action("unpark")]).labels))
+
+    def test_admit_sets_triage(self):
+        self.assertEqual({"ai-triage"}, set(apply.plan([], [action("admit")]).labels))
+
+    def test_revise_returns_to_triage(self):
+        result = apply.plan(["pending-approval"], [action("revise", "too big, split it")])
+
+        self.assertEqual({"ai-triage"}, set(result.labels))
+
+    def test_redo_requeues_completed_work(self):
+        self.assertEqual({"ready-for-work"}, set(apply.plan([], [action("redo")]).labels))
+
+    def test_several_actions_apply_in_order(self):
+        result = apply.plan(["pending-approval"], [action("approve"), action("park")])
+
+        self.assertEqual({"parked"}, set(result.labels))
+
+    def test_milestone_changes_no_labels(self):
+        result = apply.plan(["pending-approval"], [action("milestone", "v0.1")])
+
+        self.assertEqual({"pending-approval"}, set(result.labels))
+        self.assertEqual("v0.1", result.milestone)
+
+    def test_focus_and_cap_change_no_labels(self):
+        result = apply.plan(["dashboard"], [action("focus", "v0.1"), action("cap", "2")])
+
+        self.assertEqual({"dashboard"}, set(result.labels))
+        self.assertEqual("v0.1", result.focus)
+        self.assertEqual(2, result.cap)
+
+
+class FiresTriageTests(unittest.TestCase):
+    def test_newly_added_triage_fires(self):
+        self.assertTrue(apply.fires_triage(["pending-approval"], ["ai-triage"]))
+
+    def test_an_idempotent_re_add_does_not_fire(self):
+        # A replay must not fire triage a second time.
+        self.assertFalse(apply.fires_triage(["ai-triage"], ["ai-triage"]))
+
+    def test_removing_triage_does_not_fire(self):
+        self.assertFalse(apply.fires_triage(["ai-triage"], ["ready-for-work"]))
+
+    def test_no_change_does_not_fire(self):
+        self.assertFalse(apply.fires_triage(["ready-for-work"], ["ready-for-work"]))
+
+
+class AckTests(unittest.TestCase):
+    def test_an_applied_action_gets_a_your_move_ack(self):
+        text = apply.acknowledgement([action("approve")], [])
+
+        self.assertIn("ready-for-work", text)
+
+    def test_the_ack_says_what_happens_next(self):
+        text = apply.acknowledgement([action("approve")], [])
+
+        self.assertIn("next", text.lower())
+
+    def test_a_refusal_explains_and_says_nothing_changed(self):
+        skip = parser.Skip("approve-no-milestone", "This issue has no milestone.", "approve")
+
+        text = apply.acknowledgement([], [skip])
+
+        self.assertIn("no milestone", text.lower())
+        self.assertIn("nothing", text.lower())
+
+    def test_an_unknown_command_ack_names_the_closest_match(self):
+        skip = parser.Skip("unknown-command", "/aprove is not a command. Did you mean /approve?", "aprove")
+
+        self.assertIn("/approve", apply.acknowledgement([], [skip]))
+
+    def test_a_not_owner_skip_produces_no_ack_at_all(self):
+        # Replying would let a stranger make the bot post.
+        skip = parser.Skip("not-owner", "/approve from someone-else", "approve")
+
+        self.assertEqual("", apply.acknowledgement([], [skip]))
+
+    def test_an_already_applied_skip_produces_no_ack(self):
+        skip = parser.Skip("already-applied", "/approve was applied earlier", "approve")
+
+        self.assertEqual("", apply.acknowledgement([], [skip]))
+
+    def test_actions_and_refusals_appear_together(self):
+        skip = parser.Skip("cap-invalid", "/cap needs a positive whole number.", "cap")
+
+        text = apply.acknowledgement([action("approve")], [skip])
+
+        self.assertIn("ready-for-work", text)
+        self.assertIn("cap", text)
+
+
+class WatermarkTests(unittest.TestCase):
+    def test_the_watermark_is_the_eyes_reaction(self):
+        self.assertEqual("eyes", apply.WATERMARK)
+
+    def test_an_applied_comment_is_watermarked(self):
+        self.assertTrue(apply.should_watermark([action("approve")], []))
+
+    def test_a_refused_comment_is_still_watermarked(self):
+        # It was considered. Without the mark the sweep reconsiders it forever.
+        skip = parser.Skip("cap-invalid", "…", "cap")
+
+        self.assertTrue(apply.should_watermark([], [skip]))
+
+    def test_a_stranger_s_comment_is_not_watermarked(self):
+        skip = parser.Skip("not-owner", "…", "approve")
+
+        self.assertFalse(apply.should_watermark([], [skip]))
+
+    def test_a_comment_with_nothing_in_it_is_not_watermarked(self):
+        self.assertFalse(apply.should_watermark([], []))
+
+
+class NoIoTests(unittest.TestCase):
+    def test_the_module_imports_nothing_that_can_reach_the_network(self):
+        import ast
+
+        source = Path(apply.__file__).read_text()
+        imported = set()
+
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+
+        self.assertEqual(set(), imported & {"urllib", "http", "socket", "subprocess", "requests"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -153,6 +153,10 @@ account**, and it skips any comment that already has one.
   state change nobody asked for. Prefer visible-and-stuck to silent-and-doubled.
 - It is a **claim**, so the outcome gets its own reaction: 🚀 applied, 😕
   refused or not understood.
+- A **refused** comment is watermarked too. It was considered, and without the
+  mark the sweep reconsiders it every run and re-posts the same refusal. A
+  stranger's comment is *not* watermarked — reacting to it would itself be
+  letting them make the bot act.
 
 To make the gatekeeper reconsider a comment, remove its 👀.
 
@@ -430,6 +434,25 @@ comment carries a marker; a re-run finds its previous comment and **edits** it
 rather than adding another. `triage_repair.py` also detects the mess left by an
 older run that crashed mid-way — a label set without a comment, a comment
 without labels — and repairs it.
+
+### Applying an action
+
+`apply_actions.py` computes the resulting label set, the acknowledgement, and
+whether to watermark. Three rules worth knowing:
+
+- **A state change replaces, never adds.** Exactly one of the state labels is
+  on an open issue at a time. Everything else — `area:*`, `type:*`,
+  `skip-docs` — is untouched, because a state change that dropped them would
+  throw away the whole triage decision.
+- **The ack says what happens next**, not which label changed. "the nightly
+  builder can pick it up next" is the consequence; the label is a means.
+- **A refusal's ack says nothing was changed** — not the labels, not the
+  milestone — because "your command was refused" and "your command was partly
+  applied" need very different responses.
+
+Reactive triage fires **only when `ai-triage` is newly present**. An idempotent
+re-add — a replay, or a second `/admit` on an already-admitted issue — must not
+fire it again, or one stuck comment becomes a triage run every sweep.
 
 ### Recording dependencies
 


### PR DESCRIPTION
Closes #58

Works out what a parsed action actually *writes*: the resulting label set, the acknowledgement, and whether to leave the watermark. Pure, which is what makes the whole gatekeeper testable without a live repo.

**Docs:** `docs/engineering/issue-pipeline.md` — added the "Applying an action" section and the refused-comments-are-watermarked rule.

## Three decisions

**A state change replaces, never adds.** Exactly one state label is on an open issue at a time, and everything else — `area:*`, `type:*`, `skip-docs` — is untouched. A state change that dropped those would throw away the entire triage decision, so there's a test asserting unrelated labels survive.

**`fires_triage` is true only when `ai-triage` is *newly* present.** An idempotent re-add — a replay, or a second `/admit` on an already-admitted issue — must not fire triage again, or one stuck comment becomes a triage run every sweep.

**The ack says what happens next**, not which label changed: "the nightly builder can pick it up next" is the consequence, and the label is a means. A refusal's ack states explicitly that **nothing was changed** — "your command was refused" and "your command was partly applied" need very different responses from the reader.

## Who gets no ack

A stranger's comment and a replay both produce `""`. Replying to the first would let them make the bot post; replying to the second would post the same text twice.

## Refused comments are still watermarked

They were *considered*. Without the mark, the sweep reconsiders them every run and re-posts the same refusal. A stranger's comment is the exception — reacting to it would itself be letting them make the bot act.

**123 tests** in the gatekeeper suite. Written first, red on `ModuleNotFoundError`.

## Deviations and Decisions

- **The `MOVES` table encodes the semantics I inferred in #53** for `/admit`, `/propose`, `/revise`, and `/redo` — admit/propose/revise → `ai-triage`, redo → `ready-for-work`. As flagged there, this is the place to change them if any should mean something else: it's one dictionary entry each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_