### PR TITLE
ci: add Dependabot config to keep the action pins fresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+
+# Pinning every action to a commit SHA freezes security fixes along with
+# everything else. That trade is only worth making if something moves the pins,
+# and this is that something.
+#
+# Dependabot understands SHA pins: it rewrites the SHA **and** the trailing
+# `# vX.Y.Z` comment together, so its PRs satisfy the pin check rather than
+# tripping it. That is why the comment convention is worth keeping tidy.
+
+updates:
+  - package-ecosystem: github-actions
+    # `/` covers .github/workflows/ — the ecosystem knows where workflows live,
+    # and this is not a filesystem path to point at the workflows directory.
+    directory: /
+
+    schedule:
+      interval: weekly
+      # Monday morning, Central. A week's updates arrive together at the start
+      # of a week rather than trickling in, which makes them a task rather than
+      # an interruption.
+      day: monday
+      time: "09:00"
+      timezone: America/Chicago
+
+    # Small on purpose. The failure mode this guards against is a wall of
+    # dependency PRs that nobody reads and everybody merges — which is strictly
+    # worse than not pinning, because it looks like diligence.
+    open-pull-requests-limit: 3
+
+    commit-message:
+      # `chore(deps): bump …` — a valid Conventional Commit, so the PR title
+      # lint passes and release-please classifies it as a chore rather than
+      # inventing a version bump from a dependency update.
+      prefix: chore
+      include: scope
+
+    labels:
+      - area:build
+      # Dependabot's PRs touch no docs, and the reconciliation gate fails a
+      # code-only PR. Applying the escape hatch up front means its PRs arrive
+      # green instead of needing a human to unstick each one.
+      - skip-docs

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -140,9 +140,31 @@ check people resent is one they route around.
 ### Keeping pins fresh
 
 A pin that never moves is a pin that misses security fixes — the failure mode
-this convention trades *into*. Dependabot watches `github-actions` and opens a
-PR per action when a new version appears, updating the SHA **and** the trailing
-comment together.
+this convention trades *into*. `.github/dependabot.yml` configures Dependabot
+to watch `github-actions` and open a PR per action when a new version appears,
+updating the SHA **and** the trailing comment together.
+
+That last part is why the comment convention is worth keeping tidy: because
+Dependabot rewrites both, its PRs *satisfy* the pin check rather than tripping
+it.
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| `directory` | `/` | The ecosystem knows where workflows live; this is not a path to them. |
+| `schedule` | weekly, Monday 09:00 Central | A week's updates arrive together, as a task rather than an interruption. |
+| `open-pull-requests-limit` | 3 | See below. |
+| `commit-message.prefix` | `chore` + scope | Produces `chore(deps): …` — a valid Conventional Commit. |
+| `labels` | `area:build`, `skip-docs` | Its PRs touch no docs, so the gate needs the escape hatch. |
+
+**The PR limit is low on purpose.** The failure this guards against is not
+missing an update; it is a wall of dependency PRs that nobody reads and
+everybody merges, which is strictly worse than not pinning because it looks
+like diligence. Three at a time stays reviewable.
+
+**`skip-docs` is applied up front** rather than left for a human. The docs
+reconciliation gate fails a code-only PR, and every Dependabot PR is code-only
+by construction — without the label each one arrives red and needs unsticking
+before it can merge.
 
 That is the intended way pins move. Treat those PRs as real changes — read the
 upstream release notes, don't merge on autopilot — but do not let them sit. A


### PR DESCRIPTION
Locking every action to an exact commit is good for safety, but it has a catch: if the version never moves, security fixes never arrive either. This sets up Dependabot to open a small pull request whenever one of those actions releases a new version, so the pins stay current instead of quietly rotting.

Three at a time, once a week on Monday morning. That limit is deliberate — the thing to avoid isn't missing an update, it's a pile of dependency PRs nobody reads and everybody rubber-stamps. That's worse than not pinning at all, because it looks like it's being handled.

## Spec invariants

- **Dependabot's PRs must pass the pin check from #165, not trip it.** It rewrites the SHA and the `# vX.Y.Z` comment together, which is exactly the shape the checker accepts.
- **Its PR titles must pass the title lint.** `prefix: chore` + `include: scope` produces `chore(deps): …`, a valid Conventional Commit.
- **`chore` keeps release-please honest** — a dependency bump must not invent a version bump for the game.

### Verified, not assumed

Both checklist items asking for confirmation were actually run:

| Check | Command | Result |
| --- | --- | --- |
| Title lint accepts its titles | `lint_pr_title.py --title "chore(deps): bump actions/checkout from 7.0.1 to 7.0.2"` | ✅ valid, exit 0 |
| …including a major bump | `--title "chore(deps): bump game-ci/unity-builder from 4.4.0 to 5.0.0"` | ✅ valid, exit 0 |
| Pin check passes a rewritten line | `check_action_pins.py` on `…@<40-char sha> # v7.0.2` | ✅ exit 0 |

The one item I could not verify is "a Dependabot PR rewrites both the SHA and its comment" — that needs Dependabot to actually run, which happens after this merges. What I could verify is the half that matters for us: that a line in the shape Dependabot produces passes our checks. If it turns out to drop the comment, the pin check warns rather than failing, so the PR still merges and the symptom is visible rather than blocking.

## How the spec is changing

No reversals. The docs already described Dependabot's role in the pinning strategy — accurately, but aspirationally, since no config existed. This makes the description true and adds the reasoning behind two settings that look arbitrary:

**Why the PR limit is 3** rather than the default 5, or unlimited. The number encodes the actual risk: unreviewed dependency PRs are worse than stale pins, because the merge log implies someone looked.

**Why `skip-docs` is pre-applied.** Every Dependabot PR is code-only by construction, and the reconciliation gate fails code-only PRs. Without the label, each one arrives red and needs a human to unstick it — which trains everyone that red on a dependency PR is normal, the exact habit that lets a real failure through.

**Docs:** `docs/engineering/ci-cd.md` — expanded "Keeping pins fresh" from an aspirational paragraph into the actual configuration: a table of each setting with its reason, why the comment convention is what makes Dependabot's PRs pass the pin check, why the PR limit is low, and why `skip-docs` is applied up front.

## Deviations and Decisions

- **Pre-applying `skip-docs` is a decision worth flagging**, because `CLAUDE.md` treats reaching for that label as something requiring justification. Justifying it per-PR is impossible here — nobody writes those PR bodies. The justification is structural and belongs in the config: a dependency bump cannot change behaviour the docs describe. If a bump ever *does* — a major version with breaking behaviour — that PR needs a docs change and a human should notice the label is wrong.
- **`area:build` rather than a new `deps` label.** The label taxonomy is synced from `.github/labels.yml` and `area:build` already covers CI and tooling; adding a label for one bot's PRs is taxonomy creep.
- **Monday 09:00 Central, not the default.** The default is a random time, which spreads a week's updates across days. Batching them makes them a thing you sit down and do.
- **No `groups:` configuration**, which would combine all action updates into one PR. Tempting given the low limit, but it undoes the per-action review this pinning strategy exists to enable — and one combined PR touching nine actions is the wall-of-changes problem in a single diff rather than a list.

Closes #86

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nytj7GkfPuWnCs1pajjgrL)_