### PR TITLE
docs(pipeline): add the nightly builder SKILL.md

### DIFF
--- a/.claude/skills/pipeline-dev/SKILL.md
+++ b/.claude/skills/pipeline-dev/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: pipeline-dev
+description: Run a build round — select the ready queue and deliver each issue as its own branch and PR. Use for the nightly build, or when asked to work through everything that is ready.
+---
+
+# pipeline-dev
+
+The nightly builder. Pick the queue, then work it one issue at a time.
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+# 1. What are we building tonight, and in what order?
+python3 .claude/skills/pipeline-dev/select_queue.py < state.json
+
+# 2. For each selected issue, in order:
+#      mark in-progress → delegate to the dev agent → it opens its own PR
+```
+
+## The two things this never does
+
+**It never merges, and it never closes.** Not a green PR, not a one-line typo
+fix, not its own work.
+
+The pipeline exists to get work to the point where Derek can look at it. If it
+also merged, the review step would be optional in practice — and the whole
+design assumes a human reads the plan before it becomes the game. An agent that
+can approve its own output has no gate on it at all.
+
+Closing is the same rule from the other end. A PR body carries `Closes #N`, so
+GitHub closes the issue when Derek merges. The pipeline closing it directly
+would mark work done that nobody accepted.
+
+## Step 1 — the queue
+
+`select_queue.py` decides eligibility and ordering, deterministically. Ready,
+in focus, unblocked, not parked, not an epic, no open PR closing it — ordered
+dependencies-first and capped (3 by default).
+
+Both decisions are in code rather than in the model on purpose: a queue you can
+reproduce is a queue you can argue with, and a model asked to pick work will
+pick the interesting work rather than the work that unblocks the most.
+
+## Step 2 — one issue at a time
+
+Serial. Not a concurrency limit that happens to be set to one — parallel agents
+on one repository fight over `ProjectSettings.asset`, over release-please, over
+PR numbering. Selecting three issues and delivering them one after another runs
+nothing in parallel.
+
+Each issue gets a **fresh delegated session**, because context from the last
+issue is a liability: the agent that just spent an hour on the audio system will
+find a way to make the next issue about audio.
+
+For each issue, in queue order:
+
+1. Mark it **`in-progress`** — before any work, so a crashed run is visible as
+   a stuck issue rather than an invisible one.
+2. Hand it to the **dev agent** (`.claude/agents/dev.md`), which works it under
+   strict TDD and opens its own PR.
+3. Move on. Do not wait for CI, do not review, do not merge.
+
+## One branch, one PR, one issue
+
+**Never a combined PR**, even for two small issues in the same file, even when
+the second is a one-liner.
+
+| | One PR per issue | One PR for the round |
+| --- | --- | --- |
+| Reviewable | yes | not really |
+| Reject one bad change | revert one PR | unpick a diff |
+| `Closes #N` | one keyword, one issue | ambiguous |
+| Conventional Commit | one honest type | pick the least wrong one |
+
+The last row is the one that bites quietly. release-please derives the version
+from the commit type, so a PR combining a `feat:` and a `fix:` has to be
+labelled one of them, and whichever is chosen ships the wrong version number.
+
+The PR title is that issue's single Conventional-Commit line. The body carries
+the plain-English lead, `## Deviations and Decisions`, a `**Docs:**` line, and
+`Closes #N`.
+
+## `skip-docs` goes on immediately
+
+If the PR touches no files under `docs/`, apply **`skip-docs` the moment the PR
+is open** — before marking anything, before moving to the next issue, before
+anything else.
+
+The docs reconciliation gate fails a code-only PR and the label is the
+sanctioned escape hatch. Apply it late and the round's first visible result is
+a red X on a PR that was never wrong, which trains everyone to ignore red.
+
+Reaching for it should still be rare and it needs a written justification in
+`## Deviations and Decisions` — the gate cannot tell "no docs needed" from
+"forgot the docs", which is exactly why a human has to say which it was.
+
+## A failing issue is dropped, and the round continues
+
+If an issue cannot be completed — tests won't pass, the plan turns out to be
+wrong, the checklist has a box that cannot be ticked — **delete the branch,
+open no PR, and go to the next issue.**
+
+No half-PR, no draft, no "most of it works". A PR that does not close its issue
+still costs a review, and a checklist with an untickable box is a triage problem
+that a partial implementation hides rather than surfaces.
+
+The issue keeps `in-progress`, which is deliberate. Reconcile finds an open
+`in-progress` issue with no open PR and nothing on `main`, and returns it to
+`ready-for-work` — so a failure self-heals by the next round, and until then it
+is visible on the dashboard rather than silently forgotten.
+
+One failure never aborts the round. The other issues are unrelated.
+
+## When this runs
+
+Nightly at 03:00 UTC — after reconcile (01:00) and analysis (02:00). Fix the
+state, triage against fixed state, then build against a triaged queue.
+
+There is no reactive equivalent. `/approve` puts an issue in the queue; it does
+not start a build. Approving five issues in an evening should not launch five
+agents while Derek is still reading.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py pipeline-dev
+```
+
+33 tests over `select_queue.py` — eligibility, the native ∪ text blocker union,
+closing-keyword PR association, topological ordering, and the cap. No network.
+
+## See also
+
+- `.claude/agents/dev.md` — what actually writes the code
+- `docs/engineering/issue-pipeline.md` — the stage and the schedule
+- `docs/engineering/agent-workflow.md` — TDD, the lead, deviations
+- `docs/engineering/ci-cd.md` — the docs reconciliation gate

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -674,6 +674,15 @@ Serial because parallel agents on one repository fight: two branches touching
 `ProjectSettings.asset`, two release-please runs, two PRs renumbering the same
 things. Nothing raises that above one at a time.
 
+Delegated — a fresh session per issue — because context from the previous issue
+is a liability. The agent that just spent an hour on the audio system will find
+a way to make the next issue about audio.
+
+Each delegation is: mark `in-progress` **first**, so a crashed run leaves a
+visibly stuck issue rather than an invisible one; hand the issue to the
+development agent ([Agent workflow](agent-workflow.md)); let it open its own PR.
+The pipeline does not write code.
+
 #### `cap` bounds the round, not the concurrency
 
 The two are separate knobs and it is worth keeping them apart.
@@ -694,13 +703,52 @@ The cap applies **after** ordering, never before: capping first would take the
 three lowest-numbered issues and could admit a dependent without the thing it
 depends on.
 
-Delegated — a fresh session per issue — because context from the previous issue
-is a liability. The agent that just spent an hour on the audio system will find
-a way to make the next issue about audio.
+#### One branch, one PR, one issue
 
-Each delegation is: mark `in-progress`, hand the issue to the development agent
-([Agent workflow](agent-workflow.md)), and let it open its own PR. The pipeline
-does not write code, and it does not merge PRs.
+Never a combined PR, even for two small issues touching the same file.
+
+A combined PR cannot be partly rejected, carries an ambiguous closing keyword,
+and — the one that bites quietly — has to pick a single Conventional Commit
+type. release-please derives the version from that type, so a PR bundling a
+`feat:` with a `fix:` ships the wrong version number whichever label it takes.
+
+#### The builder never merges and never closes
+
+Not a green PR, not a one-line fix, not its own work.
+
+The pipeline's job is to get work to the point where Derek can look at it. A
+pipeline that also merged would make the review step optional in practice, and
+an agent that can approve its own output has no gate on it at all. Closing is
+the same rule from the other end: `Closes #N` in the PR body closes the issue
+when Derek merges, and closing it directly would mark work done that nobody
+accepted.
+
+#### `skip-docs` is applied immediately, or not at all
+
+A PR touching no files under `docs/` gets `skip-docs` **the moment it opens** —
+before anything else in the round.
+
+The reconciliation gate fails a code-only PR, and the label is the sanctioned
+escape hatch. Applying it late means the round's first visible output is a red
+X on a PR that was never wrong, which teaches everyone to skim past red. It
+still needs a written justification in `## Deviations and Decisions`, because
+the gate cannot distinguish "no docs needed" from "forgot the docs" — that is
+the whole reason a human has to say which it was.
+
+#### A failing issue is dropped, and the round continues
+
+If an issue cannot be completed — tests won't pass, the plan was wrong, a
+checklist box cannot be ticked — the branch is deleted and **no PR is opened**.
+No draft, no partial. A PR that does not close its issue still costs a review,
+and a partial implementation hides an untickable checklist box that is really a
+triage problem.
+
+The issue keeps `in-progress`, deliberately. Reconcile finds an open
+`in-progress` issue with no open PR and nothing on `main` and returns it to
+`ready-for-work`, so the failure self-heals by the next round and stays visible
+on the dashboard until it does.
+
+One failure never aborts the round — the other issues are unrelated.
 
 ### Reconciliation — drift
 


