### PR TITLE
docs(pipeline): add the pipeline-reconcile SKILL.md

### DIFF
--- a/.claude/skills/pipeline-reconcile/SKILL.md
+++ b/.claude/skills/pipeline-reconcile/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: pipeline-reconcile
+description: Sweep the board for drift between what the labels claim and what GitHub shows, fixing the mechanical cases and flagging the rest. Use for the nightly sweep, or when the board looks wrong.
+---
+
+# pipeline-reconcile
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+# Everything, including the two cron-only fixes.
+python3 .claude/skills/pipeline-reconcile/reconcile.py < state.json
+
+# The event path — same script, cron-only fixes omitted.
+jq '. + {events_only: true}' state.json | \
+  python3 .claude/skills/pipeline-reconcile/reconcile.py
+```
+
+Snapshot in, findings out. `process(data)` is pure and does no I/O; fetching
+the state and applying the fixes both live at the edges.
+
+## The rules
+
+**Auto-fix** — mechanical, one correct answer, no judgement:
+
+| Finding | Condition | Action | Runs |
+| --- | --- | --- | --- |
+| `strip_labels` | closed issue still carrying a pipeline-state label | remove it | every pass |
+| `requeue` | open, `in-progress`, no open PR, not on `main` | → `ready-for-work` | **cron only** |
+| `requeue_triage` | a state label with no triage-authored analysis | → `ai-triage` | **cron only** |
+
+**Flag** — surfaced, never touched:
+
+| Finding | Condition |
+| --- | --- |
+| `flag_merged_but_open` | the work is on `main`, the issue is still open |
+| `flag_orphaned_analysis` | an analysis comment with no state label |
+| `flag_orphaned_ready` | `ready-for-work` with no milestone |
+| `flag_prose_dependency` | `Blocked by #N` in the body with no native edge |
+| `flag_cycle` | a dependency cycle |
+| `flag_dashboard_count` | two dashboard issues, or none |
+
+The split is the design. A reconciler that guesses is one you have to audit,
+and one you have to audit is one you turn off — at which point it is worse than
+absent, because the dashboard still says it ran.
+
+Every auto-fix is a **label move**. Nothing here edits a body, posts a comment,
+sets a milestone, or closes an issue.
+
+## Why `requeue` and `requeue_triage` are cron-only
+
+Because the drift they detect is **indistinguishable from work in flight.**
+
+An issue the builder picked up ten seconds ago has `in-progress` and no PR yet.
+That is exactly `requeue`'s condition. On the event path — which runs on every
+comment, at any moment — firing it would yank an issue out from under a running
+agent, which then opens a PR for an issue the board says is merely ready.
+
+`requeue_triage` is the mirror image. Triage posts its analysis comment
+*before* setting the state label, deliberately, so a crash leaves a plan on
+`ai-triage` rather than an approval-pending issue with nothing to approve.
+Between those two writes the issue legitimately has one and not the other —
+and mid-write, the sweep's condition holds.
+
+By 01:00 the transient has resolved. An issue that still looks stalled hours
+after anything touched it genuinely is stalled.
+
+**They are omitted entirely rather than softened with a time threshold.** A
+threshold would be a guess about how long an agent takes, and it would be wrong
+in both directions: too short and it interrupts a slow build, too long and a
+stall sits there all night. `events_only=True` drops them from the output
+completely, so there is no partially-correct middle version to reason about.
+
+### Why `strip_labels` is safe on every pass
+
+It acts only on an **already-closed** issue, and a closed issue is not
+transiently anything. There is no in-flight state where "closed, still carrying
+`in-progress`" is the correct configuration that a concurrent write is about to
+resolve — the work is over. Nothing it removes can be needed a moment later,
+so there is no version of it that races.
+
+## The sweep never closes an issue
+
+Not even when the work is demonstrably on `main` and the issue is demonstrably
+open. That is `flag_merged_but_open`, and it stays a flag.
+
+"The work landed" and "the work is accepted" are different claims, and only the
+second justifies closing. What the sweep can see supports the first. If the
+keyword parse is wrong, or the commit came from a revert, or the PR merged
+something adjacent, then closing means marking work done that nobody agreed to
+— silently, overnight, on a project whose entire design assumes a human sees
+things before they become the game.
+
+`flag_merged_but_open` is also checked **before** the stall rule, so an issue
+already on `main` never reads as a stall. Without that ordering it would be
+requeued, rebuilt, and requeued again — a fresh duplicate PR every night.
+
+## Done-ness comes from commit bodies
+
+A closing keyword in a merged commit's **body**. Never the subject line, never
+a bare `#N` or `Refs #N`.
+
+The subject is excluded because a squash merge appends `(#150)` to it, and that
+is a *PR* number — reading it as a closing reference would mark an unrelated
+issue done every time anything merges. Bare references are excluded because
+commits and PRs mention issues constantly for context.
+
+## Where findings go
+
+Flags render into the dashboard's **⚠️ Reconcile** section, regenerated on every
+render like everything else on the board. Nothing is remembered between runs:
+a flag disappears when the condition stops holding, and a flag that persists
+across several days is one nobody has dealt with.
+
+That is also why flags do not post comments. A flag is a statement about the
+board's current state, and a comment would outlive the state it described.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py pipeline-reconcile
+```
+
+37 tests. Two are worth knowing about: one asserts no finding can ever close an
+issue, and one reads this module's source to assert it does not define its own
+`has_analysis_signature` — that recognizer is imported from `triage-issue`,
+because two copies drift into a requeue↔repair loop that reports no error.
+
+## See also
+
+- `triage-issue` — owns `has_analysis_signature`
+- `pipeline-dashboard` — renders the flags
+- `docs/engineering/issue-pipeline.md` — the stage and the schedule

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -835,6 +835,18 @@ that would free the most other work, which are the ones worth approving next.
 Wholly regenerated every time, apart from the config markers. Nothing on it is
 remembered, so nothing on it can be stale.
 
+#### How reconcile's flags surface
+
+The sweep's flag findings render into the board's **⚠️ Reconcile** section, and
+that is the only place they appear. They are regenerated with everything else,
+so a flag vanishes the moment its condition stops holding — and one still
+sitting there after several days is one nobody has dealt with.
+
+This is why a flag does not post a comment. A flag describes the board's state
+*right now*; a comment would outlive the state it described and turn into a
+false report of a problem that was fixed weeks ago. The dashboard can be wholly
+regenerated. A comment thread cannot.
+
 ## Skills inventory
 
 | Skill | Owns |


### PR DESCRIPTION
The written-down version of the drift sweep: what it looks for, which problems it fixes by itself, which ones it just writes down for Derek, and how to run it by hand.

Most of it is a table you could have worked out from the code. The parts worth reading are the two explanations of *timing* — why two of the automatic fixes only run overnight and never during the day, and why the third is safe to run at any moment. Both come down to the same thing: some kinds of "this looks broken" are indistinguishable from "someone is working on it right now."

## Spec invariants

- **Every auto-fix is a label move.** Stated explicitly so the boundary is defensible: nothing edits a body, posts a comment, sets a milestone, or closes anything.
- **Never closes**, restated with the landed-vs-accepted distinction, since this is the doc someone reads before adding a fourth auto-fix.
- **Flags live only on the dashboard.** No comments, so a stale flag is impossible by construction.
- **The recognizer is imported, not copied** — noted alongside the test that enforces it.

## How the spec is changing

Only one addition, and it's a gap rather than a reversal: **the docs never said where reconcile's findings actually go.**

They now say the ⚠️ Reconcile section of the dashboard, and nowhere else — and, more usefully, *why* not a comment. The dashboard is wholly regenerated every render, so a flag disappears the instant its condition stops holding. A comment can't do that. It would outlive the state it described and become a permanent report of a problem that was fixed weeks ago, on an issue thread someone reads later assuming it's current.

That property is the reason flags are safe to emit liberally: a false positive costs one line on a board that redraws itself, not a permanent artifact someone has to go and clean up.

**Docs:** `docs/engineering/issue-pipeline.md` — added "How reconcile's flags surface" under the Dashboard section, documenting that flags render only into the ⚠️ Reconcile section, that they are regenerated (so a persistent flag means nobody has dealt with it), and why a flag deliberately does not post a comment.

## Deviations and Decisions

- **No failing test first.** `SKILL.md`; `reconcile.py` landed in #150 with its 37 tests red-first. Same precedent as #144, #145, #149.
- **Explained `strip_labels`' safety in terms of races rather than just restating "it's safe".** The issue asks why it's safe on every pass, and "it only touches closed issues" is only half the argument — the other half is that there's no in-flight state where "closed but still `in-progress`" is briefly correct and about to be resolved by a concurrent write. That's what distinguishes it from the other two, and it's the test a fourth auto-fix should have to pass.
- **Documented the `events_only` invocation with `jq`.** The script takes the flag as an input field rather than a CLI argument, which isn't obvious from the module docstring; showing the actual pipeline someone would type seemed more useful than describing it.
- **Repeated the rules tables here rather than linking to the spec page.** Some duplication, deliberately: this is the page you have open while running the sweep, and a table you have to follow a link to read is one you skip. The spec page remains authoritative if they ever disagree.

Closes #69

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_