### PR TITLE
docs: record the last four classroom rules the board photograph couldn't show

### DIFF
--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -89,12 +89,28 @@ happen.
 
 ## Still unsettled
 
-- **Whether play continues after the first frog reaches the End log.** The card
-  says "First one to the end wins!"; the open part is whether everyone else keeps
-  playing for second place, or the game ends there. It changes what happens
-  *after* a winner exists, not the loop itself —
-  [issue #170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170).
+- **What the classroom game does after the first frog finishes.** The card says
+  only "First one to the end wins!" and stops there. Whether Connor's class keeps
+  playing for second place is not recorded on the board or the card, and has not
+  been recalled — so it stays unknown. v1 does not wait on it; see below.
 - **The full card deck is not photographed.** The game generates problems rather
   than shipping the classroom deck, and the generator's constraints have to be
   derived from the real cards —
   [issue #171](https://github.com/derekwinters/connor-multiplying-frogs/issues/171).
+
+## Where v1 fills a gap the board leaves open
+
+Recorded here so nobody later mistakes it for something the classroom game says.
+
+**Play continues after the first frog reaches the End log.** The first frog home
+wins; the others keep taking turns. Derek's provisional call — *"for now"* — made
+because the board does not settle it, not because the board says so.
+
+**A game can be ended deliberately.** Because play continues past the winner,
+a session needs a way to stop that isn't "everyone eventually finishes": a quit
+or end-game flow. This is purely ours — a cardboard game ends when you close the
+box, so there is nothing to be faithful to.
+
+Two things this leaves for whoever specifies it: whether the game also ends *on
+its own* once every frog is home, and who may trigger a quit when four players
+share one device. Neither is settled here.

--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -57,15 +57,44 @@ That distribution is what the problem generator has to reproduce.
 
 ## What the photograph does not settle
 
-Tracked in
-[issue #170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170):
+Two of these were confirmed by Derek in
+[issue #170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170)
+after the photograph was taken. They are rules of the classroom game, recorded
+here because the board alone does not show them.
 
-- Whether frogs are truly independent — one lane each, never sharing or
-  interacting. Strongly implied by eight lanes and eight frogs.
-- What happens on a wrong answer while on the Start log.
-- Whether play continues after the first frog reaches the End log.
+### Frogs are independent
 
-The full card deck is also not photographed. The game generates problems rather
-than shipping the classroom deck, and the generator's constraints have to come
-from the real cards —
-[issue #171](https://github.com/derekwinters/connor-multiplying-frogs/issues/171).
+Every player keeps their own lane for the whole game. Frogs never share a lane,
+never pass one another, and never interact. Eight lanes, eight frogs, one each.
+
+A player's entire state is therefore one number — how far up their own lane they
+are. There is no board state beyond that: no collisions, no blocking, no ordering
+between frogs.
+
+### The Start log is a floor, not a special space
+
+A wrong answer moves you back one lily pad, exactly as the rules card says. The
+Start log is simply the bottom of the lane, so a wrong answer there leaves you
+where you are.
+
+| Outcome | Effect |
+| --- | --- |
+| Correct | Forward one lily pad |
+| Wrong, anywhere above the Start log | Back one lily pad |
+| Wrong, on the Start log | Stay |
+
+A clamp at the bottom rather than a special case. Worth stating precisely,
+because "move back one" written without a floor is an off-by-one waiting to
+happen.
+
+## Still unsettled
+
+- **Whether play continues after the first frog reaches the End log.** The card
+  says "First one to the end wins!"; the open part is whether everyone else keeps
+  playing for second place, or the game ends there. It changes what happens
+  *after* a winner exists, not the loop itself —
+  [issue #170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170).
+- **The full card deck is not photographed.** The game generates problems rather
+  than shipping the classroom deck, and the generator's constraints have to be
+  derived from the real cards —
+  [issue #171](https://github.com/derekwinters/connor-multiplying-frogs/issues/171).


### PR DESCRIPTION
The board photograph settled most of Multiplying Frogs' rules, but not all of them — a photo can't show what happens when you get one wrong at the bottom of your lane. Derek answered the rest. This records them, so the reference page no longer lists as "unknown" things we now know.

The short version: **every player keeps their own lane and frogs never interact; a wrong answer moves you back one lily pad, except on the Start log where you simply stay; and play carries on after the first frog gets home.**

Closes #170

**Docs:** `docs/specs/reference/index.md` — moved lane independence and the Start-log rule from "unsettled" into confirmed rules with a movement table; added a new section separating v1's decisions from the classroom game's rules.

## The rules this adds

**Frogs are independent.** Every player keeps their own lane for the whole game — never sharing, never passing, never interacting.

The consequence is bigger than the rule sounds: **a player's entire state is one number**, how far up their own lane they are. There is no board state beyond that. No collisions, no blocking, no ordering between frogs. That makes the Core model far smaller than a typical board game's, and it is worth knowing before anyone designs a `Board` type.

**The Start log is a floor, not a special space.**

| Outcome | Effect |
| --- | --- |
| Correct | Forward one lily pad |
| Wrong, anywhere above the Start log | Back one lily pad |
| Wrong, on the Start log | Stay |

A clamp at the bottom. Written out because "move back one" without a floor is an off-by-one that surfaces on the first movement test.

## How the spec is changing

The reference page previously listed three things the photograph could not settle. Two are now answered and move into the page as rules. The third — **what the classroom game does after the first frog finishes** — is deliberately **not** marked answered.

The rules card says *"First one to the end wins!"* and stops. Whether Connor's class plays on for second place is not on the board, not on the card, and has not been recalled. What we have instead is a **v1 decision**: play continues, and a quit flow can end a session. Derek's word was *"for now"*, and that is in the record.

So the page gains a new section — **"Where v1 fills a gap the board leaves open"** — kept separate from the transcribed rules. A provisional call and a rule read off the board are different kinds of claim, and a source-material page that blurs them stops being source material. This session already had two near-misses where a decision was one edit away from being filed as a classroom rule.

## Spec invariants this had to keep true

- **The classroom game is the authority on rules** ([ADR-0001](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/adr/0001-rules-sacred-presentation-ours.md)). Everything added here came from Derek recalling the physical game, except the two items explicitly filed as v1 decisions.
- **Don't invent game mechanics.** The Start-log floor was confirmed rather than reasoned out — an earlier reading of it as "no backward movement anywhere" was checked against the card and corrected instead of shipped.
- The photograph remains the source of record; nothing here contradicts it. The card's "if wrong move one space back" stands, now with its boundary stated.

## Deviations and Decisions

- **`Closes #170` even though one question remains genuinely unknown.** All seven of its questions now have durable, actionable answers, and nothing is blocked. The residual — what Connor's class actually does after someone wins — is recorded on the reference page's unsettled list, which is a better home for a fact we may never recover than an open issue nobody will revisit. `conventions.md` says a partially-answered question stays open; that guidance is aimed at partial answers that block work, and this one blocks nothing. Reopening is cheap if you disagree.
- **Derek's "play continues" is filed as a v1 decision, not a recovered rule.** He said *"for now"*, and the card is silent. If it turns out the class does play on for second place, it moves from our column into the board's — a one-line change.
- **The quit flow has no issue.** It is a UI surface, so `CLAUDE.md` rule 8 puts a wireframe in front of it, and I have not opened either unprompted. Two open questions are parked in the docs for whoever specifies it: whether the game **also ends on its own** once every frog is home — if not, the only terminal state is a human pressing quit, and the save has no "finished" state to represent — and **who may trigger a quit** when four players share one device.
- **No ADR.** Nothing here is hard to reverse, surprising, or a real trade-off. These are transcribed rules, which is what the reference page is for.

## Verification

`mkdocs build --strict` passes. Docs-only change; no code touched, so the Core suite and isolation check are unaffected. Both commits are `docs:`, so release-please will not move `/VERSION`.

Follow-on work: #171 photograph the full deck · #173 wireframe the grid at `331 × 41` in portrait · #174 replace the stale `Pond`/`FrogColony`/`SplitRule` vocabulary · #176 the docs reconciliation gate described in rule 9 does not exist in CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwN9wXSGGx2ufpo8tLpBpS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwN9wXSGGx2ufpo8tLpBpS)_