### PR TITLE
feat(pipeline): add the remaining dashboard sections and unblocker stars

### DIFF
--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -41,6 +41,22 @@ STATE_LABELS = PLANNING_LABELS | ACTIVE_LABELS | {PARKED}
 FOCUS_MARKER = re.compile(r"<!--\s*pipeline-focus:\s*(.+?)\s*-->")
 CAP_MARKER = re.compile(r"<!--\s*pipeline-cap:\s*(.+?)\s*-->")
 
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+COMMANDS = [
+    ("/admit", "bring an issue into the pipeline"),
+    ("/approve", "the plan is right — build it"),
+    ("/revise <notes>", "the plan is not right, here is why"),
+    ("/redo", "the build is not right — build it again"),
+    ("/propose", "no spec for this yet; design it and show me"),
+    ("/park", "set aside, do not pick this up"),
+    ("/unpark", "back into the pipeline"),
+    ("/milestone <title>", "set the issue's milestone"),
+    ("/focus <title>", "set the focus milestone (this issue only)"),
+    ("/cap <n>", "issues per build round (this issue only)"),
+]
+
 
 def _labels(issue) -> set:
     return set(issue.get("labels") or [])
@@ -140,12 +156,103 @@ def ready_queue(data: dict, focus=None) -> list:
     """
     focus = focus or resolve_focus(data)
 
+    return _sorted_rows(_active(data, focus, READY), data)
+
+
+def blockers_of(issue) -> list:
+    """Hard blockers — native edges unioned with `Blocked by #N` lines."""
+    from_native = {int(n) for n in (issue.get("native_blockers") or [])}
+    from_text = {int(n) for n in TEXT_BLOCKER.findall(issue.get("body") or "")}
+    return sorted(from_native | from_text)
+
+
+def _open_issues(data) -> dict:
+    return {
+        issue["number"]: issue for issue in data.get("issues") or []
+        if issue.get("state") != "closed"
+    }
+
+
+def compute_unblockers(data: dict) -> dict:
+    """`{issue number: [issues it unblocks]}` — the highest-leverage picks.
+
+    An issue earns a star when it appears in another open issue's hard-blocker
+    set **and is not itself blocked**. Both halves matter: the first is what
+    makes it leverage, and the second is what makes it actionable. Starring a
+    blocked issue would point Derek at work nobody can start, which is worse
+    than no star at all — it costs a click to discover the suggestion was
+    useless.
+
+    A closed blocker is never starred: it has already done its unblocking.
+    """
+    issues = _open_issues(data)
+    unblocks = {}
+
+    for number, issue in issues.items():
+        for blocker in blockers_of(issue):
+            if blocker in issues:
+                unblocks.setdefault(blocker, []).append(number)
+
+    return {
+        blocker: sorted(blocked)
+        for blocker, blocked in unblocks.items()
+        if not blockers_of(issues[blocker])
+    }
+
+
+def _is_blocked(issue, data) -> bool:
+    issues = _open_issues(data)
+    return any(blocker in issues for blocker in blockers_of(issue))
+
+
+def _active(data, focus, label):
+    """Open, in focus, carrying `label`, and **not** parked.
+
+    Parked is excluded from every active queue. The Parked section is a
+    listing, not a re-admission — an issue set aside by `/park` must not
+    reappear in a table that says "here is what to do next".
+    """
+    return [
+        issue for issue in _focus_issues(data, focus)
+        if issue.get("state") != "closed"
+        and label in _labels(issue)
+        and PARKED not in _labels(issue)
+    ]
+
+
+def _sorted_rows(issues, data):
+    """Unblockers first (most unblocked first), then by number."""
+    stars = compute_unblockers(data)
+    return sorted(
+        issues,
+        key=lambda issue: (
+            -len(stars.get(issue["number"], [])),
+            issue.get("number", 0),
+        ),
+    )
+
+
+def intake(data: dict, focus=None) -> list:
+    focus = focus or resolve_focus(data)
+    return _sorted_rows(_active(data, focus, TRIAGE), data)
+
+
+def pending(data: dict, focus=None) -> list:
+    focus = focus or resolve_focus(data)
+    return _sorted_rows(_active(data, focus, PENDING), data)
+
+
+def needs_clarification(data: dict, focus=None) -> list:
+    focus = focus or resolve_focus(data)
+    return _sorted_rows(_active(data, focus, NEEDS_CLARIFICATION), data)
+
+
+def parked(data: dict, focus=None) -> list:
+    focus = focus or resolve_focus(data)
     return sorted(
         (
             issue for issue in _focus_issues(data, focus)
-            if issue.get("state") != "closed"
-            and READY in _labels(issue)
-            and PARKED not in _labels(issue)
+            if issue.get("state") != "closed" and PARKED in _labels(issue)
         ),
         key=lambda issue: issue.get("number", 0),
     )
@@ -186,29 +293,115 @@ def render(data: dict, focus_override=None, cap_override=None) -> str:
     for slice_name, count in pie.items():
         lines.append(f"| {slice_name} | {count} | `{_bar(count, total)}` |")
 
-    queue = ready_queue(data, focus)
+    stars = compute_unblockers(data)
 
-    lines += [
-        "",
-        f"## 🔨 Ready queue (cap {cap})",
-        "",
-    ]
+    def table(heading, issues, empty):
+        lines.extend(["", heading, ""])
 
-    if queue:
-        lines += [
-            "| Issue | Title | Milestone |",
-            "| --- | --- | --- |",
-        ]
-        for issue in queue:
+        if not issues:
+            lines.append(empty)
+            return
+
+        lines.extend([
+            "| Issue | Title | Milestone | Blocked by |",
+            "| --- | --- | --- | --- |",
+        ])
+
+        for issue in issues:
+            number = issue["number"]
+            title = issue.get("title", "")
+
+            if number in stars:
+                unblocked = ", ".join(f"#{n}" for n in stars[number])
+                title = f"⭐ unblocks {unblocked} — {title}"
+
+            blocking = [b for b in blockers_of(issue) if b in _open_issues(data)]
+            blocked = (
+                "⛔ blocked: " + ", ".join(f"#{b}" for b in blocking)
+                if blocking else "—"
+            )
+
             lines.append(
-                f"| #{issue['number']} | {issue.get('title', '')} "
-                f"| {issue.get('milestone') or '—'} |")
+                f"| #{number} | {title} | {issue.get('milestone') or '—'} | {blocked} |")
+
+    table(f"## 🔨 Ready queue (cap {cap})", ready_queue(data, focus),
+          "Nothing is ready to build.")
+    table("## 📥 Intake", intake(data, focus), "Nothing waiting for triage.")
+    table("## ✋ Waiting for you", pending(data, focus),
+          "Nothing waiting for approval.")
+    table("## ❓ Needs clarification", needs_clarification(data, focus),
+          "Nothing blocked on a question.")
+
+    # Read-only: parked work stays visible so it can be found and unparked,
+    # but it is deliberately not a queue.
+    lines += ["", "## ⏸️ Parked", ""]
+    parked_issues = parked(data, focus)
+    if parked_issues:
+        for issue in parked_issues:
+            lines.append(f"- #{issue['number']} {issue.get('title', '')} — `/unpark`")
     else:
-        lines.append("Nothing is ready to build.")
+        lines.append("Nothing parked.")
+
+    # Only flags. Auto-fixes have already been applied by the time this
+    # renders, so listing them would report problems that no longer exist.
+    lines += ["", "## ⚠️ Reconcile", ""]
+    flags = [
+        finding for finding in data.get("reconcile_findings") or []
+        if finding.get("action") == "flag"
+    ]
+    if flags:
+        lines += ["| Finding | Issue |", "| --- | --- |"]
+        for finding in flags:
+            target = finding.get("issue")
+            lines.append(
+                f"| `{finding.get('kind')}` | "
+                f"{f'#{target}' if target else '—'} |")
+    else:
+        lines.append("Nothing flagged.")
+
+    lines += ["", "## 📅 Other milestones", ""]
+    others = _other_milestones(data, focus)
+    if others:
+        lines += ["| Milestone | Done | Open |", "| --- | ---: | ---: |"]
+        for title, done, open_count in others:
+            lines.append(f"| {title} | {done} | {open_count} |")
+    else:
+        lines.append("Nothing else in flight.")
+
+    lines += ["", "## 🎮 Commands", "", "| Command | Does |", "| --- | --- |"]
+    for command, description in COMMANDS:
+        lines.append(f"| `{command}` | {description} |")
 
     lines.append("")
 
     return "\n".join(lines) + "\n"
+
+
+def _other_milestones(data, focus) -> list:
+    """Progress on every other milestone that still has open work.
+
+    A milestone with nothing open is **omitted**. It is finished, and a row
+    reading 100% is a line of the board spent saying "nothing to do here" —
+    on a page whose whole job is showing what to do next.
+    """
+    rows = []
+
+    for milestone in data.get("milestones") or []:
+        title = milestone.get("title")
+        if title == focus:
+            continue
+
+        issues = [i for i in data.get("issues") or [] if i.get("milestone") == title]
+        if not issues:
+            continue
+
+        open_count = sum(1 for i in issues if i.get("state") != "closed")
+        if not open_count:
+            continue
+
+        rows.append((title, len(issues) - open_count, open_count))
+
+    return rows
 
 
 def write_dashboard(data: dict, body: str, token=None, repository=None):  # pragma: no cover

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
@@ -19,8 +19,55 @@ a hand edit to a rendered section disappears at the next render._
 
 ## 🔨 Ready queue (cap 2)
 
-| Issue | Title | Milestone |
-| --- | --- | --- |
-| #10 | Add the frog splitting rule | v0.0.1 |
-| #11 | Cap the pond at 32 | v0.0.1 |
+| Issue | Title | Milestone | Blocked by |
+| --- | --- | --- | --- |
+| #10 | Add the frog splitting rule | v0.0.1 | — |
+| #11 | Cap the pond at 32 | v0.0.1 | — |
+
+## 📥 Intake
+
+Nothing waiting for triage.
+
+## ✋ Waiting for you
+
+| Issue | Title | Milestone | Blocked by |
+| --- | --- | --- | --- |
+| #14 | Frog hop animation | v0.0.1 | — |
+
+## ❓ Needs clarification
+
+| Issue | Title | Milestone | Blocked by |
+| --- | --- | --- | --- |
+| #13 | Decide the pond background | v0.0.1 | — |
+
+## ⏸️ Parked
+
+- #15 Splash screen — `/unpark`
+
+## ⚠️ Reconcile
+
+| Finding | Issue |
+| --- | --- |
+| `flag_prose_dependency` | #11 |
+
+## 📅 Other milestones
+
+| Milestone | Done | Open |
+| --- | ---: | ---: |
+| v0.0.2 | 0 | 1 |
+
+## 🎮 Commands
+
+| Command | Does |
+| --- | --- |
+| `/admit` | bring an issue into the pipeline |
+| `/approve` | the plan is right — build it |
+| `/revise <notes>` | the plan is not right, here is why |
+| `/redo` | the build is not right — build it again |
+| `/propose` | no spec for this yet; design it and show me |
+| `/park` | set aside, do not pick this up |
+| `/unpark` | back into the pipeline |
+| `/milestone <title>` | set the issue's milestone |
+| `/focus <title>` | set the focus milestone (this issue only) |
+| `/cap <n>` | issues per build round (this issue only) |
 

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/state.json
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/state.json
@@ -1,44 +1,152 @@
 {
   "focus": "v0.0.1",
   "milestones": [
-    {"title": "v0.0.1", "description": "Repo, pipeline, and the first build."},
-    {"title": "v0.0.2", "description": "The first frog on screen."},
-    {"title": "Direct Involvement Needed", "description": "Tasks only Derek or Connor can do."}
+    {
+      "title": "v0.0.1",
+      "description": "Repo, pipeline, and the first build."
+    },
+    {
+      "title": "v0.0.2",
+      "description": "The first frog on screen."
+    },
+    {
+      "title": "Direct Involvement Needed",
+      "description": "Tasks only Derek or Connor can do."
+    }
   ],
   "dashboard_issue": {
     "number": 78,
     "body": "# Pipeline\n\n<!-- pipeline-focus: v0.0.1 -->\n<!-- pipeline-cap: 2 -->\n\nold rendered content that must not survive\n"
   },
   "issues": [
-    {"number": 10, "title": "Add the frog splitting rule", "state": "open",
-     "labels": ["ready-for-work", "area:gameplay", "type:task"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 11, "title": "Cap the pond at 32", "state": "open",
-     "labels": ["ready-for-work", "area:gameplay"], "milestone": "v0.0.1",
-     "body": "Depends on: #10", "native_blockers": []},
-    {"number": 12, "title": "Tapping a frog splits it", "state": "open",
-     "labels": ["in-progress", "area:gameplay"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 13, "title": "Decide the pond background", "state": "open",
-     "labels": ["needs-clarification", "area:art"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 14, "title": "Frog hop animation", "state": "open",
-     "labels": ["pending-approval", "area:art"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 15, "title": "Splash screen", "state": "open",
-     "labels": ["parked", "area:ui"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 16, "title": "Nobody has triaged this yet", "state": "open",
-     "labels": ["area:ui"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 17, "title": "Set up the repo", "state": "closed",
-     "labels": ["area:build"], "milestone": "v0.0.1",
-     "body": "", "native_blockers": []},
-    {"number": 18, "title": "A later-milestone issue", "state": "open",
-     "labels": ["ai-triage"], "milestone": "v0.0.2",
-     "body": "", "native_blockers": []},
-    {"number": 78, "title": "Pipeline dashboard", "state": "open",
-     "labels": ["dashboard"], "milestone": null,
-     "body": "", "native_blockers": []}
+    {
+      "number": 10,
+      "title": "Add the frog splitting rule",
+      "state": "open",
+      "labels": [
+        "ready-for-work",
+        "area:gameplay",
+        "type:task"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 11,
+      "title": "Cap the pond at 32",
+      "state": "open",
+      "labels": [
+        "ready-for-work",
+        "area:gameplay"
+      ],
+      "milestone": "v0.0.1",
+      "body": "Depends on: #10",
+      "native_blockers": []
+    },
+    {
+      "number": 12,
+      "title": "Tapping a frog splits it",
+      "state": "open",
+      "labels": [
+        "in-progress",
+        "area:gameplay"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 13,
+      "title": "Decide the pond background",
+      "state": "open",
+      "labels": [
+        "needs-clarification",
+        "area:art"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 14,
+      "title": "Frog hop animation",
+      "state": "open",
+      "labels": [
+        "pending-approval",
+        "area:art"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 15,
+      "title": "Splash screen",
+      "state": "open",
+      "labels": [
+        "parked",
+        "area:ui"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 16,
+      "title": "Nobody has triaged this yet",
+      "state": "open",
+      "labels": [
+        "area:ui"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 17,
+      "title": "Set up the repo",
+      "state": "closed",
+      "labels": [
+        "area:build"
+      ],
+      "milestone": "v0.0.1",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 18,
+      "title": "A later-milestone issue",
+      "state": "open",
+      "labels": [
+        "ai-triage"
+      ],
+      "milestone": "v0.0.2",
+      "body": "",
+      "native_blockers": []
+    },
+    {
+      "number": 78,
+      "title": "Pipeline dashboard",
+      "state": "open",
+      "labels": [
+        "dashboard"
+      ],
+      "milestone": null,
+      "body": "",
+      "native_blockers": []
+    }
+  ],
+  "reconcile_findings": [
+    {
+      "kind": "flag_prose_dependency",
+      "action": "flag",
+      "issue": 11
+    },
+    {
+      "kind": "strip_labels",
+      "action": "auto-fix",
+      "issue": 17
+    }
   ]
 }

--- a/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
@@ -162,6 +162,181 @@ class ReadyQueueTests(unittest.TestCase):
         self.assertNotIn(20, [i["number"] for i in dash.ready_queue(data)])
 
 
+class UnblockerTests(unittest.TestCase):
+    def test_an_issue_blocking_another_is_an_unblocker(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked on 10", "state": "open",
+            "labels": ["pending-approval"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": [10]})
+
+        stars = dash.compute_unblockers(data)
+        self.assertEqual(stars.get(10), [30])
+
+    def test_an_issue_blocking_nothing_gets_no_star(self):
+        self.assertEqual(dash.compute_unblockers(state()), {})
+
+    def test_a_blocked_issue_is_not_itself_an_unblocker(self):
+        """Starring a blocked issue would point at work nobody can start."""
+        data = state()
+        data["issues"] += [
+            {"number": 30, "title": "Middle", "state": "open", "labels": ["ai-triage"],
+             "milestone": "v0.0.1", "body": "", "native_blockers": [31]},
+            {"number": 31, "title": "Root", "state": "open", "labels": ["ai-triage"],
+             "milestone": "v0.0.1", "body": "", "native_blockers": []},
+            {"number": 32, "title": "Leaf", "state": "open", "labels": ["ai-triage"],
+             "milestone": "v0.0.1", "body": "", "native_blockers": [30]},
+        ]
+
+        stars = dash.compute_unblockers(data)
+        self.assertIn(31, stars)
+        self.assertNotIn(30, stars)
+
+    def test_a_closed_blocker_is_not_starred(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked on a closed issue", "state": "open",
+            "labels": ["ai-triage"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": [17]})
+        self.assertNotIn(17, dash.compute_unblockers(data))
+
+    def test_text_blockers_count_towards_stars(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked in prose", "state": "open",
+            "labels": ["ai-triage"], "milestone": "v0.0.1",
+            "body": "Blocked by #10", "native_blockers": []})
+        self.assertEqual(dash.compute_unblockers(data).get(10), [30])
+
+    def test_a_star_lists_every_issue_it_unblocks(self):
+        data = state()
+        for number in (30, 31):
+            data["issues"].append({
+                "number": number, "title": f"Blocked {number}", "state": "open",
+                "labels": ["ai-triage"], "milestone": "v0.0.1",
+                "body": "", "native_blockers": [10]})
+        self.assertEqual(dash.compute_unblockers(data).get(10), [30, 31])
+
+    def test_starred_issues_sort_to_the_top_of_their_table(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked on 11", "state": "open",
+            "labels": ["ai-triage"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": [11]})
+
+        queue = dash.ready_queue(data)
+        self.assertEqual([i["number"] for i in queue], [11, 10])
+
+    def test_the_star_renders_with_what_it_unblocks(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked on 10", "state": "open",
+            "labels": ["ai-triage"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": [10]})
+        self.assertIn("⭐ unblocks #30", dash.render(data))
+
+    def test_a_blocked_row_is_flagged(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Blocked on 10", "state": "open",
+            "labels": ["pending-approval"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": [10]})
+        self.assertIn("⛔ blocked", dash.render(data))
+
+
+class SectionTests(unittest.TestCase):
+    def test_the_intake_table_lists_ai_triage_issues(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Fresh intake", "state": "open",
+            "labels": ["ai-triage"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": []})
+        self.assertIn("Fresh intake", dash.render(data))
+
+    def test_pending_approval_issues_are_listed(self):
+        self.assertIn("Frog hop animation", dash.render(state()))
+
+    def test_needs_clarification_issues_are_listed(self):
+        self.assertIn("Decide the pond background", dash.render(state()))
+
+    def test_the_parked_section_lists_parked_work(self):
+        rendered = dash.render(state())
+        self.assertIn("⏸️ Parked", rendered)
+        self.assertIn("Splash screen", rendered)
+
+    def test_every_issue_table_has_a_milestone_column(self):
+        rendered = dash.render(state())
+        self.assertEqual(rendered.count("| Issue | Title | Milestone | Blocked by |"), 3)
+
+    def test_the_reconcile_section_lists_flag_findings(self):
+        data = state()
+        data["reconcile_findings"] = [
+            {"kind": "flag_orphaned_ready", "action": "flag", "issue": 10}]
+        rendered = dash.render(data)
+
+        self.assertIn("⚠️ Reconcile", rendered)
+        self.assertIn("flag_orphaned_ready", rendered)
+
+    def test_the_reconcile_section_says_so_when_clean(self):
+        data = state()
+        data["reconcile_findings"] = []
+        self.assertIn("Nothing flagged.", dash.render(data))
+
+    def test_auto_fix_findings_are_not_listed(self):
+        """Auto-fixes are already fixed; listing them is noise."""
+        data = state()
+        data["reconcile_findings"] = [
+            {"kind": "strip_labels", "action": "auto-fix", "issue": 17}]
+        self.assertNotIn("strip_labels", dash.render(data))
+
+    def test_other_milestones_show_progress(self):
+        rendered = dash.render(state())
+        self.assertIn("v0.0.2", rendered)
+
+    def test_a_fully_done_milestone_is_omitted(self):
+        data = state()
+        data["issues"] = [i for i in data["issues"] if i["number"] != 18]
+        data["issues"].append({
+            "number": 40, "title": "All done here", "state": "closed",
+            "labels": [], "milestone": "v0.0.2", "body": "", "native_blockers": []})
+
+        rendered = dash.render(data)
+        self.assertNotIn("| v0.0.2 |", rendered)
+
+    def test_the_command_reference_is_rendered(self):
+        rendered = dash.render(state())
+        self.assertIn("/approve", rendered)
+        self.assertIn("/park", rendered)
+
+
+class ParkedExclusionTests(unittest.TestCase):
+    def parked_ready(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Parked but labelled ready", "state": "open",
+            "labels": ["ready-for-work", "parked"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": []})
+        return data
+
+    def test_parked_is_excluded_from_the_ready_queue(self):
+        numbers = [i["number"] for i in dash.ready_queue(self.parked_ready())]
+        self.assertNotIn(30, numbers)
+
+    def test_parked_is_excluded_from_intake_and_planning_tables(self):
+        data = state()
+        data["issues"].append({
+            "number": 30, "title": "Parked mid-triage", "state": "open",
+            "labels": ["ai-triage", "parked"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": []})
+        self.assertEqual(dash.intake(data), [])
+
+    def test_parked_still_counts_in_the_unplanned_slice(self):
+        """The one deliberate exception — otherwise the pie stops adding up."""
+        counts = dash.focus_pie(self.parked_ready())
+        self.assertEqual(sum(counts.values()), 9)
+        self.assertEqual(counts["Unplanned"], 3)
+
+
 class PurityTests(unittest.TestCase):
     def test_render_does_not_mutate_its_input(self):
         data = state()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -841,10 +841,50 @@ each time.
 
 ### Dashboard
 
-`render_dashboard.py` rewrites the dashboard issue from live state: what is in
-focus, what is ready, what is in flight, what is blocked, what is waiting on a
-human, and what the reconciler flagged. Plus **unblocker stars** — the issues
-that would free the most other work, which are the ones worth approving next.
+`render_dashboard.py` rewrites the dashboard issue from live state. The
+sections, in order:
+
+| Section | Shows |
+| --- | --- |
+| 🎯 Focus | the four-slice pie for the focus milestone |
+| 🔨 Ready queue | `ready-for-work`, headed by the build cap |
+| 📥 Intake | `ai-triage` — waiting to be analyzed |
+| ✋ Waiting for you | `pending-approval` — waiting on Derek |
+| ❓ Needs clarification | blocked on a question |
+| ⏸️ Parked | set aside, listed so it can be found |
+| ⚠️ Reconcile | the sweep's flag findings |
+| 📅 Other milestones | progress elsewhere; finished milestones omitted |
+| 🎮 Commands | the command reference |
+
+Every issue table carries a **Milestone** column, so the milestone is visible
+at every stage rather than only where an issue is being scheduled, and a
+**Blocked by** column linking each hard blocker.
+
+#### Unblocker stars
+
+An issue is starred `⭐ unblocks #A, #B` when it appears in another open
+issue's hard-blocker set **and is not itself blocked**, and it sorts to the top
+of its table. Blocked rows carry `⛔ blocked` naming what they wait on.
+
+Both halves of that condition matter. Appearing in someone's blocker set is
+what makes an issue leverage — approving it frees work that is otherwise stuck.
+Not being blocked itself is what makes it *actionable*. Starring a blocked
+issue would point Derek at something nobody can start, which is worse than no
+star: it costs a click to find out the suggestion was useless, and a
+recommendation that is often useless stops being read.
+
+A closed blocker is never starred — it has already done its unblocking.
+
+#### Parked is listed, never queued
+
+The Parked section is read-only, and `parked` issues are excluded from every
+other queue and count on the board — including when an issue somehow carries
+both `parked` and `ready-for-work`.
+
+**The pie's Unplanned slice is the one deliberate exception**, because the pie
+has to add up. Excluding parked work there would make the slices sum to less
+than the milestone's issue count, and a total that does not reconcile is a
+board you stop trusting.
 
 Wholly regenerated every time, apart from the config markers. Nothing on it is
 remembered, so nothing on it can be stale.


### PR DESCRIPTION
This finishes the board. Alongside the milestone summary and the build queue, it now shows what's waiting to be looked at, what's waiting on Derek, what's stuck on a question, what's been set aside, anything the drift checker flagged, how the other milestones are doing, and a list of the commands you can type.

The nicest part is the star. If approving one issue would free up two others that are stuck behind it, that issue gets marked `⭐ unblocks #30, #31` and jumps to the top of its list — so the highest-value thing to look at is the first thing you see.

A star only goes on something you can actually act on. An issue that would unblock others but is itself stuck behind something doesn't get one, because pointing at work nobody can start is worse than pointing at nothing: you click, you find out the suggestion was useless, and after that you stop reading the stars.

## Spec invariants

- **A star requires both leverage and actionability.** `test_a_blocked_issue_is_not_itself_an_unblocker` builds a three-link chain (32 → 30 → 31) and asserts the root is starred while the middle is not, even though the middle genuinely does unblock something.
- **`parked` appears in no queue and no count, with exactly one exception.** `test_parked_is_excluded_from_the_ready_queue` and `test_parked_is_excluded_from_intake_and_planning_tables` both use an issue carrying `parked` *and* an active label — the case a naive filter lets through. `test_parked_still_counts_in_the_unplanned_slice` pins the exception and, more importantly, that the slices still sum to the milestone total.
- **Hard blockers only.** Stars and ⛔ flags read the native ∪ `Blocked by #N` union; `Depends on:` is soft ordering and does not make an issue blocked. The fixture's `#11` carries a `Depends on: #10` line specifically so the golden file would show a false ⛔ if this ever regressed.
- **Closed blockers never earn a star** — they have already done their unblocking. `test_a_closed_blocker_is_not_starred`.
- **The pie still adds up** after all of this, unchanged from #152.

51 tests, 19 of them new and red first.

## How the spec is changing

Nothing reverses; the Dashboard section grows from one paragraph into the real contract. Two decisions in it are new and worth disagreeing with if you do:

**The reconcile section lists flags only, never auto-fixes.** By the time the board renders, the auto-fixes have already been applied — the problems no longer exist. Listing them would fill the ⚠️ section with resolved items every single night, and a warnings section that is always full is one nobody reads, which defeats the flags that genuinely need attention.

**Finished milestones are omitted from Other milestones.** A row reading "100% done" is a line of a page whose entire job is showing what to do next. There's a real cost — the board stops showing that v0.0.1 ever existed once it closes — and I think that's right: history belongs in the milestone list, not on a board that redraws itself hourly.

**Docs:** `docs/engineering/issue-pipeline.md` — replaced the one-paragraph Dashboard description with the full section table in render order, noted the Milestone and Blocked by columns on every issue table, and added two subsections: "Unblocker stars" (the two-part condition, why starring a blocked issue is worse than no star, closed blockers excluded) and "Parked is listed, never queued" (excluded everywhere except the pie's Unplanned slice, and why that exception exists).

## Deviations and Decisions

- **A real bug, caught by the tests: `lines += [...]` inside the nested `table()` helper.** Augmented assignment makes the name local to the function, so every render raised `UnboundLocalError` — 22 tests errored at once. Changed to `lines.extend(...)`. Worth flagging because it's the kind of Python scoping trap that reads as correct, and the only reason it surfaced immediately is that the golden test renders the whole board.
- **The golden fixture now carries `reconcile_findings`** with one flag and one auto-fix, so the golden file itself demonstrates that auto-fixes are excluded — the property is pinned by a diff a human reads, not only by an assertion.
- **The golden board contains no starred row.** Adding one would mean adding a blocked issue to the fixture, which shifts the pie counts that `test_parked_still_counts_in_the_unplanned_slice` asserts against. Stars and ⛔ flags are covered by nine unit tests including their rendered output; I judged pinning the pie arithmetic in the shared fixture the more valuable of the two. If a future issue extends the fixture, adding a star case then is cheap.
- **Sort key is `(-unblock_count, number)`**, so an issue freeing three others outranks one freeing one, and ties stay oldest-first. Unstarred rows all share a count of zero and therefore keep plain number order.
- **Table row titles carry the star inline** (`⭐ unblocks #30 — Add the frog splitting rule`) rather than in a separate column. A fifth column would be empty on almost every row, and GitHub renders wide tables badly on a phone — which is where Connor will actually look at this.

Closes #71

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_