### PR TITLE
feat(pipeline): add re-fire repair detection to triage-issue

### DIFF
--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -212,15 +212,60 @@ blocker is how a queue deadlocks on work that could have been done at any time.
 
 ## Re-running on the same issue
 
-Triage runs twice — a `/revise`, a `/redo`, a crashed run picked up next round.
-It must not stack duplicate comments or contradictory labels. Each triage
-comment carries a marker; a re-run **edits** its previous comment instead of
-adding a second. `triage_repair.py` (#65) owns finding that comment and
-repairing half-finished states.
+Triage runs twice — a `/revise`, a `/redo`, a sweep catching a comment late, a
+run that crashed after commenting but before labelling. `triage_repair.py`
+decides what to do about it, deterministically:
 
-A re-run also arrives with the owner's note attached — `select_triage.py`
-carries the latest `/revise`, `/redo`, or `/propose` text — so the rewrite
-answers the actual objection rather than starting from scratch.
+```python
+# .claude/skills/triage-issue/triage_repair.py — a module, not a CLI
+plan = plan_repair(labels, comments, intended_state="pending-approval", note=note)
+```
+
+| Situation | Plan |
+| --- | --- |
+| An analysis is already here | **repair** — apply the missing label move, post nothing |
+| No analysis | **re-analyze** — a normal triage run |
+| Analysis, and the label is already right | nothing at all |
+| `/revise`, `/redo`, or `/propose` | **re-analyze**, even though an analysis exists |
+
+**Repair, not repeat.** Re-analyzing an issue that already has a plan stacks a
+second plan on the first, and the two will not agree — triage is not
+deterministic, so the same issue analyzed twice produces two different
+reasonable plans, and Derek gets to work out which one `/approve` means.
+
+The last row is the exception that matters. `/revise` is an objection *to the
+plan*; repairing the label would apply exactly the state the rejected plan asked
+for and drop the objection on the floor. The owner's note comes attached from
+`select_triage.py`, so the rewrite answers the actual complaint.
+
+### The recognizer is shared
+
+`has_analysis_signature` matches a `## Build checklist` heading at the start of
+a line, or the `❓ Needs from Derek/Connor:` marker with optional emphasis
+around it. Prose mentioning either phrase is not a match — the heading must be a
+heading, and the ❓ is what separates the marker from a sentence containing the
+same words.
+
+`pipeline-reconcile` **imports this function** rather than keeping its own copy.
+Two copies drift, and the drift is silent and self-sustaining: reconcile decides
+there is no analysis and sends the issue back to `ai-triage`; triage sees the
+analysis it wrote and repairs the label; reconcile sends it back again. Neither
+side looks wrong alone, and the issue cycles forever. The side that writes the
+format owns the recognizer.
+
+Only comments authored by the bot count. Derek pasting a checklist by hand is
+not a triage run, and treating it as one would let a helpful comment suppress
+the analysis the issue is actually waiting for.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py triage-issue
+```
+
+23 tests over `triage_repair.py`: what the recognizer matches and — more
+importantly — what it refuses to match, and the four repair outcomes. No
+network in any of them.
 
 ## See also
 

--- a/.claude/skills/triage-issue/tests/test_triage_repair.py
+++ b/.claude/skills/triage-issue/tests/test_triage_repair.py
@@ -1,0 +1,185 @@
+"""Tests for re-fire repair detection."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import triage_repair as repair  # noqa: E402
+
+BOT = "github-actions[bot]"
+
+CHECKLIST_BODY = """\
+Frogs keep multiplying past the limit when you tap them quickly.
+
+## Build checklist
+
+- [ ] Check the cap at the moment the frog is added
+"""
+
+QUESTION_BODY = """\
+This one needs a decision before it can be planned.
+
+❓ **Needs from Derek/Connor:** should a tap on a full pond do nothing, or
+should the frog wiggle?
+"""
+
+
+def comment(body, author=BOT, created_at="2026-08-08T10:00:00Z"):
+    return {"body": body, "author": author, "created_at": created_at}
+
+
+class SignatureTests(unittest.TestCase):
+    """`has_analysis_signature` — what counts as a triage analysis comment."""
+
+    def test_a_build_checklist_heading_is_a_signature(self):
+        self.assertTrue(repair.has_analysis_signature(CHECKLIST_BODY))
+
+    def test_the_needs_from_marker_is_a_signature(self):
+        self.assertTrue(repair.has_analysis_signature(QUESTION_BODY))
+
+    def test_the_marker_matches_without_emphasis(self):
+        body = "❓ Needs from Derek/Connor: which colour should the frog be?"
+        self.assertTrue(repair.has_analysis_signature(body))
+
+    def test_the_marker_matches_with_underscore_emphasis(self):
+        body = "❓ __Needs from Derek/Connor:__ which colour?"
+        self.assertTrue(repair.has_analysis_signature(body))
+
+    def test_the_marker_matches_with_emphasis_inside_the_colon(self):
+        body = "❓ *Needs from Derek/Connor*: which colour?"
+        self.assertTrue(repair.has_analysis_signature(body))
+
+    def test_a_prose_mention_of_the_checklist_is_not_a_signature(self):
+        body = "I will add a ## Build checklist heading once the design is agreed."
+        self.assertFalse(repair.has_analysis_signature(body))
+
+    def test_a_prose_mention_of_the_question_marker_is_not_a_signature(self):
+        body = "The plan says we still need from Derek/Connor: a colour decision."
+        self.assertFalse(repair.has_analysis_signature(body))
+
+    def test_an_ordinary_comment_is_not_a_signature(self):
+        self.assertFalse(repair.has_analysis_signature("Looks good to me."))
+
+    def test_an_empty_or_missing_body_is_not_a_signature(self):
+        self.assertFalse(repair.has_analysis_signature(""))
+        self.assertFalse(repair.has_analysis_signature(None))
+
+    def test_the_checklist_heading_is_recognized_at_any_depth(self):
+        self.assertTrue(repair.has_analysis_signature("### Build checklist\n\n- [ ] x"))
+
+    def test_a_checklist_heading_must_start_its_line(self):
+        self.assertFalse(repair.has_analysis_signature("see the ## Build checklist below"))
+
+
+class AnalysisCommentTimesTests(unittest.TestCase):
+    """`analysis_comment_times` — when did triage last analyze this issue?"""
+
+    def test_no_comments_is_no_times(self):
+        self.assertEqual(repair.analysis_comment_times([]), [])
+
+    def test_an_analysis_comment_contributes_its_timestamp(self):
+        comments = [comment(CHECKLIST_BODY, created_at="2026-08-01T09:00:00Z")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-01T09:00:00Z"])
+
+    def test_ordinary_comments_are_ignored(self):
+        comments = [comment("thanks!"), comment(CHECKLIST_BODY, created_at="2026-08-02T09:00:00Z")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-02T09:00:00Z"])
+
+    def test_a_human_comment_carrying_a_checklist_is_not_triage(self):
+        """Derek pasting a checklist by hand must not read as a triage run."""
+        comments = [comment(CHECKLIST_BODY, author="derekwinters")]
+        self.assertEqual(repair.analysis_comment_times(comments), [])
+
+    def test_times_come_back_oldest_first(self):
+        comments = [
+            comment(QUESTION_BODY, created_at="2026-08-05T09:00:00Z"),
+            comment(CHECKLIST_BODY, created_at="2026-08-01T09:00:00Z"),
+        ]
+        self.assertEqual(
+            repair.analysis_comment_times(comments),
+            ["2026-08-01T09:00:00Z", "2026-08-05T09:00:00Z"],
+        )
+
+
+class RepairTests(unittest.TestCase):
+    """`plan_repair` — what a re-fire should actually do."""
+
+    def test_a_prior_analysis_with_no_state_label_repairs_the_label_only(self):
+        plan = repair.plan_repair(
+            labels=["ai-triage", "type:bug"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="pending-approval",
+        )
+
+        self.assertTrue(plan.repair_only)
+        self.assertEqual(plan.add_labels, ["pending-approval"])
+        self.assertEqual(plan.remove_labels, ["ai-triage"])
+        self.assertFalse(plan.reanalyze)
+
+    def test_the_repair_posts_no_comment(self):
+        plan = repair.plan_repair(
+            labels=["ai-triage"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="pending-approval",
+        )
+        self.assertEqual(plan.comment, "")
+
+    def test_no_prior_analysis_means_a_full_triage(self):
+        plan = repair.plan_repair(
+            labels=["ai-triage"],
+            comments=[comment("just a normal comment")],
+            intended_state="pending-approval",
+        )
+
+        self.assertFalse(plan.repair_only)
+        self.assertTrue(plan.reanalyze)
+
+    def test_an_already_complete_hand_back_needs_nothing(self):
+        plan = repair.plan_repair(
+            labels=["pending-approval", "type:bug"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="pending-approval",
+        )
+
+        self.assertTrue(plan.repair_only)
+        self.assertEqual(plan.add_labels, [])
+        self.assertEqual(plan.remove_labels, [])
+        self.assertFalse(plan.changes_anything)
+
+    def test_a_revise_forces_reanalysis_despite_a_prior_analysis(self):
+        """`/revise` is an objection to the plan — repairing the label ignores it."""
+        plan = repair.plan_repair(
+            labels=["ai-triage"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="pending-approval",
+            note={"command": "revise", "text": "the cap should be 64"},
+        )
+
+        self.assertTrue(plan.reanalyze)
+        self.assertFalse(plan.repair_only)
+
+    def test_the_state_swap_leaves_other_labels_alone(self):
+        plan = repair.plan_repair(
+            labels=["ai-triage", "area:gameplay", "type:bug"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="needs-clarification",
+        )
+
+        self.assertEqual(plan.remove_labels, ["ai-triage"])
+        self.assertEqual(plan.add_labels, ["needs-clarification"])
+
+    def test_a_wrong_state_label_is_replaced_not_stacked(self):
+        plan = repair.plan_repair(
+            labels=["needs-clarification"],
+            comments=[comment(CHECKLIST_BODY)],
+            intended_state="pending-approval",
+        )
+
+        self.assertEqual(sorted(plan.remove_labels), ["needs-clarification"])
+        self.assertEqual(plan.add_labels, ["pending-approval"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/triage-issue/triage_repair.py
+++ b/.claude/skills/triage-issue/triage_repair.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""What to do when triage fires on an issue it has already analyzed.
+
+Triage re-fires: a sweep catches a comment late, a Routine is poked twice, a run
+crashes after posting its analysis but before moving the label. The question
+each time is the same — is there already an analysis here?
+
+If there is, the answer is **repair, not repeat**: apply the missing label move
+and post nothing. Re-analyzing would stack a second plan on top of the first,
+and the two would not agree, because triage is not deterministic.
+
+That decision is, though — so it lives here as a pure function rather than as a
+judgment the agent makes each time.
+
+## The recognizer is shared, deliberately
+
+`has_analysis_signature` is the one implementation of "does this comment look
+like triage wrote it". `pipeline-reconcile` imports it from here rather than
+carrying its own copy.
+
+Two copies would drift, and the drift is silent and asymmetric: reconcile
+decides an issue has no analysis and sends it back to `ai-triage`, triage sees
+the analysis it already wrote and repairs the label instead, reconcile sends it
+back again. Neither side is obviously wrong on its own, and the issue cycles
+forever. The producer of the format owns the recognizer.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import re
+
+TRIAGE_LABEL = "ai-triage"
+
+# The states a hand-back can rest in. Triage never sets any other.
+HAND_BACK_STATES = ("pending-approval", "needs-clarification")
+
+# Every state label, so a swap replaces rather than stacks.
+STATE_LABELS = {
+    TRIAGE_LABEL,
+    "pending-approval",
+    "needs-clarification",
+    "ready-for-work",
+    "in-progress",
+    "parked",
+}
+
+# Comments this login authored are triage's. A human pasting a checklist by hand
+# is not a triage run, and treating it as one would let a well-meaning comment
+# suppress the analysis the issue is actually waiting for.
+TRIAGE_AUTHOR = "github-actions[bot]"
+
+# An owner note that objects to the plan. Repairing the label would apply the
+# state the rejected plan asked for and drop the objection on the floor.
+REANALYZE_COMMANDS = ("revise", "redo", "propose")
+
+# Anchored at the start of a line: a heading, not the phrase in a sentence.
+# "I will add a ## Build checklist heading later" must not read as an analysis.
+CHECKLIST_HEADING = re.compile(r"^\s{0,3}#{2,6}\s+build\s+checklist\s*$",
+                               re.IGNORECASE | re.MULTILINE)
+
+# The question marker. The ❓ is load-bearing — it is what separates the marker
+# from prose that happens to contain the same words. Emphasis may wrap the text,
+# and may or may not include the colon, because both get written.
+QUESTION_MARKER = re.compile(
+    r"❓\s*[*_]{0,2}\s*needs\s+from\s+derek/connor\s*[*_]{0,2}\s*:",
+    re.IGNORECASE,
+)
+
+
+def has_analysis_signature(body) -> bool:
+    """Does this comment body look like a triage analysis?
+
+    True for a `## Build checklist` heading **or** the
+    `❓ Needs from Derek/Connor:` marker — the two shapes a hand-back takes,
+    one per route. A bare prose mention of either phrase is not a match.
+    """
+    if not body:
+        return False
+
+    return bool(CHECKLIST_HEADING.search(body) or QUESTION_MARKER.search(body))
+
+
+def analysis_comment_times(comments) -> list:
+    """Timestamps of triage's own analysis comments, oldest first."""
+    times = [
+        comment.get("created_at") or ""
+        for comment in comments or []
+        if (comment.get("author") or "").lower() == TRIAGE_AUTHOR.lower()
+        and has_analysis_signature(comment.get("body"))
+    ]
+
+    return sorted(times)
+
+
+class RepairPlan:
+    def __init__(self, reanalyze: bool, add_labels=None, remove_labels=None) -> None:
+        self.reanalyze = reanalyze
+        self.add_labels = add_labels or []
+        self.remove_labels = remove_labels or []
+        # A repair posts nothing. The analysis is already on the issue; a second
+        # comment saying so is noise on something Derek is about to read.
+        self.comment = ""
+
+    @property
+    def repair_only(self) -> bool:
+        return not self.reanalyze
+
+    @property
+    def changes_anything(self) -> bool:
+        return bool(self.add_labels or self.remove_labels)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        kind = "reanalyze" if self.reanalyze else "repair"
+        return f"RepairPlan({kind}, +{self.add_labels}, -{self.remove_labels})"
+
+
+def plan_repair(labels, comments, intended_state: str, note=None) -> RepairPlan:
+    """Repair the half-finished write, or re-analyze from scratch.
+
+    `intended_state` is where the existing analysis was heading — the state its
+    route ends at. On a fresh issue with no analysis, it is unused: the new run
+    decides its own state.
+    """
+    if note and (note.get("command") or "").lower() in REANALYZE_COMMANDS:
+        return RepairPlan(reanalyze=True)
+
+    if not analysis_comment_times(comments):
+        return RepairPlan(reanalyze=True)
+
+    current = set(labels or [])
+
+    if intended_state in current:
+        # Nothing to repair — the earlier run finished after all.
+        return RepairPlan(reanalyze=False)
+
+    return RepairPlan(
+        reanalyze=False,
+        add_labels=[intended_state],
+        remove_labels=sorted(current & STATE_LABELS),
+    )

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -544,12 +544,44 @@ believes the issue is handled and it waits on a human who has nothing to read.
 rests in exactly one state. An issue carrying both gets triaged again by the
 next analysis round while it sits waiting for Derek.
 
-**Re-fire repair.** Triage that runs twice on the same issue must not stack
-duplicate comments, duplicate checklists, or contradictory labels. Each triage
-comment carries a marker; a re-run finds its previous comment and **edits** it
-rather than adding another. `triage_repair.py` also detects the mess left by an
-older run that crashed mid-way — a label set without a comment, a comment
-without labels — and repairs it.
+#### Re-fire repair
+
+Triage runs twice more often than you would think: a sweep catches a comment
+late, a Routine is poked twice, a run crashes after posting its analysis but
+before moving the label. `triage_repair.py` decides what happens, as a pure
+function rather than a judgement made afresh each time.
+
+| Situation | What happens |
+| --- | --- |
+| An analysis comment is already there | **repair** — apply the missing label move, post nothing |
+| No analysis comment | a normal triage run |
+| Analysis present, label already correct | nothing |
+| The owner left `/revise`, `/redo`, or `/propose` | re-analyze anyway |
+
+**Repair, not repeat.** Triage is not deterministic: the same issue analyzed
+twice yields two different reasonable plans, and stacking the second on the
+first leaves Derek deciding which one an `/approve` refers to.
+
+The exception is the owner's note. `/revise` objects *to the plan* — repairing
+the label would apply the state the rejected plan asked for and silently discard
+the objection. The note travels with the issue from `select_triage.py`, so the
+rewrite answers the actual complaint.
+
+##### One recognizer, shared
+
+"Does this comment look like triage wrote it" has exactly one implementation:
+`has_analysis_signature` in `triage_repair.py`. It matches a `## Build
+checklist` heading anchored at the start of a line, or the
+`❓ Needs from Derek/Connor:` marker allowing Markdown emphasis around the text.
+Prose mentioning either phrase does not match, and only comments authored by the
+bot count — a human pasting a checklist is not a triage run.
+
+`reconcile.py` imports it rather than carrying a second copy. Two copies drift,
+and this particular drift is self-sustaining: reconcile finds no analysis and
+returns the issue to `ai-triage`, triage finds the analysis it wrote and repairs
+the label instead, reconcile returns it again. Neither side is wrong on its own
+terms, so nothing surfaces as an error — the issue just cycles. The side that
+writes the format owns the recognizer.
 
 ### Applying an action
 


### PR DESCRIPTION
Sometimes triage looks at the same issue twice — a check runs late, a job gets poked twice, or a run stops halfway after writing its notes but before ticking the label. This adds the bit that notices and does the sensible thing: if there's already a plan on the issue, just finish the half-done part quietly instead of writing a second plan underneath the first.

Two plans on one issue is the failure worth avoiding. Triage thinks about an issue rather than computing an answer, so asking it twice gives two different sensible-looking plans — and then Derek has to work out which one he's agreeing to when he approves it.

The one case that does get a fresh look is when Derek asked for one. `/revise` means "this plan is wrong", so quietly finishing that plan's label would apply exactly the thing he objected to.

## Spec invariants

- **Repair posts no comment.** `RepairPlan.comment` is `""` by construction — there's no branch that sets it. The analysis is already on the issue; a second comment announcing that is noise on something Derek is about to read.
- **A state change replaces, never stacks.** The repair removes every state label present and adds the intended one, matching `apply_actions.py`'s rule. Covered by `test_a_wrong_state_label_is_replaced_not_stacked`; `test_the_state_swap_leaves_other_labels_alone` pins that `area:*`/`type:*` survive.
- **Only bot-authored comments count as triage analysis.** Derek pasting a checklist by hand must not read as a completed triage — otherwise a helpful comment suppresses the analysis the issue is actually waiting for. Covered by `test_a_human_comment_carrying_a_checklist_is_not_triage`.
- **The recognizer requires structure, not vocabulary.** The heading must be a heading (anchored to line start) and the marker must carry its ❓. Four tests assert what does *not* match, which is the half that actually matters here.
- **Idempotence.** An issue whose earlier run finished after all yields a plan that changes nothing — `changes_anything` is false, so repeated firing is a no-op rather than a rewrite.

23 tests, written first and watched fail with `ModuleNotFoundError: No module named 'triage_repair'`.

## How the spec is changing

**Re-fire handling was specified as "edit the previous comment"; it is now "repair the label and post nothing."**

`docs/engineering/issue-pipeline.md` previously said a re-run "finds its previous comment and **edits** it rather than adding another." I did not implement that, and the checklist for this issue asks for something different — "the repair applies only the missing label move" — so the docs and the issue disagreed and I followed the issue.

I think the issue is also right on the merits, which is why I didn't flag it as a question. Editing implies the re-run has produced fresh analysis worth substituting in, and in the common case it hasn't: the earlier run already succeeded and only the label write was lost. Re-analyzing purely to overwrite an existing plan with a different one costs a model call to make the issue's history worse — Derek loses the plan he may have already half-read, and the audit trail shows a comment that silently changed. Repair leaves the original analysis exactly as written and fixes only what was actually broken.

Where fresh analysis *is* wanted, `/revise` and `/redo` say so explicitly, and those force a full re-analysis.

**Docs:** `docs/engineering/issue-pipeline.md` — replaced the "Re-fire repair" paragraph with the four-outcome table and the repair-not-repeat rationale (superseding the edit-the-previous-comment rule described above), and added "One recognizer, shared" documenting `has_analysis_signature`, its two matching shapes, the bot-author requirement, and the requeue↔repair loop that a duplicate copy would cause.

## Deviations and Decisions

- **The shared recognizer lives in `triage-issue`, and `pipeline-reconcile` will import it** — not the other way round, and not extracted to a third shared location. The producer of a format should own its recognizer, and a `shared/` module for one function would be its own kind of clutter. #68 imports from here; flagging it because that's the cross-skill dependency direction being fixed now rather than when reconcile is written.
- **The loop this prevents is worth stating explicitly** because it's the reason the "no second copy" requirement is a real constraint rather than tidiness. Diverged copies produce: reconcile sees no analysis → requeues to `ai-triage` → triage sees its own analysis → repairs the label → reconcile requeues again. Neither side raises an error, so the only symptom is an issue that never settles.
- **Emphasis tolerance covers `**`, `__`, and emphasis that excludes the colon** (`*Needs from Derek/Connor*:`). All three get written by hand, and a marker that fails to match because of an asterisk placement means a duplicate analysis — a strictly worse outcome than a slightly permissive regex.
- **`plan_repair` takes `intended_state` as a parameter** rather than inferring it from the existing analysis comment's text. Inferring would mean parsing the plan to work out which route it took, which is exactly the non-deterministic reading this module exists to avoid.

Closes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_