### PR TITLE
docs(pipeline): add the pipeline-dashboard SKILL.md

### DIFF
--- a/.claude/skills/pipeline-dashboard/SKILL.md
+++ b/.claude/skills/pipeline-dashboard/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pipeline-dashboard
+description: Render the pipeline dashboard issue from live repo state. Use to preview the board, to refresh it by hand, or when the dashboard looks out of date.
+---
+
+# pipeline-dashboard
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+
+# Preview — prints the board, writes nothing anywhere.
+python3 .claude/skills/pipeline-dashboard/render_dashboard.py < state.json
+
+# Refresh for real — PATCHes the dashboard issue body.
+python3 .claude/skills/pipeline-dashboard/render_dashboard.py --write < state.json
+```
+
+## In production this is a workflow, not an agent
+
+The dashboard is rendered by `dashboard.yml` — hourly, and after each pipeline
+run. **There is no model in the loop and nothing about the body is generated
+prose.** Every line comes out of `render()`, which is a pure function of the
+state you hand it.
+
+That matters because the board is what Derek reads to decide what to approve
+next. A summary written by a model is a summary that can be subtly, fluently
+wrong — and wrong in a way that reads perfectly. A table computed from labels
+either matches GitHub or has a bug someone can find.
+
+This skill exists for the times you want to look at the board without waiting
+for the hour, or check what a render *would* produce before letting it run.
+
+## Preview writes nothing
+
+Without `--write`, the script prints to stdout and touches nothing. That is the
+default deliberately: previewing is the common case, and the safe thing should
+not need a flag.
+
+Use it to check a `/focus` change before it lands, or to see whether a rendering
+bug is in the data or the renderer.
+
+## `--write` and what it can touch
+
+`--write` PATCHes **one endpoint**: `/repos/:owner/:repo/issues/:number` for the
+dashboard issue, with a body and nothing else.
+
+- Authenticates with **`GITHUB_TOKEN`**, never a PAT. The workflow token is
+  scoped to this repository and expires with the job.
+- The issue number comes from the state passed in, so a render cannot wander
+  onto a different issue.
+- No labels, no comments, no milestones, no other issues.
+
+That is the whole write surface. The renderer reads the entire board and can
+modify exactly one body — which is what makes it safe to run hourly without
+anybody watching it.
+
+## Read-only everywhere else
+
+The render **mutates nothing but the dashboard issue body.**
+
+It reports on issues all over the repository — starred, blocked, parked,
+flagged — and changes none of them. A star is a suggestion, not a state change.
+A `⛔ blocked` flag is a description, not a label.
+
+This is why an incorrect render is cheap: it produces a wrong page, which the
+next render replaces. If the renderer also applied labels, a bug in the star
+logic would be a bug that reorganises the board.
+
+## Everything is regenerated
+
+The whole body is rewritten every time, apart from the two config markers,
+which are parsed out of the current body and written back verbatim:
+
+```html
+<!-- pipeline-focus: v0.0.1 -->
+<!-- pipeline-cap: 3 -->
+```
+
+**So edit the markers, never the rendered sections.** A hand edit to a table
+disappears at the next render — and looks like it worked until it does.
+
+Rendering is **byte-stable**: the same state produces the same bytes. Without
+that, every hourly run would PATCH the issue and the dashboard's history would
+be a stream of meaningless edits.
+
+Settings resolve **override → marker → default**. A `/focus` naming no live
+milestone is rejected rather than stored, because a typo renders a board whose
+every section is empty — indistinguishable from a finished milestone, and the
+most misleading output this script can produce. A malformed `cap` marker falls
+back to 3, because a board that does not render is worse than one with a
+default cap.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py pipeline-dashboard
+```
+
+51 tests. The centrepiece is a golden-snapshot test rendering a fixture board
+and comparing byte-for-byte against a committed file. A dashboard is a wall of
+generated Markdown, and a whole-board diff is the only review that catches a
+section quietly changing shape.
+
+**If the golden test fails and the change was intended**, regenerate the
+expected file and *read the diff* before committing it. The golden file is only
+as strong as the review it gets.
+
+## See also
+
+- `pipeline-reconcile` — produces the ⚠️ flags this renders
+- `docs/engineering/issue-pipeline.md` — the sections, the pie, the markers

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -893,6 +893,28 @@ Rendering is **deterministic and byte-stable**: the same state produces the
 same bytes. Without that, every hourly run would PATCH the issue and the
 dashboard would generate a stream of meaningless edits.
 
