### PR TITLE
feat(pipeline): add build-queue selection to pipeline-dev

### DIFF
--- a/.claude/skills/pipeline-dev/select_queue.py
+++ b/.claude/skills/pipeline-dev/select_queue.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""What the nightly builder builds tonight, and in what order.
+
+Eligibility and ordering are decided here, deterministically, rather than by
+the model. Two reasons. A queue you can reproduce is a queue you can argue with
+— "why did it not pick #47" has an answer you can read. And a model asked to
+pick work will pick the interesting work, which is not the same as the work
+that unblocks the most other work.
+
+    echo '{"issues": [...], "pulls": [...], "focus": "v0.0.1"}' | python3 select_queue.py
+
+Stdlib only, no network: fetching is the caller's job.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+READY_LABEL = "ready-for-work"
+PARKED_LABEL = "parked"
+EPIC_LABEL = "type:epic"
+
+# What the builder takes on in one night when nobody has said otherwise. Small
+# on purpose: three issues that land beat six that half-land, and the cap is
+# the only thing standing between a quiet night and thirty open PRs.
+DEFAULT_CAP = 3
+
+# A hard blocker, written in prose. Structured only — "this is similar to #42"
+# is not a dependency, and treating it as one would stall issues at random.
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+# Soft ordering. Does not gate the issue — it sequences it.
+TEXT_DEPENDS = re.compile(r"^\s*depends\s+on\s*:?\s*#(\d+)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+# GitHub's closing keywords. An issue with an open PR that *closes* it is
+# already being worked; one merely referenced by a PR is not.
+CLOSING_KEYWORD = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def _numbers(pattern, body) -> set:
+    return {int(number) for number in pattern.findall(body or "")}
+
+
+def blockers_of(issue: dict) -> list:
+    """Every issue this one is *blocked by* — native edges unioned with text.
+
+    **One helper, both sources.** A dependency can be recorded natively while
+    another sits in prose in the same body, and reading only one source means
+    releasing an issue that is still half-blocked. Union is the only safe
+    merge, and doing it in one place is what stops the two readings drifting.
+    """
+    from_native = {int(number) for number in (issue.get("native_blockers") or [])}
+    return sorted(from_native | _numbers(TEXT_BLOCKER, issue.get("body")))
+
+
+def depends_on(issue: dict) -> list:
+    """Soft ordering hints. Never gates — see `docs/engineering/issue-pipeline.md`."""
+    return sorted(_numbers(TEXT_DEPENDS, issue.get("body")))
+
+
+def closed_by_open_pr(issue_number: int, pulls) -> bool:
+    """Is an open PR already claiming to close this issue?"""
+    return any(
+        pull.get("state", "open") == "open"
+        and issue_number in _numbers(CLOSING_KEYWORD, pull.get("body"))
+        for pull in pulls or []
+    )
+
+
+def _blocker_resolved(blocker) -> bool:
+    """A blocker stops blocking once it is closed or merged."""
+    if blocker is None:
+        # Unknown is not resolved. Not knowing whether the thing you depend on
+        # is done is exactly the case where starting is expensive.
+        return False
+
+    return blocker.get("state") == "closed" or bool(blocker.get("merged"))
+
+
+def is_eligible(issue: dict, focus, pulls, snapshot) -> bool:
+    labels = set(issue.get("labels") or [])
+
+    if issue.get("state", "open") != "open":
+        return False
+
+    if READY_LABEL not in labels or PARKED_LABEL in labels:
+        return False
+
+    # An epic is a container. Its children are the work, and they carry their
+    # own labels; building the epic itself would mean building all of them at
+    # once in a single PR.
+    if EPIC_LABEL in labels:
+        return False
+
+    # No milestone is not the focus milestone. An issue marked ready with no
+    # milestone is a broken invariant, and reconcile flags it rather than the
+    # builder guessing which milestone was meant.
+    if issue.get("milestone") != focus:
+        return False
+
+    if closed_by_open_pr(issue["number"], pulls):
+        return False
+
+    return all(
+        _blocker_resolved(snapshot.get(number)) for number in blockers_of(issue)
+    )
+
+
+def order(issues) -> list:
+    """Dependencies first, then issue number.
+
+    A stable topological sort: at each step take the lowest-numbered issue
+    whose in-queue dependencies have already been placed. Both hard blockers
+    and soft `Depends on:` lines order — a blocker that is still open would
+    have failed eligibility, but one closed this evening still says which of
+    two ready issues was meant to come first.
+    """
+    remaining = {issue["number"]: issue for issue in issues}
+
+    edges = {
+        number: {
+            other for other in blockers_of(issue) + depends_on(issue)
+            if other in remaining
+        }
+        for number, issue in remaining.items()
+    }
+
+    ordered = []
+    placed = set()
+
+    while remaining:
+        ready = sorted(
+            number for number, needs in edges.items()
+            if number in remaining and needs <= placed
+        )
+
+        if not ready:
+            # A cycle. Reconcile flags those; the builder must not hang or
+            # silently drop the issues, so it falls back to number order.
+            ready = sorted(remaining)
+
+        # One at a time, re-checking after each. Placing the whole ready batch
+        # would scatter a dependent away from the thing it depends on — with a
+        # cap of 2, `#11, #12` instead of `#11, #10` — and the cap is far more
+        # useful when it cuts a coherent chain than an arbitrary slice.
+        number = ready[0]
+        ordered.append(remaining.pop(number))
+        placed.add(number)
+
+    return ordered
+
+
+def process(data: dict) -> dict:
+    focus = data.get("focus")
+    pulls = data.get("pulls") or []
+    cap = data.get("cap")
+    cap = DEFAULT_CAP if cap is None else int(cap)
+
+    # Snapshot keys arrive as ints in-process and as strings through JSON.
+    raw_snapshot = data.get("snapshot") or {}
+    snapshot = {int(number): value for number, value in raw_snapshot.items()}
+
+    eligible = [
+        issue for issue in data.get("issues") or []
+        if is_eligible(issue, focus, pulls, snapshot)
+    ]
+
+    # Order first, then cap. Capping first would take the three lowest-numbered
+    # issues and could leave a dependent in without the thing it depends on.
+    chosen = order(eligible)[:cap]
+
+    queue = [
+        {"number": issue["number"], "milestone": issue.get("milestone")}
+        for issue in chosen
+    ]
+
+    return {"queue": queue, "count": len(queue)}
+
+
+def main(argv=None) -> int:
+    json.dump(process(json.load(sys.stdin)), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-dev/tests/test_select_queue.py
+++ b/.claude/skills/pipeline-dev/tests/test_select_queue.py
@@ -1,0 +1,201 @@
+"""Tests for build-queue selection."""
+
+import json
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import select_queue as queue  # noqa: E402
+
+FOCUS = "v0.0.1"
+
+
+def issue(number=10, labels=("ready-for-work",), milestone=FOCUS, body="",
+          native_blockers=(), state="open"):
+    return {
+        "number": number,
+        "state": state,
+        "labels": list(labels),
+        "milestone": milestone,
+        "body": body,
+        "native_blockers": list(native_blockers),
+    }
+
+
+def pull(number=100, body="Closes #10", state="open"):
+    return {"number": number, "body": body, "state": state}
+
+
+def selected(issues, pulls=(), focus=FOCUS, cap=None, snapshot=None):
+    data = {
+        "issues": list(issues),
+        "pulls": list(pulls),
+        "focus": focus,
+        "snapshot": snapshot or {},
+    }
+    if cap is not None:
+        data["cap"] = cap
+    return [entry["number"] for entry in queue.process(data)["queue"]]
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_a_ready_issue_in_focus_is_selected(self):
+        self.assertEqual(selected([issue(10)]), [10])
+
+    def test_an_issue_without_ready_for_work_is_not(self):
+        self.assertEqual(selected([issue(10, labels=("pending-approval",))]), [])
+
+    def test_an_issue_in_another_milestone_is_not(self):
+        self.assertEqual(selected([issue(10, milestone="v0.0.2")]), [])
+
+    def test_an_issue_with_no_milestone_is_not(self):
+        self.assertEqual(selected([issue(10, milestone=None)]), [])
+
+    def test_a_parked_issue_is_not(self):
+        self.assertEqual(selected([issue(10, labels=("ready-for-work", "parked"))]), [])
+
+    def test_a_closed_issue_is_not(self):
+        self.assertEqual(selected([issue(10, state="closed")]), [])
+
+    def test_an_epic_is_not(self):
+        """An epic is a container; its children are the work."""
+        self.assertEqual(selected([issue(10, labels=("ready-for-work", "type:epic"))]), [])
+
+
+class BlockerTests(unittest.TestCase):
+    def test_an_open_native_blocker_suppresses_the_issue(self):
+        snapshot = {42: {"state": "open", "labels": []}}
+        self.assertEqual(
+            selected([issue(10, native_blockers=(42,))], snapshot=snapshot), [])
+
+    def test_a_closed_native_blocker_does_not(self):
+        snapshot = {42: {"state": "closed", "labels": []}}
+        self.assertEqual(
+            selected([issue(10, native_blockers=(42,))], snapshot=snapshot), [10])
+
+    def test_a_text_blocker_line_suppresses_the_issue_too(self):
+        snapshot = {42: {"state": "open", "labels": []}}
+        self.assertEqual(
+            selected([issue(10, body="Blocked by #42")], snapshot=snapshot), [])
+
+    def test_native_and_text_blockers_are_unioned(self):
+        """Half-cleared is still blocked, whichever half was written where."""
+        snapshot = {42: {"state": "closed"}, 43: {"state": "open"}}
+        blocked = issue(10, body="Blocked by #43", native_blockers=(42,))
+        self.assertEqual(selected([blocked], snapshot=snapshot), [])
+
+    def test_a_depends_on_line_is_not_a_blocker(self):
+        snapshot = {42: {"state": "open", "labels": []}}
+        self.assertEqual(
+            selected([issue(10, body="Depends on: #42")], snapshot=snapshot), [10])
+
+    def test_a_prose_mention_is_not_a_blocker(self):
+        body = "This is similar to #42 but simpler."
+        self.assertEqual(selected([issue(10, body=body)]), [10])
+
+    def test_an_unknown_blocker_is_not_assumed_resolved(self):
+        """Not knowing is not the same as knowing it is done."""
+        self.assertEqual(selected([issue(10, native_blockers=(42,))], snapshot={}), [])
+
+    def test_one_merge_helper_backs_both_sources(self):
+        merged = queue.blockers_of(issue(10, body="Blocked by #43", native_blockers=(42,)))
+        self.assertEqual(merged, [42, 43])
+
+
+class OpenPullRequestTests(unittest.TestCase):
+    def test_an_open_pr_closing_the_issue_suppresses_it(self):
+        self.assertEqual(selected([issue(10)], pulls=[pull(body="Closes #10")]), [])
+
+    def test_a_pr_that_merely_mentions_the_issue_does_not(self):
+        self.assertEqual(
+            selected([issue(10)], pulls=[pull(body="Related to #10")]), [10])
+
+    def test_a_bare_reference_does_not_suppress(self):
+        self.assertEqual(selected([issue(10)], pulls=[pull(body="See #10")]), [10])
+
+    def test_a_closed_pr_does_not_suppress(self):
+        self.assertEqual(
+            selected([issue(10)], pulls=[pull(body="Closes #10", state="closed")]), [10])
+
+    def test_every_closing_keyword_counts(self):
+        for keyword in ("Closes", "Fixes", "Resolves", "closed", "fixed"):
+            with self.subTest(keyword=keyword):
+                self.assertEqual(
+                    selected([issue(10)], pulls=[pull(body=f"{keyword} #10")]), [])
+
+
+class OrderingTests(unittest.TestCase):
+    def test_issues_come_back_in_number_order_by_default(self):
+        self.assertEqual(selected([issue(12), issue(10), issue(11)]), [10, 11, 12])
+
+    def test_a_soft_dependency_orders_before_its_dependent(self):
+        """`Depends on:` does not block, but it does order."""
+        issues = [issue(10, body="Depends on: #11"), issue(11)]
+        self.assertEqual(selected(issues), [11, 10])
+
+    def test_ordering_survives_a_chain(self):
+        issues = [
+            issue(10, body="Depends on: #11"),
+            issue(11, body="Depends on: #12"),
+            issue(12),
+        ]
+        self.assertEqual(selected(issues), [12, 11, 10])
+
+    def test_a_dependency_outside_the_queue_is_ignored_for_ordering(self):
+        self.assertEqual(selected([issue(10, body="Depends on: #99")]), [10])
+
+    def test_a_cycle_does_not_hang_or_drop_issues(self):
+        issues = [issue(10, body="Depends on: #11"), issue(11, body="Depends on: #10")]
+        self.assertEqual(sorted(selected(issues)), [10, 11])
+
+
+class CapTests(unittest.TestCase):
+    def test_the_cap_defaults_to_three(self):
+        self.assertEqual(selected([issue(n) for n in (10, 11, 12, 13, 14)]),
+                         [10, 11, 12])
+
+    def test_an_explicit_cap_is_honored(self):
+        self.assertEqual(selected([issue(n) for n in (10, 11, 12, 13)], cap=2),
+                         [10, 11])
+
+    def test_a_cap_of_zero_selects_nothing(self):
+        self.assertEqual(selected([issue(10)], cap=0), [])
+
+    def test_the_cap_applies_after_ordering_not_before(self):
+        issues = [issue(10, body="Depends on: #11"), issue(11), issue(12)]
+        self.assertEqual(selected(issues, cap=2), [11, 10])
+
+
+class ShapeTests(unittest.TestCase):
+    def test_process_is_pure_and_reports_a_count(self):
+        data = {"issues": [issue(10)], "pulls": [], "focus": FOCUS, "snapshot": {}}
+        before = json.dumps(data, sort_keys=True)
+        result = queue.process(data)
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(json.dumps(data, sort_keys=True), before)
+
+    def test_no_issues_is_an_empty_queue_not_an_error(self):
+        self.assertEqual(queue.process({}), {"queue": [], "count": 0})
+
+    def test_main_reads_stdin_and_writes_json(self):
+        data = {"issues": [issue(10)], "pulls": [], "focus": FOCUS, "snapshot": {}}
+        out = StringIO()
+
+        with patch.object(sys, "stdin", StringIO(json.dumps(data))), \
+                patch.object(sys, "stdout", out):
+            self.assertEqual(queue.main([]), 0)
+
+        self.assertEqual(json.loads(out.getvalue())["count"], 1)
+
+    def test_the_queue_carries_the_milestone_through(self):
+        data = {"issues": [issue(10)], "pulls": [], "focus": FOCUS, "snapshot": {}}
+        self.assertEqual(queue.process(data)["queue"][0]["milestone"], FOCUS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -81,7 +81,7 @@ explain yourself in the same comment.
 | `/unpark` | bring it back. |
 | `/milestone <title>` | set the issue's milestone, by title. |
 | `/focus <title>` | set the pipeline's focus milestone. **Dashboard issue only.** |
-| `/cap <n>` | set the max concurrent `in-progress` issues. **Dashboard issue only.** |
+| `/cap <n>` | set how many issues one build round takes on. **Dashboard issue only.** |
 
 Deliberately absent: anything that closes an issue, edits a body, or merges a
 PR. Those have perfectly good GitHub buttons, and a command vocabulary that can
@@ -321,7 +321,7 @@ Both are stored as HTML-comment markers in the body of the dashboard issue:
 
 ```html
 <!-- pipeline:focus=v0.0.1 -->
-<!-- pipeline:cap=1 -->
+<!-- pipeline:cap=3 -->
 ```
 
 The dashboard issue is the one carrying the `dashboard` label. There is exactly
@@ -631,15 +631,40 @@ to have it.
 **Eligibility** — all of:
 
 - `ready-for-work`;
-- in the focus milestone;
-- not blocked by an open issue;
+- in the focus milestone (no milestone is not the focus milestone);
+- every hard blocker closed or merged;
+- not `parked`;
 - not a `type:epic` (epics are containers; their children are the work);
-- has no open PR already referencing it.
+- has no open PR **closing** it.
 
-**Ordering** — a topological sort over the blocked-by graph, so an issue that
-unblocks others is worked before one that unblocks nothing. Ties break oldest
-first, so nothing starves. A cycle in the graph is reported, not resolved: a
-cycle is a triage mistake, and silently picking an entry point hides it.
+Two of those are narrower than they look.
+
+**Hard blockers are native edges unioned with `Blocked by #N` lines**, merged by
+one helper. An issue can have one dependency recorded natively and another still
+written in prose, and reading either source alone releases work that is still
+half-blocked. A blocker the caller knows nothing about counts as unresolved:
+not knowing whether the thing you depend on is finished is precisely the case
+where starting is expensive.
+
+**An open PR only suppresses an issue if it *closes* it** — a closing keyword,
+not a bare `#47`. PRs reference issues constantly for context, and treating a
+mention as "already being worked" would silently starve an issue that nobody is
+actually working. This is the same keyword rule reconcile uses to decide
+done-ness.
+
+**Ordering** — a stable topological sort. At each step the lowest-numbered
+issue whose in-queue dependencies are already placed, so dependencies come
+first and ties break oldest-first with nothing starving. Soft `Depends on:`
+lines order here even though they never gate: a blocker closed this evening
+still says which of two ready issues was meant to come first.
+
+The sort places **one issue per step**, re-checking after each. Placing the
+whole ready set at once would scatter a dependent away from the thing it
+depends on — with a cap of 2, `#11, #12` rather than `#11, #10` — and a cap is
+far more useful when it cuts a coherent chain than an arbitrary slice.
+
+A cycle is a triage mistake, and reconcile flags it. The builder must not hang
+or drop issues on one, so it falls back to number order for the tangled set.
 
 ### Serial delegated delivery
 
@@ -647,8 +672,27 @@ Issues are worked **one at a time**, each delegated to its own agent session.
 
 Serial because parallel agents on one repository fight: two branches touching
 `ProjectSettings.asset`, two release-please runs, two PRs renumbering the same
-things. The `cap` marker exists to raise this above 1 if that ever stops being
-true, and its default is 1.
+things. Nothing raises that above one at a time.
+
+#### `cap` bounds the round, not the concurrency
+
+The two are separate knobs and it is worth keeping them apart.
+
+| | Means | Value |
+| --- | --- | --- |
+| Concurrency | issues worked at once | always **1** |
+| `cap` | issues the round takes on at all | **3** by default |
+
+`select_queue.py` returns at most `cap` issues; the builder then works through
+them one after another. A night that picks up three issues and delivers them
+serially is entirely compatible with "parallel agents fight" — nothing is
+running in parallel.
+
+The cap is small on purpose. Three issues that land beat six that half-land,
+and it is the only thing standing between a quiet night and thirty open PRs.
+The cap applies **after** ordering, never before: capping first would take the
+three lowest-numbered issues and could admit a dependent without the thing it
+depends on.
 
 Delegated — a fresh session per issue — because context from the previous issue
 is a liability. The agent that just spent an hour on the audio system will find


### PR DESCRIPTION
This is the part that decides what actually gets built each night. It looks at every issue marked ready, throws out the ones that aren't really ready — still blocked, parked, in a different milestone, or already covered by someone's PR — and puts what's left in a sensible order.

The ordering matters more than it sounds. If issue A can't sensibly be done before issue B, B goes first. And because only a few issues get picked per night, the list is cut *after* sorting, so you get a run of related work rather than three unconnected issues.

It's plain code rather than something the model decides, for two reasons: you can ask "why didn't it pick #47" and get an answer you can read, and a model asked to choose work tends to choose the interesting work instead of the work that unblocks everything else.

## Spec invariants

- **Unknown blocker ≠ resolved.** A blocker missing from the snapshot counts as unresolved, matching `check_revisits.py`. Not knowing whether your dependency is finished is exactly when starting is expensive. `test_an_unknown_blocker_is_not_assumed_resolved`.
- **Native ∪ text, through one helper.** `blockers_of` merges both sources; `test_native_and_text_blockers_are_unioned` pins the half-cleared case (one blocker closed, the other still open, recorded in different places) that reading either source alone would wrongly release.
- **`Depends on:` never gates.** It orders and nothing else — converting soft ordering into a hard gate is how a queue deadlocks on work that could have been done at any time. `test_a_depends_on_line_is_not_a_blocker`.
- **Only structured lines count.** "This is similar to #42" is not a dependency. `test_a_prose_mention_is_not_a_blocker`.
- **Epics stay containers.** Building an epic would mean building all its children in one PR. `test_an_epic_is_not`.
- **Cap after ordering, never before.** Capping first could admit a dependent without its dependency. `test_the_cap_applies_after_ordering_not_before`.
- **A cycle neither hangs nor drops issues** — it falls back to number order, because reconcile is what flags cycles and the builder losing issues silently is worse. `test_a_cycle_does_not_hang_or_drop_issues`.

33 tests, written first. The first run was red on the import; a later red caught a genuine bug — see below.

## How the spec is changing

**`cap` meant concurrency; it now means how much a round takes on.** This is the one to look at.

`docs/engineering/issue-pipeline.md` described `/cap` as "the max concurrent `in-progress` issues", with a default of **1**, and said the marker "exists to raise this above 1 if that ever stops being true". This issue's checklist asks for a cap that bounds queue length, "defaulting to **3** when no cap marker is present". Those are different knobs with different defaults, so I could not satisfy both.

I treated the issue as authoritative and split the two concepts explicitly:

| | Means | Value |
| --- | --- | --- |
| Concurrency | issues worked at once | always 1 |
| `cap` | issues the round takes on at all | 3 by default |

The good news is that this doesn't cost the property the old wording was protecting. The reason for serial work is that parallel agents on one repo fight over `ProjectSettings.asset`, release-please, and PR numbering — and selecting three issues to deliver *one after another* runs nothing in parallel. Serial delivery is now unconditional rather than a default that `cap` could raise.

What genuinely changes: **nothing raises concurrency above 1 any more.** If `/cap` was meant to stay the concurrency escape hatch, this is the line to push back on, and the fix is to give queue length its own marker rather than to reinterpret this one.

**Eligibility gained `parked` and lost vagueness.** The docs listed "not blocked by an open issue" and "no open PR already referencing it". Both are now precise: blockers are the native ∪ text union with unknown treated as unresolved, and a PR only suppresses an issue if it *closes* it. "Referencing" would have let any PR mentioning `#47` for context silently starve that issue forever. `parked` was in the issue's checklist but absent from the docs list; it's now in both.

**Docs:** `docs/engineering/issue-pipeline.md` — rewrote "Development — the ready queue" (precise eligibility incl. `parked` and the closing-keyword rule, the union-with-one-helper rule, unknown-is-not-resolved, one-issue-per-step ordering and why, cycle fallback); added "`cap` bounds the round, not the concurrency" distinguishing the two knobs and superseding the cap-default-1 text; updated the `/cap` command-table description and the `pipeline:cap` marker example from `1` to `3`.

## Deviations and Decisions

- **A test caught a real ordering bug, and the fix is load-bearing.** My first sort placed the entire ready set each pass, so `#10 depends on #11` with `#12` also ready produced `[11, 12, 10]` — and a cap of 2 then yields `#11, #12`, dropping the dependent while keeping an unrelated issue. Placing one issue per step and re-checking gives `[11, 10, 12]`, so the cap cuts a coherent chain. Worth flagging because it only misbehaves when a cap truncates, which is every real night.
- **Kept the `type:epic` exclusion the issue's checklist omitted.** The docs require it and the reason is sound. Silently dropping it would have been changing the contract without saying so.
- **Raised the duplicated blocker regex as #147 instead of fixing it here.** The `Blocked by #N` pattern is now written four times — three copies predate this PR, and `select_queue.py` adds a fourth. "One shared merge helper" is satisfied *within* this script, but repo-wide it isn't true, and I'd rather say so than imply otherwise. Consolidating means solving where a cross-skill module lives given `run_python_tests.py`'s per-suite `sys.path` model, which touches three existing suites — a different change from adding a queue selector, and not something to bundle into a PR that closes one issue.
- **Snapshot keys are normalised to `int`** because they arrive as ints in-process and as strings through JSON. Without it the stdin path silently finds no blockers and releases blocked work — the most dangerous possible direction for this bug.

Closes #66