### PR TITLE
docs(pipeline): add the milestone-orchestration skill

### DIFF
--- a/.claude/skills/milestone-orchestration/SKILL.md
+++ b/.claude/skills/milestone-orchestration/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: milestone-orchestration
+description: Drive a set of handed-off issues through merge, one at a time, each on a branch cut from the latest main. Use when Derek hands over several issues at once and wants them delivered, not just proposed.
+---
+
+# milestone-orchestration
+
+The owner-invoked counterpart to the nightly builder. Same dev agent, same TDD,
+same one-PR-per-issue — one difference, and it is the whole point:
+
+|  | Nightly builder | This |
+| --- | --- | --- |
+| Gate between issues | **PR opened** | **PR merged** |
+| Invoked by | the schedule | Derek, explicitly |
+| On failure | drop the issue, continue | **halt the whole run** |
+
+**No script.** The issue set comes from the handoff — whatever Derek said to
+work on — so there is nothing to compute and nothing to select.
+
+## Merged is the gate
+
+Each issue is finished only when its PR is **merged**, not when it is opened.
+Then the next issue starts, on a branch cut fresh from the updated `main`.
+
+That is what makes a multi-issue run conflict-free by construction. Every new
+branch already contains all the previously delivered work, so two issues in the
+same run cannot produce conflicting diffs — there is never a moment when two
+branches are open against the same base.
+
+The nightly builder can open three PRs at once because they sit unmerged until
+Derek reviews them, and he resolves any overlap by choosing what to merge.
+Here, the run *is* merging, so the sequencing has to do that job instead.
+
+The cost is real: a run of six issues takes as long as six CI runs in series.
+That is the price of ending with six merged issues and no conflicts, rather
+than six open PRs that need untangling.
+
+## The loop
+
+For each issue, in the order Derek gave them:
+
+1. **`git fetch origin main`** and cut a fresh branch from it. Not from the
+   previous issue's branch — from `main`, after the previous merge landed.
+2. Mark the issue **`in-progress`**.
+3. Hand it to the **dev agent** (`.claude/agents/dev.md`): tests first, one
+   issue, one PR, with a `## Deviations and Decisions` section and `Closes #N`.
+4. Apply **`skip-docs`** immediately if the PR touches no `docs/` files.
+5. Wait with **`ci-watch`** until every check has finished.
+6. Green → **merge**. Then go to 1.
+7. Not green → **stop the run.**
+
+## A failure halts everything
+
+Not "skip it and carry on" — that is the nightly builder's rule, and it is
+wrong here.
+
+The difference is what the next issue is built on. In this run, issue two is
+built on the `main` that issue one merged into. If issue one failed and was
+skipped, issue two is built on a `main` that is missing work the handoff
+assumed was there — and whether that matters is unknowable without reading
+both issues. Continuing means building on a base nobody intended.
+
+There is also a plainer reason: Derek asked for these issues, and he is
+around. A run that stops with "issue three failed, here is why" is one he can
+act on immediately. A run that quietly delivers four of six is one he has to
+audit.
+
+**Stop at the failing issue.** Say which issue, what failed, and what the
+remaining ones were. The merged work stays merged — it is finished and correct.
+
+## Owner-invoked only
+
+**This is never part of a scheduled routine.** Not nightly, not hourly, not
+triggered by a label.
+
+It merges. Everything else in the pipeline stops at "PR opened" so that a
+human sees the work before it becomes the game — and that gate is the entire
+reason the pipeline is trustworthy. This skill exists because Derek sometimes
+wants to say "do these six and merge them as you go", which is him applying
+that judgement up front, to a set he chose.
+
+An automated trigger would turn a decision he made about six specific issues
+into a standing grant to merge anything. If you find yourself wiring this into
+a workflow, that is the mistake.
+
+## See also
+
+- `pipeline-dev` — the scheduled sibling that stops at "PR opened"
+- `ci-watch` — waits for checks and reports pass or fail
+- `.claude/agents/dev.md` — what actually writes the code
+- `docs/engineering/issue-pipeline.md` — how this differs from the nightly round

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -798,6 +798,35 @@ still needs a written justification in `## Deviations and Decisions`, because
 the gate cannot distinguish "no docs needed" from "forgot the docs" — that is
 the whole reason a human has to say which it was.
 