### PR DESCRIPTION
This is the nightly build round: work out what's ready, then build those issues one at a time, each on its own branch with its own pull request.

The two rules that shape everything else are things it *won't* do. It never merges a PR and it never closes an issue — its job is to get work to the point where Derek can look at it, and something that can approve its own homework isn't really being checked. And if an issue doesn't work out, it throws the work away entirely rather than opening a half-finished PR: a PR that doesn't finish its issue still costs someone a review, and "most of it works" hides the problem instead of showing it.

## Spec invariants

- **Never merges, never closes.** The approval gate is the reason the pipeline exists; a builder that merged would make review optional in practice.
- **`in-progress` is set before work starts, not after.** A run that crashes then leaves a visibly stuck issue rather than an invisible one — and that is exactly the state reconcile's `requeue` fix looks for, so the failure self-heals next round.
- **One branch, one PR, one issue.** Preserves reviewability, revertability, an unambiguous `Closes #N`, and — the load-bearing one — a single honest Conventional Commit type, since release-please derives the version from it.
- **A failure drops the issue but not the round.** The other selected issues are unrelated to it.
- **Serial is unconditional**, not a concurrency setting that happens to be 1. Matches the `cap`-is-not-concurrency split established in #148.

## How the spec is changing

Mostly this fills gaps rather than moving lines — four rules that existed in the build checklist and in nobody's documentation:

