### PR TITLE
fix(pipeline): paginate every list read, and seed the dashboard issue

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/_github_api.py
+++ b/.claude/skills/pipeline-gatekeeper/_github_api.py
@@ -54,6 +54,65 @@ def github_api(token=None, repository=None):
     return api
 
 
+PER_PAGE = 100
+
+# A backstop, not a limit anyone should reach: 100 pages is 10,000 items. It
+# exists so a bug in the stop condition cannot spin forever against the API.
+MAX_PAGES = 100
+
+
+def collect_pages(fetch_page, per_page: int = PER_PAGE, max_pages: int = MAX_PAGES) -> list:
+    """Every item across every page, given a `fetch_page(n)` returning one page.
+
+    **Every list endpoint in this pipeline must go through this.** GitHub caps
+    a page at 100 items and says nothing when it truncates — the response is a
+    well-formed list that happens to be missing everything after the hundredth
+    item.
+
+    On this repository that is not hypothetical. `/issues?state=all` returns
+    100 items of which most are pull requests, so a single-page read saw 28
+    issues out of far more. A board rendered from that is quietly, plausibly
+    wrong, and the pie still adds up — against the wrong total.
+
+    Stops on the first short page. Page numbers rather than the `Link` header's
+    `next` URL, because that URL uses an opaque `/repositories/{id}/` form and
+    keeping every request on `/repos/{owner}/{repo}/` is both simpler to reason
+    about and easier to fake in a test.
+    """
+    items: list = []
+
+    for page in range(1, max_pages + 1):
+        batch = fetch_page(page) or []
+        items.extend(batch)
+
+        if len(batch) < per_page:
+            return items
+
+    return items
+
+
+def paged(token=None, repository=None):
+    """A `get_all(path)` that reads every page of a list endpoint."""
+    token = token or os.environ["GITHUB_TOKEN"]
+    repository = repository or os.environ["GITHUB_REPOSITORY"]
+
+    def get_all(path: str) -> list:
+        separator = "&" if "?" in path else "?"
+
+        def fetch_page(page: int):
+            url = f"{API_ROOT}/repos/{repository}{path}{separator}page={page}"
+            request = urllib.request.Request(url, method="GET")
+            request.add_header("Authorization", f"Bearer {token}")
+            request.add_header("Accept", "application/vnd.github+json")
+
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode() or "[]")
+
+        return collect_pages(fetch_page)
+
+    return get_all
+
+
 def set_labels(api, issue_number: int, labels) -> None:
     api("PUT", f"/issues/{issue_number}/labels", {"labels": sorted(set(labels))})
 
@@ -92,10 +151,16 @@ def rerender_dashboard(api, focus_override=None, cap_override=None) -> None:
     api("PATCH", f"/issues/{state['dashboard_issue']['number']}", {"body": body})
 
 
