### PR TITLE
docs(pipeline): add the pipeline-analysis dispatcher SKILL.md

### DIFF
--- a/.claude/skills/pipeline-analysis/SKILL.md
+++ b/.claude/skills/pipeline-analysis/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pipeline-analysis
+description: Run a triage round — find every issue waiting for triage and dispatch triage-issue once per issue. Use for the nightly backstop round, or when asked to triage everything untriaged.
+---
+
+# pipeline-analysis
+
+The nightly triage round. A loop, and deliberately nothing more.
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+# 1. Who needs triage, and what does each one carry into it?
+python3 .claude/skills/pipeline-analysis/select_triage.py < issues.json
+
+# 2. One triage-issue invocation per eligible issue, bounded concurrency.
+#      triage-issue 47
+#      triage-issue 51
+#      ...
+```
+
+## This skill writes nothing
+
+**Every write belongs to `triage-issue`.** No labels, no comments, no milestones,
+no summary comment saying what the round did. The dispatcher's entire output is
+having invoked the single-issue skill the right number of times.
+
+That is the point of splitting the two. A round that made its own writes would
+be a second thing that can be wrong about an issue — and wrong at batch scale,
+across every issue in the queue, in a way no single triage run could produce.
+Keeping the loop empty means a bad night is a set of independently-bad issues,
+each one reviewable and fixable on its own.
+
+It also keeps `triage-issue` genuinely standalone. Reactive triage invokes it
+directly with no dispatcher anywhere in sight, and that only works while the
+dispatcher owns nothing the single-issue skill needs.
+
+## Step 1 — discovery
+
+`select_triage.py` decides eligibility. Open, carrying `ai-triage`, and not an
+epic, the dashboard, or `parked`.
+
+Each eligible issue comes back with its number, its milestone, and the latest
+owner `/revise`, `/redo`, or `/propose` note. **Pass that note through.** It is
+why a re-triage answers the actual objection instead of producing the same plan
+that was rejected the first time.
+
+The script is pure and stdlib-only: JSON in, JSON out, no network. Fetching the
+issues is the caller's job, which is what makes the eligibility rules testable
+without a live repo.
+
+## Step 2 — dispatch, with concurrency chosen above
+
+Invoke `triage-issue` once per eligible issue, several at a time.
+
+**The concurrency limit is set by the orchestration layer, not written into the
+script.** `select_triage.py` reports what needs triage; it has no opinion on how
+fast to work through it. The right number depends on API rate limits and how
+much the runner can take — things that change without the eligibility rules
+changing at all.
+
+A number hard-coded in the discovery script is a number nobody can adjust for
+one busy night without editing a file that has tests pinned to it, and it would
+be one more thing to keep in sync with the dev round's own limit. Keep it where
+the run is configured.
+
+Issues are dispatched oldest-first. A triage that fails is one issue's problem:
+it keeps `ai-triage`, so the next round picks it up again. Do not abort the
+round for it.
+
+## When this runs, and when it doesn't
+
+| | Scheduled round | Reactive triage |
+| --- | --- | --- |
+| Trigger | nightly, 02:00 UTC | `ai-triage` newly added |
+| Scope | every eligible issue | exactly one issue |
+| Runs this skill? | yes | **no** — `triage-issue` directly |
+
+**Reactive triage is the normal path.** Filing an issue and getting triage hours
+later is a bad experience when the person who filed it is sitting right there,
+so the gatekeeper pokes a Routine the moment `ai-triage` appears and that issue
+gets triaged immediately.
+
+**This round is the backstop.** It exists for what reactive triage missed: the
+POST that failed, the secrets that were never configured, an issue whose label
+was changed by hand rather than by a command, one carried back by the blocker
+sweep. On a healthy night it finds nothing, and that is the expected result — an
+empty round is the system working, not a wasted run.
+
+It runs after reconcile (01:00) and before development (03:00): fix the state,
+triage against fixed state, then build against a triaged queue.
+
+Reactive fire happens **only when `ai-triage` is newly present**, never on an
+idempotent re-add. Otherwise one stuck comment becomes a triage run every sweep.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py pipeline-analysis
+```
+
+18 tests over `select_triage.py` — eligibility, the carried owner note, and the
+pure-`process` / stdin-stdout shape. No network in any of them.
+
+## See also
+
+- `triage-issue` — everything this skill dispatches to
+- `docs/engineering/issue-pipeline.md` — the stage, the schedule, reactive fire

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -457,6 +457,33 @@ The dispatcher (`pipeline-analysis`) is a thin loop over that list. It makes no
 decisions itself — the decisions are in `triage-issue`, one issue at a time,
 which keeps a bad triage contained to one issue instead of one batch.
 