- **`skip-docs` timing.** The docs said the label exists and needs justification; they never said *when* to apply it. It has to be immediate, because applying it late means the round's first visible output is a red X on a PR that was never wrong — and a team that regularly sees red-then-fine stops reading red at all.
- **What happens to a failing issue.** Previously unspecified, which left "open a draft PR" looking like a reasonable choice. It isn't: the issue keeps `in-progress` and reconcile requeues it, which is a self-healing path that a draft PR would actually break — reconcile's `requeue` fix requires *no open PR*, so a draft would pin the issue in `in-progress` indefinitely.
- **Never closes** was documented only as "does not merge PRs". Closing is a separate power and needed saying out loud.
- **One-PR-per-issue** was implied by "one issue per PR" in `CLAUDE.md` but had no statement of what a combined PR actually costs.

One genuine ordering fix: my #148 edit inserted the `cap` subsection between "delegated to its own agent session" and the paragraph explaining *why* delegated, splitting one argument across an unrelated table. The delegation explanation is now contiguous and `cap` follows it.

**Docs:** `docs/engineering/issue-pipeline.md` — reordered "Serial delegated delivery" so the delegation rationale is contiguous (fixing a split I introduced in #148) and noting `in-progress` is set first; added four subsections under it — "One branch, one PR, one issue" with the release-please version-number consequence, "The builder never merges and never closes", "`skip-docs` is applied immediately, or not at all", and "A failing issue is dropped, and the round continues" including how reconcile requeues it.

## Deviations and Decisions

- **No failing test first.** `SKILL.md`, no behaviour code; `select_queue.py` landed in #148 with its 33 tests red-first. Same precedent as #144, #145, and `core-unity-split`.
- **Stated that there is no reactive equivalent to the nightly build**, which the issue did not ask for. `/approve` queues an issue; it does not start a build. Worth writing down because reactive triage exists and the symmetry is tempting — but approving five issues over an evening should not launch five agents while Derek is still reading, and the analysis-stage docs now advertise reactive firing as the normal path.
- **Described the failure path as "delete the branch"** rather than leaving the branch in place. The issue says the branch is deleted; the reason is that an abandoned branch with no PR is invisible in the UI and accumulates silently. Reconcile keys off "no open PR", so a leftover branch changes nothing about recovery — it is purely litter.
- **Did not document a retry.** A failing issue is not retried within the round. It returns to the queue via reconcile and gets a fresh session next night, which is strictly better than retrying in a session that has already gone wrong once.

Closes #67

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_