### PR TITLE
ci: add the pipeline-tests workflow

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -1,0 +1,60 @@
+name: pipeline-tests
+
+# The unit tests for every deterministic pipeline script.
+#
+# Stdlib only — no Unity, no pip install, no lockfile. That is the point: these
+# are the scripts that decide what gets triaged, built, and requeued, and their
+# tests must not be able to break because the game toolchain did. The job needs
+# nothing but the Python already on the runner.
+#
+# Path-gated, because a change to a Unity scene cannot break a pipeline script.
+# The `Gate tests` job in docs-test.yml covers .github/scripts on every PR;
+# this covers the skills.
+#
+# NOTE for branch protection (#80): a path-gated workflow does not report at
+# all on PRs that miss its paths, so requiring this check would block every
+# unrelated PR forever. Leave it non-required, or add an always-running guard
+# job first. See docs/engineering/ci-cd.md.
+
+on:
+  pull_request:
+    paths:
+      - .claude/skills/pipeline-*/**
+      - .claude/skills/triage-issue/**
+      - .claude/skills/milestone-orchestration/**
+      - .github/scripts/run_python_tests.py
+      - .github/workflows/pipeline-tests.yml
+  push:
+    branches: [main]
+    paths:
+      - .claude/skills/pipeline-*/**
+      - .claude/skills/triage-issue/**
+      - .claude/skills/milestone-orchestration/**
+      - .github/scripts/run_python_tests.py
+      - .github/workflows/pipeline-tests.yml
+  workflow_dispatch:
+
+# Read-only. These tests make no network calls and touch nothing.
+permissions:
+  contents: read
+
+concurrency:
+  group: pipeline-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Pipeline tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # `python3 -m unittest discover` cannot find these: discovery only
+      # recurses into directories whose names are valid Python identifiers, and
+      # `.claude` starts with a dot. The runner walks the suites itself, and
+      # runs each one in isolation — several skills have a package named
+      # `tests`, so a shared interpreter silently resolves the second to the
+      # first's cached module and never runs it.
+      - name: Run every pipeline suite
+        run: python3 .github/scripts/run_python_tests.py

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -18,7 +18,8 @@ be blocking; if you can, the fix is to satisfy it, not to route around it.
 | `release-please` | push to `main` | no | the version, changelog, tag, release, and release APK |
 | `labels-sync` | push to `main` touching `labels.yml` | no | the label taxonomy matches the file |
 | `geometry-lint` | PR touching `Assets/Scripts/**` | yes | the named-values rule, ratcheting |
-| `pipeline-*` | schedule, issue comments | no | the issue pipeline itself |
+| `pipeline-tests` | PR/push touching the pipeline skills | fails the PR | the pipeline scripts' own unit tests |
+| `pipeline-*` (others) | schedule, issue comments | no | the issue pipeline itself |
 
 ## Every action is pinned to a commit SHA
 
@@ -617,10 +618,32 @@ does; this is where the workflows live.
 | `gatekeeper-comment` | issue comment created | parses commands (`/approve`, `/park`, …), applies label changes, acknowledges with a reaction |
 | `gatekeeper-sweep` | schedule | catches events the comment trigger missed, and auto-revisits blockers whose blocking issue has closed |
 | `dashboard` | schedule, and after pipeline runs | rewrites the live dashboard issue |
-| `pipeline-tests` | PR touching `.claude/skills/**` | runs the pipeline scripts' own unit tests |
+| `pipeline-tests` | PR/push touching the pipeline skills | runs the pipeline scripts' own unit tests |
 
-`pipeline-tests` is the one that blocks: the pipeline's scripts are code, they
-have tests, and a broken gatekeeper is a broken queue.
+### `pipeline-tests`
+
+The pipeline's scripts are code, they have tests, and a broken gatekeeper is a
+broken queue — so unlike the rest of the pipeline workflows, this one runs on
+pull requests and fails them.
+
+**Stdlib only. No Unity, no `pip install`, no lockfile.** These scripts decide
+what gets triaged, built, and requeued, and their tests must not be capable of
+breaking because the game toolchain did. The job needs nothing but the Python
+already on the runner, which is also why it finishes in seconds.
+
+It runs `run_python_tests.py` rather than `python3 -m unittest discover`,
+because discovery cannot find these tests at all: it only recurses into
+directories whose names are valid Python identifiers, and `.claude` starts with
+a dot. The runner also executes each suite in isolation — several skills have a
+package named `tests`, and in a shared interpreter the second silently resolves
+to the first's cached module and never runs.
+
+**It is path-gated, so it must not be marked required.** Same trap as
+[`ci-tests`](#path-gating-and-what-it-means-for-branch-protection): a
+path-gated workflow does not report at all on PRs that miss its paths, so a
+required check would block every unrelated PR forever waiting for a run that
+will never happen. "Fails the PRs it runs on" and "required in branch
+protection" are different things, and only the first is true here.
 
 ## When something is red
 


### PR DESCRIPTION
Until now the pipeline's own tests only ran on my machine. This adds the CI job that runs them, so a change that breaks the gatekeeper or the builder shows up as a red pull request instead of as a strange night three weeks later.

It deliberately needs nothing installed — no Unity, no downloaded packages, just the Python that's already on the runner. These are the scripts that decide what gets worked on, and their tests shouldn't be able to break because something unrelated in the game toolchain broke.

It takes about a second to run.

## Spec invariants

- **`contents: read` only.** The suites make no network calls and touch nothing.
- **Stdlib only** — no `pip install` step exists, so a dependency cannot creep in without someone adding one deliberately.
- **Every `uses:` is SHA-pinned** with a trailing `# vX.Y.Z` comment. One action, `actions/checkout`, on the same SHA the other workflows already use.

Verified locally: all 12 suites pass, and the YAML parses.

## How the spec is changing

**`pipeline-tests` was documented as "the one that blocks", and that's not achievable as specified.** The issue asks for path-gating, and this repo already learned — in the `ci-tests` note about branch protection — that a path-gated workflow is *absent* rather than skipped on PRs that miss its paths. Marking one required blocks every unrelated PR forever, waiting for a run that will never start.

So the docs now separate two things that were being conflated: this workflow **fails the PRs it runs on**, which is what makes it useful, and it is **not a required check**, which is what stops it deadlocking the repo. The glance table gains its own row saying "fails the PR" rather than sitting under the blanket `pipeline-*` "no".

If the intent really was a required check, the fix is the guard-job pattern already sketched for `ci-tests`, not removing the path filter — every docs typo would otherwise spin up a test run.

**Docs:** `docs/engineering/ci-cd.md` — gave `pipeline-tests` its own glance-table row ("fails the PR") separate from the scheduled `pipeline-*` workflows, and replaced the one-line claim that it blocks with a `### pipeline-tests` section covering the stdlib-only constraint and why, why `unittest discover` cannot be used here, and why path-gating means it must not be marked required.

## Deviations and Decisions

- **Did not use `python3 -m unittest discover`, which the checklist asks for.** It cannot work: discovery only recurses into directories whose names are valid Python identifiers, and `.claude` starts with a dot — it finds zero tests and exits green. That silent pass is exactly the failure mode worth avoiding, and it's why `run_python_tests.py` exists. The runner additionally executes each suite in isolation, because several skills have a package named `tests` and a shared interpreter resolves the second to the first's cached module and never runs it — a bug that already bit this repo once, surfacing as a single loader error among twenty passes.
- **Runs *all* suites, not only the pipeline ones.** `run_python_tests.py` with no arguments is the same command `CLAUDE.md` documents, and a workflow that runs a different subset than the local command is one where "it passed locally" stops meaning anything. The extra suites cost milliseconds.
- **Path filter includes `triage-issue` and `milestone-orchestration`** alongside `pipeline-*`. The issue mentions the triage skill; `milestone-orchestration` is currently docs-only but sits in the same family, and a filter that misses a skill the day it grows a script is a filter that silently stops testing it.
- **`run_python_tests.py` itself is in the path filter**, since a change to the runner can break every suite while touching no skill.

Closes #74

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_