### PR TITLE
ci: fail any workflow with an unpinned action

### DIFF
--- a/.github/scripts/check_action_pins.py
+++ b/.github/scripts/check_action_pins.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail any workflow that reaches third-party code without a full SHA pin.
+
+The platform already rejects an unpinned action at run time under this
+repository's policy, but that surfaces as a confusing failure partway through a
+run — and only on the workflows something happens to trigger. A tag that slips
+into a rarely-fired workflow can sit there for months.
+
+This is the review-time signal instead: cheap, offline, and it sees every
+workflow whether or not anything runs it.
+
+    python3 .github/scripts/check_action_pins.py
+
+Stdlib only. See docs/engineering/ci-cd.md.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(".github/workflows")
+
+# A `uses:` at the start of its content, so a step's `- uses:` and a job-level
+# `uses:` both match, and the word inside prose or a shell string does not.
+USES_LINE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)")
+
+FULL_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+
+# `# v7.0.1`, `# v4`, `# v1.2.3-beta`. The point is that a human can read the
+# version without resolving the SHA.
+VERSION_COMMENT = re.compile(r"#\s*v\d+(?:\.\d+)*\S*")
+
+# Forms that do not reach a third-party repository at a mutable ref:
+#   ./...        a local composite action or reusable workflow, versioned with
+#                this repo — pinning it to a SHA would pin the repo to itself
+#   docker://    an image reference, governed by the registry not by Actions
+LOCAL_PREFIXES = ("./", "docker://")
+
+
+class Finding:
+    def __init__(self, path: str, line: int, kind: str, reference: str,
+                 fatal: bool) -> None:
+        self.path = path
+        self.line = line
+        self.kind = kind
+        self.reference = reference
+        self.fatal = fatal
+
+    def __eq__(self, other) -> bool:  # pragma: no cover - test convenience
+        return isinstance(other, Finding) and vars(self) == vars(other)
+
+    def __repr__(self) -> str:
+        marker = "error" if self.fatal else "warning"
+        return f"{self.path}:{self.line}: {marker}: {self.kind}: {self.reference}"
+
+
+def check_text(path: str, text: str) -> list:
+    """Every pin problem in one workflow file."""
+    findings = []
+
+    for number, line in enumerate(text.splitlines(), start=1):
+        # A commented-out `uses:` is not a `uses:`.
+        if line.lstrip().startswith("#"):
+            continue
+
+        match = USES_LINE.match(line)
+        if not match:
+            continue
+
+        reference = match.group(1)
+
+        if reference.startswith(LOCAL_PREFIXES):
+            continue
+
+        _, _, version = reference.partition("@")
+
+        if not FULL_SHA.match(version):
+            findings.append(Finding(
+                path, number, "unpinned", reference, fatal=True))
+            continue
+
+        if not VERSION_COMMENT.search(line):
+            # A warning, not a failure. The pin is correct and the build is
+            # safe; what is missing is the human-readable part, and failing a
+            # PR over a comment would train people to distrust this check.
+            findings.append(Finding(
+                path, number, "no-version-comment", reference, fatal=False))
+
+    return findings
+
+
+def check_paths(paths) -> list:
+    findings = []
+    for path in sorted(paths):
+        findings.extend(check_text(str(path), Path(path).read_text()))
+    return findings
+
+
+def exit_code(findings) -> int:
+    return 1 if any(finding.fatal for finding in findings) else 0
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    root = Path(argv[0]) if argv else WORKFLOWS
+
+    paths = sorted(root.glob("*.yml")) + sorted(root.glob("*.yaml"))
+
+    if not paths:
+        print(f"No workflows found under {root}.", file=sys.stderr)
+        return 1
+
+    findings = check_paths(paths)
+
+    for finding in findings:
+        stream = sys.stderr if finding.fatal else sys.stdout
+        level = "error" if finding.fatal else "warning"
+        print(f"::{level} file={finding.path},line={finding.line}::"
+              f"{_message(finding)}", file=stream)
+
+    if not findings:
+        print(f"All {len(paths)} workflows are pinned to full commit SHAs.")
+
+    return exit_code(findings)
+
+
+def _message(finding: Finding) -> str:
+    if finding.kind == "unpinned":
+        return (f"`{finding.reference}` is not pinned to a full 40-character "
+                f"commit SHA. Tags and branches move; a SHA does not. "
+                f"Run .github/scripts/resolve_action_pin.sh to resolve it.")
+
+    return (f"`{finding.reference}` is pinned but has no trailing "
+            f"`# vX.Y.Z` comment, so nobody can tell which version it is.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_check_action_pins.py
+++ b/.github/scripts/tests/test_check_action_pins.py
@@ -1,0 +1,128 @@
+"""Tests for the action-pin check."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_action_pins as pins  # noqa: E402
+
+SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+
+def findings(text, path="wf.yml"):
+    return pins.check_text(path, text)
+
+
+def kinds(text):
+    return [finding.kind for finding in findings(text)]
+
+
+class PinnedTests(unittest.TestCase):
+    def test_a_full_sha_with_a_version_comment_is_clean(self):
+        self.assertEqual(findings(f"      - uses: actions/checkout@{SHA} # v7.0.1"), [])
+
+    def test_uppercase_hex_is_accepted(self):
+        line = f"      - uses: actions/checkout@{SHA.upper()} # v7.0.1"
+        self.assertEqual(kinds(line), [])
+
+    def test_a_pinned_line_without_a_version_comment_warns(self):
+        self.assertEqual(kinds(f"      - uses: actions/checkout@{SHA}"), ["no-version-comment"])
+
+    def test_a_warning_is_not_a_failure(self):
+        found = findings(f"      - uses: actions/checkout@{SHA}")
+        self.assertFalse(found[0].fatal)
+
+    def test_a_comment_that_is_not_a_version_still_warns(self):
+        line = f"      - uses: actions/checkout@{SHA} # pinned"
+        self.assertEqual(kinds(line), ["no-version-comment"])
+
+
+class UnpinnedTests(unittest.TestCase):
+    def test_a_tag_is_rejected(self):
+        found = findings("      - uses: actions/checkout@v4")
+        self.assertEqual([f.kind for f in found], ["unpinned"])
+        self.assertTrue(found[0].fatal)
+
+    def test_a_branch_is_rejected(self):
+        self.assertEqual(kinds("      - uses: actions/checkout@main"), ["unpinned"])
+
+    def test_a_short_sha_is_rejected(self):
+        self.assertEqual(kinds("      - uses: actions/checkout@3d3c42e"), ["unpinned"])
+
+    def test_a_thirty_nine_character_sha_is_rejected(self):
+        self.assertEqual(kinds(f"      - uses: actions/checkout@{SHA[:-1]}"), ["unpinned"])
+
+    def test_a_reference_with_no_version_at_all_is_rejected(self):
+        self.assertEqual(kinds("      - uses: actions/checkout"), ["unpinned"])
+
+    def test_the_finding_carries_the_line_number(self):
+        text = f"jobs:\n  a:\n    steps:\n      - uses: actions/checkout@v4\n"
+        self.assertEqual(findings(text)[0].line, 4)
+
+
+class DeliberateFormsTests(unittest.TestCase):
+    """Forms that are not third-party actions and must not be flagged."""
+
+    def test_a_local_reusable_workflow_is_allowed(self):
+        self.assertEqual(kinds("    uses: ./.github/workflows/release-build.yml"), [])
+
+    def test_a_local_composite_action_is_allowed(self):
+        self.assertEqual(kinds("      - uses: ./.github/actions/setup"), [])
+
+    def test_a_docker_reference_is_allowed(self):
+        self.assertEqual(kinds("      - uses: docker://alpine:3.20"), [])
+
+    def test_a_remote_reusable_workflow_still_needs_a_pin(self):
+        """`uses:` at job level reaches third-party code just the same."""
+        line = "    uses: some-org/shared/.github/workflows/build.yml@v1"
+        self.assertEqual(kinds(line), ["unpinned"])
+
+
+class NotAUsesLineTests(unittest.TestCase):
+    def test_a_commented_out_uses_is_ignored(self):
+        self.assertEqual(kinds("      # - uses: actions/checkout@v4"), [])
+
+    def test_the_word_uses_in_prose_is_ignored(self):
+        self.assertEqual(kinds("# This workflow uses: nothing in particular"), [])
+
+    def test_a_string_containing_uses_is_ignored(self):
+        self.assertEqual(kinds('        run: echo "uses: actions/checkout@v4"'), [])
+
+
+class ReportingTests(unittest.TestCase):
+    def test_only_fatal_findings_fail_the_run(self):
+        clean = [pins.Finding("wf.yml", 1, "no-version-comment", "x", fatal=False)]
+        self.assertEqual(pins.exit_code(clean), 0)
+
+    def test_a_fatal_finding_fails_the_run(self):
+        bad = [pins.Finding("wf.yml", 1, "unpinned", "x", fatal=True)]
+        self.assertEqual(pins.exit_code(bad), 1)
+
+    def test_no_findings_passes(self):
+        self.assertEqual(pins.exit_code([]), 0)
+
+
+class RealWorkflowTests(unittest.TestCase):
+    """The check must pass on this repository as it stands."""
+
+    def test_every_workflow_in_this_repo_is_pinned(self):
+        root = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+        fatal = [
+            finding
+            for path in sorted(root.glob("*.yml"))
+            for finding in pins.check_text(str(path), path.read_text())
+            if finding.fatal
+        ]
+
+        self.assertEqual(fatal, [], f"unpinned actions: {fatal}")
+
+    def test_the_repo_has_workflows_to_check(self):
+        """Guards against the suite passing because it found nothing."""
+        root = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+        self.assertGreater(len(list(root.glob("*.yml"))), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Test the CI scripts
         run: python3 .github/scripts/run_python_tests.py scripts
 
+      # Here rather than in its own workflow: it runs on every PR at no extra
+      # cost, and it must see every workflow file — a path filter would miss
+      # exactly the case it exists for, a tag slipping into a workflow that
+      # nothing happens to trigger.
+      - name: Every action is pinned to a commit SHA
+        run: python3 .github/scripts/check_action_pins.py
+
   build:
     name: Docs
     runs-on: ubuntu-latest

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -112,6 +112,31 @@ If a new action is genuinely needed: check it is permitted by the repository's
 Actions policy (a denied action fails the run with a policy message, which is at
 least a loud failure), pin it, add it to this table, and say why in the PR.
 
+### The check that enforces it
+
+`check_action_pins.py` scans every file under `.github/workflows/` and **fails
+the PR** on any `uses:` whose ref is not a full 40-character hex SHA. Tags,
+branches, short SHAs, and a bare `owner/repo` with no ref are all rejected.
+
+It runs inside the `Gate tests` job rather than as its own workflow: that job
+already runs on every PR, so the check costs no extra run — and it is
+deliberately **not** path-filtered. A path filter would miss precisely the case
+this exists for, which is a tag slipping into a workflow that nothing happens
+to trigger. The platform's own policy would eventually reject it, mid-run,
+months later.
+
+Two things it deliberately does not flag:
+
+- **`./…`** — a local composite action or reusable workflow, versioned with
+  this repository. Pinning it to a SHA would pin the repo to itself.
+- **`docker://…`** — an image reference, governed by the registry rather than
+  by Actions.
+
+A missing `# vX.Y.Z` comment is a **warning, not a failure**. The pin is
+correct and the build is safe; what is missing is the human-readable part.
+Failing a PR over a comment teaches people that this check is pedantic, and a
+check people resent is one they route around.
+
 ### Keeping pins fresh
 
 A pin that never moves is a pin that misses security fixes — the failure mode


### PR DESCRIPTION
Every third-party action this project uses is locked to an exact commit rather than a moving label like `v4`. This adds the check that keeps it that way — a pull request that introduces a loose reference now fails immediately, with a message saying what to run to fix it.

GitHub would eventually reject a loose reference too, but only when that particular workflow next runs, and only as a confusing failure partway through. A tag added to a workflow that fires rarely could sit unnoticed for months.

## Spec invariants

- **Full 40-character hex SHAs only.** `test_a_thirty_nine_character_sha_is_rejected` pins the boundary; short SHAs, tags, branches and bare `owner/repo` are all rejected.
- **A missing version comment warns, never fails.** `test_a_warning_is_not_a_failure` asserts the flag, and `exit_code` only counts fatal findings.
- **The repo passes today** — `test_every_workflow_in_this_repo_is_pinned` runs the checker over the real `.github/workflows/`, so this can never regress silently.
- **The suite can't pass by finding nothing.** `test_the_repo_has_workflows_to_check` asserts there are more than five workflow files — otherwise a broken glob would make the previous test vacuously green, which is the failure mode a "check everything" test is most prone to.

128 script tests, 22 new and red first.

### Verified both directions

Not just asserted — run:

- Against this repository: `All 14 workflows are pinned to full commit SHAs.`, exit 0.
- Against a fixture with `actions/checkout@v4` and an uncommented SHA: one `::error`, one `::warning`, exit 1.

## How the spec is changing

Nothing reverses. The pinning convention was already documented; what was missing is that **nothing enforced it inside the repo**, and the docs implied the platform policy was sufficient backstop. It isn't, for the reason above — policy enforcement is per-run, not per-review.

The one judgement worth reviewing is that a **missing `# vX.Y.Z` comment warns rather than fails**. The comment is genuinely valuable — without it nobody can tell `a98b568…` is v6.0.0 without resolving it — but the pin is correct and the build is safe, and the trade is deliberate: failing a PR over a comment teaches people the check is pedantic, and a check people resent is a check they route around.

**Docs:** `docs/engineering/ci-cd.md` — added "The check that enforces it" under the pinning section, documenting what fails, why it lives in the existing `Gate tests` job rather than its own workflow, why it is deliberately not path-filtered, the two reference forms it skips on purpose, and why a missing version comment warns rather than fails.

## Deviations and Decisions

- **Handled `./…` and `docker://…` as explicit skips with reasons in code.** The issue asks for these to be "handled deliberately, not accidentally", so both have named tests and a comment saying why: a local action is versioned with this repo, so pinning it to a SHA would pin the repo to itself; a Docker image reference is the registry's business, not Actions'.
- **A remote reusable workflow still needs a pin.** `uses:` at job level reaching another org is third-party code with a token, exactly like a step-level action, so the check treats it identically. `test_a_remote_reusable_workflow_still_needs_a_pin` covers it. This repo has one such line — `./.github/workflows/release-build.yml` — which is local and correctly skipped.
- **Line-based rather than YAML-parsed.** A parsed approach would lose line numbers for the annotations, and it would happily accept a file that YAML can load but Actions rejects. Three tests cover the cases a naive `grep` would get wrong: a commented-out `uses:`, the word in prose, and a `uses:` inside a shell string.
- **Emits GitHub annotation syntax** (`::error file=…,line=…`), so a failure appears on the offending line in the PR's Files view rather than only in the log.

Closes #85

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_