+#### The owner-invoked alternative: `milestone-orchestration`
+
+When Derek hands over several issues at once and wants them *delivered*, the
+`milestone-orchestration` skill runs the same dev agent with one difference:
+the gate between issues is **merged**, not **PR opened**.
+
+| | Nightly builder | `milestone-orchestration` |
+| --- | --- | --- |
+| Gate between issues | PR opened | **PR merged** |
+| Invoked by | the 03:00 schedule | Derek, explicitly |
+| A failing issue | dropped, round continues | **halts the run** |
+
+Merging between issues is what makes a multi-issue run conflict-free by
+construction: every branch is cut from a `main` that already contains all
+previously delivered work, so two issues in one run cannot produce conflicting
+diffs. The nightly builder does not need this, because its PRs sit unmerged
+until Derek reviews them and he resolves any overlap by choosing what to merge.
+
+A failure **halts** rather than skipping, because the next issue would be built
+on a `main` that is missing work the handoff assumed was there. Whether that
+matters is unknowable without reading both issues, so the run stops and says
+which issue failed.
+
+**It is owner-invoked only, never scheduled.** Everything else in the pipeline
+stops at "PR opened" so a human sees the work before it becomes the game. This
+skill merges, and it exists because Derek sometimes applies that judgement up
+front to a set he chose. Wiring it to a trigger would convert a decision about
+six specific issues into a standing grant to merge anything.
+
 #### A failing issue is dropped, and the round continues
 
 If an issue cannot be completed — tests won't pass, the plan was wrong, a


### PR DESCRIPTION
This is for when Derek hands over a batch of issues and wants them actually finished, not just proposed. It builds them one at a time — but unlike the nightly run, it waits for each one to be merged before starting the next.

That waiting is the whole idea. Because each new branch starts from a `main` that already has the previous work in it, two issues in the same batch can't end up conflicting with each other. It's slower — you wait for CI six times in a row — but you end up with six merged issues instead of six pull requests that need untangling.

If something goes wrong it stops the whole run rather than skipping ahead, and it's only ever started by Derek asking for it.

## Spec invariants

- **Merged, not opened, is the gate.** This is the one difference from the nightly builder and everything else follows from it.
- **Branches are cut from `main` after the previous merge** — never from the previous issue's branch. That's what makes the no-conflict property hold.
- **A failure halts.** Deliberately the opposite of `pipeline-dev`'s drop-and-continue.
- **Never scheduled.** The only thing in the pipeline that merges, so the only thing that must stay attached to an explicit human decision.
- Everything else — TDD, one PR per issue, `Closes #N`, `## Deviations and Decisions`, immediate `skip-docs` — is unchanged from #149.

## How the spec is changing

Only an addition, but a significant one: **this is the first component in the pipeline that merges.**

Every other stage stops at "PR opened", and the docs lean on that fairly hard — it's the reason the pipeline is trustworthy at all. A skill that merges is a real exception to the project's central safety property, so it needed writing down alongside that property rather than in a corner.

The resolution is that Derek applies the review judgement *up front*, to a specific set of issues he chose, instead of per-PR afterwards. That's a legitimate thing for him to decide, and it's why the never-scheduled rule is load-bearing rather than stylistic: a trigger would silently convert "merge these six" into "merge whatever you build".

**Docs:** `docs/engineering/issue-pipeline.md` — added "The owner-invoked alternative: `milestone-orchestration`" under Serial delegated delivery, contrasting it with the nightly builder in a table, explaining why merging between issues makes a run conflict-free by construction, why a failure halts rather than skips, and why it must never be scheduled given that every other stage stops at "PR opened".

## Deviations and Decisions

- **No failing test first, and no script at all.** The issue specifies `SKILL.md` only — the issue set comes from the handoff, so there is nothing to compute or select. Nothing here is testable.
- **The issue titles this "bring over" the skill, but I wrote it fresh.** I have no access to `derekwinters/lucas-doggiehood`, and the content is entirely determined by this repo's own components — `pipeline-dev`, `ci-watch`, the dev agent. Consequently there is **no `.claude/.skills-manifest.json` entry**: the manifest is a port ledger, and recording a port I did not perform would be false provenance. If the upstream version has material this lacks, it's worth diffing.
- **Stated the cost of serial merging explicitly** — six issues means six CI runs in series. The no-conflict property is worth it, but a skill doc that only lists advantages is one someone reaches for in the wrong situation.
- **Did not specify what happens to the failing issue's branch.** `pipeline-dev` deletes it; here the run halts with a human present, and the branch is likely the most useful thing to look at. Leaving it is the better default, but I'm flagging it as an unstated case rather than claiming it was decided.

Closes #73

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_