### PR TITLE
docs(pipeline): add the pipeline-gatekeeper SKILL.md

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/SKILL.md
+++ b/.claude/skills/pipeline-gatekeeper/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: pipeline-gatekeeper
+description: Parse and apply Derek's slash commands on issues, and run the board-wide sweep. Use to run the gatekeeper by hand, to work out why a command was refused, or when a comment did not take effect.
+---
+
+# pipeline-gatekeeper
+
+```bash
+export GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs
+export PIPELINE_OWNER=derekwinters
+
+# One comment event. Reads the webhook payload on stdin.
+python3 .claude/skills/pipeline-gatekeeper/run_comment_event.py < event.json
+
+# The board-wide sweep. Reads a state snapshot on stdin.
+python3 .claude/skills/pipeline-gatekeeper/run_sweep.py               < state.json
+python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --events-only < state.json
+```
+
+## In production this is two workflows, with no model in the loop
+
+`gatekeeper-comment.yml` on every `issue_comment`, and `gatekeeper-sweep.yml`
+every fifteen minutes. Both run these scripts directly. **Nothing here asks a
+model anything.**
+
+That is the whole point of the design. The gatekeeper is what turns Derek
+typing `/approve` into an issue the builder will pick up — it is the boundary
+between "a human decided" and "the machine acted". A model interpreting that
+boundary could be persuaded, could misread, could be creative on a bad day.
+A parser either matches the line or does not.
+
+This skill exists for running the same logic by hand: replaying an event that
+did not take, or working out why a command was refused.
+
+## The command vocabulary
+
+Commands are lines beginning with `/`. A comment can carry several; they apply
+in order, and prose around them is ignored, so you can explain yourself in the
+same comment.
+
+| Command | Effect |
+| --- | --- |
+| `/admit` | bring an issue into the pipeline — becomes `ai-triage` |
+| `/propose` | ask triage to design it → `ai-triage` |
+| `/approve` | the plan is right → `ready-for-work`. **Both gates apply** |
+| `/revise <notes>` | the plan is wrong → `ai-triage`, with the notes |
+| `/redo` | the built work is wrong → `ready-for-work` |
+| `/park` | set aside deliberately |
+| `/unpark` | bring it back → `ai-triage` |
+| `/milestone <title>` | set the milestone, by title |
+| `/focus <title>` | set the focus milestone. **Dashboard issue only** |
+| `/cap <n>` | issues per build round. **Dashboard issue only** |
+
+**Nothing here closes an issue, edits a body, or merges a PR.** Those have
+perfectly good GitHub buttons, and a command vocabulary that can do
+irreversible things is one that eventually does an irreversible thing by
+accident.
+
+A command inside a fenced code block is documentation, not an instruction —
+otherwise writing this table in a comment would execute it.
+
+## The owner gate, and why refusal is silent
+
+**Only the repository owner's commands are obeyed.** Anyone can comment on a
+public issue; nobody but Derek can drive the pipeline.
+
+A stranger's command is dropped **silently** — no reply, and *no reaction*.
+Replying would let an outsider make the bot post, which is a smaller hole of
+exactly the same shape as obeying them. So the comment is left completely
+untouched, as if it were ordinary conversation, which is what it is.
+
+The check happens in the parser **and again** in `run_comment_event.py`. That
+redundancy is deliberate: a script that is safe only because the workflow's
+`if:` filtered for it is one careless edit away from not being safe at all.
+
+## The 👀 watermark
+
+An applied comment gets an `eyes` reaction from the bot, and a comment already
+carrying one is never reconsidered.
+
+This is what makes the fifteen-minute sweep safe. The sweep re-reads recent
+comments to catch anything the event path missed — a dropped webhook, a
+workflow that failed to start — and without a marker it would re-apply every
+command it found, every time.
+
+Two details matter:
+
+- **Only the bot's own 👀 counts.** A human reacting out of interest must not
+  silence a command.
+- **A refused comment is watermarked too** — except a stranger's. It was
+  considered and answered; without the mark the sweep would re-post the same
+  refusal every fifteen minutes forever.
+
+If a reaction lookup fails, the comment is treated as **already watermarked**.
+Re-applying a command is worse than skipping one, and the next sweep retries.
+
+## The two approval gates
+
+`/approve` is the only command that can put work in the builder's path, so it
+is the only one with gates:
+
+| Gate | Refuses when |
+| --- | --- |
+| `milestone-presence` | the issue has no milestone |
+| `milestone-order` | an open blocker is scheduled later than the issue |
+
+**Both refuse; neither auto-bumps.** A gate that fixed the problem itself would
+be choosing a milestone, and that is a scheduling decision about what ships
+when — which is Derek's, not the pipeline's. The refusal names the specific
+problem, so the fix is one `/milestone` away.
+
+The second gate is worth understanding. An issue in `v0.0.1` blocked by one in
+`v0.1` is a silent stall: the builder correctly skips the dependent, but the
+blocker is not in the focus milestone to be built either. Nothing ever runs,
+and from every individual angle each issue looks fine. Only the relationship is
+wrong.
+
+`/milestone` is gated on order too, since setting a milestone is the other way
+to create that inversion. `/admit` deliberately is not — admitting an issue is
+part of what *fixes* a missing milestone.
+
+## A refusal changes nothing
+
+Not the labels, not the milestone, not a partial application of a multi-command
+comment. The acknowledgement says so explicitly, because "your command was
+refused" and "your command was partly applied" call for very different
+responses from the person reading it.
+
+## Running by hand
+
+Both entry points read JSON on stdin and take the API as an injected callable
+internally, so every decision is reachable in a test without a network call.
+
+- `run_comment_event.py` — an `issue_comment` webhook payload. Snapshot →
+  parse → gate → apply → write labels, ack, reaction → re-render the dashboard
+  **once**, after all label writes.
+- `run_sweep.py` — a state snapshot. Revisits cleared blockers, then reconciles.
+  `--events-only` drops reconcile's two cron-only fixes; use it when simulating
+  the fifteen-minute pass.
+
+Authentication is `GITHUB_TOKEN`, never a PAT.
+
+## Running the tests
+
+```bash
+python3 .github/scripts/run_python_tests.py pipeline-gatekeeper
+```
+
+158 tests. The parser, the gates, the label planning, the revisit rules, and
+the I/O ordering — none of them touch the network.
+
+## See also
+
+- `docs/engineering/issue-pipeline.md` — the state machine and every refusal code
+- `pipeline-reconcile` — the sweep's second half
+- `pipeline-dashboard` — what the re-render calls

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -631,6 +631,21 @@ only because its caller filtered is one edited `if:` away from letting a
 stranger drive the pipeline, and the workflow trigger is exactly the kind of
 line that gets edited for an unrelated reason.
 
