### PR TITLE
docs(pipeline): add the single-issue triage-issue skill

### DIFF
--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: triage-issue
+description: Triage exactly one admitted issue — diagnose it, plan it, and hand it back to Derek for approval. Use when an issue carries ai-triage, when a triage run needs redoing, or when asked to work out what an issue actually involves.
+---
+
+# triage-issue
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+# Triage one issue. That is the whole interface.
+#   triage-issue 47
+```
+
+One issue in, one hand-back out. Runnable standalone on a single issue number —
+nothing about this skill knows or cares whether a batch is running around it.
+
+## What this skill will not do
+
+**It never invents a game mechanic, and it never sets `ready-for-work`.**
+
+Those are the same rule wearing two hats. Every route below ends with the issue
+waiting on a human: `pending-approval` if there is a plan to agree with,
+`needs-clarification` if there is a question to answer. The label that says
+"build this" is only ever applied by Derek typing `/approve`.
+
+This matters more here than anywhere else in the pipeline. Triage is the stage
+that decides what the game *is* — and this is Connor's game. An agent that fills
+a specification gap with its own reasonable idea has quietly taken a design
+decision away from an eight-year-old, and it will do it convincingly enough that
+nobody notices for weeks.
+
+If `/docs` does not say how something behaves, that is not an ambiguity to
+resolve. It is the finding.
+
+## Reads widely, writes narrowly
+
+Read whatever helps: `/docs`, the code, sibling issues, the milestone list,
+closed issues that solved something similar.
+
+Write to **exactly one issue — the one you were invoked for.** No comments on
+other issues, no relabelling a sibling that looks mis-triaged, no tidying.
+
+The reason is blast radius. A triage run that writes to one issue can be wrong
+about one issue. A triage run that writes to whatever it reads can be wrong
+about all of them, and the batch that dispatched it has no idea it happened.
+
+The single exception is **recording a dependency you discovered** — that is a
+relationship, it needs both ends, and leaving it unrecorded is how the builder
+walks into a blocker nobody can see. Nothing else.
+
+## The four routes
+
+Read the issue, then pick exactly one. Most of the skill is knowing which.
+
+| Route | When | Ends at |
+| --- | --- | --- |
+| **Bug** | Something behaves against what `/docs` says | `pending-approval` + `type:bug` |
+| **Spec-covered feature** | `/docs` already says how this behaves | `pending-approval` |
+| **Needs a design call** | `/docs` doesn't say, or it's UI with no wireframe | `needs-clarification` |
+| **`/propose` authorized** | Derek explicitly asked for a design | `pending-approval`, marked PROPOSAL |
+
+### Bug
+
+Diagnose the **root cause**, not the symptom. Then: the fix approach, a
+`## Build checklist`, the milestone, `type:bug`, `pending-approval`.
+
+A bug report says "the frogs kept splitting past 32". The diagnosis says which
+code path skipped the check and why. A plan written against the symptom fixes
+the one case in the report and leaves the other three.
+
+#### When the root cause is a missing rule
+
+Sometimes there is no coding mistake. The code does exactly what someone
+intended; nobody ever wrote down what it should do, so two parts of the game
+disagree and one of them looks like a bug.
+
+That is a **spec gap**, and patching the code alone guarantees the same class of
+bug returns somewhere else. The plan proposes the missing **invariant** in
+plain English, and the checklist gets an item that tests it:
+
+> **Proposed invariant:** a frog never splits when the pond is at its cap,
+> whatever caused the split — timer, tap, or another frog landing on it.
+>
+> - [ ] Test: a tap on a frog at cap produces no new frog
+
+Proposing an invariant is not inventing a mechanic: it is writing down the rule
+the existing behaviour already implies, so it can be agreed or corrected. If the
+rule is a genuinely new choice about how the game plays, that is the
+**needs a design call** route instead — and if you cannot tell which, it is that
+route. See `docs/engineering/agent-workflow.md` on specs stating rules.
+
+### Spec-covered feature
+
+`/docs` already answers how this behaves, so the work is implementation, not
+design. Produce the implementation plan, the `## Build checklist`, the milestone
+matched from the live list, and `pending-approval`.
+
+If the plan changes what a spec *says*, state the shift in plain English — used
+to say X, now says Y, and why Y is better. Not "the docs were updated". A
+reviewer skimming needs to see the contract move, because that is the part they
+might disagree with.
+
+### Needs a design call or a wireframe
+
+Stop. Do not write a plan, a checklist, or a milestone — a plan on an
+undecided question is an answer smuggled in as paperwork, and half of it will
+survive into the build because it was already written down.
+
+Ask one concrete question:
+
+```markdown
+❓ **Needs from Derek/Connor:** when the pond is full and Connor taps a frog,
+should nothing happen, or should the frog wiggle to show it heard the tap?
+
+Either is easy to build. I've not guessed because it changes how the game feels
+when you're winning.
+```
+
+Concrete means answerable with a sentence. "How should this work?" hands the
+whole design back; naming the two or three options Connor can choose between is
+the useful version.
+
+Then `needs-clarification`, and nothing else.
+
+**UI with no agreed wireframe always takes this route**, whatever else the issue
+says — no UI code exists before a `type:wireframe` issue is agreed. See
+`docs/engineering/ui-design-process.md`.
+
+### `/propose` authorized
+
+`/propose` is Derek saying "go ahead and design this one". Only then does triage
+draft a design — and it is drafted as a **clearly marked proposal**:
+
+```markdown
+## 🎨 PROPOSAL — not decided
+
+This is a suggestion for Connor to react to, not a plan. Change any of it.
+```
+
+Then the checklist, the milestone, `pending-approval`. The marking is what keeps
+the exception from eroding the rule: three weeks later a proposal that isn't
+labelled as one reads exactly like a spec.
+
+## The hand-back comment
+
+**Opens with the plain-English lead — two or three skimmable sentences, before
+any diagnosis or file detail.** Same rule as a PR body, same reason: a wrong
+plan has to be catchable on a skim, and technical accuracy agrees with a wrong
+plan just as fluently as a right one.
+
+> Frogs keep multiplying past the limit when you tap them quickly. The counter
+> is checked before the tap is processed instead of after, so two fast taps
+> both see room for one more. The fix is to check at the moment the frog is
+> added.
+
+Then the diagnosis or plan, the `## Build checklist`, the spec-pages line, and
+any question. The checklist **is** the acceptance criteria — the dev agent
+cannot tick a box it cannot verify, so vague boxes come back as unfinished
+issues.
+
+See `docs/engineering/agent-workflow.md` for the lead's full rationale.
+
+## Write ordering: comment first, then the label
+
+**Post the analysis comment. Then set the state label. Always that order.**
+
+Not style — it is what makes the bad state structurally impossible. If the run
+dies between the two writes:
+
+| Order | If it dies halfway | Recoverable? |
+| --- | --- | --- |
+| comment → label | a plan sitting on `ai-triage` | yes — the next run redoes it |
+| label → comment | `pending-approval` with **no plan** | no — it waits for approval of nothing |
+
+The second one is silent. Derek sees an issue awaiting approval, opens it, and
+there is nothing to approve — and until he does, the pipeline believes that
+issue is handled. The first one just looks untriaged, which is what it is.
+
+`triage_repair.py` cleans up the second case when it happens anyway. Ordering is
+what stops it happening.
+
+## Labels and the milestone
+
+Set the milestone as a **field**, by matching the live milestone descriptions —
+never by guessing from a title, and never from a list written down in the docs.
+Milestones change; the API is the truth. `milestone-ops` resolves a title to the
+number the API needs.
+
+Remove `ai-triage` **in the same write** that adds the new state label. Exactly
+one state label belongs on an open issue, and an issue carrying both is an issue
+the next analysis round picks up and triages again — while it sits in
+`pending-approval` waiting for Derek.
+
+Every issue also leaves triage with one `area:*` and one `type:*` label.
+
+## Dependencies are structural, never prose
+
+| Relationship | How to record it |
+| --- | --- |
+| Cannot start until #42 is done | **native** blocked-by (`issue-blockers`) |
+| Easier after #42, but not blocked | `Depends on: #42` line |
+| This is part of epic #12 | **sub-issue** of #12 |
+
+A dependency written as a sentence in the body is a dependency the nightly
+builder cannot see, so it walks straight into the issue and starts it. Record it
+the moment you notice it — this is the one write allowed outside the issue being
+triaged.
+
+`Depends on:` deliberately has no native form; converting one into a hard
+blocker is how a queue deadlocks on work that could have been done at any time.
+
+## Re-running on the same issue
+
+Triage runs twice — a `/revise`, a `/redo`, a crashed run picked up next round.
+It must not stack duplicate comments or contradictory labels. Each triage
+comment carries a marker; a re-run **edits** its previous comment instead of
+adding a second. `triage_repair.py` (#65) owns finding that comment and
+repairing half-finished states.
+
+A re-run also arrives with the owner's note attached — `select_triage.py`
+carries the latest `/revise`, `/redo`, or `/propose` text — so the rewrite
+answers the actual objection rather than starting from scratch.
+
+## See also
+
+- `docs/engineering/issue-pipeline.md` — the stage this sits in
+- `docs/engineering/agent-workflow.md` — the plain-English lead, spec invariants
+- `docs/engineering/ui-design-process.md` — wireframe before UI code
+- `issue-blockers`, `milestone-ops` — the two skills this one calls

--- a/docs/engineering/agent-workflow.md
+++ b/docs/engineering/agent-workflow.md
@@ -135,6 +135,17 @@ It has a second effect: an agent that cannot write the lead usually doesn't
 understand the issue yet. That's worth finding out before the code is written,
 not after.
 
+### Triage hand-backs open with it too
+
+The rule is not PR-specific. **A `triage-issue` hand-back comment opens with the
+same two or three sentences**, before any diagnosis, plan, or file detail.
+
+The argument is if anything stronger there. A PR's wrong plan has already cost
+the work; a triage hand-back is the moment *before* anything is built, and
+`/approve` on a plan nobody skim-checked is how a whole issue gets built wrong.
+The lead is what makes "that's not what I meant" visible in five seconds,
+which is the only speed at which it reliably gets said.
+
 ## Specs state rules, not only outcomes
 
 A spec page that only lists outcomes can be satisfied by code that is wrong in

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -462,7 +462,7 @@ which keeps a bad triage contained to one issue instead of one batch.
 `triage-issue` reads an issue and produces:
 
 - an **`area:*` and `type:*` label**;
-- a **milestone proposal**, resolved against the live list;
+- the **milestone**, set as a field by matching the live milestone descriptions;
 - a **build checklist** — the acceptance criteria, as checkboxes;
 - a **spec-pages line** naming what in `/docs` it touches;
 - **dependencies**, recorded natively (below);
@@ -470,7 +470,52 @@ which keeps a bad triage contained to one issue instead of one batch.
   question that blocks it.
 
 It writes one comment containing its reasoning, so an `/approve` is a human
-agreeing with something they can read rather than rubber-stamping a label.
+agreeing with something they can read rather than rubber-stamping a label. That
+comment **opens with the plain-English lead** — the same two or three skimmable
+sentences a PR body opens with, and for the same reason: a wrong plan has to be
+catchable on a skim.
+
+**It never sets `ready-for-work`, and it never invents a mechanic.** Every route
+ends with the issue waiting on a human. The label that means "build this" is
+only ever applied by `/approve`.
+
+#### The four routes
+
+| Route | When | Ends at |
+| --- | --- | --- |
+| Bug | behaviour contradicts what `/docs` says | `pending-approval` + `type:bug` |
+| Spec-covered feature | `/docs` already says how this behaves | `pending-approval` |
+| Needs a design call | `/docs` doesn't say, or UI with no wireframe | `needs-clarification` |
+| `/propose` authorized | Derek asked for a design | `pending-approval`, marked PROPOSAL |
+
+Two of these are worth spelling out.
+
+**A bug whose root cause is a missing rule** gets an invariant, not just a
+patch. When the code does what someone intended and the real fault is that
+nobody wrote the rule down, the plan proposes the missing invariant in plain
+English and the checklist gains an item that tests it. Patching the code alone
+guarantees the same class of bug reappears elsewhere. If the rule is a genuinely
+new choice about how the game plays, it is a design call instead — and when it
+is unclear which, it is a design call.
+
+**The design-call route writes no plan at all** — no checklist, no milestone,
+just one concrete question and `needs-clarification`. A plan attached to an
+undecided question is an answer smuggled in as paperwork, and half of it
+survives into the build because it was already written down.
+
+#### Write ordering: comment first, then the label
+
+The analysis comment is posted **before** the state label is set, always.
+
+This is what makes the bad state structurally impossible rather than merely
+unlikely. A run that dies between the two writes leaves either a plan still
+sitting on `ai-triage` — untriaged, which the next round simply redoes — or
+`pending-approval` with nothing to approve, which is silent: the pipeline
+believes the issue is handled and it waits on a human who has nothing to read.
+
+`ai-triage` is removed in the same write that adds the new state, so a hand-back
+rests in exactly one state. An issue carrying both gets triaged again by the
+next analysis round while it sits waiting for Derek.
 
 **Re-fire repair.** Triage that runs twice on the same issue must not stack
 duplicate comments, duplicate checklists, or contradictory labels. Each triage


### PR DESCRIPTION
This adds the skill that does the actual thinking in the pipeline: take one issue that's been let in, work out what it really involves, and hand it back to Derek with either a plan to approve or a question to answer.

The most important thing about it is what it refuses to do. It never marks an issue as ready to build, and it never makes up how the game should work. If `/docs` doesn't say how something behaves, that silence *is* the answer it reports — it stops and asks Connor rather than filling the gap with its own reasonable-sounding idea. A guess here wouldn't look like a mistake; it would look like a plan, and it'd be built before anyone noticed the decision had been taken away from him.

There are four routes an issue can take — bug, feature the docs already cover, needs-a-design-call, and "Derek said design it" — and all four end with a person holding the decision.

## Spec invariants

- **Never `ready-for-work`.** Only `/approve` produces that label; every route here ends at `pending-approval` or `needs-clarification`. This is the invariant the whole approval gate rests on — if triage could set it, the gate would be decorative.
- **Reads widely, writes to one issue.** The blast radius of a bad triage is one issue, not the batch. The single exception is recording a discovered dependency, because a relationship needs both ends and an unrecorded one is one the builder walks straight into.
- **Comment before label, always.** Kept because the failure modes aren't symmetric: dying after the comment leaves a plan on `ai-triage`, which just looks untriaged and gets redone; dying after the label leaves `pending-approval` with nothing to approve, which is *silent* — the pipeline thinks the issue is handled while Derek opens it and finds nothing.
- **`ai-triage` removed in the same write as the new state.** One state label per open issue. An issue carrying both gets re-triaged by the next round while it sits waiting for approval.
- **`Depends on:` stays prose.** Hard blockers go native; soft ordering deliberately has no native form, because converting a preference into a gate is how the queue deadlocks on work that could have been done at any time. Matches the rule already in `issue-blockers`.

## How the spec is changing

**The plain-English lead is no longer PR-only.** `docs/engineering/agent-workflow.md` previously stated it as a rule about PR bodies. It now also governs triage hand-back comments. The reasoning transfers and gets stronger: a PR's wrong plan has already cost the work, whereas a triage hand-back is the moment *before* anything is built — and an `/approve` on a plan nobody skim-checked is how an entire issue gets built wrong.

**Milestone wording tightened.** The pipeline page described triage as producing "a milestone proposal, resolved against the live list". The skill sets the milestone **field**, by matching live milestone descriptions. "Proposal" undersold it — it's a real write, and it's part of what `/approve` is approving.

**Docs:** `docs/engineering/issue-pipeline.md` — expanded "Triage — one issue" with the four-route table, the missing-rule/invariant case, why the design-call route writes no plan, the comment-before-label ordering and its asymmetric failure modes, and the same-write removal of `ai-triage`; corrected "milestone proposal" to the milestone field. `docs/engineering/agent-workflow.md` — added "Triage hand-backs open with it too" extending the plain-English lead beyond PR bodies.

## Deviations and Decisions

- **No failing test first.** This issue's deliverable is a `SKILL.md` — prose, no behaviour code — so there is nothing a test could have gone red against. `core-unity-split` is the existing precedent for a documentation-only skill with no test suite. `triage_repair.py` (#65) is the executable part of this skill and gets tests written first, as normal.
- **No `.claude/.skills-manifest.json` entry, and I was imprecise about why last time.** In #143 I said `pipeline-analysis` would get one alongside its `SKILL.md`. That was the wrong reason. The manifest is a *port ledger* — it records where a skill was copied from so a future sync doesn't clobber local divergence. `triage-issue` and `pipeline-analysis` were authored here, not ported from `lucas-doggiehood`, so neither has provenance to record and neither should get an entry.
- **The invariant-vs-design-call boundary resolves toward asking.** Proposing an invariant means writing down the rule existing behaviour already implies. Choosing a rule the game doesn't yet have is a design call. The skill says that when you can't tell which one you're doing, it's a design call — the cheaper error is an unnecessary question to Connor, not a mechanic invented on his behalf.
- **Named the concrete-question format** (`❓ Needs from Derek/Connor:` plus two or three options to pick between) rather than leaving "ask a specific question" to interpretation. "How should this work?" hands the whole design back and is the failure mode worth naming explicitly.

Closes #64

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_