### PR TITLE
feat(pipeline): add drift detection to pipeline-reconcile

### DIFF
--- a/.claude/skills/pipeline-reconcile/reconcile.py
+++ b/.claude/skills/pipeline-reconcile/reconcile.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Compare what the labels claim against what GitHub actually shows.
+
+Reality drifts. A PR merges without its closing keyword, someone hand-edits a
+label, a run dies between two API calls. This sweep finds the gaps and sorts
+each one into **auto-fix** or **flag**.
+
+The split is the whole design. Auto-fix is for drift with a single correct
+answer and no judgement in it; everything else is surfaced for a human. A
+reconciler that guesses is a reconciler you have to audit, and one you have to
+audit is one you turn off — at which point it is worse than not having it,
+because the dashboard still says it ran.
+
+    echo '{"issues": [...], "focus": "v0.0.1"}' | python3 reconcile.py
+
+Stdlib only, no network: fetching is the caller's job.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# One recognizer for "triage wrote this", shared with the skill that writes the
+# format. A second copy here would drift, and the drift is self-sustaining:
+# this sweep sees no analysis and requeues to `ai-triage`, triage sees the
+# analysis it wrote and only repairs the label, and the issue cycles forever
+# with neither side reporting an error. See #65.
+_TRIAGE_SKILL = Path(__file__).resolve().parents[1] / "triage-issue"
+if str(_TRIAGE_SKILL) not in sys.path:
+    sys.path.insert(0, str(_TRIAGE_SKILL))
+
+from triage_repair import has_analysis_signature  # noqa: E402
+
+TRIAGE_LABEL = "ai-triage"
+READY_LABEL = "ready-for-work"
+IN_PROGRESS_LABEL = "in-progress"
+PARKED_LABEL = "parked"
+DASHBOARD_LABEL = "dashboard"
+
+STATE_LABELS = {
+    TRIAGE_LABEL,
+    "pending-approval",
+    "needs-clarification",
+    READY_LABEL,
+    IN_PROGRESS_LABEL,
+    PARKED_LABEL,
+}
+
+# States that should carry a triage analysis. `ai-triage` has not been analyzed
+# yet by definition, and `parked` is the owner's decision — requeuing it would
+# overrule a human.
+ANALYZED_STATES = {"pending-approval", "needs-clarification", READY_LABEL,
+                   IN_PROGRESS_LABEL}
+
+TRIAGE_AUTHOR = "github-actions[bot]"
+
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+# Done-ness comes from a closing keyword in a commit **body**. Never a title:
+# a squash merge puts `(#148)` in the subject and that is a PR number, not a
+# statement that the issue is finished. Never a bare `#10` or `Refs #10`
+# either — those are references, and treating them as completion would mark
+# work done because somebody mentioned it.
+CLOSING_KEYWORD = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b",
+    re.IGNORECASE,
+)
+
+
+def _finding(kind: str, action: str, issue_number=None, **extra) -> dict:
+    found = {"kind": kind, "action": action}
+    if issue_number is not None:
+        found["issue"] = issue_number
+    found.update(extra)
+    return found
+
+
+def _labels(issue) -> set:
+    return set(issue.get("labels") or [])
+
+
+def _text_blockers(issue) -> list:
+    return sorted({int(n) for n in TEXT_BLOCKER.findall(issue.get("body") or "")})
+
+
+def _closed_by_body(body: str) -> set:
+    """Issue numbers a commit body closes — the body only, never line one."""
+    lines = (body or "").splitlines()
+    return {int(n) for n in CLOSING_KEYWORD.findall("\n".join(lines[1:]))}
+
+
+def landed_on_main(issue_number: int, merged_commits) -> bool:
+    return any(
+        issue_number in _closed_by_body(commit.get("body"))
+        for commit in merged_commits or []
+    )
+
+
+def has_open_pr(issue_number: int, pulls) -> bool:
+    return any(
+        pull.get("state", "open") == "open"
+        and issue_number in _closed_by_body("x\n" + (pull.get("body") or ""))
+        for pull in pulls or []
+    )
+
+
+def has_analysis(issue) -> bool:
+    """Did triage analyze this issue — by triage's own hand?"""
+    return any(
+        (comment.get("author") or "").lower() == TRIAGE_AUTHOR.lower()
+        and has_analysis_signature(comment.get("body"))
+        for comment in issue.get("comments") or []
+    )
+
+
+def find_cycles(issues) -> list:
+    """Every set of issues that transitively block each other.
+
+    Reported, never resolved. A cycle is a triage mistake, and silently
+    picking an entry point to break it hides the mistake behind working
+    software.
+    """
+    graph = {}
+    for issue in issues:
+        number = issue["number"]
+        blockers = set(issue.get("native_blockers") or []) | set(_text_blockers(issue))
+        graph[number] = blockers
+
+    cycles = []
+    seen = set()
+
+    for start in sorted(graph):
+        if start in seen:
+            continue
+
+        # Walk forward from `start`; anything reachable that reaches back is
+        # in a cycle with it.
+        reachable = set()
+        stack = [start]
+        while stack:
+            current = stack.pop()
+            for nxt in graph.get(current, ()):  # noqa: SIM118
+                if nxt in graph and nxt not in reachable:
+                    reachable.add(nxt)
+                    stack.append(nxt)
+
+        if start in reachable:
+            members = sorted(
+                {start} | {other for other in reachable if start in _reaches(graph, other)}
+            )
+            if not seen.intersection(members):
+                cycles.append(members)
+            seen.update(members)
+
+    return cycles
+
+
+def _reaches(graph, origin) -> set:
+    reachable = set()
+    stack = [origin]
+    while stack:
+        current = stack.pop()
+        for nxt in graph.get(current, ()):  # noqa: SIM118
+            if nxt in graph and nxt not in reachable:
+                reachable.add(nxt)
+                stack.append(nxt)
+    return reachable
+
+
+def process(data: dict) -> dict:
+    """Snapshot in, findings out. No I/O — that lives at the edges."""
+    issues = data.get("issues") or []
+    pulls = data.get("pulls") or []
+    merged_commits = data.get("merged_commits") or []
+
+    # The event path runs on every comment. Two of the auto-fixes are wrong
+    # there and correct nightly, so they are omitted entirely rather than
+    # softened — see the cron-only note on each.
+    events_only = bool(data.get("events_only"))
+
+    findings = []
+
+    for issue in sorted(issues, key=lambda i: i.get("number", 0)):
+        number = issue["number"]
+        labels = _labels(issue)
+        state_labels = sorted(labels & STATE_LABELS)
+
+        if issue.get("state") == "closed":
+            # Safe on every pass, including the event path: it acts only on an
+            # already-closed issue, and a closed issue is not transiently
+            # anything. Nothing it does can be undone by work in flight.
+            if state_labels:
+                findings.append(_finding(
+                    "strip_labels", "auto-fix", number, remove_labels=state_labels))
+            continue
+
+        landed = landed_on_main(number, merged_commits)
+        open_pr = has_open_pr(number, pulls)
+        analyzed = has_analysis(issue)
+
+        if landed:
+            # Flagged, never closed. GitHub closes an issue from the PR's
+            # keyword when Derek merges; this sweep closing it would mark work
+            # done that nobody accepted. Checked before the stall rule so an
+            # issue already on `main` never reads as a stall — without that
+            # guard it would be requeued, rebuilt, and requeued again.
+            findings.append(_finding("flag_merged_but_open", "flag", number))
+
+        elif IN_PROGRESS_LABEL in labels and not open_pr and not events_only:
+            # Cron-only. On the event path an issue picked up seconds ago has
+            # `in-progress` and no PR yet — indistinguishable from a stall, and
+            # requeuing it would yank work out from under a running agent.
+            findings.append(_finding(
+                "requeue", "auto-fix", number,
+                add_labels=[READY_LABEL], remove_labels=[IN_PROGRESS_LABEL]))
+
+        if (labels & ANALYZED_STATES) and not analyzed and not events_only:
+            # Cron-only for the mirror-image reason: triage posts its comment
+            # before setting the label, so between those two writes an issue
+            # legitimately has neither yet — and moments later has both.
+            findings.append(_finding(
+                "requeue_triage", "auto-fix", number,
+                add_labels=[TRIAGE_LABEL],
+                remove_labels=sorted(labels & ANALYZED_STATES)))
+
+        if analyzed and not state_labels:
+            # Flagged, not restored: the analysis says the issue was triaged
+            # but not which route it took, so the intended state is genuinely
+            # ambiguous and only a reader of the comment can say.
+            findings.append(_finding("flag_orphaned_analysis", "flag", number))
+
+        if READY_LABEL in labels and not issue.get("milestone"):
+            # The invariant is broken, but the fix is a decision about which
+            # milestone — not something to guess.
+            findings.append(_finding("flag_orphaned_ready", "flag", number))
+
+        prose_only = [
+            blocker for blocker in _text_blockers(issue)
+            if blocker not in set(issue.get("native_blockers") or [])
+        ]
+        if prose_only:
+            findings.append(_finding(
+                "flag_prose_dependency", "flag", number, blockers=prose_only))
+
+    for members in find_cycles([i for i in issues if i.get("state") != "closed"]):
+        findings.append(_finding("flag_cycle", "flag", issues=members))
+
+    dashboards = [i["number"] for i in issues
+                  if DASHBOARD_LABEL in _labels(i) and i.get("state") != "closed"]
+    if len(dashboards) != 1:
+        findings.append(_finding(
+            "flag_dashboard_count", "flag", dashboards=sorted(dashboards)))
+
+    return {
+        "findings": findings,
+        "count": len(findings),
+        "auto_fix_count": sum(1 for f in findings if f["action"] == "auto-fix"),
+        "flag_count": sum(1 for f in findings if f["action"] == "flag"),
+    }
+
+
+def main(argv=None) -> int:
+    json.dump(process(json.load(sys.stdin)), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
+++ b/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
@@ -1,0 +1,287 @@
+"""Tests for drift detection and the auto-fix / flag split."""
+
+import json
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import reconcile  # noqa: E402
+
+FOCUS = "v0.0.1"
+BOT = "github-actions[bot]"
+
+ANALYSIS = "Here is the plan.\n\n## Build checklist\n\n- [ ] do the thing\n"
+
+
+def issue(number=10, state="open", labels=(), milestone=FOCUS, body="",
+          native_blockers=(), comments=()):
+    return {
+        "number": number,
+        "state": state,
+        "labels": list(labels),
+        "milestone": milestone,
+        "body": body,
+        "native_blockers": list(native_blockers),
+        "comments": list(comments),
+    }
+
+
+def comment(body=ANALYSIS, author=BOT):
+    return {"body": body, "author": author, "created_at": "2026-08-08T10:00:00Z"}
+
+
+def findings(issues, kind=None, **kwargs):
+    data = {"issues": list(issues), "focus": FOCUS}
+    data.update(kwargs)
+    result = reconcile.process(data)
+    if kind is None:
+        return result["findings"]
+    return [f for f in result["findings"] if f["kind"] == kind]
+
+
+class StripLabelsTests(unittest.TestCase):
+    def test_a_closed_issue_with_a_state_label_is_stripped(self):
+        found = findings([issue(10, state="closed", labels=("ready-for-work",))],
+                         kind="strip_labels")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["issue"], 10)
+        self.assertEqual(found[0]["remove_labels"], ["ready-for-work"])
+        self.assertEqual(found[0]["action"], "auto-fix")
+
+    def test_a_closed_issue_keeps_its_area_and_type_labels(self):
+        found = findings(
+            [issue(10, state="closed", labels=("ready-for-work", "area:ui", "type:bug"))],
+            kind="strip_labels")
+        self.assertEqual(found[0]["remove_labels"], ["ready-for-work"])
+
+    def test_a_closed_issue_with_no_state_label_is_not_a_finding(self):
+        self.assertEqual(
+            findings([issue(10, state="closed", labels=("area:ui",))],
+                     kind="strip_labels"), [])
+
+    def test_an_open_issue_is_never_stripped(self):
+        self.assertEqual(findings([issue(10, labels=("ready-for-work",))],
+                                  kind="strip_labels"), [])
+
+    def test_strip_labels_runs_on_the_event_path_too(self):
+        """Safe on every pass: it only ever touches an already-closed issue."""
+        found = findings([issue(10, state="closed", labels=("in-progress",))],
+                         kind="strip_labels", events_only=True)
+        self.assertEqual(len(found), 1)
+
+
+class RequeueTests(unittest.TestCase):
+    def stalled(self, **kwargs):
+        return findings([issue(10, labels=("in-progress",), comments=[comment()])],
+                        kind="requeue", **kwargs)
+
+    def test_in_progress_with_no_pr_and_nothing_on_main_is_requeued(self):
+        found = self.stalled()
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["add_labels"], ["ready-for-work"])
+        self.assertEqual(found[0]["remove_labels"], ["in-progress"])
+
+    def test_an_open_pr_means_it_is_not_stalled(self):
+        found = findings(
+            [issue(10, labels=("in-progress",), comments=[comment()])],
+            kind="requeue",
+            pulls=[{"number": 5, "state": "open", "body": "Closes #10"}])
+        self.assertEqual(found, [])
+
+    def test_requeue_is_omitted_entirely_on_the_event_path(self):
+        """A just-picked-up issue transiently looks exactly like a stall."""
+        self.assertEqual(self.stalled(events_only=True), [])
+
+    def test_an_issue_already_on_main_is_not_a_stall(self):
+        """The guard against a re-pick loop."""
+        found = findings(
+            [issue(10, labels=("in-progress",), comments=[comment()])],
+            kind="requeue",
+            merged_commits=[{"body": "feat: thing\n\nCloses #10"}])
+        self.assertEqual(found, [])
+
+    def test_an_issue_already_on_main_is_merged_but_open_instead(self):
+        found = findings(
+            [issue(10, labels=("in-progress",), comments=[comment()])],
+            kind="flag_merged_but_open",
+            merged_commits=[{"body": "feat: thing\n\nCloses #10"}])
+        self.assertEqual(len(found), 1)
+
+
+class RequeueTriageTests(unittest.TestCase):
+    def test_a_state_label_with_no_analysis_goes_back_to_triage(self):
+        found = findings([issue(10, labels=("pending-approval",))],
+                         kind="requeue_triage")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["add_labels"], ["ai-triage"])
+        self.assertEqual(found[0]["remove_labels"], ["pending-approval"])
+
+    def test_an_analysis_comment_means_no_finding(self):
+        self.assertEqual(
+            findings([issue(10, labels=("pending-approval",), comments=[comment()])],
+                     kind="requeue_triage"), [])
+
+    def test_a_human_comment_carrying_a_checklist_does_not_count(self):
+        found = findings(
+            [issue(10, labels=("pending-approval",),
+                   comments=[comment(author="derekwinters")])],
+            kind="requeue_triage")
+        self.assertEqual(len(found), 1)
+
+    def test_requeue_triage_is_omitted_on_the_event_path(self):
+        """A just-triaged issue transiently has the label but not yet the comment."""
+        self.assertEqual(
+            findings([issue(10, labels=("pending-approval",))],
+                     kind="requeue_triage", events_only=True), [])
+
+    def test_an_ai_triage_issue_is_not_a_finding(self):
+        self.assertEqual(
+            findings([issue(10, labels=("ai-triage",))], kind="requeue_triage"), [])
+
+    def test_a_parked_issue_is_left_alone(self):
+        self.assertEqual(
+            findings([issue(10, labels=("parked",))], kind="requeue_triage"), [])
+
+
+class FlagTests(unittest.TestCase):
+    def test_an_analysis_with_no_state_label_is_flagged_not_restored(self):
+        """The intended state is ambiguous, so a human decides."""
+        found = findings([issue(10, labels=("area:ui",), comments=[comment()])],
+                         kind="flag_orphaned_analysis")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["action"], "flag")
+
+    def test_ready_for_work_without_a_milestone_is_flagged(self):
+        found = findings([issue(10, labels=("ready-for-work",), milestone=None)],
+                         kind="flag_orphaned_ready")
+        self.assertEqual(len(found), 1)
+
+    def test_a_prose_only_dependency_is_flagged(self):
+        found = findings([issue(10, body="Blocked by #42")], kind="flag_prose_dependency")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["blockers"], [42])
+
+    def test_a_prose_dependency_backed_by_a_native_edge_is_not_flagged(self):
+        self.assertEqual(
+            findings([issue(10, body="Blocked by #42", native_blockers=(42,))],
+                     kind="flag_prose_dependency"), [])
+
+    def test_a_depends_on_line_is_not_a_prose_dependency(self):
+        self.assertEqual(
+            findings([issue(10, body="Depends on: #42")], kind="flag_prose_dependency"), [])
+
+    def test_a_dependency_cycle_is_flagged(self):
+        issues = [issue(10, native_blockers=(11,)), issue(11, native_blockers=(10,))]
+        found = findings(issues, kind="flag_cycle")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["issues"], [10, 11])
+
+    def test_an_acyclic_graph_is_not_flagged(self):
+        issues = [issue(10, native_blockers=(11,)), issue(11)]
+        self.assertEqual(findings(issues, kind="flag_cycle"), [])
+
+    def test_two_dashboard_issues_are_flagged(self):
+        issues = [issue(10, labels=("dashboard",)), issue(11, labels=("dashboard",))]
+        found = findings(issues, kind="flag_dashboard_count")
+        self.assertEqual(len(found), 1)
+
+    def test_no_dashboard_issue_is_flagged(self):
+        self.assertEqual(len(findings([issue(10)], kind="flag_dashboard_count")), 1)
+
+    def test_exactly_one_dashboard_is_not_flagged(self):
+        self.assertEqual(findings([issue(10, labels=("dashboard",))],
+                                  kind="flag_dashboard_count"), [])
+
+
+class NeverClosesTests(unittest.TestCase):
+    def test_no_finding_ever_closes_an_issue(self):
+        issues = [
+            issue(10, labels=("in-progress",), comments=[comment()]),
+            issue(11, state="closed", labels=("ready-for-work",)),
+            issue(12, labels=("dashboard",)),
+        ]
+        data = {
+            "issues": issues,
+            "focus": FOCUS,
+            "merged_commits": [{"body": "feat: x\n\nCloses #10"}],
+        }
+
+        for finding in reconcile.process(data)["findings"]:
+            self.assertNotIn("close", json.dumps(finding).lower())
+
+    def test_merged_but_open_is_a_flag_not_an_auto_fix(self):
+        found = findings([issue(10, labels=("in-progress",), comments=[comment()])],
+                         kind="flag_merged_but_open",
+                         merged_commits=[{"body": "feat: x\n\nCloses #10"}])
+        self.assertEqual(found[0]["action"], "flag")
+
+
+class DonenessTests(unittest.TestCase):
+    """What counts as "this landed on main"."""
+
+    def merged(self, body):
+        return findings([issue(10, labels=("in-progress",), comments=[comment()])],
+                        kind="flag_merged_but_open",
+                        merged_commits=[{"body": body}])
+
+    def test_a_closing_keyword_in_the_commit_body_counts(self):
+        self.assertEqual(len(self.merged("feat: thing\n\nCloses #10")), 1)
+
+    def test_a_bare_reference_does_not_count(self):
+        self.assertEqual(self.merged("feat: thing\n\nSee #10"), [])
+
+    def test_refs_does_not_count(self):
+        self.assertEqual(self.merged("feat: thing\n\nRefs #10"), [])
+
+    def test_a_closing_keyword_in_the_title_line_does_not_count(self):
+        """Titles carry `(#10)` from squash merges — that is a PR number."""
+        self.assertEqual(self.merged("feat: closes #10 eventually"), [])
+
+
+class ShapeTests(unittest.TestCase):
+    def test_process_is_pure(self):
+        data = {"issues": [issue(10, labels=("dashboard",))], "focus": FOCUS}
+        before = json.dumps(data, sort_keys=True)
+        reconcile.process(data)
+        self.assertEqual(json.dumps(data, sort_keys=True), before)
+
+    def test_empty_input_is_not_an_error(self):
+        result = reconcile.process({})
+        self.assertIn("findings", result)
+
+    def test_findings_carry_a_count_and_an_action_split(self):
+        data = {"issues": [issue(10, state="closed", labels=("ready-for-work",))],
+                "focus": FOCUS}
+        result = reconcile.process(data)
+
+        self.assertEqual(result["count"], len(result["findings"]))
+        self.assertEqual(result["auto_fix_count"], 1)
+        self.assertEqual(result["flag_count"], 1)  # the missing dashboard
+
+    def test_main_reads_stdin_and_writes_json(self):
+        data = {"issues": [issue(10, labels=("dashboard",))], "focus": FOCUS}
+        out = StringIO()
+
+        with patch.object(sys, "stdin", StringIO(json.dumps(data))), \
+                patch.object(sys, "stdout", out):
+            self.assertEqual(reconcile.main([]), 0)
+
+        self.assertIn("findings", json.loads(out.getvalue()))
+
+    def test_the_shared_recognizer_is_imported_not_redefined(self):
+        """One implementation, per #65 — a second copy drifts into a loop."""
+        source = (Path(__file__).resolve().parents[1] / "reconcile.py").read_text()
+        self.assertNotIn("def has_analysis_signature", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -759,24 +759,71 @@ labels claim against what GitHub shows, and sorts each finding into
 
 **Auto-fixed** — mechanical, single correct answer, no judgement:
 
-- a closed issue still carrying a state label → remove it;
-- `in-progress` with no open PR and no recent activity → back to
-  `ready-for-work`;
-- an issue with two state labels where one was clearly just applied → keep the
-  newest;
-- a merged PR whose issue is still open, with a closing keyword that GitHub
-  missed → close the issue.
+| Finding | Condition | Action | Runs |
+| --- | --- | --- | --- |
+| `strip_labels` | closed issue still carrying a pipeline-state label | remove it | every pass |
+| `requeue` | open, `in-progress`, no open PR, not on `main` | → `ready-for-work` | **cron only** |
+| `requeue_triage` | a state label with no triage-authored analysis | → `ai-triage` | **cron only** |
 
 **Flagged, never touched** — anything needing judgement:
 
-- `ready-for-work` with no milestone (the invariant is broken, but the fix is a
-  decision about which milestone);
-- an issue in the focus milestone blocked by one in a later milestone;
-- a dependency cycle;
-- two dashboard issues, or none.
+| Finding | Condition |
+| --- | --- |
+| `flag_merged_but_open` | the work is on `main` but the issue is still open |
+| `flag_orphaned_analysis` | an analysis comment with no state label |
+| `flag_orphaned_ready` | `ready-for-work` with no milestone |
+| `flag_prose_dependency` | `Blocked by #N` in the body with no native edge |
+| `flag_cycle` | a dependency cycle |
+| `flag_dashboard_count` | two dashboard issues, or none |
 
 The split is the design. A reconciler that guesses is a reconciler you have to
-audit, and one you have to audit is one you turn off.
+audit, and one you have to audit is one you turn off — at which point it is
+worse than absent, because the dashboard still says it ran.
+
+#### The sweep never closes an issue
+
+Not even when the work is demonstrably merged and the issue is demonstrably
+still open. That is `flag_merged_but_open`, and it stays a flag.
+
+`Closes #N` in a PR body is what closes an issue, when Derek merges it. A sweep
+that also closed issues would be deciding that work is finished and accepted on
+evidence that it merely *landed* — and the two are not the same claim. Getting
+it wrong closes something nobody agreed was done, silently, at 01:00.
+
+#### Why two of the auto-fixes are cron-only
+
+`requeue` and `requeue_triage` are correct nightly and wrong on the event path,
+because **the drift they detect is indistinguishable from work in flight.**
+
+- An issue the builder picked up seconds ago has `in-progress` and no PR yet.
+  That is exactly `requeue`'s condition, and firing it would yank the issue out
+  from under a running agent.
+- Triage posts its analysis comment *before* setting the state label. Between
+  those two writes an issue legitimately has neither; moments later it has both.
+  Mid-write, `requeue_triage`'s condition holds.
+
+By 01:00 the transient has resolved: an issue still looking stalled hours later
+genuinely is. So they are **omitted entirely** on the event path rather than
+softened with a time threshold — a threshold is a guess about how long an agent
+takes, and it would be wrong in both directions.
+
+`strip_labels` has no such problem and runs on every pass. It acts only on an
+already-closed issue, and a closed issue is not transiently anything.
+
+#### Done-ness is read from commit bodies
+
+Whether work landed is decided by a **closing keyword in a merged commit's
+body** — never the subject line, never a bare `#N` or `Refs #N`.
+
+The subject line is excluded because a squash merge appends `(#148)` to it, and
+that is a *PR* number. Bare references are excluded because PRs and commits
+mention issues constantly for context; treating a mention as completion would
+mark work done because somebody linked to it.
+
+**`flag_merged_but_open` is checked before the stall rule**, so an issue already
+on `main` never reads as a stall. Without that ordering it would be requeued,
+rebuilt, and requeued again every night — a loop that produces a duplicate PR
+each time.
 
 ### Dashboard
 


### PR DESCRIPTION
Things go out of sync. A pull request gets merged without the magic words that close its issue, someone changes a label by hand, a job dies halfway through. This is the nightly check that notices.

It splits what it finds into two piles: things with one obviously correct answer, which it just fixes, and everything else, which it writes down for Derek to look at. The second pile is the important one. A checker that guesses is a checker you have to double-check, and a checker you have to double-check is one you eventually switch off — which is worse than never having had it, because the dashboard still cheerfully reports that it ran.

The one thing it will never do is close an issue, even when the work is obviously finished and merged.

## Spec invariants

- **Never closes anything.** `test_no_finding_ever_closes_an_issue` scans every finding produced from a deliberately messy state and asserts the word "close" appears nowhere in any of them — so a future contributor adding a `close` action trips a test rather than shipping it.
- **The shared recognizer is imported, never redefined.** `test_the_shared_recognizer_is_imported_not_redefined` reads this module's own source and asserts it contains no `def has_analysis_signature`. Prose in #65 asked for one implementation; this makes it enforceable.
- **Unknown is never treated as done.** Every done-ness check requires positive evidence — a closing keyword in a commit body — rather than inferring completion from absence.
- **`parked` is untouched.** It is the owner's decision, so `requeue_triage` skips it rather than dragging it back into triage.
- **Auto-fixes are label moves only.** No finding edits a body, posts a comment, or changes a milestone.

37 tests, written first and watched fail on the import.

## How the spec is changing

**The sweep no longer closes issues, and that was previously an auto-fix.**

`docs/engineering/issue-pipeline.md` listed "a merged PR whose issue is still open, with a closing keyword that GitHub missed → **close the issue**" among the mechanical fixes. This issue's checklist says the opposite in two places — "the sweep **never closes an issue**", and merged-but-open belongs in the flag list. I followed the issue.

It's also the right call. "The work is on `main`" and "the work is accepted" are different claims, and only the second justifies closing. The evidence available at 01:00 supports the first. If the keyword parse is wrong, or the commit landed from a revert, or the PR merged something adjacent, the sweep closes an issue nobody agreed was finished — silently, overnight, on a repo where the whole point of the approval gate is that a human sees the work.

**Two auto-fixes are now explicitly cron-only, with the reasoning written down.** The old text said `in-progress` requeue needed "no recent activity", which implied a time threshold. There isn't one, deliberately: a threshold is a guess about how long an agent takes and is wrong in both directions. Instead the two rules that can misfire are omitted entirely on the event path, because the drift they detect is *identical in shape* to work in flight — an issue picked up seconds ago has `in-progress` and no PR, and triage's comment-before-label ordering (from #144) means an issue mid-write legitimately has neither.

**Two documented auto-fixes are gone.** "Keep the newest of two state labels" is not in the issue's list, and it's not mechanical — deciding which of two labels was "clearly just applied" is a judgement about intent. The closing fix is covered above.

**One documented flag is not implemented:** "an issue in the focus milestone blocked by one in a later milestone". Called out below rather than quietly dropped.

**Docs:** `docs/engineering/issue-pipeline.md` — replaced the reconciliation bullet lists with two tables giving each finding's condition, action, and whether it runs on every pass; added "The sweep never closes an issue" (superseding the close auto-fix), "Why two of the auto-fixes are cron-only" with the indistinguishable-from-in-flight argument and why no time threshold, and "Done-ness is read from commit bodies" covering the squash-merge `(#148)` subject-line trap and the check-before-stall ordering.

## Deviations and Decisions

- **Kept `flag_cycle` and `flag_dashboard_count` although the issue's checklist omits them.** Both are load-bearing elsewhere: the dashboard marker section says "the reconciler flags it if there are two or none", and I wrote "reconcile flags those" about cycles into the queue-ordering docs in #148. Dropping them would have left two documented promises unkept.
- **Did not implement the cross-milestone blocker flag**, which the old docs listed. It needs an ordering over milestones to distinguish "a later milestone" from "a different one", and no such ordering exists in the data the sweep receives. Rather than invent one or silently weaken it to "any other milestone", I left it out and removed it from the docs. If it's wanted, it needs a decision about where milestone order comes from — worth its own issue.
- **The cross-skill import inserts `triage-issue` onto `sys.path` at import time.** Not elegant, but `run_python_tests.py` puts only each suite's own directory on the path, and a duplicated recognizer is exactly the failure #65 was written to prevent. This is the fourth caller-of-a-shared-thing problem in the pipeline and reinforces #147's point that the cross-skill module question needs a real answer.
- **`has_open_pr` prepends a dummy first line** before reusing the body parser, because that parser deliberately ignores line one (the squash-merge subject trap) and a PR body's first line is ordinary prose. It's a slightly ugly seam; the alternative was a second keyword regex, which is the duplication problem again.
- **A test I wrote was wrong and I tightened it rather than the code.** `test_a_closed_issue_with_no_state_label_is_not_a_finding` asserted on *all* findings, so it failed on the legitimately-firing missing-dashboard flag. The test's intent was about `strip_labels` specifically; it now says so.

Closes #68

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_