+#### Running either entry point by hand
+
+Both read JSON on **stdin**, which is what makes replaying a missed event or
+rehearsing a sweep possible without waiting for a trigger:
+
+| Entry point | Expects on stdin |
+| --- | --- |
+| `run_comment_event.py` | an `issue_comment` webhook payload |
+| `run_sweep.py` | a state snapshot — issues, pulls, merged commits, focus |
+
+`run_sweep.py --events-only` simulates the fifteen-minute pass by dropping
+reconcile's two cron-only fixes. Running it *without* that flag outside the
+nightly window will requeue whatever the builder currently has in flight, which
+is the one way to do real damage with these scripts by hand.
+
 ### Applying an action
 
 `apply_actions.py` computes the resulting label set, the acknowledgement, and


### PR DESCRIPTION
The reference page for the part that reads Derek's comments and acts on them: every command, when each one gets refused and why, and how to run the whole thing by hand if a comment didn't take effect.

The thing worth saying out loud is that no AI is involved anywhere in this. It's a parser. That's the entire safety story — this is the boundary between "a human decided something" and "the machine did something", and a parser either matches the line you typed or it doesn't. It can't be talked into anything and it can't have an off day.

## Spec invariants

- **No model in the command path.** Restated as the reason the design is safe, not as an implementation detail.
- **A stranger gets silence — no reply, no reaction.** The subtle half: replying is a smaller version of the same hole as obeying, because it still lets an outsider make the bot post.
- **Only the bot's own 👀 counts**, and a *refused* comment is watermarked too — otherwise the sweep re-posts the same refusal every fifteen minutes forever.
- **A failed reaction lookup means "already watermarked."** Re-applying beats skipping; the next sweep retries.
- **Both gates refuse, neither auto-bumps.** Choosing a milestone is a scheduling decision.
- **A refusal changes nothing** — not labels, not milestone, not part of a multi-command comment.

## How the spec is changing

No reversals. One addition: **how to run either entry point by hand, and the one way to do damage with them.**

The docs described the I/O layer after #155 but never said what the scripts expect on stdin, which makes replaying a missed event guesswork. They now do — and they carry the warning that matters: running `run_sweep.py` *without* `--events-only` outside the nightly window will requeue whatever the builder currently has in flight.

That's a genuinely dangerous default and it isn't obvious. The flag reads like an optimisation ("skip some checks") when it's actually the safety catch for interactive use. Someone debugging a stuck sweep at 3pm would reach for the plain invocation, and it would yank work out from under a running agent.

**Docs:** `docs/engineering/issue-pipeline.md` — added "Running either entry point by hand" under the I/O layer section, documenting what each script expects on stdin and warning that a plain `run_sweep.py` outside the nightly window requeues in-flight work.

## Deviations and Decisions

- **No failing test first.** `SKILL.md`; the 158 tests behind it landed across #146, #155, and the earlier gatekeeper issues, red first each time. Same precedent as the other five skill docs in this milestone.
- **Explained the `milestone-order` gate rather than just naming it.** The failure it prevents is invisible in a way the other gate's isn't: an issue in `v0.0.1` blocked by one in `v0.1` stalls forever, and every issue involved looks individually fine — only the relationship is wrong. Someone hitting that refusal without this explanation would reasonably conclude the gate is being pedantic and reach for a way around it.
- **Documented that `/admit` is deliberately un-gated on milestone order**, which the checklist doesn't mention. It's the one exception in `gates.GATES` and it looks like an oversight; admitting an issue is part of what fixes a missing milestone, so gating it would make the fix impossible.
- **Repeated the command table here rather than linking.** Same call as #151: this is the page you have open while working out why `/approve` was refused, and a table behind a link is one you skip. The spec page stays authoritative if they ever diverge.

Closes #61

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_