+**The dispatcher writes nothing at all** — no labels, no comments, not even a
+summary of the round. Every write belongs to the single-issue skill. A round
+that made its own writes would be a second thing that can be wrong, wrong at
+batch scale across the whole queue, in a way no individual triage run could
+produce. It also keeps `triage-issue` genuinely standalone, which is what lets
+reactive triage invoke it with no dispatcher present.
+
+**Concurrency is set by the orchestration layer, not the script.**
+`select_triage.py` reports what needs triage and has no opinion on how fast to
+work through it: the right number depends on rate limits and runner capacity,
+which change without the eligibility rules changing. A limit baked into the
+discovery script is one nobody can adjust for a busy night without editing a
+file with tests pinned to it.
+
+A triage that fails is one issue's problem — it keeps `ai-triage` and the next
+round picks it up. The round does not abort for it.
+
+#### The scheduled round is the backstop, not the main path
+
+Reactive triage is how an issue normally gets triaged: the gatekeeper fires it
+the moment `ai-triage` appears, and the issue is analyzed within minutes.
+
+The 02:00 round exists for what reactive triage missed — a failed POST, secrets
+that were never configured, a label changed by hand instead of by a command, an
+issue carried back by the blocker sweep. On a healthy night it finds nothing.
+**An empty round is the system working**, not a wasted run.
+
 ### Triage — one issue
 
 `triage-issue` reads an issue and produces:


### PR DESCRIPTION
This is the nightly round that catches anything still waiting to be triaged. It asks the discovery script who's waiting, then hands each one to the `triage-issue` skill, a few at a time.

The interesting thing about it is how little it does. It writes nothing at all — no labels, no comments, not even a note saying the round ran. All of that belongs to the single-issue skill. If a night goes badly, the result is a handful of issues each wrong on its own terms, which someone can read and fix one at a time, rather than one mistake smeared across the whole queue.

It's also not the main path. Issues normally get triaged within minutes of being let in, because the gatekeeper pokes triage the moment that happens. This round is the safety net for the cases where that didn't fire — so on a good night it finds nothing, and that's the result we want.

## Spec invariants

- **The dispatcher writes nothing.** Kept by having no write step in the skill at all — the loop's only output is having invoked `triage-issue` the right number of times. This also preserves the invariant from #144 that `triage-issue` is runnable standalone: reactive triage calls it with no dispatcher present, which only works while the dispatcher owns nothing it needs.
- **Concurrency lives above the script.** `select_triage.py` gained no concurrency parameter in #143 and gains none here; it reports what needs triage and stops there.
- **Reactive fire only on a newly-added `ai-triage`.** Restated here because it's what stops the two paths double-triaging. Already enforced in `apply_actions.fires_triage` with tests behind it.
- **A failed triage does not abort the round.** The issue keeps `ai-triage`, so the next round retries it — the same self-healing property the eligibility rule already provides.

## How the spec is changing

`docs/engineering/issue-pipeline.md` already listed both the 02:00 round and reactive triage in the schedule table, but never said which one is normal. Read as written, the nightly round looked like the primary mechanism and reactive triage like an optimisation bolted on top.

That's backwards, and it matters for reading the logs: **reactive triage is the main path; the scheduled round is the backstop.** The consequence is now stated explicitly — a round that finds nothing is the system working correctly, not a misconfiguration. Without that written down, the first person to see "0 issues triaged" in a nightly log reasonably concludes something is broken and goes looking for the bug.

**Docs:** `docs/engineering/issue-pipeline.md` — extended the analysis-stage section with the dispatcher's no-writes rule and why batch-scale writes are a different risk from single-issue ones; the orchestration-layer concurrency decision; failure isolation within a round; and a new subsection establishing the scheduled round as backstop rather than main path, including that an empty round is a healthy result.

## Deviations and Decisions

- **No failing test first.** The deliverable is a `SKILL.md`; the executable part of this skill is `select_triage.py`, which landed in #143 with its 18 tests written red first. Same precedent as #144 and `core-unity-split`.
- **No manifest entry** — `pipeline-analysis` was authored here, not ported, and `.claude/.skills-manifest.json` is a port ledger. Same reasoning as #144.
- **Documented the dispatch order as oldest-first** rather than leaving it unstated. `select_triage.py` already sorts by issue number, so this describes existing behaviour; writing it down stops a future dispatcher from "helpfully" reordering by milestone and quietly starving old issues.
- **Did not specify a default concurrency number**, even as a suggestion. The issue asks for the choice to live at the orchestration layer, and a number written here — however hedged — is the number that gets copied into the workflow without thought when #74 wires this up.

Closes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_