### PR TITLE
ci: add the gatekeeper-sweep workflow

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/run_sweep.py
@@ -108,13 +108,83 @@ def run(state: dict, api, events_only: bool = False, rerender=None) -> dict:
     return {"woken": woken, "fixed": fixed, "findings": findings}
 
 
+def fetch_state(api, focus=None) -> dict:  # pragma: no cover - network shape
+    """Build the sweep's snapshot from the API.
+
+    Separate from the dashboard's fetch because the sweep needs three things
+    the renderer does not: open PRs, recent merged commits on `main`, and the
+    state of every issue named as a blocker.
+    """
+    raw = api("GET", "/issues?state=all&per_page=100&filter=all") or []
+
+    issues = []
+    for item in raw:
+        if "pull_request" in item:
+            continue
+
+        number = item["number"]
+        issues.append({
+            "number": number,
+            "title": item.get("title", ""),
+            "state": item.get("state", "open"),
+            "labels": [label["name"] for label in item.get("labels") or []],
+            "milestone": (item.get("milestone") or {}).get("title"),
+            "body": item.get("body") or "",
+            "native_blockers": _blocked_by(api, number),
+            "comments": _comments(api, number),
+        })
+
+    by_number = {issue["number"]: issue for issue in issues}
+
+    return {
+        "issues": issues,
+        "pulls": [
+            {"number": p["number"], "state": p.get("state", "open"),
+             "body": p.get("body") or ""}
+            for p in api("GET", "/pulls?state=open&per_page=100") or []
+        ],
+        "merged_commits": [
+            {"body": c.get("commit", {}).get("message", "")}
+            for c in api("GET", "/commits?sha=main&per_page=100") or []
+        ],
+        # Every issue's own record doubles as the blocker snapshot.
+        "snapshot": by_number,
+        "focus": focus,
+    }
+
+
+def _blocked_by(api, number) -> list:  # pragma: no cover - network shape
+    try:
+        edges = api("GET", f"/issues/{number}/dependencies/blocked_by") or []
+    except Exception:  # noqa: BLE001 - unknown, not "none"
+        return []
+    return [edge["number"] for edge in edges if isinstance(edge.get("number"), int)]
+
+
+def _comments(api, number) -> list:  # pragma: no cover - network shape
+    return [
+        {"body": c.get("body") or "",
+         "author": (c.get("user") or {}).get("login", ""),
+         "created_at": c.get("created_at", "")}
+        for c in api("GET", f"/issues/{number}/comments?per_page=100") or []
+    ]
+
+
 def main(argv=None) -> int:  # pragma: no cover - the workflow entry point
     import json
+    import os
 
     argv = sys.argv[1:] if argv is None else argv
-    state = json.load(sys.stdin)
+    api = github_api()
 
-    result = run(state, github_api(), events_only="--events-only" in argv)
+    # `--fetch` is how the workflow runs it; stdin is how you rehearse a sweep
+    # against a snapshot you captured earlier.
+    if "--fetch" in argv:
+        state = fetch_state(api, focus=os.environ.get("PIPELINE_FOCUS"))
+    else:
+        state = json.load(sys.stdin)
+
+    result = run(state, api, events_only="--events-only" in argv)
 
     print(f"woke {len(result['woken'])}, fixed {len(result['fixed'])}, "
           f"flagged {sum(1 for f in result['findings'] if f['action'] == 'flag')}")

