### PR TITLE
ci: add the gatekeeper-comment workflow

### DIFF
--- a/.github/workflows/gatekeeper-comment.yml
+++ b/.github/workflows/gatekeeper-comment.yml
@@ -1,0 +1,63 @@
+name: gatekeeper-comment
+
+# Derek types `/approve`; the label moves seconds later.
+#
+# Deterministic — `run_comment_event.py` is a parser, not a model. This is the
+# boundary between "a human decided" and "the machine acted", and the component
+# that can change state has a fixed vocabulary it either matches or does not.
+#
+# See docs/engineering/issue-pipeline.md.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  # Labels, comments, and the reaction.
+  issues: write
+  # The dashboard re-render reads the whole board, including open PRs.
+  pull-requests: read
+  contents: read
+
+concurrency:
+  # Per issue, and NOT cancel-in-progress. Two commands on one issue must apply
+  # in the order they were written — cancelling the first would drop a command
+  # Derek typed and acknowledge only the second.
+  group: gatekeeper-comment-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply the command
+    runs-on: ubuntu-latest
+
+    # Cheap filters, so the common case (an ordinary conversational comment)
+    # costs nothing. The script re-checks the author itself as defense in
+    # depth — a script that is safe only because this `if:` filtered for it is
+    # one careless edit away from not being safe at all.
+    if: >-
+      github.event.comment.user.login == github.repository_owner &&
+      github.event.comment.user.type != 'Bot' &&
+      !github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/')
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Parse and apply
+        env:
+          # GITHUB_TOKEN only, never a PAT. Two reasons, and the second is the
+          # subtle one: the workflow token is scoped to this repository and
+          # expires with the job, AND GitHub suppresses workflow runs from
+          # events initiated by it. A PAT-authored acknowledgement would look
+          # like a new comment and re-trigger this workflow — an unbounded
+          # loop that the platform's own no-recursion guard is what prevents.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PIPELINE_OWNER: ${{ github.repository_owner }}
+          # Reactive triage. Absent, firing is a clean no-op and the nightly
+          # round picks the issue up — a missing secret costs latency, not
+          # correctness. See issue #83.
+          AI_TRIAGE_URL: ${{ secrets.AI_TRIAGE_URL }}
+          AI_TRIAGE_SECRET: ${{ secrets.AI_TRIAGE_SECRET }}
+        run: python3 .claude/skills/pipeline-gatekeeper/run_comment_event.py

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -620,6 +620,33 @@ does; this is where the workflows live.
 | `dashboard` | schedule, and after pipeline runs | rewrites the live dashboard issue |
 | `pipeline-tests` | PR/push touching the pipeline skills | runs the pipeline scripts' own unit tests |
 
+### `gatekeeper-comment`
+
+`on: issue_comment: [created]`, so a command applies seconds after it is typed
+rather than waiting for a scheduled round.
+
+**Concurrency is per issue, with `cancel-in-progress: false`.** Two commands on
+one issue have to apply in the order they were written; cancelling the first
+run would drop a command Derek typed and acknowledge only the second. Grouping
+per issue rather than globally keeps unrelated issues from queueing behind each
+other.
+
+The workflow-level `if:` filters to a non-bot comment from the repository owner
+on an issue rather than a PR, and starting with `/`. That is a cost filter —
+the script re-checks the author itself, because a script that is safe only
+because a workflow's `if:` filtered for it is one careless edit away from not
+being safe at all.
+
+**`GITHUB_TOKEN` only, never a PAT**, and here the usual scoping argument is
+the *less* important one. GitHub suppresses workflow runs from events initiated
+by `GITHUB_TOKEN`. A PAT-authored acknowledgement would look like a new comment
+and re-trigger this same workflow — an unbounded loop that the platform's
+no-recursion guard is precisely what prevents.
+
+The reactive-triage secrets (`AI_TRIAGE_URL`, `AI_TRIAGE_SECRET`, see #83) are
+surfaced as env vars. Absent, firing is a clean no-op: the nightly round picks
+the issue up, so a missing secret costs latency rather than correctness.
+
 ### `pipeline-tests`
 
 The pipeline's scripts are code, they have tests, and a broken gatekeeper is a


### PR DESCRIPTION
This is what makes typing `/approve` on an issue actually do something, within seconds, instead of waiting for a job that runs overnight.

It runs the parser that was already written and tested — no AI involved. Derek types a command, the parser recognises it or doesn't, the label moves or a reply explains why it didn't.

## Spec invariants

- **Commands on one issue apply in order.** `cancel-in-progress: false`, grouped per issue. Cancelling an in-flight run would silently drop a command Derek typed and acknowledge only the later one.
- **The workflow `if:` is a cost filter, not the security boundary.** The script re-checks the author itself, per #155.
- **`GITHUB_TOKEN` only** — the loop argument below is why this one is not negotiable.
- **Permissions are the minimum that works:** `issues: write` for labels, comments and the reaction; `pull-requests: read` and `contents: read` because the dashboard re-render reads the whole board.
- **Missing triage secrets are a no-op**, not a failure — the nightly round still picks the issue up.

## How the spec is changing

Only an addition, but it captures the reasoning behind a rule that would otherwise look like ordinary security hygiene.

**Why `GITHUB_TOKEN` and not a PAT** was documented as a scoping argument — the workflow token is limited to this repo and expires with the job. True, and not the main reason here. GitHub suppresses workflow runs from events initiated by `GITHUB_TOKEN`, so this workflow posting an acknowledgement does not re-trigger itself. Swap in a PAT and the ack becomes an ordinary new comment, which fires `issue_comment: created`, which posts another ack. The platform's no-recursion guard is the only thing standing between this design and an infinite loop.

That's worth writing down because "use a PAT so the bot's comments trigger other workflows" is a genuinely common and often correct piece of GitHub Actions advice. Here it would be catastrophic, and the reason isn't obvious from the workflow file.

**Docs:** `docs/engineering/ci-cd.md` — added a `### gatekeeper-comment` section covering the per-issue concurrency and why cancellation would lose commands, the `if:` filter as cost-not-security with the script's own re-check, the `GITHUB_TOKEN`-not-PAT rule with the self-retrigger loop as the primary reason, and the reactive-triage secrets degrading to a no-op.

## Deviations and Decisions

- **Added `startsWith(github.event.comment.body, '/')` to the `if:`**, which the checklist doesn't list. Almost every comment on an issue is ordinary conversation, and without it each one spins up a runner to parse nothing. It is only a cost filter — a command on a later line still reaches the script via the sweep, which is the mechanism that exists for exactly this kind of miss.
- **Grouped concurrency per issue rather than globally.** The ordering guarantee only needs to hold within one issue, and a global group would make a comment on issue #12 wait behind an unrelated command on #47.
- **No `timeout-minutes`.** The job is a handful of API calls; the default is fine and an arbitrary short timeout would turn a slow GitHub API day into a dropped command.
- **Untested, deliberately.** This is the one class of thing in the pipeline with no test coverage — a workflow file's real behaviour only exists on GitHub's runners. Everything with a decision in it sits in `run_comment_event.py`, which has 19 tests behind it. This file is trigger, permissions, and environment, and the only way to verify it is to watch it run.

Closes #75

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_