-def _fetch_state(api) -> dict:  # pragma: no cover - network shape
-    """Everything the renderer needs, in the shape it expects."""
-    raw_issues = api("GET", "/issues?state=all&per_page=100") or []
-    milestones = api("GET", "/milestones?state=open&per_page=100") or []
+def _fetch_state(api, get_all=None) -> dict:  # pragma: no cover - network shape
+    """Everything the renderer needs, in the shape it expects.
+
+    Paginated. A single-page read of `/issues` on this repository returns 100
+    items of which most are pull requests, so the board would silently be
+    missing everything past the first page.
+    """
+    get_all = get_all or paged()
+    raw_issues = get_all("/issues?state=all&per_page=100")
+    milestones = get_all("/milestones?state=open&per_page=100")
 
     issues = [
         {

--- a/.claude/skills/pipeline-gatekeeper/run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/run_sweep.py
@@ -115,7 +115,12 @@ def fetch_state(api, focus=None) -> dict:  # pragma: no cover - network shape
     the renderer does not: open PRs, recent merged commits on `main`, and the
     state of every issue named as a blocker.
     """
-    raw = api("GET", "/issues?state=all&per_page=100&filter=all") or []
+    from _github_api import paged  # noqa: PLC0415
+
+    get_all = paged()
+    # Paginated: a single page is 100 items and GitHub says nothing when it
+    # truncates, so an unpaginated sweep would simply not see older issues.
+    raw = get_all("/issues?state=all&per_page=100")
 
     issues = []
     for item in raw:
@@ -141,8 +146,12 @@ def fetch_state(api, focus=None) -> dict:  # pragma: no cover - network shape
         "pulls": [
             {"number": p["number"], "state": p.get("state", "open"),
              "body": p.get("body") or ""}
-            for p in api("GET", "/pulls?state=open&per_page=100") or []
+            for p in get_all("/pulls?state=open&per_page=100")
         ],
+        # Deliberately ONE page, unlike the lists above. This answers "did this
+        # land recently", and the whole history of `main` cannot change that
+        # answer — an issue whose commit is 500 merges back was reconciled long
+        # ago. Paginating here would grow without bound for no new information.
         "merged_commits": [
             {"body": c.get("commit", {}).get("message", "")}
             for c in api("GET", "/commits?sha=main&per_page=100") or []

--- a/.claude/skills/pipeline-gatekeeper/tests/test_github_api.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_github_api.py
@@ -1,0 +1,75 @@
+"""Tests for page collection.
+
+The rest of `_github_api` is network plumbing. This part is the logic that
+silently loses data when it is wrong — a truncated read is a well-formed list,
+so nothing downstream can tell it happened.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import _github_api as api  # noqa: E402
+
+
+def pages(*sizes):
+    """A fake `fetch_page` serving pages of the given sizes, and recording calls."""
+    served = []
+    number = [0]
+
+    def fetch_page(page):
+        served.append(page)
+        size = sizes[page - 1] if page <= len(sizes) else 0
+        batch = [{"n": number[0] + i} for i in range(size)]
+        number[0] += size
+        return batch
+
+    fetch_page.served = served
+    return fetch_page
+
+
+class CollectPagesTests(unittest.TestCase):
+    def test_a_single_short_page_is_returned_whole(self):
+        fetch = pages(7)
+        self.assertEqual(len(api.collect_pages(fetch, per_page=100)), 7)
+        self.assertEqual(fetch.served, [1])
+
+    def test_a_full_page_is_followed_by_another_request(self):
+        """The bug this exists to prevent: stopping at exactly 100."""
+        fetch = pages(100, 28)
+        self.assertEqual(len(api.collect_pages(fetch, per_page=100)), 128)
+        self.assertEqual(fetch.served, [1, 2])
+
+    def test_several_full_pages_are_all_collected(self):
+        fetch = pages(100, 100, 5)
+        self.assertEqual(len(api.collect_pages(fetch, per_page=100)), 205)
+
+    def test_an_exactly_full_last_page_costs_one_extra_empty_request(self):
+        """Unavoidable: a full page is indistinguishable from a truncated one."""
+        fetch = pages(100)
+        self.assertEqual(len(api.collect_pages(fetch, per_page=100)), 100)
+        self.assertEqual(fetch.served, [1, 2])
+
+    def test_an_empty_first_page_is_an_empty_result(self):
+        self.assertEqual(api.collect_pages(pages(0), per_page=100), [])
+
+    def test_a_none_page_is_treated_as_empty_rather_than_raising(self):
+        self.assertEqual(api.collect_pages(lambda page: None, per_page=100), [])
+
+    def test_items_keep_their_order_across_pages(self):
+        collected = api.collect_pages(pages(3, 2), per_page=3)
+        self.assertEqual([item["n"] for item in collected], [0, 1, 2, 3, 4])
+
+    def test_the_page_cap_stops_a_runaway(self):
+        """A stop-condition bug must not spin against the API forever."""
+        fetch = pages(*([100] * 500))
+        collected = api.collect_pages(fetch, per_page=100, max_pages=3)
+
+        self.assertEqual(len(collected), 300)
+        self.assertEqual(fetch.served, [1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -339,7 +339,12 @@ board that does not render is worse than one with a default cap, and the next
 `/cap` fixes it.
 
 The dashboard issue is the one carrying the `dashboard` label. There is exactly
-one; the reconciler flags it if there are two or none.
+one — [**issue #163**](https://github.com/derekwinters/connor-multiplying-frogs/issues/163)
+— and the reconciler flags it if there are ever two or none.
+
+Nothing hard-codes that number. Every script finds the board by its label, so
+recreating it is a matter of moving the label rather than editing code; the
+number here is for people, not for programs.
 
 ### Why markers, and why re-rendering beats hand-editing
 


### PR DESCRIPTION
The pipeline now has its board: issue #163, seeded with the two hidden settings lines that say which milestone is in focus and how many issues a build round takes on.

Checking that it actually worked turned up a genuine bug, and it's the kind worth knowing about. The code that reads the repository's issues was only ever seeing the first hundred results. GitHub hands back a hundred at a time and doesn't mention there are more — so what came back looked completely normal. Because this repo has a lot of pull requests mixed in, that first hundred contained only 28 actual issues out of 91.

A board built from that would have looked entirely convincing. The numbers would have added up, the percentages would have been consistent, and it would have been wrong. That's the worst shape a bug can take on a page whose whole job is being trustworthy.

## Spec invariants

- **The board is found by label, never by number.** #163 appears in the docs for humans; no script hard-codes it, so recreating the board means moving a label.
- **Pagination logic is tested, not trusted.** `collect_pages` takes an injected `fetch_page`, so the stop condition is covered without a network. `test_a_full_page_is_followed_by_another_request` is precisely the bug that shipped.
- **A runaway is capped** at 100 pages — a stop-condition bug must not spin against the API forever.
- **Merged commits stay single-page**, deliberately, with the reasoning in a comment.

164 gatekeeper tests, 8 of them new.

### Verified against the live repository

Not asserted — actually run:

| Check | Result |
| --- | --- |
| Issues fetched | 91 (was 28 before the fix) |
| Focus milestone total | 74 issues in v0.0.1 |
| Pie slices sum to that total | ✅ 4 + 0 + 0 + 70 = 74 |
| `pipeline-focus` survives a round trip | ✅ `v0.0.1` |
| `pipeline-cap` survives a round trip | ✅ `3` |
| Re-render with only a later timestamp | ✅ correctly not a write |

## How the spec is changing

The dashboard section now names #163 and — more usefully — says that **nothing depends on the number**. Recording an issue number in documentation invites someone to reference it from code later, and the label-based lookup is what makes the board recreatable if it's ever lost or superseded.

**Docs:** `docs/engineering/issue-pipeline.md` — recorded the live dashboard issue as #163 with a link, and stated that scripts locate it by its `dashboard` label rather than by number, so the number is for people rather than programs.

## Deviations and Decisions

- **Fixed the pagination bug rather than filing it, despite it belonging to #155 and #160.** #78's final checklist box is "run the renderer once and confirm the board renders" — and it did render, incorrectly. Ticking that box while knowing the output was wrong would have been the optimistic tick `CLAUDE.md` warns against, and filing a follow-up would leave the board actively misleading in the meantime.
- **Page numbers instead of the `Link` header's `next` URL.** I implemented and tested the `Link` parser first; it then failed with a 403 against the live API, because the `next` URL uses an opaque `/repositories/{id}/…` form that this environment's proxy rejects. Page numbers keep every request on `/repos/{owner}/{repo}/…`, are simpler to fake in a test, and are equally correct for these endpoints. Worth flagging that the first approach was discarded after a real failure, not on taste.
- **`/commits?sha=main` is deliberately *not* paginated.** It answers "did this land recently", and the entire history of `main` cannot change that answer — an issue whose commit is 500 merges back was reconciled long ago. Paginating it would grow without bound for no new information. This is now a comment in the code so it doesn't read as a missed case.
- **An exactly-full final page costs one extra empty request**, which `test_an_exactly_full_last_page_costs_one_extra_empty_request` documents. Unavoidable without the `Link` header: a full page is indistinguishable from a truncated one.
- **The seeded body explains the markers rather than being a stub.** It's replaced at the first render, but between now and then it's what someone finds if they open the issue, and "Awaiting its first render" alone would not tell them not to hand-edit it.

Closes #78

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_