+#### No model renders the board
+
+Production rendering is `dashboard.yml` running `render_dashboard.py`. Nothing
+about the body is generated prose — every line comes out of a pure function of
+the state.
+
+The board is what Derek reads to decide what to approve next. A model-written
+summary can be subtly, fluently wrong in a way that reads perfectly; a table
+computed from labels either matches GitHub or has a bug someone can find.
+
+#### The render's write surface is one issue body
+
+The renderer reads the whole board and can modify **exactly one thing**: the
+dashboard issue's body, via a single `PATCH`, authenticated with `GITHUB_TOKEN`
+rather than a PAT. No labels, no comments, no milestones, no other issues. Run
+without `--write` it does not write at all — previewing is the default, because
+it is the common case and the safe option should not need a flag.
+
+That narrow surface is what makes an incorrect render cheap. A wrong board is
+replaced by the next render; if the renderer also applied labels, a bug in the
+star logic would be a bug that reorganises the pipeline.
+
 #### The focus pie always adds up
 
 The focus milestone is summarised as four slices:


### PR DESCRIPTION
The written-down version of the dashboard renderer: how to look at the board without changing it, how the real refresh works, and what it's allowed to touch.

The main thing it says is that nothing on the board is written by a model. Every line is computed from what GitHub actually reports. That's on purpose — the board is what Derek reads to decide what to approve next, and a summary written by an AI can be confidently, readably wrong. A table computed from labels either matches reality or has a bug someone can go and find.

The other thing worth knowing: the renderer reads the entire repository and is able to change exactly one thing — the text of the dashboard issue itself. Not a label, not a comment, nothing else.

## Spec invariants

- **No model in the render path.** The body is a pure function of state; `render()` performs no I/O at all.
- **Preview is the default.** Writing requires `--write`; the safe option needs no flag, because previewing is the common case and a default that mutates is a default people learn to fear.
- **One endpoint, `GITHUB_TOKEN` only.** A single `PATCH` to the dashboard issue, with the issue number coming from the passed-in state so a render cannot wander onto a different issue. No PAT.
- **Read-only everywhere else.** A star is a suggestion, not a state change; a `⛔ blocked` flag is a description, not a label.
- **Markers are the only surviving content**, and settings resolve override → marker → default.

## How the spec is changing

Two properties existed in the code but had never been argued for in the docs, and both are the kind of thing a future change would erode without noticing:

**Why no model renders the board.** Now stated with its reason rather than as a fact about the implementation. Someone will eventually want a friendly one-line summary at the top of the board, and the argument against it needs to be written down before that conversation, not during it — a generated sentence can be fluently wrong in a way a computed table cannot.

**Why the write surface is one issue body.** This is what makes an incorrect render *cheap*: a wrong page is replaced by the next render an hour later. If the renderer also applied labels — an easy and tempting extension, since it already computes who is blocked by whom — then a bug in the star logic would stop being a cosmetic problem and start reorganising the pipeline.

**Docs:** `docs/engineering/issue-pipeline.md` — added "No model renders the board" (production rendering is the workflow, and why a computed table beats a generated summary for something Derek makes decisions from) and "The render's write surface is one issue body" (the single `PATCH`, `GITHUB_TOKEN` not a PAT, preview-by-default, and why the narrow surface is what makes a bad render cheap).

## Deviations and Decisions

- **No failing test first.** `SKILL.md`; `render_dashboard.py` landed across #152 and #153 with 51 tests, red first in both. Same precedent as #144, #145, #149, #151.
- **Added a note the issue didn't ask for: how to handle a failing golden test.** Regenerate, then *read the diff* before committing. A golden file is only as strong as the review it gets, and the natural response to a red golden test is to regenerate it until it passes — which converts the strongest test in the suite into a rubber stamp. This is the page someone will have open when that happens.
- **Documented `--write`'s write surface as an explicit list of what it cannot touch**, not just what it does. "PATCHes the dashboard body" describes today's behaviour; "no labels, no comments, no milestones, no other issues" is a boundary someone has to consciously cross.

Closes #72

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_