### PR TITLE
ci: add the dashboard workflow

### DIFF
--- a/.claude/skills/pipeline-dashboard/fetch_state.py
+++ b/.claude/skills/pipeline-dashboard/fetch_state.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Print the dashboard's state snapshot as JSON, for piping into the renderer.
+
+    python3 fetch_state.py | python3 render_dashboard.py --write
+
+Split from the renderer on purpose. `render_dashboard.render()` is a pure
+function of the state it is handed — that is what makes the golden test
+possible and what stops a wrong board being anything worse than a wrong page.
+Fetching is the part that needs a network, so it lives on its own.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# The REST helper lives with the gatekeeper, which is the other caller.
+_GATEKEEPER = Path(__file__).resolve().parents[1] / "pipeline-gatekeeper"
+if str(_GATEKEEPER) not in sys.path:
+    sys.path.insert(0, str(_GATEKEEPER))
+
+from _github_api import _fetch_state, github_api  # noqa: E402
+
+
+def main(argv=None) -> int:  # pragma: no cover - network shape
+    state = _fetch_state(github_api())
+
+    focus = os.environ.get("PIPELINE_FOCUS")
+    if focus:
+        state["focus"] = focus
+
+    json.dump(state, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -265,8 +265,29 @@ def _bar(count: int, total: int, width: int = 20) -> str:
     return "█" * filled + "░" * (width - filled)
 
 
-def render(data: dict, focus_override=None, cap_override=None) -> str:
-    """The whole dashboard body. Byte-stable for a given input."""
+AS_OF_LINE = re.compile(r"^_Board as of .*_$", re.MULTILINE)
+
+
+def body_changed(current: str, new: str) -> bool:
+    """Do these two bodies differ in anything but their timestamp?
+
+    The "as of" line makes every render textually different, which would
+    defeat byte-stability's whole purpose: the scheduled runs would PATCH the
+    issue every time and the dashboard's history would be a wall of edits that
+    changed nothing.
+
+    So the timestamp is rendered, but it is not on its own a reason to write.
+    """
+    strip = lambda body: AS_OF_LINE.sub("", body or "")  # noqa: E731
+    return strip(current) != strip(new)
+
+
+def render(data: dict, focus_override=None, cap_override=None, as_of=None) -> str:
+    """The whole dashboard body. Byte-stable for a given input.
+
+    `as_of` is an input like any other — the renderer never reads a clock, so
+    the same arguments always produce the same bytes.
+    """
     focus = resolve_focus(data, focus_override)
     cap = resolve_cap(data, cap_override)
 
@@ -282,6 +303,12 @@ def render(data: dict, focus_override=None, cap_override=None) -> str:
         f"<!-- pipeline-focus: {focus} -->",
         f"<!-- pipeline-cap: {cap} -->",
         "",
+    ]
+
+    if as_of:
+        lines += [f"_Board as of {as_of}._", ""]
+
+    lines += [
         f"## 🎯 Focus: {focus}",
         "",
         f"{total} issue{'' if total == 1 else 's'} in this milestone.",
@@ -409,10 +436,16 @@ def write_dashboard(data: dict, body: str, token=None, repository=None):  # prag
 
     Authenticates with `GITHUB_TOKEN` — never a PAT. The token's scope is this
     repository, and the only endpoint touched is this one issue.
+
+    Skips the write entirely when nothing but the timestamp changed, so a
+    scheduled render on an unchanged board costs no edit.
     """
     token = token or os.environ["GITHUB_TOKEN"]
     repository = repository or os.environ["GITHUB_REPOSITORY"]
     number = data["dashboard_issue"]["number"]
+
+    if not body_changed(data["dashboard_issue"].get("body") or "", body):
+        return None
 
     request = urllib.request.Request(
         f"https://api.github.com/repos/{repository}/issues/{number}",
@@ -430,7 +463,10 @@ def main(argv=None) -> int:
     argv = sys.argv[1:] if argv is None else argv
     data = json.load(sys.stdin)
 
-    body = render(data)
+    # Passed in rather than read from a clock, so `render` stays a pure
+    # function of its arguments and the golden test stays possible.
+    as_of = os.environ.get("DASHBOARD_AS_OF") or None
+    body = render(data, as_of=as_of)
 
     if "--write" in argv:  # pragma: no cover - network path
         write_dashboard(data, body)

--- a/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
@@ -337,6 +337,46 @@ class ParkedExclusionTests(unittest.TestCase):
         self.assertEqual(counts["Unplanned"], 3)
 
 
+class AsOfTests(unittest.TestCase):
+    """The timestamp, and how it avoids defeating byte-stability."""
+
+    def test_no_timestamp_is_rendered_by_default(self):
+        self.assertNotIn("as of", dash.render(state()))
+
+    def test_the_timestamp_is_rendered_when_given(self):
+        rendered = dash.render(state(), as_of="8 Aug 2026, 3:04 PM CDT")
+        self.assertIn("8 Aug 2026, 3:04 PM CDT", rendered)
+
+    def test_rendering_is_still_byte_stable_for_a_given_timestamp(self):
+        stamp = "8 Aug 2026, 3:04 PM CDT"
+        self.assertEqual(dash.render(state(), as_of=stamp),
+                         dash.render(state(), as_of=stamp))
+
+    def test_two_renders_differing_only_by_timestamp_are_not_a_change(self):
+        """Otherwise every scheduled run rewrites the issue for nothing."""
+        first = dash.render(state(), as_of="8 Aug 2026, 3:04 PM CDT")
+        second = dash.render(state(), as_of="8 Aug 2026, 4:04 PM CDT")
+
+        self.assertNotEqual(first, second)
+        self.assertFalse(dash.body_changed(first, second))
+
+    def test_a_real_change_is_still_a_change(self):
+        data = state()
+        first = dash.render(data, as_of="8 Aug 2026, 3:04 PM CDT")
+
+        data["issues"].append({
+            "number": 30, "title": "Something new", "state": "open",
+            "labels": ["ready-for-work"], "milestone": "v0.0.1",
+            "body": "", "native_blockers": []})
+        second = dash.render(data, as_of="8 Aug 2026, 4:04 PM CDT")
+
+        self.assertTrue(dash.body_changed(first, second))
+
+    def test_a_body_that_never_had_a_timestamp_still_compares(self):
+        rendered = dash.render(state())
+        self.assertFalse(dash.body_changed(rendered, rendered))
+
+
 class PurityTests(unittest.TestCase):
     def test_render_does_not_mutate_its_input(self):
         data = state()

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,74 @@
+name: dashboard
+
+# Regenerates the dashboard issue from live repo state.
+#
+# Deterministic — `render_dashboard.py` is a pure function of the state, with
+# no model anywhere near it. The board is what Derek reads to decide what to
+# approve next, and a generated summary can be fluently, confidently wrong in
+# a way a computed table cannot.
+#
+# WHY THE GATEKEEPER ALSO RE-RENDERS INLINE
+#
+# GitHub suppresses workflow runs from events initiated by `GITHUB_TOKEN`. The
+# gatekeeper's own label moves are made with that token, so they do NOT fire
+# the `issues: labeled` trigger below — this workflow would never see the very
+# changes it most needs to reflect. That is why `run_comment_event.py` and
+# `run_sweep.py` call the renderer directly after their label writes.
+#
+# The trigger here is for label changes made by a human in the GitHub UI, and
+# the schedule is the backstop for everything else.
+#
+# See docs/engineering/issue-pipeline.md.
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  schedule:
+    # Offset after each nightly routine, so the board reflects the run that
+    # just finished: reconcile 01:00, analysis 02:00, development 03:00.
+    - cron: '40 1 * * *'
+    - cron: '40 2 * * *'
+    - cron: '40 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  # The dashboard issue body.
+  issues: write
+  # The board reports on open PRs.
+  pull-requests: read
+  contents: read
+
+concurrency:
+  # One group, and NOT cancel-in-progress — a burst of label changes should
+  # collapse to one final render on the latest state. Cancelling mid-run would
+  # be safe (the render is idempotent), but queueing means the last render in
+  # a burst is the one that sees everything.
+  group: dashboard
+  cancel-in-progress: false
+
+jobs:
+  render:
+    name: Render the dashboard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Computed here rather than in the renderer, which never reads a clock —
+      # that is what keeps `render()` a pure function and the golden test
+      # possible. Central time because that is where Derek and Connor are.
+      - name: Timestamp
+        id: stamp
+        run: |
+          echo "as_of=$(TZ=America/Chicago date '+%-d %b %Y, %-I:%M %p %Z')" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Render and write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DASHBOARD_AS_OF: ${{ steps.stamp.outputs.as_of }}
+        run: |
+          set -euo pipefail
+          python3 .claude/skills/pipeline-dashboard/fetch_state.py \
+            | python3 .claude/skills/pipeline-dashboard/render_dashboard.py --write

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -617,7 +617,7 @@ does; this is where the workflows live.
 | --- | --- | --- |
 | `gatekeeper-comment` | issue comment created | parses commands (`/approve`, `/park`, …), applies label changes, acknowledges with a reaction |
 | `gatekeeper-sweep` | issue/PR events, 6-hourly cron, dispatch | auto-revisits blockers that have cleared, and applies reconcile's fixes |
-| `dashboard` | schedule, and after pipeline runs | rewrites the live dashboard issue |
+| `dashboard` | human label changes, daily schedules, dispatch | rewrites the live dashboard issue |
 | `pipeline-tests` | PR/push touching the pipeline skills | runs the pipeline scripts' own unit tests |
 
 ### `gatekeeper-comment`
@@ -673,6 +673,41 @@ because it only ever touches an already-closed issue.
 `gatekeeper-comment`. This sweep reads and rewrites the whole board, so two
 overlapping runs would each be acting on a snapshot the other has already
 invalidated.
+
+### `dashboard`
+
+Renders the board on `issues: [labeled, unlabeled]`, on three daily schedules
+offset after the nightly routines, and on dispatch.
+
+**Why the gatekeeper also re-renders inline.** GitHub suppresses workflow runs
+from events initiated by `GITHUB_TOKEN`, and the gatekeeper's label moves use
+that token — so they do *not* fire the `labeled` trigger here. This workflow
+would never see the very changes it most needs to reflect. That is why
+`run_comment_event.py` and `run_sweep.py` call the renderer directly after
+their label writes. The trigger here catches label changes a human makes in the
+GitHub UI; the schedule is the backstop for everything else.
+
+**Concurrency is one group with `cancel-in-progress: false`,** so a burst of
+label changes collapses to one final render on the latest state. Cancelling
+would also be safe — the render is idempotent — but queueing guarantees the
+last render in a burst is the one that sees everything.
+
+#### The timestamp, and how it avoids defeating byte-stability
+
+The "as of" line is computed in the workflow (`TZ=America/Chicago`) and passed
+in as an environment variable. **The renderer never reads a clock**, which is
+what keeps `render()` a pure function of its arguments and the golden test
+possible.
+
+A timestamp makes every render textually different, which would undo what
+byte-stability was for: the scheduled runs would PATCH the issue every time and
+the board's history would become a wall of edits that changed nothing. So
+`write_dashboard` compares the new body against the current one **with the
+timestamp line excluded**, and skips the write when nothing else moved.
+
+The board therefore says when it was last *rendered*, while its edit history
+records only when it last *changed* — which are two genuinely different
+questions, and both worth being able to answer.
 
 ### `pipeline-tests`
 


### PR DESCRIPTION
This is the job that keeps the board up to date — after each nightly run, whenever someone changes a label by hand, or on demand.

The board now says when it was last refreshed. That sounds trivial but it needed care: a clock in the page means every refresh produces different text, so the issue would be edited every few hours even when nothing about the project had changed, and its history would fill up with edits that say nothing. So the timestamp is shown, but it doesn't count as a change on its own — if the only difference is the time, the board isn't rewritten.

The result is that the page tells you when it last *looked*, while its edit history tells you when something last *moved*. Those are different questions and both are worth being able to answer.

## Spec invariants

- **The renderer still never reads a clock.** `as_of` is an argument like any other, so `render()` remains a pure function and the golden test stays possible. `test_rendering_is_still_byte_stable_for_a_given_timestamp` pins it.
- **A timestamp-only difference is not a change.** `test_two_renders_differing_only_by_timestamp_are_not_a_change` asserts the bodies genuinely differ *and* that `body_changed` returns false — so the test would fail if I'd cheated by not rendering the timestamp at all.
- **A real change is still a change** — `test_a_real_change_is_still_a_change` adds an issue and asserts the write goes ahead.
- **The write surface is unchanged** from #154: one `PATCH`, `GITHUB_TOKEN`, the dashboard issue only.
- **`issues: write`, `pull-requests: read`, `contents: read`** — the minimum that lets the board report on open PRs.

57 tests, 6 new and red first.

## How the spec is changing

**A `no-op` render now costs no edit.** Byte-stability previously meant "identical input, identical bytes, therefore no PATCH". Adding a timestamp breaks that identity, so the property is restated at the level that actually matters: *a render only writes when something other than the time changed*. Same guarantee, one layer up.

**Why the gatekeeper re-renders inline is now written down where it belongs.** GitHub suppresses workflow runs from events initiated by `GITHUB_TOKEN`, so the gatekeeper's own label moves never fire the `labeled` trigger in this workflow. Read quickly, the inline re-render in `run_comment_event.py` looks redundant now that a dashboard workflow exists — and deleting it would silently stop the board updating after every command, the single most visible thing the pipeline does. The reasoning is in the workflow header and the CI docs.

**Docs:** `docs/engineering/ci-cd.md` — added a `### dashboard` section covering the triggers, why the gatekeeper re-renders inline despite this workflow existing (the `GITHUB_TOKEN` no-recursion guard), and the burst-collapsing concurrency; added a subsection on the timestamp, where it is computed and why not in the renderer, and how the write is skipped when only the time changed; corrected the glance-table row, which described the trigger as "schedule, and after pipeline runs".

## Deviations and Decisions

- **Added `fetch_state.py`, which the issue doesn't mention.** The renderer reads a state snapshot on stdin and nothing built one for this path — `_fetch_state` existed only as a private helper inside the gatekeeper's API module. A separate fetch script keeps the renderer a pure function rather than growing a network call into it. Same shape as the `--fetch` addition in #160.
- **Three daily schedules, not hourly.** The issue asks for "a few daily entries offset after the routines", and I read the hourly cadence mentioned elsewhere as predating the inline re-renders. With the gatekeeper and sweep both re-rendering after their own writes, an hourly cron would almost always find nothing changed — and now that a no-change render skips the write, it would be 24 daily API sweeps to produce nothing. The three entries sit 40 minutes after reconcile, analysis, and development.
- **`cancel-in-progress: false` rather than `true`.** Cancelling would be safe here — the render is idempotent, unlike the gatekeeper's ordered command application. I chose queueing anyway so the final render in a burst is the one that observes every change; cancel-in-progress would let a mid-burst render be the last one to complete.
- **`%-d`/`%-I` GNU date format specifiers** produce "8 Aug 2026, 3:04 PM CDT" rather than "08 Aug 2026, 03:04 PM". Fine on `ubuntu-latest`, and not portable to BSD date — noting it since the timestamp is the one part of this that is shell rather than Python.

Closes #77

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_