--- a/.github/workflows/gatekeeper-sweep.yml
+++ b/.github/workflows/gatekeeper-sweep.yml
@@ -1,0 +1,81 @@
+name: gatekeeper-sweep
+
+# The board-wide sweep: wake issues whose blockers cleared, and fix drift.
+#
+# Two paths, and the difference between them is the whole design:
+#
+#   event path   — runs on the events that can actually change the board.
+#                  `strip_labels` only.
+#   cron path    — every six hours, plus manual dispatch. Everything, including
+#                  the two requeue fixes.
+#
+# WHY `requeue` AND `requeue_triage` ARE CRON-ONLY
+#
+# Because the drift they detect is indistinguishable from work in flight.
+#
+# An issue the builder picked up ten seconds ago has `in-progress` and no PR
+# yet — exactly a stall's shape. On the event path, which fires the moment a
+# label changes, requeuing it would yank the issue out from under a running
+# agent, which then opens a PR for an issue the board says is merely ready.
+#
+# `requeue_triage` is the mirror image. Triage posts its analysis comment
+# BEFORE setting the state label, deliberately, so a crash leaves a plan on
+# `ai-triage` rather than an approval-pending issue with nothing to approve.
+# Between those two writes the issue legitimately has one and not the other.
+#
+# By the six-hourly run the transient has resolved. They are omitted entirely
+# rather than softened with a time threshold, because a threshold is a guess
+# about how long an agent takes and is wrong in both directions.
+#
+# See docs/engineering/issue-pipeline.md.
+
+on:
+  issues:
+    # `closed` clears blockers; `labeled` is how every state change arrives.
+    types: [closed, labeled]
+  pull_request:
+    types: [closed]
+  schedule:
+    # Every six hours. Frequent enough that a stall is caught the same day,
+    # rare enough that it is never racing a build.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  # ONE constant group, board-wide. Unlike the comment workflow, this sweep
+  # reads and rewrites the whole board — two overlapping runs would each act on
+  # a snapshot the other has already invalidated.
+  group: gatekeeper-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep the board
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Sweep
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PIPELINE_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          # The flag is the safety catch, not an optimisation. Anything that is
+          # not the cron or a deliberate dispatch takes the event path.
+          if [ "${{ github.event_name }}" = "schedule" ] \
+            || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Cron path — all fixes, including requeue."
+            python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --fetch
+          else
+            echo "Event path — strip_labels only."
+            python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --fetch --events-only
+          fi

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -616,7 +616,7 @@ does; this is where the workflows live.
 | Workflow | Trigger | Does |
 | --- | --- | --- |
 | `gatekeeper-comment` | issue comment created | parses commands (`/approve`, `/park`, …), applies label changes, acknowledges with a reaction |
-| `gatekeeper-sweep` | schedule | catches events the comment trigger missed, and auto-revisits blockers whose blocking issue has closed |
+| `gatekeeper-sweep` | issue/PR events, 6-hourly cron, dispatch | auto-revisits blockers that have cleared, and applies reconcile's fixes |
 | `dashboard` | schedule, and after pipeline runs | rewrites the live dashboard issue |
 | `pipeline-tests` | PR/push touching the pipeline skills | runs the pipeline scripts' own unit tests |
 
