### PR TITLE
ci: activate Unity in CI, and fix the editor scripts that never compiled

### DIFF
--- a/.github/scripts/check_assembly_references.py
+++ b/.github/scripts/check_assembly_references.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Fail if a script imports a project namespace its assembly cannot see.
+
+Unity decides which assembly a `.cs` file compiles into by where it sits: the
+nearest `.asmdef` above it, or — if there is none — one of the *predefined*
+assemblies, `Assembly-CSharp` and `Assembly-CSharp-Editor`. What a file may
+`using` follows from that, and the rules are not visible in the C#:
+
+  * An assembly definition sees only what its `references` list names.
+  * A predefined assembly has no references list to edit. It automatically sees
+    every assembly definition marked `autoReferenced: true`, and *cannot* be
+    made to see one marked false.
+
+So `Frogs.Core.asmdef` setting `autoReferenced: false` — which it does, on
+purpose, so that nothing drifts into depending on Core by accident — makes
+`using Frogs.Core;` a compile error in any file that is not inside an assembly
+definition that names it. That error surfaces only in an editor, minutes into a
+build, behind a licence. This check surfaces it in milliseconds, anywhere.
+
+Usage:
+    python .github/scripts/check_assembly_references.py [--verbose]
+
+Exits 0 when every import is reachable, 1 with one line per violation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ASSETS_ROOT = REPO_ROOT / "Assets"
+
+# `using Frogs.Core;`, `using static Frogs.Core.AppVersion;`,
+# `global using Frogs.Core;`, and the aliased `using Stamp = Frogs.Core.BuildStamp;`.
+USING_PATTERN = re.compile(
+    r"^\s*(?:global\s+)?using\s+(?:static\s+)?(?:[A-Za-z_]\w*\s*=\s*)?([\w.]+)\s*;",
+    re.MULTILINE,
+)
+
+# guid: 0e6403fcc68e43bab1fee384ab964ce0 — in an .asmdef.meta.
+GUID_PATTERN = re.compile(r"^guid:\s*([0-9a-fA-F]+)\s*$", re.MULTILINE)
+
+# The name Unity gives the assembly a file lands in when no .asmdef covers it.
+# Both predefined assemblies behave identically for our purposes.
+PREDEFINED = "Assembly-CSharp"
+
+
+class Assembly:
+    def __init__(self, path: Path, data: dict, guid: str | None):
+        self.path = path
+        self.directory = path.parent
+        self.name = data.get("name") or path.stem
+        # An empty rootNamespace means Unity uses the assembly name, which is
+        # also the convention this project follows.
+        self.root_namespace = data.get("rootNamespace") or self.name
+        self.references = list(data.get("references") or [])
+        # Unity's default when the key is absent is true.
+        self.auto_referenced = data.get("autoReferenced", True) is not False
+        self.guid = guid
+
+    def owns(self, namespace: str) -> bool:
+        return namespace == self.root_namespace or namespace.startswith(
+            self.root_namespace + "."
+        )
+
+    def can_see(self, other: "Assembly") -> bool:
+        for reference in self.references:
+            if reference == other.name:
+                return True
+            if reference.startswith("GUID:") and other.guid:
+                if reference[len("GUID:") :].strip().lower() == other.guid.lower():
+                    return True
+        return False
+
+
+def load_assemblies(assets_root: Path) -> list[Assembly]:
+    assemblies = []
+    for path in sorted(assets_root.rglob("*.asmdef")):
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as error:
+            raise SystemExit(f"{path}: invalid JSON — {error}")
+
+        meta = path.with_suffix(".asmdef.meta")
+        guid = None
+        if meta.exists():
+            found = GUID_PATTERN.search(meta.read_text())
+            guid = found.group(1) if found else None
+
+        assemblies.append(Assembly(path, data, guid))
+    return assemblies
+
+
+def owning_assembly(source: Path, assemblies: list[Assembly]) -> Assembly | None:
+    """The nearest .asmdef at or above `source`, or None for a predefined one."""
+    candidates = [a for a in assemblies if a.directory in source.parents]
+    if not candidates:
+        return None
+    # Nearest wins: the deepest directory of those that contain the file.
+    return max(candidates, key=lambda a: len(a.directory.parts))
+
+
+def scan(assets_root: Path) -> list[str]:
+    """One human-readable line per import that will not compile."""
+    assets_root = Path(assets_root)
+    if not assets_root.is_dir():
+        return []
+
+    assemblies = load_assemblies(assets_root)
+    problems: list[str] = []
+
+    for source in sorted(assets_root.rglob("*.cs")):
+        owner = owning_assembly(source, assemblies)
+        where = source.relative_to(assets_root)
+
+        for namespace in USING_PATTERN.findall(source.read_text()):
+            target = next((a for a in assemblies if a.owns(namespace)), None)
+
+            # Not one of ours — System, UnityEngine, a package. Not our business.
+            if target is None or target is owner:
+                continue
+
+            if owner is None:
+                if not target.auto_referenced:
+                    problems.append(
+                        f"Assets/{where}: `using {namespace};` — this file is in no "
+                        f"assembly definition, so it compiles into {PREDEFINED}, "
+                        f"which cannot reference {target.name} because that assembly "
+                        f"sets autoReferenced: false. Give the folder its own "
+                        f".asmdef referencing {target.name}."
+                    )
+                continue
+
+            if not owner.can_see(target):
+                problems.append(
+                    f"Assets/{where}: `using {namespace};` — {owner.name} does not "
+                    f"reference {target.name}. Add it to the references list in "
+                    f"{owner.path.name}."
+                )
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    verbose = "--verbose" in argv
+    problems = scan(ASSETS_ROOT)
+
+    if problems:
+        print("Imports that will not compile:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        print(
+            "\nSee docs/engineering/tech-stack.md for how the assemblies fit together.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verbose:
+        print("Every project import is reachable from the assembly it is used in.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test_check_assembly_references.py
+++ b/.github/scripts/tests/test_check_assembly_references.py
@@ -1,0 +1,181 @@
+"""Unit tests for the assembly-reference check.
+
+The rule being pinned is the one that cost a whole CI cycle to find: a `using`
+of a project namespace only compiles if the assembly the file lands in can
+actually see the assembly that namespace lives in. Unity answers that question
+minutes into a build, in an editor, and only after a licence has been sorted
+out. These tests answer it in milliseconds.
+
+The cases below are the ones that differ from intuition — the predefined
+assembly that cannot be given a reference, and the `autoReferenced: false` flag
+that decides whether it gets one anyway.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_assembly_references as check  # noqa: E402
+
+ASMDEF_META = """fileFormatVersion: 2
+guid: {guid}
+AssemblyDefinitionImporter:
+  externalObjects: {{}}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+"""
+
+
+class Tree:
+    """A throwaway Assets/ tree, built a file at a time."""
+
+    def __init__(self, root):
+        self.root = Path(root)
+
+    def asmdef(self, directory, name, *, references=(), auto_referenced=True, guid=None):
+        import json
+
+        folder = self.root / directory
+        folder.mkdir(parents=True, exist_ok=True)
+        path = folder / f"{name}.asmdef"
+        path.write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "rootNamespace": name,
+                    "references": list(references),
+                    "autoReferenced": auto_referenced,
+                }
+            )
+        )
+        if guid:
+            path.with_suffix(".asmdef.meta").write_text(ASMDEF_META.format(guid=guid))
+        return path
+
+    def source(self, path, body):
+        full = self.root / path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(body)
+        return full
+
+
+class PredefinedAssemblyTests(unittest.TestCase):
+    """Scripts in a folder with no .asmdef land in Assembly-CSharp*."""
+
+    def test_it_cannot_see_an_asmdef_that_is_not_auto_referenced(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.source("Editor/Applier.cs", "using Frogs.Core;\n")
+
+            problems = check.scan(tree.root)
+
+            self.assertEqual(1, len(problems))
+            self.assertIn("Editor/Applier.cs", problems[0])
+            self.assertIn("Frogs.Core", problems[0])
+
+    def test_it_can_see_an_asmdef_that_is_auto_referenced(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=True)
+            tree.source("Editor/Applier.cs", "using Frogs.Core;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+
+class AssemblyDefinitionTests(unittest.TestCase):
+    def test_a_listed_reference_is_fine(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.asmdef("Editor", "Frogs.EditorTools", references=["Frogs.Core"])
+            tree.source("Editor/Applier.cs", "using Frogs.Core;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+    def test_a_missing_reference_is_flagged(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.asmdef("Editor", "Frogs.EditorTools", references=[])
+            tree.source("Editor/Applier.cs", "using Frogs.Core;\n")
+
+            problems = check.scan(tree.root)
+
+            self.assertEqual(1, len(problems))
+            self.assertIn("Frogs.EditorTools", problems[0])
+
+    def test_a_guid_reference_resolves_through_the_meta_file(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            guid = "0e6403fcc68e43bab1fee384ab964ce0"
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False, guid=guid)
+            tree.asmdef("Editor", "Frogs.EditorTools", references=[f"GUID:{guid}"])
+            tree.source("Editor/Applier.cs", "using Frogs.Core;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+    def test_a_file_using_its_own_assembly_needs_no_reference(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.source("Scripts/Core/Version.cs", "using Frogs.Core;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+    def test_a_nested_namespace_counts_as_the_same_assembly(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.asmdef("Editor", "Frogs.EditorTools", references=["Frogs.Core"])
+            tree.source("Editor/Applier.cs", "using Frogs.Core.Frogs;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+    def test_the_nearest_asmdef_upwards_owns_the_file(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.asmdef("Editor", "Frogs.EditorTools", references=["Frogs.Core"])
+            tree.source("Editor/Deep/Nested/Applier.cs", "using Frogs.Core;\n")
+
+            self.assertEqual([], check.scan(tree.root))
+
+
+class IgnoredTests(unittest.TestCase):
+    """Only project assemblies are checked — engine and BCL namespaces are not."""
+
+    def test_engine_and_framework_usings_are_ignored(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.source(
+                "Editor/Applier.cs",
+                "using System;\nusing UnityEditor;\nusing UnityEngine;\n",
+            )
+
+            self.assertEqual([], check.scan(tree.root))
+
+    def test_static_and_global_usings_are_read(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.source("Editor/Applier.cs", "global using static Frogs.Core.AppVersion;\n")
+
+            self.assertEqual(1, len(check.scan(tree.root)))
+
+    def test_an_aliased_using_is_read(self):
+        with TemporaryDirectory() as tmp:
+            tree = Tree(tmp)
+            tree.asmdef("Scripts/Core", "Frogs.Core", auto_referenced=False)
+            tree.source("Editor/Applier.cs", "using Stamp = Frogs.Core.BuildStamp;\n")
+
+            self.assertEqual(1, len(check.scan(tree.root)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -67,16 +67,32 @@ jobs:
       # Before anything expensive. A missing licence must fail the job loudly:
       # a required check that goes green because the suite never ran is worse
       # than no check at all.
+      #
+      # All three secrets, not just the licence. GameCI never passes
+      # UNITY_LICENSE into the Unity container — it parses the serial out of the
+      # .ulf and activates with `unity-editor -serial -username -password`, so a
+      # licence without the account credentials dies inside the container with
+      # "License activation strategy could not be determined". Catching that
+      # here costs a second; catching it in there costs the image pull first.
       - name: Require the Unity licence
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         run: |
-          if [ -z "$UNITY_LICENSE" ]; then
-            echo "::error::The UNITY_LICENSE secret is not set, so the EditMode suite" \
-                 "cannot run. This job fails rather than skipping — see issue #82."
+          missing=
+          for secret in UNITY_LICENSE UNITY_EMAIL UNITY_PASSWORD; do
+            if [ -z "${!secret}" ]; then
+              missing="$missing $secret"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::These secrets are not set —$missing — so the EditMode" \
+                 "suite cannot run. This job fails rather than skipping — see" \
+                 "issue #82."
             exit 1
           fi
-          echo "UNITY_LICENSE is present."
+          echo "The Unity licence secrets are all present."
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -100,6 +116,8 @@ jobs:
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           unityVersion: 6000.0.81f1
           testMode: EditMode

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Core is engine-free
         run: python3 .github/scripts/check_core_isolation.py
 
+      # Also cheap, and it answers in milliseconds what Unity only answers
+      # minutes into a build, in an editor, behind a licence: whether a `using`
+      # of a project namespace can actually see the assembly it names.
+      - name: Every import is reachable
+        run: python3 .github/scripts/check_assembly_references.py
+
       - name: Run the Core suite
         run: dotnet test Tests/Core/Frogs.Core.Tests.csproj --verbosity normal
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,15 +36,27 @@ jobs:
       # is a lie. This one is a convenience: no APK is an absent convenience,
       # not a false claim, and failing every PR over it would train everyone to
       # ignore a red check.
+      #
+      # All three secrets, not just the licence: GameCI activates with
+      # `unity-editor -serial -username -password`, never with the .ulf itself.
+      # See the same gate in ci-tests.yml.
       - name: Check for the Unity licence
         id: licence
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         run: |
-          if [ -z "$UNITY_LICENSE" ]; then
-            echo "::warning::No UNITY_LICENSE secret, so no debug APK for this PR." \
-                 "See issue #82. Skipping rather than failing — this build is a" \
-                 "convenience, not a correctness gate."
+          missing=
+          for secret in UNITY_LICENSE UNITY_EMAIL UNITY_PASSWORD; do
+            if [ -z "${!secret}" ]; then
+              missing="$missing $secret"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::These secrets are not set —$missing — so no debug APK" \
+                 "for this PR. See issue #82. Skipping rather than failing — this" \
+                 "build is a convenience, not a correctness gate."
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "present=true" >> "$GITHUB_OUTPUT"
@@ -86,6 +98,8 @@ jobs:
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
           FROGS_BUILD_SHA: ${{ steps.stamp.outputs.build_sha }}
           FROGS_APPLICATION_ID_SUFFIX: .debug

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -30,14 +30,26 @@ jobs:
       # Warns and skips, like pr-build: an RC is something to play with, not a
       # correctness gate, and failing the release branch over a missing secret
       # would make the release PR look broken when it is not.
+      #
+      # All three secrets, not just the licence: GameCI activates with
+      # `unity-editor -serial -username -password`, never with the .ulf itself.
+      # See the same gate in ci-tests.yml.
       - name: Check for the Unity licence
         id: licence
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         run: |
-          if [ -z "$UNITY_LICENSE" ]; then
-            echo "::warning::No UNITY_LICENSE secret, so no release candidate." \
-                 "See issue #82."
+          missing=
+          for secret in UNITY_LICENSE UNITY_EMAIL UNITY_PASSWORD; do
+            if [ -z "${!secret}" ]; then
+              missing="$missing $secret"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::These secrets are not set —$missing — so no release" \
+                 "candidate. See issue #82."
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "present=true" >> "$GITHUB_OUTPUT"
@@ -100,6 +112,8 @@ jobs:
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
           FROGS_RC_NUMBER: ${{ steps.stamp.outputs.rc }}
           FROGS_APPLICATION_ID_SUFFIX: .debug

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,14 +50,26 @@ jobs:
       # warns rather than failing. A release without its APK is a gap to
       # backfill — this workflow is the backfill — not a reason to mark a
       # completed release as failed.
+      #
+      # All three secrets, not just the licence: GameCI activates with
+      # `unity-editor -serial -username -password`, never with the .ulf itself.
+      # See the same gate in ci-tests.yml.
       - name: Check for the Unity licence
         id: licence
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         run: |
-          if [ -z "$UNITY_LICENSE" ]; then
-            echo "::warning::No UNITY_LICENSE secret, so ${{ inputs.tag }} gets no APK." \
-                 "See issue #82. Re-run this workflow once the secret exists."
+          missing=
+          for secret in UNITY_LICENSE UNITY_EMAIL UNITY_PASSWORD; do
+            if [ -z "${!secret}" ]; then
+              missing="$missing $secret"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::These secrets are not set —$missing — so ${{ inputs.tag }}" \
+                 "gets no APK. See issue #82. Re-run this workflow once they exist."
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "present=true" >> "$GITHUB_OUTPUT"
@@ -104,6 +116,8 @@ jobs:
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
           FROGS_ANDROID_PROFILE: device
         with:
@@ -122,6 +136,8 @@ jobs:
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
           FROGS_ANDROID_PROFILE: emulator
         with:

--- a/Assets/Editor/Frogs.EditorTools.asmdef
+++ b/Assets/Editor/Frogs.EditorTools.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Frogs.EditorTools",
+    "rootNamespace": "Frogs.EditorTools",
+    "references": [
+        "Frogs.Core"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Editor/Frogs.EditorTools.asmdef.meta
+++ b/Assets/Editor/Frogs.EditorTools.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b4e142ebf9d76b73c508557047e2a87f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -419,15 +419,32 @@ grown a dependency on the engine.
 #### A missing licence fails, it does not skip
 
 The EditMode job's **first** step, before any checkout or container pull,
-asserts that `UNITY_LICENSE` is set — and fails the job if it isn't.
+asserts that `UNITY_LICENSE`, `UNITY_EMAIL`, and `UNITY_PASSWORD` are all set —
+and fails the job if any is missing.
 
 Skipping would be the friendlier behaviour and the wrong one. A required check
 that goes green because the suite never ran is worse than no check at all: it
 reports "tested" on a PR nothing tested, and nobody looks twice at a green tick.
 
-Until the secret exists (#82), this job is red on every PR that touches the
+Until the secrets exist (#82), this job is red on every PR that touches the
 Unity project. That is the intended behaviour, and it is visible rather than
 quiet.
+
+#### Three secrets, not one
+
+A Unity Personal licence needs **all three** of `UNITY_LICENSE`, `UNITY_EMAIL`,
+and `UNITY_PASSWORD`, in every workflow that starts a Unity container.
+
+The name of the first one is misleading. GameCI never passes `UNITY_LICENSE`
+into the container at all — it parses the serial out of the `.ulf` on the runner
+and activates inside the container with
+`unity-editor -serial … -username … -password …`. A licence on its own gets as
+far as producing a valid serial and then dies with *"License activation strategy
+could not be determined"*, several minutes and one image pull later.
+
+So the licence gates check all three up front. The secrets are the raw contents
+of `Unity_lic.ulf` — the XML, verbatim, not base64 and not flattened onto one
+line — plus the Unity ID that licence belongs to.
 
 #### Path-gating, and what it means for branch protection
 

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -412,9 +412,15 @@ Two jobs, deliberately separate because they cost wildly different amounts:
 
 See [Testing](testing.md) for what belongs in each.
 
-The Core job also runs `check_core_isolation.py` first. It costs nothing and it
-fails for a reason the test output would never explain: game logic that has
-grown a dependency on the engine.
+The Core job also runs two static checks first. Both cost nothing and both fail
+for reasons the test output would never explain:
+
+- `check_core_isolation.py` — game logic that has grown a dependency on the
+  engine.
+- `check_assembly_references.py` — a `using` of a project namespace from an
+  assembly that cannot see it. Unity gives the same verdict, but only inside an
+  editor, minutes into a build, after a licence has been sorted out. See
+  [the Core/Unity split](tech-stack.md#the-check-that-catches-it).
 
 #### A missing licence fails, it does not skip
 

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -103,6 +103,7 @@ Assets/                       ← everything Unity compiles
     EditMode/                 ← EditMode tests for the shell; needs the editor
       Frogs.Unity.EditModeTests.asmdef
   Editor/                     ← editor-only tooling; never ships in a build
+    Frogs.EditorTools.asmdef  ← references Frogs.Core; Editor-only platform
   Scenes/  Art/  Audio/  Prefabs/
 Tests/
   Core/                       ← plain NUnit. Outside Assets/, so Unity ignores it
@@ -131,6 +132,29 @@ compiler rather than by remembering.
 
 `Frogs.Core` is also `autoReferenced: false`: nothing picks it up implicitly, so
 an assembly that wants Core has to say so. `Frogs.Unity` says so.
+
+**Which means every folder of `.cs` needs an asmdef, including `Editor/`.** A
+file in a folder no asmdef covers compiles into a *predefined* assembly —
+`Assembly-CSharp` or `Assembly-CSharp-Editor` — and a predefined assembly has no
+references list anyone can edit. It sees `autoReferenced: true` assemblies and
+nothing else, so `using Frogs.Core;` there cannot compile, whatever the file
+does. `Assets/Editor/` therefore has `Frogs.EditorTools.asmdef`.
+
+That asmdef sets `includePlatforms: ["Editor"]`, and it has to. The `Editor`
+folder name only makes code editor-only while the folder is part of a predefined
+assembly; once it has an asmdef of its own, the folder convention no longer
+applies and the platform list is what keeps build tooling out of the player.
+
+#### The check that catches it
+
+```bash
+python .github/scripts/check_assembly_references.py
+```
+
+It reads every `using` under `Assets/`, works out which assembly the file
+compiles into, and fails if that assembly cannot see the one the namespace
+belongs to — the same verdict Unity gives, without an editor or a licence. CI
+runs it beside `check_core_isolation.py` ([CI/CD](ci-cd.md)).
 
 #### Two layers of enforcement
 


### PR DESCRIPTION
CI could not start Unity even though the licence secret was set correctly. It turns out the secret's name is misleading: GameCI never hands `UNITY_LICENSE` to Unity at all — it reads the serial number out of the licence file and then logs in with an email and password, like a person would. This adds those two extra secrets everywhere Unity runs.

With Unity finally starting, it immediately found a second problem that had been hiding behind the first: two of the three scripts in `Assets/Editor/` have never compiled, because they ask for code they are not allowed to see. That is fixed here too, along with a check that will catch the next one in milliseconds instead of minutes.

## Part one: the licence

On [run 31273272633](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31273272633), the `Require the Unity licence` step passed and the container still failed with `No valid license activation strategy could be determined`.

Reading the pinned actions rather than guessing:

- `unity-test-runner@0ff419b` — `src/model/image-environment-factory.ts:21` forwards `UNITY_EMAIL`, `UNITY_PASSWORD`, `UNITY_SERIAL`, `UNITY_LICENSING_SERVER` into the container. `UNITY_LICENSE` is not on that list and never crosses the boundary.
- `src/model/input.ts:193-203` — with no serial set, it derives one from the `.ulf` instead. That worked: the serial was masked at `input.ts:206`, which only fires at exactly 27 characters, and `dist/platforms/ubuntu/entrypoint.sh:3` reported the `F` prefix of a Personal licence.
- `dist/platforms/ubuntu/activate.sh:3` — activation runs `unity-editor -serial … -username "$UNITY_EMAIL" -password "$UNITY_PASSWORD"`, gated on all three being non-empty. Serial alone matches no branch.

`unity-builder@d829bfc` (v5.0.0) has the identical env list at `image-environment-factory.ts:35-37`, so all three build workflows would have hit the same wall.

Confirmed working on the first push of this PR:

```
User *** logged in successfully
[Licensing::Module] Successfully returned the entitlement license
[Licensing::Client] Successfully returned ULF license with serial number : "***"
```

## Part two: the editor scripts that never compiled

Unity got past activation and stopped on:

```
Assets/Editor/BuildStampApplier.cs(4,13): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Frogs'
Assets/Editor/BuildStampPreprocessor.cs(2,13): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Frogs'
Assets/Editor/BuildStampApplier.cs(47,34): error CS0246: The type or namespace name 'BuildStamp' could not be found
Assets/Editor/BuildStampApplier.cs(56,16): error CS0246: The type or namespace name 'AppVersion' could not be found
```

`Assets/Editor/` had no `.asmdef`, so its scripts compiled into the predefined `Assembly-CSharp-Editor`. A predefined assembly has no references list anyone can edit: it sees assemblies marked `autoReferenced: true` and nothing else. `Frogs.Core` is deliberately `autoReferenced: false`, so `using Frogs.Core;` there could never compile.

`Frogs.EditorTools.asmdef` fixes it, referencing `Frogs.Core`. It sets `includePlatforms: ["Editor"]`, which is required rather than decorative — the `Editor` folder name only makes code editor-only while the folder belongs to a predefined assembly, and adding an asmdef ends that. Checked against Unity's manual rather than reasoned out, per rule 6.

## How the spec is changing

- **Old rule:** the Unity licence is one secret, `UNITY_LICENSE`, and the gates assert that one thing is set.
- **New rule:** a Unity Personal licence in CI is three secrets — `UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD` — and every gate asserts all three.
- **Why it is better:** the old rule described a secret GameCI does not use for activation. A gate that passes and then lets the job fail on the very thing the gate exists to prevent is worse than no gate, because it points the next reader at the wrong half of the problem — which is exactly what happened.

The Core/Unity split gains a corollary it always implied but never said: **`autoReferenced: false` on Core means every folder of `.cs` under `Assets/` needs its own asmdef**, `Editor/` included. The old shape in `tech-stack.md` showed an `Editor/` with no asmdef while the prose said "an assembly that wants Core has to say so". The prose was right and the shape was wrong, so the shape moved.

## Spec invariants kept

- **`ci-tests` fails, it does not skip.** The EditMode gate still `exit 1`s, still runs first, still before checkout and the image pull. It now names the missing secrets rather than only the licence.
- **The build workflows warn and skip.** `pr-build`, `rc-build`, and `release-build` still emit `::warning::` and set `present=false`, so a missing secret costs an APK, never a red PR.
- **Core stays engine-free.** `check_core_isolation.py` green; the new asmdef references `Frogs.Core` one-way and Core's own asmdef is untouched.
- **Editor tooling never ships in a build.** Previously guaranteed by the `Editor/` folder convention; now guaranteed by `includePlatforms: ["Editor"]`, which is what that convention stops providing once an asmdef exists.
- **No new dependencies, no new network reach.** Two env vars, one asmdef, one stdlib-only Python script.

## Verification

`check_assembly_references.py` landed as its own commit *before* the fix and was red against the repo at that point, reproducing CI's two CS0234s exactly. Its 10 unit tests pin the cases that differ from intuition — the predefined assembly that cannot be given a reference, and the `autoReferenced` flag that decides whether it gets one anyway.

Also run locally: 139 script tests, `check_core_isolation.py`, `check_action_pins.py`, YAML parse of all four workflows, `mkdocs build --strict`. The licence gate's shell logic was exercised in all three secret states; licence-only prints `FAIL -> UNITY_EMAIL UNITY_PASSWORD` in the job's first second.

**Docs:** docs/engineering/ci-cd.md — added "Three secrets, not one" explaining why GameCI needs the account credentials and what the secret values should literally contain, corrected the EditMode gate description, and documented the new check beside `check_core_isolation.py`. docs/engineering/tech-stack.md — added `Frogs.EditorTools.asmdef` to the project shape, and a corollary explaining why every `.cs` folder needs an asmdef and why `includePlatforms` is required in `Editor/`.

## Deviations and Decisions

- **This PR does two things, at Derek's explicit instruction.** The compile break was found by this PR's own CI and I proposed filing it separately, per one-issue-per-PR; Derek chose to fold it in so CI reaches green in one go. Flagging it because the rule is otherwise firm.
- **No test lands for the workflow changes.** Nothing in the repo asserts workflow YAML — `.github/scripts/tests/` covers the Python scripts only — so there was no suite in which a failing test could have been written first. The gate's shell logic was exercised by hand against all three secret states instead. A workflow-linting suite is a larger decision than this fix should make.
- **The asmdef fix did get a test first**, in the only form available without an editor: a static check, committed red, then made green.
- **`Frogs.EditorTools` sets `autoReferenced: false`**, where `Frogs.Unity` sets `true`. Build tooling should not be picked up implicitly by anything; an assembly that wants it can say so. Easy to flip if you disagree.
- **Widened the licence gates instead of only adding the env vars.** Passing the credentials through is enough to make CI work. The gate change is what stops the *next* missing secret costing an image pull and a confusing container error.
- **Left the exit-code hole alone.** In the failing run `steps.tests.outputs.exitCode` was `0` while Docker exited 1, so `ci-tests.yml`'s `|| '0'` default would have let a never-started run past that half of the gate; only the missing-results-XML check caught it. Fixing it touches `verify_editmode_results.py`, which has real tests and deserves its own red-green loop. Worth its own issue.
- **`Closes #82` retained.** #82's stated verification — "the EditMode job runs the suite" — is now reachable on this PR. If EditMode is not green when this merges, reopen it.

Closes #82
