### PR TITLE
feat(pipeline): add the dashboard renderer core

### DIFF
--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Render the dashboard issue body from live repo state.
+
+A pure function of the state, with no model in the loop. The board is what
+Derek looks at to decide what to approve next, so it has to be **true** — and
+the only way to guarantee that is to derive every line of it from GitHub and
+regenerate the whole thing every time. Nothing on it is remembered, so nothing
+on it can be stale.
+
+    python3 render_dashboard.py < state.json          # print, write nothing
+    python3 render_dashboard.py --write < state.json  # PATCH the issue body
+
+Stdlib only. `render()` does no I/O at all; `--write` is the only path that
+touches the network, and the only thing it can touch is the dashboard issue's
+own body.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.request
+
+DEFAULT_CAP = 3
+
+TRIAGE = "ai-triage"
+PENDING = "pending-approval"
+NEEDS_CLARIFICATION = "needs-clarification"
+READY = "ready-for-work"
+IN_PROGRESS = "in-progress"
+PARKED = "parked"
+
+PLANNING_LABELS = {TRIAGE, PENDING, NEEDS_CLARIFICATION}
+ACTIVE_LABELS = {READY, IN_PROGRESS}
+STATE_LABELS = PLANNING_LABELS | ACTIVE_LABELS | {PARKED}
+
+FOCUS_MARKER = re.compile(r"<!--\s*pipeline-focus:\s*(.+?)\s*-->")
+CAP_MARKER = re.compile(r"<!--\s*pipeline-cap:\s*(.+?)\s*-->")
+
+
+def _labels(issue) -> set:
+    return set(issue.get("labels") or [])
+
+
+def _body(data) -> str:
+    return (data.get("dashboard_issue") or {}).get("body") or ""
+
+
+def _milestone_titles(data) -> list:
+    return [m.get("title") for m in data.get("milestones") or []]
+
+
+def resolve_focus(data: dict, override=None) -> str:
+    """Focus milestone: override → marker → the `focus` key.
+
+    An override naming no live milestone is **rejected, never stored**. A
+    typo'd `/focus v0.0.10` would otherwise render a board where every section
+    is empty — which looks exactly like a finished milestone, and is the most
+    misleading thing this script could produce.
+    """
+    live = _milestone_titles(data)
+
+    if override is not None:
+        if live and override not in live:
+            raise ValueError(
+                f"No live milestone named {override!r}. "
+                f"Milestones are: {', '.join(str(t) for t in live)}.")
+        return override
+
+    found = FOCUS_MARKER.search(_body(data))
+    if found:
+        return found.group(1)
+
+    return data.get("focus")
+
+
+def resolve_cap(data: dict, override=None) -> int:
+    """Build cap: override → marker → 3."""
+    if override is not None:
+        return int(override)
+
+    found = CAP_MARKER.search(_body(data))
+    if found:
+        try:
+            return int(found.group(1))
+        except ValueError:
+            # A malformed marker falls back to the default rather than failing
+            # the render. A board that does not render is worse than one with
+            # a default cap, and the next `/cap` fixes it.
+            return DEFAULT_CAP
+
+    return DEFAULT_CAP
+
+
+def _focus_issues(data, focus) -> list:
+    return [
+        issue for issue in data.get("issues") or []
+        if issue.get("milestone") == focus
+    ]
+
+
+def focus_pie(data: dict, focus=None) -> dict:
+    """Four slices, and **every focus issue lands in exactly one.**
+
+    Ordered checks rather than independent predicates, so nothing can fall
+    through and nothing can be counted twice. The total is the milestone's
+    issue count — which is what makes the pie trustworthy: an issue cannot
+    silently vanish from the board by having an odd label combination.
+    """
+    focus = focus or resolve_focus(data)
+    counts = {"Unplanned": 0, "In Planning": 0, "Ready": 0, "Done": 0}
+
+    for issue in _focus_issues(data, focus):
+        labels = _labels(issue)
+
+        if issue.get("state") == "closed":
+            counts["Done"] += 1
+        elif PARKED in labels or not (labels & STATE_LABELS):
+            # Parked and never-triaged are both "not being worked and not
+            # waiting on anybody" — different reasons, same meaning for
+            # planning purposes.
+            counts["Unplanned"] += 1
+        elif labels & ACTIVE_LABELS:
+            counts["Ready"] += 1
+        else:
+            counts["In Planning"] += 1
+
+    return counts
+
+
+def ready_queue(data: dict, focus=None) -> list:
+    """Focus-milestone issues waiting to be built, lowest number first.
+
+    `parked` is excluded even when it also carries `ready-for-work`. The
+    Parked section is a listing, not a re-admission.
+    """
+    focus = focus or resolve_focus(data)
+
+    return sorted(
+        (
+            issue for issue in _focus_issues(data, focus)
+            if issue.get("state") != "closed"
+            and READY in _labels(issue)
+            and PARKED not in _labels(issue)
+        ),
+        key=lambda issue: issue.get("number", 0),
+    )
+
+
+def _bar(count: int, total: int, width: int = 20) -> str:
+    if not total:
+        return "░" * width
+    filled = round(width * count / total)
+    return "█" * filled + "░" * (width - filled)
+
+
+def render(data: dict, focus_override=None, cap_override=None) -> str:
+    """The whole dashboard body. Byte-stable for a given input."""
+    focus = resolve_focus(data, focus_override)
+    cap = resolve_cap(data, cap_override)
+
+    pie = focus_pie(data, focus)
+    total = sum(pie.values())
+
+    lines = [
+        "# 🐸 Pipeline dashboard",
+        "",
+        "_Regenerated on every render. Edit the markers, never the sections —",
+        "a hand edit to a rendered section disappears at the next render._",
+        "",
+        f"<!-- pipeline-focus: {focus} -->",
+        f"<!-- pipeline-cap: {cap} -->",
+        "",
+        f"## 🎯 Focus: {focus}",
+        "",
+        f"{total} issue{'' if total == 1 else 's'} in this milestone.",
+        "",
+        "| Slice | Count | |",
+        "| --- | ---: | --- |",
+    ]
+
+    for slice_name, count in pie.items():
+        lines.append(f"| {slice_name} | {count} | `{_bar(count, total)}` |")
+
+    queue = ready_queue(data, focus)
+
+    lines += [
+        "",
+        f"## 🔨 Ready queue (cap {cap})",
+        "",
+    ]
+
+    if queue:
+        lines += [
+            "| Issue | Title | Milestone |",
+            "| --- | --- | --- |",
+        ]
+        for issue in queue:
+            lines.append(
+                f"| #{issue['number']} | {issue.get('title', '')} "
+                f"| {issue.get('milestone') or '—'} |")
+    else:
+        lines.append("Nothing is ready to build.")
+
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_dashboard(data: dict, body: str, token=None, repository=None):  # pragma: no cover
+    """PATCH the dashboard issue body. The only write this script can make.
+
+    Authenticates with `GITHUB_TOKEN` — never a PAT. The token's scope is this
+    repository, and the only endpoint touched is this one issue.
+    """
+    token = token or os.environ["GITHUB_TOKEN"]
+    repository = repository or os.environ["GITHUB_REPOSITORY"]
+    number = data["dashboard_issue"]["number"]
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/issues/{number}",
+        data=json.dumps({"body": body}).encode(),
+        method="PATCH",
+    )
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.status
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    data = json.load(sys.stdin)
+
+    body = render(data)
+
+    if "--write" in argv:  # pragma: no cover - network path
+        write_dashboard(data, body)
+        return 0
+
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
@@ -1,0 +1,26 @@
+# 🐸 Pipeline dashboard
+
+_Regenerated on every render. Edit the markers, never the sections —
+a hand edit to a rendered section disappears at the next render._
+
+<!-- pipeline-focus: v0.0.1 -->
+<!-- pipeline-cap: 2 -->
+
+## 🎯 Focus: v0.0.1
+
+8 issues in this milestone.
+
+| Slice | Count | |
+| --- | ---: | --- |
+| Unplanned | 2 | `█████░░░░░░░░░░░░░░░` |
+| In Planning | 2 | `█████░░░░░░░░░░░░░░░` |
+| Ready | 3 | `████████░░░░░░░░░░░░` |
+| Done | 1 | `██░░░░░░░░░░░░░░░░░░` |
+
+## 🔨 Ready queue (cap 2)
+
+| Issue | Title | Milestone |
+| --- | --- | --- |
+| #10 | Add the frog splitting rule | v0.0.1 |
+| #11 | Cap the pond at 32 | v0.0.1 |
+

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/state.json
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/state.json
@@ -1,0 +1,44 @@
+{
+  "focus": "v0.0.1",
+  "milestones": [
+    {"title": "v0.0.1", "description": "Repo, pipeline, and the first build."},
+    {"title": "v0.0.2", "description": "The first frog on screen."},
+    {"title": "Direct Involvement Needed", "description": "Tasks only Derek or Connor can do."}
+  ],
+  "dashboard_issue": {
+    "number": 78,
+    "body": "# Pipeline\n\n<!-- pipeline-focus: v0.0.1 -->\n<!-- pipeline-cap: 2 -->\n\nold rendered content that must not survive\n"
+  },
+  "issues": [
+    {"number": 10, "title": "Add the frog splitting rule", "state": "open",
+     "labels": ["ready-for-work", "area:gameplay", "type:task"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 11, "title": "Cap the pond at 32", "state": "open",
+     "labels": ["ready-for-work", "area:gameplay"], "milestone": "v0.0.1",
+     "body": "Depends on: #10", "native_blockers": []},
+    {"number": 12, "title": "Tapping a frog splits it", "state": "open",
+     "labels": ["in-progress", "area:gameplay"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 13, "title": "Decide the pond background", "state": "open",
+     "labels": ["needs-clarification", "area:art"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 14, "title": "Frog hop animation", "state": "open",
+     "labels": ["pending-approval", "area:art"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 15, "title": "Splash screen", "state": "open",
+     "labels": ["parked", "area:ui"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 16, "title": "Nobody has triaged this yet", "state": "open",
+     "labels": ["area:ui"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 17, "title": "Set up the repo", "state": "closed",
+     "labels": ["area:build"], "milestone": "v0.0.1",
+     "body": "", "native_blockers": []},
+    {"number": 18, "title": "A later-milestone issue", "state": "open",
+     "labels": ["ai-triage"], "milestone": "v0.0.2",
+     "body": "", "native_blockers": []},
+    {"number": 78, "title": "Pipeline dashboard", "state": "open",
+     "labels": ["dashboard"], "milestone": null,
+     "body": "", "native_blockers": []}
+  ]
+}

--- a/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
@@ -1,0 +1,178 @@
+"""Tests for the dashboard renderer.
+
+The centrepiece is a golden-snapshot test: render the fixture state and compare
+byte-for-byte against a committed expected body. A dashboard is a wall of
+generated Markdown, and a diff of the whole board is the only review that
+catches a section quietly changing shape.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import render_dashboard as dash  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+GOLDEN = FIXTURES / "expected_dashboard.md"
+
+
+def state():
+    return json.loads((FIXTURES / "state.json").read_text())
+
+
+class GoldenTests(unittest.TestCase):
+    def test_the_rendered_board_matches_the_golden_file(self):
+        rendered = dash.render(state())
+        expected = GOLDEN.read_text()
+
+        if rendered != expected:  # pragma: no cover - only on a real mismatch
+            self.fail(
+                "Rendered dashboard differs from the golden file.\n"
+                "If the change is intended, update "
+                f"{GOLDEN.relative_to(Path.cwd()) if GOLDEN.is_relative_to(Path.cwd()) else GOLDEN}"
+                " and review the diff.\n\n" + rendered)
+
+    def test_rendering_is_byte_stable(self):
+        """Same input, same bytes — or every hourly run is a spurious edit."""
+        self.assertEqual(dash.render(state()), dash.render(state()))
+
+    def test_the_render_replaces_the_old_body_entirely(self):
+        self.assertNotIn("old rendered content", dash.render(state()))
+
+
+class PieTests(unittest.TestCase):
+    def counts(self, data=None):
+        return dash.focus_pie(data or state())
+
+    def test_the_four_slices_are_present(self):
+        self.assertEqual(
+            list(self.counts()), ["Unplanned", "In Planning", "Ready", "Done"])
+
+    def test_every_focus_issue_lands_in_exactly_one_slice(self):
+        data = state()
+        focus_issues = [
+            i for i in data["issues"]
+            if i["milestone"] == data["focus"]
+        ]
+
+        self.assertEqual(sum(self.counts(data).values()), len(focus_issues))
+
+    def test_parked_counts_as_unplanned(self):
+        self.assertEqual(self.counts()["Unplanned"], 2)  # #15 parked, #16 no state
+
+    def test_an_issue_with_no_state_label_counts_as_unplanned(self):
+        data = state()
+        data["issues"] = [i for i in data["issues"] if i["number"] != 15]
+        self.assertEqual(self.counts(data)["Unplanned"], 1)
+
+    def test_closed_counts_as_done_whatever_its_labels(self):
+        self.assertEqual(self.counts()["Done"], 1)
+
+    def test_ready_and_in_progress_are_both_ready(self):
+        self.assertEqual(self.counts()["Ready"], 3)  # #10, #11, #12
+
+    def test_planning_covers_triage_pending_and_clarification(self):
+        self.assertEqual(self.counts()["In Planning"], 2)  # #13, #14
+
+    def test_issues_outside_the_focus_milestone_are_excluded(self):
+        """#18 is v0.0.2 and #78 has no milestone."""
+        self.assertEqual(sum(self.counts().values()), 8)
+
+
+class ResolveFocusTests(unittest.TestCase):
+    def test_an_override_wins_over_the_marker(self):
+        self.assertEqual(dash.resolve_focus(state(), override="v0.0.2"), "v0.0.2")
+
+    def test_the_marker_is_used_when_there_is_no_override(self):
+        data = state()
+        data.pop("focus")
+        self.assertEqual(dash.resolve_focus(data), "v0.0.1")
+
+    def test_an_override_naming_no_live_milestone_is_rejected(self):
+        with self.assertRaises(ValueError):
+            dash.resolve_focus(state(), override="v9.9.9")
+
+    def test_the_rejection_names_the_live_milestones(self):
+        with self.assertRaises(ValueError) as caught:
+            dash.resolve_focus(state(), override="v9.9.9")
+        self.assertIn("v0.0.1", str(caught.exception))
+
+
+class ResolveCapTests(unittest.TestCase):
+    def test_an_override_wins(self):
+        self.assertEqual(dash.resolve_cap(state(), override=5), 5)
+
+    def test_the_marker_is_used_next(self):
+        self.assertEqual(dash.resolve_cap(state()), 2)
+
+    def test_the_default_is_three(self):
+        data = state()
+        data["dashboard_issue"]["body"] = "# Pipeline\n"
+        self.assertEqual(dash.resolve_cap(data), 3)
+
+    def test_a_malformed_marker_falls_back_to_the_default(self):
+        data = state()
+        data["dashboard_issue"]["body"] = "<!-- pipeline-cap: lots -->"
+        self.assertEqual(dash.resolve_cap(data), 3)
+
+
+class MarkerTests(unittest.TestCase):
+    def test_both_markers_are_re_emitted(self):
+        rendered = dash.render(state())
+        self.assertIn("<!-- pipeline-focus: v0.0.1 -->", rendered)
+        self.assertIn("<!-- pipeline-cap: 2 -->", rendered)
+
+    def test_an_override_is_written_into_the_marker(self):
+        rendered = dash.render(state(), focus_override="v0.0.2", cap_override=4)
+        self.assertIn("<!-- pipeline-focus: v0.0.2 -->", rendered)
+        self.assertIn("<!-- pipeline-cap: 4 -->", rendered)
+
+    def test_markers_survive_a_round_trip(self):
+        """Render, feed the output back in, and the settings are unchanged."""
+        data = state()
+        data["dashboard_issue"]["body"] = dash.render(data, cap_override=7)
+        data.pop("focus")
+
+        self.assertEqual(dash.resolve_cap(data), 7)
+        self.assertEqual(dash.resolve_focus(data), "v0.0.1")
+
+
+class ReadyQueueTests(unittest.TestCase):
+    def test_the_queue_is_headed_by_the_cap(self):
+        self.assertIn("cap 2", dash.render(state()))
+
+    def test_ready_issues_appear_in_the_queue(self):
+        rendered = dash.render(state())
+        self.assertIn("#10", rendered)
+        self.assertIn("#11", rendered)
+
+    def test_in_progress_is_not_in_the_ready_queue(self):
+        queue = dash.ready_queue(state())
+        self.assertNotIn(12, [i["number"] for i in queue])
+
+    def test_a_parked_issue_is_never_in_the_ready_queue(self):
+        data = state()
+        data["issues"].append({
+            "number": 20, "title": "Parked but ready", "state": "open",
+            "labels": ["ready-for-work", "parked"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": []})
+        self.assertNotIn(20, [i["number"] for i in dash.ready_queue(data)])
+
+
+class PurityTests(unittest.TestCase):
+    def test_render_does_not_mutate_its_input(self):
+        data = state()
+        before = json.dumps(data, sort_keys=True)
+        dash.render(data)
+        self.assertEqual(json.dumps(data, sort_keys=True), before)
+
+    def test_the_module_makes_no_network_calls_at_import(self):
+        source = (Path(__file__).resolve().parents[1] / "render_dashboard.py").read_text()
+        self.assertNotIn("urllib.request.urlopen", source.split("def write_dashboard")[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -320,9 +320,23 @@ thread rather than being a label that changed itself overnight.
 Both are stored as HTML-comment markers in the body of the dashboard issue:
 
 ```html
-<!-- pipeline:focus=v0.0.1 -->
-<!-- pipeline:cap=3 -->
+<!-- pipeline-focus: v0.0.1 -->
+<!-- pipeline-cap: 3 -->
 ```
+
+Each setting resolves **override → marker → default**: an explicit `/focus` or
+`/cap` on this run wins, otherwise the marker currently in the body, otherwise
+the default (3 for `cap`; `focus` has no default and must come from one of the
+first two).
+
+A `/focus` naming **no live milestone is rejected, not stored.** A typo'd
+`v0.0.10` would otherwise render a board whose every section is empty — which
+looks exactly like a finished milestone, and is the most misleading output the
+renderer could produce. The refusal names the milestones that do exist.
+
+A malformed `cap` marker falls back to 3 rather than failing the render: a
+board that does not render is worse than one with a default cap, and the next
+`/cap` fixes it.
 
 The dashboard issue is the one carrying the `dashboard` label. There is exactly
 one; the reconciler flags it if there are two or none.
@@ -834,6 +848,34 @@ that would free the most other work, which are the ones worth approving next.
 
 Wholly regenerated every time, apart from the config markers. Nothing on it is
 remembered, so nothing on it can be stale.
+
+Rendering is **deterministic and byte-stable**: the same state produces the
+same bytes. Without that, every hourly run would PATCH the issue and the
+dashboard would generate a stream of meaningless edits.
+
+#### The focus pie always adds up
+
+The focus milestone is summarised as four slices:
+
+| Slice | What is in it |
+| --- | --- |
+| **Unplanned** | `parked`, or carrying no pipeline-state label at all |
+| **In Planning** | `ai-triage`, `pending-approval`, `needs-clarification` |
+| **Ready** | `ready-for-work`, `in-progress` |
+| **Done** | closed, whatever its labels say |
+
+Every issue in the milestone falls into **exactly one**, and the four counts
+sum to the milestone's issue total. That is the property worth protecting: it
+means an issue cannot quietly disappear from the board by ending up with an odd
+combination of labels. The slices are assigned by ordered checks rather than
+independent predicates, so there is no gap to fall through and no overlap to be
+counted twice.
+
+Parked and never-triaged share the Unplanned slice because they mean the same
+thing for planning — not being worked, and not waiting on anybody — even though
+they got there for different reasons. This is the **one** place a `parked`
+issue is counted; every active-work queue excludes it, because the board's
+Parked section is a listing, not a re-admission.
 
 #### How reconcile's flags surface
 


### PR DESCRIPTION
This builds the board Derek looks at to decide what to approve next: a summary of how the current milestone is going, and the list of what's queued up to be built.

The whole thing is redrawn from scratch every time, from what GitHub actually says. Nothing on it is remembered, which is the point — nothing on it can be out of date. The only bits that survive a redraw are two hidden settings lines saying which milestone is in focus and how many issues a build round takes on.

The summary is four buckets, and the useful property is that they always add up to the number of issues in the milestone. It's not possible for an issue to quietly fall off the board because it ended up with an odd combination of labels.

## Spec invariants

- **The pie is a partition.** Slices are assigned by ordered checks, not independent predicates, so there is no gap to fall through and no overlap to double-count. `test_every_focus_issue_lands_in_exactly_one_slice` asserts the sum equals the milestone's issue count directly from the fixture rather than against a hardcoded number, so it keeps holding as the fixture grows.
- **Byte-stability.** `test_rendering_is_byte_stable` pins it. Without this the hourly render PATCHes the issue every time and the dashboard becomes a stream of meaningless edits.
- **`parked` is counted once, in Unplanned, and appears in no active queue.** `test_a_parked_issue_is_never_in_the_ready_queue` covers a `parked` issue that *also* carries `ready-for-work` — the case where a naive filter would let it back in.
- **Markers round-trip.** `test_markers_survive_a_round_trip` renders, feeds the output back as the current body, and checks the settings are unchanged. This is the property `/focus` and `/cap` persistence depends on, since they work by re-rendering rather than editing.
- **`render()` does no I/O**, and a test asserts no `urlopen` appears before the `write_dashboard` function. The only network path is `--write`, and the only thing it can touch is the dashboard issue's own body.

28 tests. Red first on the import.

## How the spec is changing

**The marker syntax changed, and this is my error to own.** The docs used `<!-- pipeline:focus=v0.0.1 -->`. This issue specifies `<!-- pipeline-focus: v0.0.1 -->`, and since the renderer is the only thing that reads or writes markers, its format is the real one. The docs now match.

Worth noting how the wrong syntax got there: it predates me, but I copied it forward in #148 when I changed the cap example from `1` to `3` without questioning the surrounding form. The lesson is that editing a value inside an example is not the same as having checked the example.

**Two behaviours are newly specified**, both about what happens when a setting is wrong:

- **A `/focus` naming no live milestone is rejected, not stored.** This is the one with teeth. Storing a typo'd `v0.0.10` renders a board where every section is empty — and an empty board is indistinguishable from a completed milestone. It's the single most misleading output this script could produce, and it would look like good news.
- **A malformed `cap` marker falls back to 3 rather than failing.** The opposite call, deliberately: a board that doesn't render at all is worse than one with a default cap, and the failure is self-correcting on the next `/cap`.

The asymmetry is intentional — a bad focus produces a *plausible wrong answer*, a bad cap produces a slightly-off number.

**Docs:** `docs/engineering/issue-pipeline.md` — corrected both marker examples to the `<!-- pipeline-focus: … -->` / `<!-- pipeline-cap: N -->` form; documented the override → marker → default precedence, the rejection of a focus naming no live milestone and why an empty board is the dangerous failure, and the cap fallback; added "The focus pie always adds up" with the four-slice table, the partition property, and why `parked` shares the Unplanned slice while being excluded from every active queue.

## Deviations and Decisions

- **The golden file was generated from the implementation, then read and checked by hand.** Hand-writing the expected Markdown before the renderer existed would have produced a test of my ability to predict my own table formatting, and the first run would have failed on whitespace rather than on anything meaningful. I saw the suite red on the missing module first, then verified the generated board by eye — the slice counts (2 + 2 + 3 + 1 = 8) match the fixture's eight focus issues. Flagging it because "golden file matches implementation" is only as strong as the review of that file, and this is me saying I did that review.
- **`in-progress` is in the Ready slice but not the ready queue.** The slice answers "is this planned and moving" — yes for both. The queue answers "what should the builder pick up" — no for something already being built. Same label, two questions.
- **The fixture is a small but realistic board**: eight focus issues spanning every slice, one in a later milestone, one with no milestone, a `parked` issue, and an untriaged one. #71 extends it rather than replacing it, so its diff shows only what that issue adds.
- **The pie has no percentages, only counts and a bar.** Percentages of eight issues invite over-reading — "62% done" is a claim the underlying data does not support when a single issue moves it by 12 points.

Closes #70

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_