### PR TITLE
feat(pipeline): add the gatekeeper I/O glue

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/_github_api.py
+++ b/.claude/skills/pipeline-gatekeeper/_github_api.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""REST helpers for the gatekeeper, and the shared dashboard re-render.
+
+Thin on purpose. Everything with a decision in it lives in the pure modules —
+`parse_commands`, `gates`, `apply_actions`, `check_revisits` — which are
+testable without a network. This file is the part that cannot be, so the less
+of it there is, the better.
+
+**`GITHUB_TOKEN` only, never a PAT.** The workflow token is scoped to this
+repository and expires with the job. A personal access token would carry
+whatever the person who made it can do, into a job nobody is watching.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+API_ROOT = "https://api.github.com"
+
+_DASHBOARD_SKILL = Path(__file__).resolve().parents[1] / "pipeline-dashboard"
+if str(_DASHBOARD_SKILL) not in sys.path:
+    sys.path.insert(0, str(_DASHBOARD_SKILL))
+
+
+def github_api(token=None, repository=None):
+    """A callable `api(method, path, body=None)` bound to this repository.
+
+    Returned as a closure so every pure module can take `api` as an argument
+    and be tested with a fake.
+    """
+    token = token or os.environ["GITHUB_TOKEN"]
+    repository = repository or os.environ["GITHUB_REPOSITORY"]
+
+    def api(method: str, path: str, body=None):
+        url = f"{API_ROOT}/repos/{repository}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+
+        request = urllib.request.Request(url, data=data, method=method)
+        request.add_header("Authorization", f"Bearer {token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        if data:
+            request.add_header("Content-Type", "application/json")
+
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read().decode() or "null"
+            return json.loads(raw)
+
+    return api
+
+
+def set_labels(api, issue_number: int, labels) -> None:
+    api("PUT", f"/issues/{issue_number}/labels", {"labels": sorted(set(labels))})
+
+
+def set_milestone(api, issue_number: int, milestone_number) -> None:
+    api("PATCH", f"/issues/{issue_number}", {"milestone": milestone_number})
+
+
+def comment(api, issue_number: int, body: str) -> None:
+    api("POST", f"/issues/{issue_number}/comments", {"body": body})
+
+
+def watermark(api, comment_id: int) -> None:
+    """Leave the 👀 so this comment is never reconsidered."""
+    api("POST", f"/issues/comments/{comment_id}/reactions", {"content": "eyes"})
+
+
+def rerender_dashboard(api, focus_override=None, cap_override=None) -> None:
+    """Re-render the dashboard, optionally with a new focus or cap.
+
+    **This is how `/focus` and `/cap` persist.** The markers live in the
+    dashboard body, and the body is regenerated wholesale on every render — so
+    the only way to change a marker and have it survive is to render with the
+    override. Hand-editing the body would work exactly once, until the next
+    render overwrote it.
+
+    Called **once**, after all label writes. Rendering between them would
+    produce a board describing a half-applied command.
+    """
+    import render_dashboard  # noqa: PLC0415 - path is set up above
+
+    state = _fetch_state(api)
+    body = render_dashboard.render(
+        state, focus_override=focus_override, cap_override=cap_override)
+
+    api("PATCH", f"/issues/{state['dashboard_issue']['number']}", {"body": body})
+
+
+def _fetch_state(api) -> dict:  # pragma: no cover - network shape
+    """Everything the renderer needs, in the shape it expects."""
+    raw_issues = api("GET", "/issues?state=all&per_page=100") or []
+    milestones = api("GET", "/milestones?state=open&per_page=100") or []
+
+    issues = [
+        {
+            "number": issue["number"],
+            "title": issue.get("title", ""),
+            "state": issue.get("state", "open"),
+            "labels": [label["name"] for label in issue.get("labels") or []],
+            "milestone": (issue.get("milestone") or {}).get("title"),
+            "body": issue.get("body") or "",
+            "native_blockers": [],
+        }
+        for issue in raw_issues
+        if "pull_request" not in issue
+    ]
+
+    dashboard = next(
+        (i for i in issues if "dashboard" in i["labels"] and i["state"] == "open"), None)
+
+    return {
+        "issues": issues,
+        "milestones": [{"title": m["title"], "description": m.get("description", "")}
+                       for m in milestones],
+        "dashboard_issue": {
+            "number": dashboard["number"] if dashboard else None,
+            "body": _issue_body(api, dashboard["number"]) if dashboard else "",
+        },
+        "reconcile_findings": [],
+    }
+
+
+def _issue_body(api, number) -> str:  # pragma: no cover - network shape
+    return (api("GET", f"/issues/{number}") or {}).get("body") or ""

--- a/.claude/skills/pipeline-gatekeeper/run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/run_comment_event.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Handle one `issue_comment` event, end to end.
+
+Snapshot → parse → gate → apply → write → re-render. The interesting parts are
+all somewhere else; this file's job is to call them in the right order and to
+write the results down.
+
+The order is the part that can be wrong, so it is the part with tests.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import apply_actions  # noqa: E402
+import fetch_comment_event  # noqa: E402
+import gates  # noqa: E402
+import parse_commands  # noqa: E402
+from _github_api import (  # noqa: E402
+    comment as post_comment,
+    github_api,
+    rerender_dashboard,
+    set_labels,
+    watermark,
+)
+
+
+class Result:
+    def __init__(self, applied: bool, detail: str = "") -> None:
+        self.applied = applied
+        self.detail = detail
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"Result(applied={self.applied!r}, {self.detail!r})"
+
+
+def run(event: dict, api, owner: str, rerender=None) -> Result:
+    """One comment, one pass. Never raises on an ordinary refusal."""
+    snapshot = fetch_comment_event.build(event, api, owner)
+
+    if snapshot is None:
+        return Result(False, "not an issue comment worth acting on")
+
+    issue = snapshot["issue"]
+    comment = snapshot["comment"]
+
+    if comment["watermarked"]:
+        # Already handled. Re-applying a command is worse than skipping one.
+        return Result(False, "already applied")
+
+    # Defense in depth. The workflow filters on the author too, but a script
+    # that only works because its caller filtered is one bad `if` away from
+    # letting a stranger drive the pipeline.
+    if (comment["author"] or "").lower() != (owner or "").lower():
+        return Result(False, "not the owner")
+
+    context = parse_commands.Context(
+        owner=owner, labels=issue["labels"], is_dashboard=issue["is_dashboard"])
+    outcome = parse_commands.parse(comment, context)
+
+    actions, skips = _apply_gates(outcome, issue)
+
+    if not actions and not skips:
+        return Result(False, "no commands")
+
+    plan = apply_actions.plan(issue["labels"], actions)
+    changed_labels = sorted(set(plan.labels)) != sorted(set(issue["labels"]))
+
+    if changed_labels:
+        set_labels(api, issue["number"], plan.labels)
+
+    acknowledgement = apply_actions.acknowledgement(actions, skips)
+    if acknowledgement:
+        post_comment(api, issue["number"], acknowledgement)
+
+    if apply_actions.should_watermark(actions, skips):
+        watermark(api, comment["id"])
+
+    # Once, after every label write. Rendering in between would publish a board
+    # describing a half-applied command.
+    if changed_labels or plan.focus or plan.cap is not None:
+        rerender = rerender or (lambda **kwargs: rerender_dashboard(api, **kwargs))
+        rerender(focus_override=plan.focus, cap_override=plan.cap)
+
+    return Result(bool(actions), acknowledgement)
+
+
+def _apply_gates(outcome, issue):
+    """Run each action's gates; a refusal becomes a Skip, never a silent pass."""
+    actions = []
+    skips = list(outcome.skips)
+
+    for action in outcome.actions:
+        verdict = _check(action, issue)
+        if verdict is None:
+            actions.append(action)
+        else:
+            skips.append(parse_commands.Skip(
+                verdict.reason, verdict.detail, action.command))
+
+    return actions, skips
+
+
+# `gates.GATES` names gates in the vocabulary of the docs; these are the
+# functions that implement them. Mapped explicitly rather than derived from the
+# name, so renaming a function cannot silently skip a gate — a missing key here
+# raises, where a clever `getattr` would quietly find nothing to run.
+GATE_FUNCTIONS = {
+    "milestone-presence": gates.milestone_present,
+    "milestone-order": gates.milestone_order_ok,
+}
+
+
+def _check(action, issue):
+    for gate in gates.gates_for(action.command):
+        verdict = GATE_FUNCTIONS[gate](issue)
+        if not verdict.ok:
+            return verdict
+    return None
+
+
+def main(argv=None) -> int:  # pragma: no cover - the workflow entry point
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    event = json.loads(Path(event_path).read_text()) if event_path else json.load(sys.stdin)
+
+    result = run(event, github_api(), owner=os.environ["PIPELINE_OWNER"])
+    print(result.detail or "nothing to do")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-gatekeeper/run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/run_sweep.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""The board-wide sweep: catch missed comments, wake cleared blockers, reconcile.
+
+Runs every 15 minutes from the sweep workflow, and nightly from the reconcile
+Routine. The difference between those two is one flag, and it matters:
+
+    run_sweep.py                  # cron — everything
+    run_sweep.py --events-only    # the 15-minute pass
+
+**`--events-only` omits reconcile's two requeue fixes**, because the drift they
+detect is indistinguishable from work in flight. An issue the builder picked up
+ten seconds ago has `in-progress` and no PR — exactly a stall's shape — and
+requeuing it would yank the work out from under a running agent.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+_RECONCILE_SKILL = Path(__file__).resolve().parents[1] / "pipeline-reconcile"
+if str(_RECONCILE_SKILL) not in sys.path:
+    sys.path.insert(0, str(_RECONCILE_SKILL))
+
+import check_revisits  # noqa: E402
+import reconcile  # noqa: E402
+from _github_api import (  # noqa: E402
+    comment as post_comment,
+    github_api,
+    rerender_dashboard,
+    set_labels,
+)
+
+
+def apply_revisits(api, issues, snapshot) -> list:
+    """Wake issues whose blockers have all cleared.
+
+    A state-derived transition, not a command — nothing else would ever wake an
+    issue set aside only because it was blocked.
+    """
+    woken = []
+
+    for revisit in check_revisits.find_revisits(issues, snapshot):
+        issue = next(i for i in issues if i["number"] == revisit.issue_number)
+        labels = [
+            label for label in issue.get("labels") or []
+            if label not in revisit.remove_labels
+        ] + revisit.add_labels
+
+        set_labels(api, revisit.issue_number, labels)
+        post_comment(api, revisit.issue_number, revisit.comment)
+        woken.append(revisit.issue_number)
+
+    return woken
+
+
+def apply_fixes(api, findings, issues) -> list:
+    """Apply the auto-fix findings. Flags are left for the dashboard."""
+    fixed = []
+
+    for finding in findings:
+        if finding.get("action") != "auto-fix":
+            continue
+
+        number = finding["issue"]
+        issue = next((i for i in issues if i["number"] == number), None)
+        if issue is None:
+            continue
+
+        labels = set(issue.get("labels") or [])
+        labels -= set(finding.get("remove_labels") or [])
+        labels |= set(finding.get("add_labels") or [])
+
+        set_labels(api, number, sorted(labels))
+        fixed.append(number)
+
+    return fixed
+
+
+def run(state: dict, api, events_only: bool = False, rerender=None) -> dict:
+    """One sweep. Returns what it did, for the workflow log."""
+    issues = state.get("issues") or []
+    snapshot = state.get("snapshot") or {}
+
+    woken = apply_revisits(api, issues, snapshot)
+
+    findings = reconcile.process({
+        "issues": issues,
+        "pulls": state.get("pulls") or [],
+        "merged_commits": state.get("merged_commits") or [],
+        "focus": state.get("focus"),
+        "events_only": events_only,
+    })["findings"]
+
+    fixed = apply_fixes(api, findings, issues)
+
+    # Once, at the end. The board should describe the state the sweep left
+    # behind, not one of the states it passed through.
+    if woken or fixed:
+        rerender = rerender or (lambda **kwargs: rerender_dashboard(api, **kwargs))
+        rerender()
+
+    return {"woken": woken, "fixed": fixed, "findings": findings}
+
+
+def main(argv=None) -> int:  # pragma: no cover - the workflow entry point
+    import json
+
+    argv = sys.argv[1:] if argv is None else argv
+    state = json.load(sys.stdin)
+
+    result = run(state, github_api(), events_only="--events-only" in argv)
+
+    print(f"woke {len(result['woken'])}, fixed {len(result['fixed'])}, "
+          f"flagged {sum(1 for f in result['findings'] if f['action'] == 'flag')}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
@@ -1,0 +1,159 @@
+"""Tests for the gatekeeper's I/O wiring.
+
+The API is injected as a callable, so the ordering decisions — which are the
+part that can actually be wrong — are asserted without a network call.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import run_comment_event as runner  # noqa: E402
+
+OWNER = "derekwinters"
+
+
+class RecordingApi:
+    """Records every call, answers the reads the runner makes."""
+
+    def __init__(self, reactions=None, dependencies=None):
+        self.calls = []
+        self._reactions = reactions or []
+        self._dependencies = dependencies or []
+
+    def __call__(self, method, path, body=None):
+        self.calls.append((method, path, body))
+
+        if path.endswith("/reactions") and method == "GET":
+            return self._reactions
+        if path.endswith("/blocked_by"):
+            return self._dependencies
+        return {}
+
+    def methods_on(self, fragment):
+        return [m for m, p, _ in self.calls if fragment in p]
+
+    @property
+    def writes(self):
+        return [(m, p, b) for m, p, b in self.calls if m in ("POST", "PATCH", "DELETE")]
+
+
+def event(body="/approve", author=OWNER, labels=("pending-approval",),
+          milestone="v0.0.1", number=10, is_dashboard=False):
+    return {
+        "issue": {
+            "number": number,
+            "labels": [{"name": name} for name in labels]
+                      + ([{"name": "dashboard"}] if is_dashboard else []),
+            "body": "",
+            "milestone": {"title": milestone} if milestone else None,
+        },
+        "comment": {"id": 999, "body": body, "user": {"login": author, "type": "User"}},
+    }
+
+
+class OwnerRecheckTests(unittest.TestCase):
+    def test_a_stranger_gets_no_writes_at_all(self):
+        api = RecordingApi()
+        runner.run(event(author="a-stranger"), api, owner=OWNER)
+        self.assertEqual(api.writes, [])
+
+    def test_the_owner_check_happens_in_the_script_too(self):
+        """Defense in depth — the workflow filters, and so does this."""
+        api = RecordingApi()
+        result = runner.run(event(author="someone-else"), api, owner=OWNER)
+        self.assertFalse(result.applied)
+
+    def test_a_bot_comment_is_ignored(self):
+        api = RecordingApi()
+        payload = event()
+        payload["comment"]["user"]["type"] = "Bot"
+        runner.run(payload, api, owner=OWNER)
+        self.assertEqual(api.writes, [])
+
+
+class RerenderTests(unittest.TestCase):
+    def test_the_dashboard_is_rerendered_once_after_a_label_change(self):
+        api = RecordingApi()
+        rerenders = []
+
+        runner.run(event(), api, owner=OWNER, rerender=lambda **kw: rerenders.append(kw))
+        self.assertEqual(len(rerenders), 1)
+
+    def test_the_rerender_happens_after_the_label_writes(self):
+        api = RecordingApi()
+        order = []
+
+        def note_rerender(**kwargs):
+            order.append(("rerender", len(api.writes)))
+
+        runner.run(event(), api, owner=OWNER, rerender=note_rerender)
+
+        self.assertTrue(order)
+        # At least the label write has already happened when the render runs.
+        self.assertGreater(order[0][1], 0)
+
+    def test_no_label_change_means_no_rerender(self):
+        api = RecordingApi()
+        rerenders = []
+
+        runner.run(event(body="not a command"), api, owner=OWNER,
+                   rerender=lambda **kw: rerenders.append(kw))
+        self.assertEqual(rerenders, [])
+
+
+class FocusAndCapTests(unittest.TestCase):
+    def test_focus_persists_via_a_rerender_override(self):
+        api = RecordingApi()
+        rerenders = []
+
+        runner.run(event(body="/focus v0.0.2", is_dashboard=True), api, owner=OWNER,
+                   rerender=lambda **kw: rerenders.append(kw))
+
+        self.assertEqual(len(rerenders), 1)
+        self.assertEqual(rerenders[0].get("focus_override"), "v0.0.2")
+
+    def test_cap_persists_via_a_rerender_override(self):
+        api = RecordingApi()
+        rerenders = []
+
+        runner.run(event(body="/cap 5", is_dashboard=True), api, owner=OWNER,
+                   rerender=lambda **kw: rerenders.append(kw))
+        self.assertEqual(rerenders[0].get("cap_override"), 5)
+
+    def test_the_issue_body_is_never_patched_directly(self):
+        """Markers are written by re-rendering, never by hand-editing."""
+        api = RecordingApi()
+        runner.run(event(body="/focus v0.0.2", is_dashboard=True), api, owner=OWNER,
+                   rerender=lambda **kw: None)
+
+        for method, path, body in api.writes:
+            if method == "PATCH" and isinstance(body, dict):
+                self.assertNotIn("body", body)
+
+
+class WatermarkTests(unittest.TestCase):
+    def test_an_applied_command_leaves_the_eyes(self):
+        api = RecordingApi()
+        runner.run(event(), api, owner=OWNER, rerender=lambda **kw: None)
+        self.assertIn("POST", api.methods_on("/reactions"))
+
+    def test_an_already_watermarked_comment_is_not_reapplied(self):
+        api = RecordingApi(reactions=[
+            {"content": "eyes", "user": {"login": "github-actions[bot]"}}])
+        result = runner.run(event(), api, owner=OWNER, rerender=lambda **kw: None)
+        self.assertFalse(result.applied)
+
+
+class TokenTests(unittest.TestCase):
+    def test_the_api_helper_uses_the_workflow_token_not_a_pat(self):
+        source = (Path(__file__).resolve().parents[1] / "_github_api.py").read_text()
+        self.assertIn("GITHUB_TOKEN", source)
+        for forbidden in ("PERSONAL_ACCESS_TOKEN", "GH_PAT", "PAT_TOKEN"):
+            self.assertNotIn(forbidden, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_sweep.py
@@ -1,0 +1,119 @@
+"""Tests for the sweep's wiring."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import run_sweep  # noqa: E402
+
+
+class RecordingApi:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, method, path, body=None):
+        self.calls.append((method, path, body))
+        return {}
+
+    @property
+    def label_writes(self):
+        return [(p, b) for m, p, b in self.calls if m == "PUT" and p.endswith("/labels")]
+
+
+def issue(number=10, state="open", labels=(), body="", native_blockers=(),
+          comments=(), milestone="v0.0.1"):
+    return {
+        "number": number, "state": state, "labels": list(labels),
+        "body": body, "native_blockers": list(native_blockers),
+        "comments": list(comments), "milestone": milestone,
+    }
+
+
+class RequeueGatingTests(unittest.TestCase):
+    def stalled_state(self):
+        analysis = {"body": "## Build checklist\n\n- [ ] x",
+                    "author": "github-actions[bot]",
+                    "created_at": "2026-08-08T10:00:00Z"}
+        return {"issues": [issue(10, labels=("in-progress",), comments=[analysis])],
+                "focus": "v0.0.1"}
+
+    def test_the_cron_pass_requeues_a_stalled_issue(self):
+        api = RecordingApi()
+        result = run_sweep.run(self.stalled_state(), api, rerender=lambda **kw: None)
+        self.assertEqual(result["fixed"], [10])
+
+    def test_the_event_pass_does_not(self):
+        api = RecordingApi()
+        result = run_sweep.run(self.stalled_state(), api, events_only=True,
+                               rerender=lambda **kw: None)
+
+        self.assertEqual(result["fixed"], [])
+        self.assertEqual(api.label_writes, [])
+
+
+class RevisitTests(unittest.TestCase):
+    def blocked_state(self, blocker_state="closed"):
+        return {
+            "issues": [issue(10, labels=("needs-clarification",), body="Blocked by #42")],
+            "snapshot": {42: {"state": blocker_state, "labels": []}},
+            "focus": "v0.0.1",
+        }
+
+    def test_a_cleared_blocker_wakes_the_issue(self):
+        api = RecordingApi()
+        result = run_sweep.run(self.blocked_state(), api, rerender=lambda **kw: None)
+        self.assertEqual(result["woken"], [10])
+
+    def test_waking_posts_an_explanatory_comment(self):
+        api = RecordingApi()
+        run_sweep.run(self.blocked_state(), api, rerender=lambda **kw: None)
+
+        comments = [b for m, p, b in api.calls if p.endswith("/comments")]
+        self.assertTrue(comments)
+        self.assertIn("#42", comments[0]["body"])
+
+    def test_an_open_blocker_leaves_it_alone(self):
+        api = RecordingApi()
+        result = run_sweep.run(self.blocked_state("open"), api, rerender=lambda **kw: None)
+        self.assertEqual(result["woken"], [])
+
+
+class RerenderTests(unittest.TestCase):
+    def test_the_board_is_rerendered_once_at_the_end(self):
+        renders = []
+        state = {
+            "issues": [issue(10, state="closed", labels=("ready-for-work",))],
+            "focus": "v0.0.1",
+        }
+
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: renders.append(kw))
+        self.assertEqual(len(renders), 1)
+
+    def test_a_sweep_that_changed_nothing_does_not_rerender(self):
+        renders = []
+        run_sweep.run({"issues": [issue(10, labels=("ai-triage",))], "focus": "v0.0.1"},
+                      RecordingApi(), rerender=lambda **kw: renders.append(kw))
+        self.assertEqual(renders, [])
+
+
+class FlagTests(unittest.TestCase):
+    def test_flags_are_returned_but_never_written(self):
+        api = RecordingApi()
+        analysis = {"body": "## Build checklist\n\n- [ ] x",
+                    "author": "github-actions[bot]",
+                    "created_at": "2026-08-08T10:00:00Z"}
+        state = {"issues": [issue(10, labels=("ready-for-work",), milestone=None,
+                                  comments=[analysis])],
+                 "focus": "v0.0.1"}
+
+        result = run_sweep.run(state, api, rerender=lambda **kw: None)
+        kinds = [f["kind"] for f in result["findings"]]
+
+        self.assertIn("flag_orphaned_ready", kinds)
+        self.assertEqual(api.label_writes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -353,8 +353,15 @@ the only part of the body that survives a render.
 
 Which gives the rule: **edit the markers, never the rendered sections.** A hand
 edit to a rendered section disappears at the next render, and — worse — looks
-like it worked until it does. Setting focus via `/focus` writes the marker,
-which is the same thing done in the place that keeps it.
+like it worked until it does.
+
+`/focus` and `/cap` therefore persist **by re-rendering with an override**, not
+by editing the body. The gatekeeper passes the new value to the renderer, which
+writes it into the marker as part of the regenerated body. Hand-editing the
+marker directly would work exactly once — until the next render, which reads
+the marker it is about to overwrite and would find the old value if the write
+had raced. Going through the renderer means there is only ever one writer of
+that body.
 
 Markers rather than a config file in the repo because focus and cap are
 *operational* state that changes between merges. A PR to change which milestone
@@ -596,6 +603,33 @@ returns the issue to `ai-triage`, triage finds the analysis it wrote and repairs
 the label instead, reconcile returns it again. Neither side is wrong on its own
 terms, so nothing surfaces as an error — the issue just cycles. The side that
 writes the format owns the recognizer.
+
+### The I/O layer
+
+Everything with a decision in it is pure and tested without a network. Three
+thin modules wire those pieces to GitHub:
+
+| Module | Does |
+| --- | --- |
+| `_github_api.py` | REST helpers, and the shared dashboard re-render |
+| `run_comment_event.py` | one `issue_comment` event, end to end |
+| `run_sweep.py` | the board-wide revisit + reconcile pass |
+
+`run_comment_event.py` is: snapshot → parse → gate → apply → write labels, ack,
+and reaction → **re-render the dashboard once, after every label write.**
+Rendering in between would publish a board describing a half-applied command.
+`run_sweep.py` re-renders once at the end for the same reason, and takes
+`--events-only` to drop reconcile's two cron-only fixes on the 15-minute pass.
+
+**Authentication is `GITHUB_TOKEN`, never a PAT.** The workflow token is scoped
+to this repository and expires with the job; a personal access token would
+carry everything its owner can do into a job nobody is watching.
+
+**The owner check is repeated in the script.** The workflows already filter on
+the comment author, so this is redundant — deliberately. A script that is safe
+only because its caller filtered is one edited `if:` away from letting a
+stranger drive the pipeline, and the workflow trigger is exactly the kind of
+line that gets edited for an unrelated reason.
 
 ### Applying an action
 


### PR DESCRIPTION
This is the plumbing that connects the gatekeeper's thinking to GitHub. Everything that involves a judgement — reading a command, deciding whether it's allowed, working out which labels change — was already written and tested. This is just the part that fetches, writes, and calls those pieces in the right order.

It's deliberately boring. The one thing it can genuinely get wrong is *ordering*, so that's what has tests: labels get written first, and the dashboard is redrawn exactly once at the end. Redraw it halfway through and you publish a board describing a command that's only half applied.

## Spec invariants

- **One re-render, after all label writes.** `test_the_rerender_happens_after_the_label_writes` asserts writes have already occurred when the render fires; `test_the_dashboard_is_rerendered_once_after_a_label_change` pins the count at one.
- **`/focus` and `/cap` never hand-edit the body.** They pass an override to the renderer. `test_the_issue_body_is_never_patched_directly` walks every write the runner made and asserts no `PATCH` carries a `body` key — so this stays true even if someone adds a new write path.
- **`GITHUB_TOKEN` only.** `test_the_api_helper_uses_the_workflow_token_not_a_pat` reads the source and asserts the common PAT variable names appear nowhere.
- **A stranger produces zero writes.** Not "no label change" — no writes at all, including the reaction, since reacting would itself let them make the bot act.
- **`--events-only` drops the cron-only fixes.** `test_the_event_pass_does_not` asserts both an empty fix list and no label writes.

19 new tests. The API is injected as a callable throughout, so all of this is asserted without a network call.

## How the spec is changing

**How `/focus` and `/cap` persist was never written down**, and the obvious implementation is wrong. The natural thing is to `PATCH` the marker into the issue body. That works exactly once — the dashboard body is regenerated wholesale on every render, and the renderer reads the marker it is about to overwrite. Two writers of one body is a race with a silent loser.

Going through the renderer with an override means there is only ever one writer. The docs now say so.

**The duplicated owner check is now documented as deliberate.** It looks redundant — the workflows already filter on comment author — and redundant-looking code gets deleted by someone tidying up. The reason it stays: a script that is safe only because its caller filtered is one edited `if:` away from letting a stranger drive the pipeline, and a workflow trigger is exactly the kind of line that gets edited for an unrelated reason.

**Docs:** `docs/engineering/issue-pipeline.md` — added "The I/O layer" describing the three modules, the snapshot→parse→gate→apply→write→re-render order and why the render is last and singular, `--events-only`, the `GITHUB_TOKEN`-not-PAT rule, and why the owner re-check is intentional redundancy; extended the marker section to state that `/focus` and `/cap` persist via a re-render override rather than a body edit, with the two-writers reasoning.

## Deviations and Decisions

- **The issue calls this layer "deliberately untested"; I tested part of it.** Not a disagreement about the untestable parts — `_fetch_state` and the HTTP plumbing are marked `pragma: no cover` and have no tests. But "call these in the right order" is testable with an injected fake, and it is precisely where the bugs in this file would live. Leaving the ordering untested because the module is labelled I/O would have skipped the only part worth checking.
- **A test caught a real bug: gate names are not function names.** `gates.GATES` uses documentation vocabulary (`"milestone-presence"`), while the functions are `milestone_present` / `milestone_order_ok`. My first version used `getattr(gates, gate)` and raised on every `/approve`. Fixed with an explicit `GATE_FUNCTIONS` map — chosen over a naming convention so that renaming a function fails loudly with a `KeyError` rather than quietly finding no gate to run. A silently-skipped gate is the worst possible failure here.
- **One of my tests was wrong and I fixed the test.** `test_flags_are_returned_but_never_written` used an issue with no analysis comment, so `requeue_triage` correctly fired and wrote a label. The test's intent was to isolate flag behaviour; it now gives the issue an analysis comment.
- **`_fetch_state` returns empty `native_blockers` and `reconcile_findings`.** The dependency graph needs a per-issue API call and the findings come from the sweep, so wiring both is real work that belongs with the workflows in #75–#77. Consequence today: a dashboard rendered from a gatekeeper action shows no ⭐/⛔ from native edges and an empty ⚠️ section. Text `Blocked by #N` lines still work. Flagging it because it is a visible gap, not a hidden one.
- **`run_sweep.py` imports `reconcile` across skills**, the same `sys.path` insertion pattern as #150. Third instance of this; #147 remains the place to solve it properly.

Closes #59

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_