### PR TITLE
feat(pipeline): add triage discovery to pipeline-analysis

### DIFF
--- a/.claude/skills/pipeline-analysis/select_triage.py
+++ b/.claude/skills/pipeline-analysis/select_triage.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Which issues are eligible for triage, and what context each one carries.
+
+Pure `process(data)` plus a stdin/stdout `main()`, like the other pipeline
+scripts. Deciding *what to triage* is deterministic and unit-testable; deciding
+*how to triage it* is the `triage-issue` skill's job, and that separation is
+what keeps a bad triage contained to one issue instead of one batch.
+
+    echo '{"issues": [...], "owner": "..."}' | python3 select_triage.py
+
+Stdlib only.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+TRIAGE_LABEL = "ai-triage"
+
+# Excluded even when carrying ai-triage. An epic is a container — its children
+# are the work. The dashboard is the pipeline's own furniture. And `parked` is a
+# decision the owner made, which triage does not get to overrule.
+EXCLUDED_LABELS = ("type:epic", "dashboard", "parked")
+
+# The owner commands that leave triage something to read: what was wrong last
+# time, or permission to design.
+NOTE_COMMANDS = ("revise", "redo", "propose")
+
+NOTE_LINE = re.compile(
+    r"^\s{0,3}/(" + "|".join(NOTE_COMMANDS) + r")\b\s*(.*?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _latest_note(comments, owner: str):
+    """The most recent `/revise`, `/redo`, or `/propose` from the owner.
+
+    Only the latest: an issue revised twice should be triaged against the
+    current feedback, not a conversation. Only the owner's, for the same reason
+    the parser has a bad-actor gate — a stranger cannot steer triage either.
+    """
+    best = None
+
+    for comment in comments or []:
+        if (comment.get("author") or "").lower() != (owner or "").lower():
+            continue
+
+        for command, text in NOTE_LINE.findall(comment.get("body") or ""):
+            candidate = {
+                "command": command.lower(),
+                "text": text,
+                "at": comment.get("created_at") or "",
+            }
+            # Compared by timestamp rather than position, because the caller's
+            # ordering is not guaranteed.
+            if best is None or candidate["at"] >= best["at"]:
+                best = candidate
+
+    return best
+
+
+def is_eligible(issue: dict) -> bool:
+    labels = set(issue.get("labels") or [])
+
+    return (
+        issue.get("state", "open") == "open"
+        and TRIAGE_LABEL in labels
+        and not labels.intersection(EXCLUDED_LABELS)
+    )
+
+
+def process(data: dict) -> dict:
+    owner = data.get("owner", "")
+    eligible = []
+
+    for issue in sorted(data.get("issues") or [], key=lambda i: i.get("number", 0)):
+        if not is_eligible(issue):
+            continue
+
+        eligible.append({
+            "number": issue["number"],
+            "milestone": issue.get("milestone"),
+            "note": _latest_note(issue.get("comments"), owner),
+        })
+
+    return {"eligible": eligible, "count": len(eligible)}
+
+
+def main(argv=None) -> int:
+    json.dump(process(json.load(sys.stdin)), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-analysis/tests/test_select_triage.py
+++ b/.claude/skills/pipeline-analysis/tests/test_select_triage.py
@@ -1,0 +1,127 @@
+"""Tests for triage discovery."""
+
+import json
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import select_triage as select  # noqa: E402
+
+
+def issue(number=10, state="open", labels=("ai-triage",), milestone="v0.0.1", comments=()):
+    return {
+        "number": number,
+        "state": state,
+        "labels": list(labels),
+        "milestone": milestone,
+        "comments": list(comments),
+    }
+
+
+def comment(body, author="derekwinters", created_at="2026-08-08T10:00:00Z"):
+    return {"body": body, "author": author, "created_at": created_at}
+
+
+def eligible_numbers(issues, owner="derekwinters"):
+    return [entry["number"] for entry in select.process({"issues": issues, "owner": owner})["eligible"]]
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_an_open_ai_triage_issue_is_eligible(self):
+        self.assertEqual([10], eligible_numbers([issue()]))
+
+    def test_a_closed_issue_is_not(self):
+        self.assertEqual([], eligible_numbers([issue(state="closed")]))
+
+    def test_an_issue_without_ai_triage_is_not(self):
+        self.assertEqual([], eligible_numbers([issue(labels=["pending-approval"])]))
+
+    def test_an_epic_is_not(self):
+        # Epics are containers; their children are the work.
+        self.assertEqual([], eligible_numbers([issue(labels=["ai-triage", "type:epic"])]))
+
+    def test_the_dashboard_issue_is_not(self):
+        self.assertEqual([], eligible_numbers([issue(labels=["ai-triage", "dashboard"])]))
+
+    def test_a_parked_issue_is_not(self):
+        # Even carrying ai-triage: parking is the owner's decision.
+        self.assertEqual([], eligible_numbers([issue(labels=["ai-triage", "parked"])]))
+
+    def test_several_eligible_issues_come_back_oldest_first(self):
+        found = eligible_numbers([issue(number=30), issue(number=10), issue(number=20)])
+
+        self.assertEqual([10, 20, 30], found)
+
+
+class CarriedContextTests(unittest.TestCase):
+    def entry(self, comments):
+        return select.process(
+            {"issues": [issue(comments=comments)], "owner": "derekwinters"})["eligible"][0]
+
+    def test_the_milestone_is_carried(self):
+        self.assertEqual("v0.0.1", self.entry([])["milestone"])
+
+    def test_no_note_when_there_are_no_commands(self):
+        self.assertIsNone(self.entry([comment("looks fine")])["note"])
+
+    def test_a_revise_note_is_carried(self):
+        entry = self.entry([comment("/revise the scope is too big")])
+
+        self.assertEqual("revise", entry["note"]["command"])
+        self.assertEqual("the scope is too big", entry["note"]["text"])
+
+    def test_redo_and_propose_are_carried_too(self):
+        self.assertEqual("redo", self.entry([comment("/redo")])["note"]["command"])
+        self.assertEqual("propose", self.entry([comment("/propose")])["note"]["command"])
+
+    def test_only_the_latest_note_is_carried(self):
+        entry = self.entry([
+            comment("/revise first go", created_at="2026-08-01T10:00:00Z"),
+            comment("/revise second go", created_at="2026-08-08T10:00:00Z"),
+        ])
+
+        self.assertEqual("second go", entry["note"]["text"])
+
+    def test_notes_are_found_regardless_of_comment_order(self):
+        entry = self.entry([
+            comment("/revise second go", created_at="2026-08-08T10:00:00Z"),
+            comment("/revise first go", created_at="2026-08-01T10:00:00Z"),
+        ])
+
+        self.assertEqual("second go", entry["note"]["text"])
+
+    def test_a_note_from_anyone_but_the_owner_is_ignored(self):
+        # Same gate as the parser: a stranger cannot steer triage either.
+        entry = self.entry([comment("/revise do it differently", author="a-stranger")])
+
+        self.assertIsNone(entry["note"])
+
+    def test_an_unrelated_command_is_not_a_note(self):
+        self.assertIsNone(self.entry([comment("/approve")])["note"])
+
+
+class ShapeTests(unittest.TestCase):
+    def test_process_is_pure_and_returns_a_count(self):
+        result = select.process({"issues": [issue()], "owner": "derekwinters"})
+
+        self.assertEqual(1, result["count"])
+
+    def test_no_issues_at_all_is_an_empty_result_not_an_error(self):
+        self.assertEqual({"eligible": [], "count": 0}, select.process({"issues": []}))
+
+    def test_main_reads_stdin_and_writes_json(self):
+        payload = json.dumps({"issues": [issue()], "owner": "derekwinters"})
+        out = StringIO()
+
+        with patch("sys.stdin", StringIO(payload)), patch("sys.stdout", out):
+            self.assertEqual(0, select.main([]))
+
+        self.assertEqual(1, json.loads(out.getvalue())["count"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -429,10 +429,29 @@ the defence; the Routine ignoring it is the other half, and its prompt says so.
 
 ### Analysis — find what needs triage
 
-`select_triage.py` lists candidate issues: open, not the dashboard, and either
-carrying no state label or carrying `ai-triage`. It returns them oldest-first,
-with everything the triage stage needs already fetched, so the dispatcher can
-fan out without each triage run re-querying.
+`select_triage.py` lists candidate issues. An issue is eligible when it is
+**open** and carries **`ai-triage`**, and is none of the following:
+
+| Excluded | Why |
+| --- | --- |
+| `type:epic` | An epic is a container. Its children are the work, and they carry their own labels. |
+| `dashboard` | The pipeline's own furniture, not something the pipeline works on. |
+| `parked` | A decision the owner made with `/park`. Triage does not get to overrule it — only `/unpark` does. |
+
+Carrying `ai-triage` is the whole entry condition, so an issue with no state
+label at all is not a candidate: it has not been `/admit`ted, and admitting is
+the owner's call. That is the same rule the command table above describes, and
+picking up unadmitted issues would make `/admit` mean nothing.
+
+Each eligible issue comes back with its **number**, its **current milestone**,
+and the **latest owner note** — the most recent `/revise`, `/redo`, or
+`/propose` comment, with its text. Only the latest, because an issue revised
+twice should be triaged against the current feedback rather than a
+conversation; and only the owner's, for the same reason the parser has a
+bad-actor gate. Carrying the note here means the triage run does not have to
+re-read the thread to find out why it is running again.
+
+Results are sorted by issue number, oldest first.
 
 The dispatcher (`pipeline-analysis`) is a thin loop over that list. It makes no
 decisions itself — the decisions are in `triage-issue`, one issue at a time,


### PR DESCRIPTION
Before the pipeline can triage anything, something has to decide *what* to triage. This adds that decision as a small, boring script: give it a list of issues and it tells you which ones are waiting for triage, and what each one needs the triage run to know.

An issue is on the list if it is open and labelled `ai-triage`, and it is not an epic, the dashboard issue, or parked. Each one comes back with its number, its milestone, and the most recent `/revise`, `/redo`, or `/propose` note Derek left on it — so a re-triage already knows why it is running again instead of re-reading the whole thread.

Deciding *what* to triage lives here; deciding *how* to triage it is the `triage-issue` skill's job. Keeping those apart is what stops one bad triage from becoming a bad batch.

## Spec invariants

- **Owner-only notes.** A note is carried only if the comment's author is the repo owner, matching the gatekeeper parser's bad-actor gate — a stranger cannot steer triage any more than they can move a label. Covered by `test_a_note_from_anyone_but_the_owner_is_ignored`.
- **Latest note only.** An issue revised twice is triaged against the current feedback, not a conversation. Compared by timestamp rather than list position, because the caller's ordering isn't guaranteed — `test_only_the_latest_note_is_carried` and `test_notes_are_found_regardless_of_comment_order`.
- **`parked` is the owner's decision.** Triage does not overrule it; only `/unpark` does. Covered by `test_a_parked_issue_is_not`.
- **No I/O in `process`.** Pure function in, dict out; `main()` is the only thing that touches stdin/stdout, and it's stdlib-only. Covered by `test_process_is_pure_and_returns_a_count` and `test_main_reads_stdin_and_writes_json`.

18 tests, written first and watched fail with `ModuleNotFoundError: No module named 'select_triage'` before a line of the script existed.

## How the spec is changing

`docs/engineering/issue-pipeline.md` previously described the analysis stage as picking up issues that were open, not the dashboard, and *"either carrying no state label or carrying `ai-triage`"*. That contradicted the same page's own command table, which says `/admit` is what brings an issue into the pipeline and makes it `ai-triage`. Under the old wording, every issue anyone filed would be triaged whether or not it had been admitted, and `/admit` would mean nothing.

The new rule is the narrow one: carrying `ai-triage` is the whole entry condition. I treated the issue's build checklist as authoritative over the prose, and the doc now matches — with the three exclusions written out in a table alongside why each one is excluded.

**Docs:** `docs/engineering/issue-pipeline.md` — rewrote the "Analysis — find what needs triage" section: narrowed the eligibility rule to `ai-triage` only (from "no state label or `ai-triage`"), tabulated the three exclusions with their reasons, and documented the carried context (number, milestone, latest owner note) and the oldest-first ordering.

## Deviations and Decisions

- **Narrowed the documented eligibility rule rather than widening the code to match.** The two disagreed; I picked the issue's checklist and said why above. Flagging it because this is a contract change, not a wording tidy — if the intent really was to sweep up unadmitted issues, this is the line to push back on.
- **No `.claude/.skills-manifest.json` entry yet.** The manifest records one entry per skill, and `pipeline-analysis` has no `SKILL.md` until #63. Adding a provenance entry for a directory that isn't yet a loadable skill would put the manifest ahead of reality; it goes in with the dispatcher.
- **Notes are matched at the start of a line, allowing up to three leading spaces** — the same shape the gatekeeper parser uses, so a command indented inside a list still counts and one quoted mid-sentence does not.

Closes #62

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_