@@ -646,6 +646,33 @@ no-recursion guard is precisely what prevents.
 The reactive-triage secrets (`AI_TRIAGE_URL`, `AI_TRIAGE_SECRET`, see #83) are
 surfaced as env vars. Absent, firing is a clean no-op: the nightly round picks
 the issue up, so a missing secret costs latency rather than correctness.
+
+### `gatekeeper-sweep`
+
+Runs on the events that can actually change the board picture — an issue
+closed or labelled, a PR closed — plus a six-hourly cron and manual dispatch.
+
+**Two paths, and the difference is the point.** The event path applies
+`strip_labels` only. The cron path applies everything, including reconcile's
+two requeue fixes.
+
+Those two are cron-only because **the drift they detect is indistinguishable
+from work in flight**. An issue the builder picked up ten seconds ago has
+`in-progress` and no PR yet — exactly a stall's shape — and requeuing it on the
+event path would yank the issue out from under a running agent. Triage's
+comment-before-label ordering creates the mirror-image window for
+`requeue_triage`. By the six-hourly run those transients have resolved.
+
+They are omitted entirely rather than softened with a time threshold: a
+threshold is a guess about how long an agent takes, and it is wrong in both
+directions — too short and it interrupts a slow build, too long and a stall
+sits there all day. `strip_labels` has no such problem and runs on every pass,
+because it only ever touches an already-closed issue.
+
+**Concurrency is one constant group, board-wide** — not per issue like
+`gatekeeper-comment`. This sweep reads and rewrites the whole board, so two
+overlapping runs would each be acting on a snapshot the other has already
+invalidated.
 
 ### `pipeline-tests`
 


### PR DESCRIPTION
This is the tidy-up pass. It wakes issues that were waiting on something now finished, and fixes small inconsistencies — like a closed issue still wearing a label that says it's being worked on.

It runs two different ways, and the difference matters. When something happens on the board it does the safe subset. Every six hours it does everything, including putting stalled work back in the queue.

The reason for the split is that "this issue looks stuck" and "someone started this ten seconds ago" look *identical* from the outside — both are an issue marked in-progress with no pull request yet. Six hours later that ambiguity is gone. Running the full check on every event would mean occasionally snatching an issue back from an agent that was actively working on it.

## Spec invariants

- **`requeue` and `requeue_triage` never run on the event path.** Enforced by the workflow passing `--events-only` for anything that is not the cron or an explicit dispatch, and by `reconcile.process` omitting them from its output entirely when that flag is set — belt and braces, with tests behind the second.
- **`strip_labels` runs on every pass**, safe because it only ever touches an already-closed issue, which is not transiently anything.
- **One board-wide concurrency group**, unlike `gatekeeper-comment`'s per-issue grouping. The sweep rewrites the whole board; two overlapping runs would each act on a snapshot the other invalidated.
- **`cancel-in-progress: false`** — a half-finished sweep that gets cancelled leaves the board mid-edit.
- **`GITHUB_TOKEN` only.**

## How the spec is changing

No reversals. The cron-only rule was decided in #150 and documented in the pipeline spec; this adds it to the CI reference where someone editing the workflow will actually see it, and — more importantly — puts the full reasoning in a header comment in the workflow file itself.

That placement is deliberate. The line that enforces this is a shell `if` choosing between two nearly identical commands, and it looks exactly like something worth simplifying. Anyone tidying it needs the reason in front of them, not one link away.

**Docs:** `docs/engineering/ci-cd.md` — added a `### gatekeeper-sweep` section covering the two paths, why the two requeue fixes are cron-only (drift indistinguishable from work in flight, in both directions), why no time threshold is used, why `strip_labels` is exempt, and why concurrency is board-wide rather than per issue; corrected the glance-table row, which described the trigger as "schedule" only and the purpose as catching missed comments.

## Deviations and Decisions

- **Added `--fetch` to `run_sweep.py`, which is new scope.** The sweep reads a state snapshot on stdin, and nothing built one — `_github_api._fetch_state` serves the dashboard and lacks three things the sweep needs: open PRs, recent merged commits on `main`, and per-issue blockers and comments. The alternative was inline Python in YAML, which is untestable and unreadable. Stdin still works, so rehearsing a sweep against a captured snapshot is unchanged.
- **The cron is `17 */6 * * *`, not on the hour.** GitHub's scheduled runs bunch heavily at :00 and get delayed; an offset minute is the standard mitigation. Six-hourly rather than the 15-minute cadence mentioned elsewhere in the docs, because the issue asks for "low-frequency" and the event triggers now cover the responsive cases — a 15-minute cron would be 96 full board reads a day to catch drift that only appears when something changed.
- **Did not implement "replays any comment command the primary workflow missed."** The sweep has no comment-replay path — `run_sweep.py` does revisits and reconcile, and adding replay means iterating recent comments through the parser with watermark checks, which is a real feature rather than wiring. The watermark machinery it would need exists and is tested, but the loop does not. **This checklist box is not ticked**, and the consequence is that a comment lost to a dropped webhook stays lost until someone re-comments. I'd rather flag that than tick it optimistically.
- **`issues: [closed, labeled]` without `unlabeled`.** Removing a label never clears a blocker or creates the drift this sweep fixes; the dashboard workflow is what cares about `unlabeled`.
- **Untested, like every workflow file.** The decisions all sit in `run_sweep.py` and `reconcile.py`, which have tests. This file is triggers, permissions, and one branch.

Closes #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_