### PR TITLE
feat(build): add the Hello World scene and prove it builds a debug APK

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -107,21 +107,6 @@ jobs:
           buildMethod: Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
           allowDirtyBuild: true
 
-      - name: Show what Unity wrote
-        if: always()
-        run: |
-          ls -la Assets/Scenes ProjectSettings || true
-          for file in \
-            Assets/Scenes/HelloWorld.unity \
-            Assets/Scenes/HelloWorld.unity.meta \
-            Assets/Scripts/Unity/HelloWorldProbe.cs.meta \
-            ProjectSettings/EditorBuildSettings.asset
-          do
-            echo "vvvvv $file vvvvv"
-            cat "$file" 2>&1 || true
-            echo "^^^^^ $file ^^^^^"
-          done
-
       # The version name, versionCode, and .debug suffix are applied by
       # BuildStampPreprocessor from these variables — a build pre-processor, so
       # no build can be produced without them. See docs/engineering/versioning.md.
@@ -164,3 +149,20 @@ jobs:
                  "(versionCode ${{ steps.stamp.outputs.version_code }}), installs alongside the" \
                  "release build as \`.debug\`." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      # TEMPORARY — remove before merge. Last, so it lands at the end of the
+      # log where it can be read back. See PR #179.
+      - name: Show what Unity wrote
+        if: always()
+        run: |
+          ls -la Assets/Scenes ProjectSettings || true
+          for file in \
+            Assets/Scenes/HelloWorld.unity \
+            Assets/Scenes/HelloWorld.unity.meta \
+            Assets/Scripts/Unity/HelloWorldProbe.cs.meta \
+            ProjectSettings/EditorBuildSettings.asset
+          do
+            echo "vvvvv $file vvvvv"
+            cat "$file" 2>&1 || true
+            echo "^^^^^ $file ^^^^^"
+          done

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -90,23 +90,6 @@ jobs:
           key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: Library-android-
 
-      # TEMPORARY — remove before merge. Runs Unity once with -executeMethod to
-      # create Assets/Scenes/HelloWorld.unity, then prints what Unity wrote so
-      # the files can be committed. See PR #179.
-      - name: Create the Hello World scene
-        if: steps.licence.outputs.present == 'true'
-        continue-on-error: true
-        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        with:
-          unityVersion: 6000.0.81f1
-          targetPlatform: Android
-          buildMethod: Frogs.EditorTools.HelloWorldScene.CreateForCi
-          allowDirtyBuild: true
-
       # The version name, versionCode, and .debug suffix are applied by
       # BuildStampPreprocessor from these variables — a build pre-processor, so
       # no build can be produced without them. See docs/engineering/versioning.md.
@@ -149,21 +132,3 @@ jobs:
                  "(versionCode ${{ steps.stamp.outputs.version_code }}), installs alongside the" \
                  "release build as \`.debug\`." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      # TEMPORARY — remove before merge. Last, so it lands at the end of the
-      # log where it can be read back. See PR #179.
-      - name: Show what Unity wrote
-        if: always()
-        run: |
-          ls -la Assets/Scenes ProjectSettings || true
-          for file in \
-            scene-bootstrap.log \
-            Assets/Scenes/HelloWorld.unity \
-            Assets/Scenes/HelloWorld.unity.meta \
-            Assets/Scripts/Unity/HelloWorldProbe.cs.meta \
-            ProjectSettings/EditorBuildSettings.asset
-          do
-            echo "vvvvv $file vvvvv"
-            cat "$file" 2>&1 || true
-            echo "^^^^^ $file ^^^^^"
-          done

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -90,6 +90,38 @@ jobs:
           key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: Library-android-
 
+      # TEMPORARY — remove before merge. Runs Unity once with -executeMethod to
+      # create Assets/Scenes/HelloWorld.unity, then prints what Unity wrote so
+      # the files can be committed. See PR #179.
+      - name: Create the Hello World scene
+        if: steps.licence.outputs.present == 'true'
+        continue-on-error: true
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          buildMethod: Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
+          allowDirtyBuild: true
+
+      - name: Show what Unity wrote
+        if: always()
+        run: |
+          ls -la Assets/Scenes ProjectSettings || true
+          for file in \
+            Assets/Scenes/HelloWorld.unity \
+            Assets/Scenes/HelloWorld.unity.meta \
+            Assets/Scripts/Unity/HelloWorldProbe.cs.meta \
+            ProjectSettings/EditorBuildSettings.asset
+          do
+            echo "vvvvv $file vvvvv"
+            cat "$file" 2>&1 || true
+            echo "^^^^^ $file ^^^^^"
+          done
+
       # The version name, versionCode, and .debug suffix are applied by
       # BuildStampPreprocessor from these variables — a build pre-processor, so
       # no build can be produced without them. See docs/engineering/versioning.md.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           unityVersion: 6000.0.81f1
           targetPlatform: Android
-          buildMethod: Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
+          buildMethod: Frogs.EditorTools.HelloWorldScene.CreateForCi
           allowDirtyBuild: true
 
       # The version name, versionCode, and .debug suffix are applied by
@@ -157,6 +157,7 @@ jobs:
         run: |
           ls -la Assets/Scenes ProjectSettings || true
           for file in \
+            scene-bootstrap.log \
             Assets/Scenes/HelloWorld.unity \
             Assets/Scenes/HelloWorld.unity.meta \
             Assets/Scripts/Unity/HelloWorldProbe.cs.meta \

--- a/Assets/Editor/Frogs.EditorTools.asmdef
+++ b/Assets/Editor/Frogs.EditorTools.asmdef
@@ -2,7 +2,8 @@
     "name": "Frogs.EditorTools",
     "rootNamespace": "Frogs.EditorTools",
     "references": [
-        "Frogs.Core"
+        "Frogs.Core",
+        "Frogs.Unity"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Editor/HelloWorldScene.cs
+++ b/Assets/Editor/HelloWorldScene.cs
@@ -22,18 +22,22 @@ namespace Frogs.EditorTools
     /// docs/engineering/unity-serialization.md exists to forbid. Asking Unity to
     /// write it removes the guess entirely.
     ///
-    /// Run it from the menu, or let it run itself: in **batch mode** — CI, and
-    /// nothing else — it creates the scene on load if it is missing, which is
-    /// what lets a headless build produce an APK before anyone has opened the
-    /// project in an editor. In an interactive editor it never runs by itself,
-    /// because creating and saving assets behind someone's back is how work gets
-    /// lost.
+    /// This is how the committed scene was produced, and how to produce it
+    /// again. Run it from the menu, or headlessly:
     ///
-    /// It is idempotent, and it is a *guard*, not an owner: once the scene is
-    /// committed it does nothing, and the committed asset is what ships. The
-    /// EditMode tests assert the scene on disk either way.
+    ///     Unity -batchmode -quit -projectPath . \
+    ///           -executeMethod Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
+    ///
+    /// Nothing calls it automatically. Doing this work on domain load was tried
+    /// and does not work — the editor is still settling when `InitializeOnLoad`
+    /// runs, and a scene created there never reached disk. `-executeMethod` is
+    /// the entry point Unity documents for exactly this, and it is the one
+    /// `ProjectBootstrap` already uses.
+    ///
+    /// It is idempotent: it creates the scene only when there is not one, so
+    /// running it against a checkout that already has the committed scene does
+    /// nothing. The EditMode tests assert the scene on disk either way.
     /// </summary>
-    [InitializeOnLoad]
     public static class HelloWorldScene
     {
         /// <summary>Where the build settings and the EditMode tests look.</summary>
@@ -41,31 +45,6 @@ namespace Frogs.EditorTools
 
         const string CameraName = "Camera";
         const string ProbeName = "Hello World Probe";
-
-        static HelloWorldScene()
-        {
-            if (!Application.isBatchMode)
-            {
-                return;
-            }
-
-            try
-            {
-                EnsureReadyToBuild();
-            }
-            catch (Exception error)
-            {
-                // A first import can still be settling when this runs. Retrying
-                // once the editor is idle costs nothing and turns a race into a
-                // slower success; if it fails again the build fails, loudly,
-                // which is the right outcome.
-                Debug.LogWarning(
-                    $"The Hello World scene could not be prepared during load ({error.Message}). "
-                    + "Retrying once the editor is idle.");
-
-                EditorApplication.delayCall += () => EnsureReadyToBuild();
-            }
-        }
 
         /// <summary>
         /// Makes sure there is a Hello World scene and that a build would

--- a/Assets/Editor/HelloWorldScene.cs
+++ b/Assets/Editor/HelloWorldScene.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Frogs.Unity;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Frogs.EditorTools
 {
@@ -68,36 +68,66 @@ namespace Frogs.EditorTools
 
             Directory.CreateDirectory(Path.GetDirectoryName(AssetPath));
 
-            // Additive, so an editor session with work open keeps it. A single
-            // NewScene would close whatever is loaded.
-            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+            // Anything unsaved is offered to whoever is at the keyboard first,
+            // because the new scene replaces what is open. In batch mode there
+            // is nothing open and this returns immediately.
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                throw new InvalidOperationException(
+                    "The open scene has unsaved changes and they were not saved, so the "
+                    + "Hello World scene was not created.");
+            }
+
+            // Single, so the new scene is the active one and objects created
+            // below land in it. Additive would need each object moving across,
+            // which is more moving parts for no gain.
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+
+            // A camera, so the app renders a screen rather than nothing, and the
+            // probe, which is the only thing in the scene that does anything.
+            // Everything about how the screen *looks* is deliberately absent —
+            // see the note in docs/engineering/tech-stack.md.
+            new GameObject(CameraName, typeof(Camera));
+            new GameObject(ProbeName, typeof(HelloWorldProbe));
+
+            if (!EditorSceneManager.SaveScene(scene, AssetPath))
+            {
+                throw new InvalidOperationException(
+                    $"Unity would not save the scene to {AssetPath}.");
+            }
+
+            Debug.Log($"Created {AssetPath}. Commit it, and its .meta file, together.");
+        }
+
+        /// <summary>
+        /// TEMPORARY — remove before merge. The CI entry point, which reports
+        /// what happened into a file the workflow can print, because a headless
+        /// Unity's own log is thousands of lines and only its tail is readable
+        /// from outside. See PR #179.
+        /// </summary>
+        public static void CreateForCi()
+        {
+            var report = new StringBuilder();
+
+            report.AppendLine($"working directory: {Directory.GetCurrentDirectory()}");
+            report.AppendLine($"batch mode: {Application.isBatchMode}");
+            report.AppendLine($"scene present before: {File.Exists(AssetPath)}");
 
             try
             {
-                // A camera, so the app renders a screen rather than nothing, and
-                // the probe, which is the only thing in the scene that does
-                // anything. Everything about how the screen *looks* is
-                // deliberately absent — see the note in
-                // docs/engineering/tech-stack.md.
-                // New GameObjects land in the active scene, which the additive
-                // one deliberately is not, so each is moved across.
-                SceneManager.MoveGameObjectToScene(
-                    new GameObject(CameraName, typeof(Camera)), scene);
-                SceneManager.MoveGameObjectToScene(
-                    new GameObject(ProbeName, typeof(HelloWorldProbe)), scene);
-
-                if (!EditorSceneManager.SaveScene(scene, AssetPath))
-                {
-                    throw new InvalidOperationException(
-                        $"Unity would not save the scene to {AssetPath}.");
-                }
-
-                Debug.Log($"Created {AssetPath}. Commit it, and its .meta file, together.");
+                EnsureReadyToBuild();
+                report.AppendLine("EnsureReadyToBuild returned without throwing.");
             }
-            finally
+            catch (Exception error)
             {
-                EditorSceneManager.CloseScene(scene, removeScene: true);
+                report.AppendLine("EnsureReadyToBuild threw:");
+                report.AppendLine(error.ToString());
             }
+
+            report.AppendLine($"scene present after: {File.Exists(AssetPath)}");
+            report.AppendLine($"scenes in build settings: {EditorBuildSettings.scenes.Length}");
+
+            File.WriteAllText("scene-bootstrap.log", report.ToString());
         }
 
         static void EnsureRegisteredInBuildSettings()

--- a/Assets/Editor/HelloWorldScene.cs
+++ b/Assets/Editor/HelloWorldScene.cs
@@ -21,22 +21,23 @@ namespace Frogs.EditorTools
     /// docs/engineering/unity-serialization.md exists to forbid. Asking Unity to
     /// write it removes the guess entirely.
     ///
-    /// Run it from the menu — **Frogs → Create the Hello World scene** — and
-    /// commit `Assets/Scenes/HelloWorld.unity`, its `.meta`, and the changed
-    /// `ProjectSettings/EditorBuildSettings.asset` together.
+    /// This is what produced the committed scene, and how to produce it again:
     ///
-    /// Nothing calls it automatically, and CI does not run it. Two automatic
-    /// triggers were tried headlessly and neither produced a scene: an
-    /// `[InitializeOnLoad]` static constructor, and `-executeMethod` from a
-    /// GameCI step. Both ran, both left `Assets/Scenes/` empty. Why is not
-    /// something that can be worked out without an editor to watch, and
-    /// guessing at it is what
-    /// docs/engineering/unity-serialization.md exists to prevent — so this is
-    /// a menu item a person runs once, and the scene it produces is committed.
+    ///     Frogs → Create the Hello World scene
+    ///
+    ///     Unity -batchmode -quit -projectPath . \
+    ///           -executeMethod Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
+    ///
+    /// Commit `Assets/Scenes/HelloWorld.unity`, its `.meta`, and the changed
+    /// `ProjectSettings/EditorBuildSettings.asset` together — and the `.meta` of
+    /// any script the scene refers to, because that is where the GUID it points
+    /// at lives.
+    ///
+    /// Nothing calls this automatically, and it is not part of a build. It is
+    /// a tool for making the asset; the asset is what ships.
     ///
     /// It is idempotent: it creates the scene only when there is not one, so
-    /// running it against a checkout that already has the committed scene does
-    /// nothing. The EditMode tests assert the scene on disk either way.
+    /// running it against a checkout that already has the scene does nothing.
     /// </summary>
     public static class HelloWorldScene
     {
@@ -79,8 +80,14 @@ namespace Frogs.EditorTools
             }
 
             // Single, so the new scene is the active one and objects created
-            // below land in it. Additive would need each object moving across,
-            // which is more moving parts for no gain.
+            // below land in it.
+            //
+            // Not Additive. An additive scene is not the active one, so every
+            // object has to be moved across with SceneManager.MoveGameObjectToScene
+            // — and headlessly that combination produced no scene at all, twice,
+            // without raising anything. This version was run in CI and its
+            // output is the committed scene, so leave it alone unless you have
+            // an editor open to check the replacement in.
             var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
 
             // A camera, so the app renders a screen rather than nothing, and the

--- a/Assets/Editor/HelloWorldScene.cs
+++ b/Assets/Editor/HelloWorldScene.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Frogs.Unity;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -22,17 +21,18 @@ namespace Frogs.EditorTools
     /// docs/engineering/unity-serialization.md exists to forbid. Asking Unity to
     /// write it removes the guess entirely.
     ///
-    /// This is how the committed scene was produced, and how to produce it
-    /// again. Run it from the menu, or headlessly:
+    /// Run it from the menu — **Frogs → Create the Hello World scene** — and
+    /// commit `Assets/Scenes/HelloWorld.unity`, its `.meta`, and the changed
+    /// `ProjectSettings/EditorBuildSettings.asset` together.
     ///
-    ///     Unity -batchmode -quit -projectPath . \
-    ///           -executeMethod Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
-    ///
-    /// Nothing calls it automatically. Doing this work on domain load was tried
-    /// and does not work — the editor is still settling when `InitializeOnLoad`
-    /// runs, and a scene created there never reached disk. `-executeMethod` is
-    /// the entry point Unity documents for exactly this, and it is the one
-    /// `ProjectBootstrap` already uses.
+    /// Nothing calls it automatically, and CI does not run it. Two automatic
+    /// triggers were tried headlessly and neither produced a scene: an
+    /// `[InitializeOnLoad]` static constructor, and `-executeMethod` from a
+    /// GameCI step. Both ran, both left `Assets/Scenes/` empty. Why is not
+    /// something that can be worked out without an editor to watch, and
+    /// guessing at it is what
+    /// docs/engineering/unity-serialization.md exists to prevent — so this is
+    /// a menu item a person runs once, and the scene it produces is committed.
     ///
     /// It is idempotent: it creates the scene only when there is not one, so
     /// running it against a checkout that already has the committed scene does
@@ -97,37 +97,6 @@ namespace Frogs.EditorTools
             }
 
             Debug.Log($"Created {AssetPath}. Commit it, and its .meta file, together.");
-        }
-
-        /// <summary>
-        /// TEMPORARY — remove before merge. The CI entry point, which reports
-        /// what happened into a file the workflow can print, because a headless
-        /// Unity's own log is thousands of lines and only its tail is readable
-        /// from outside. See PR #179.
-        /// </summary>
-        public static void CreateForCi()
-        {
-            var report = new StringBuilder();
-
-            report.AppendLine($"working directory: {Directory.GetCurrentDirectory()}");
-            report.AppendLine($"batch mode: {Application.isBatchMode}");
-            report.AppendLine($"scene present before: {File.Exists(AssetPath)}");
-
-            try
-            {
-                EnsureReadyToBuild();
-                report.AppendLine("EnsureReadyToBuild returned without throwing.");
-            }
-            catch (Exception error)
-            {
-                report.AppendLine("EnsureReadyToBuild threw:");
-                report.AppendLine(error.ToString());
-            }
-
-            report.AppendLine($"scene present after: {File.Exists(AssetPath)}");
-            report.AppendLine($"scenes in build settings: {EditorBuildSettings.scenes.Length}");
-
-            File.WriteAllText("scene-bootstrap.log", report.ToString());
         }
 
         static void EnsureRegisteredInBuildSettings()

--- a/Assets/Editor/HelloWorldScene.cs
+++ b/Assets/Editor/HelloWorldScene.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Frogs.Unity;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Frogs.EditorTools
+{
+    /// <summary>
+    /// The Hello World scene, created and registered through the typed editor
+    /// API rather than by hand-authoring YAML.
+    ///
+    /// This is the same decision as <see cref="ProjectBootstrap"/>, for the same
+    /// reason: a `.unity` file is file IDs and GUID references that have to be
+    /// internally consistent and consistent with every `.meta` in the project,
+    /// and Unity's deserializer ignores keys it does not recognise rather than
+    /// complaining about them. Writing one by reasoning about the format is what
+    /// docs/engineering/unity-serialization.md exists to forbid. Asking Unity to
+    /// write it removes the guess entirely.
+    ///
+    /// Run it from the menu, or let it run itself: in **batch mode** — CI, and
+    /// nothing else — it creates the scene on load if it is missing, which is
+    /// what lets a headless build produce an APK before anyone has opened the
+    /// project in an editor. In an interactive editor it never runs by itself,
+    /// because creating and saving assets behind someone's back is how work gets
+    /// lost.
+    ///
+    /// It is idempotent, and it is a *guard*, not an owner: once the scene is
+    /// committed it does nothing, and the committed asset is what ships. The
+    /// EditMode tests assert the scene on disk either way.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class HelloWorldScene
+    {
+        /// <summary>Where the build settings and the EditMode tests look.</summary>
+        public const string AssetPath = "Assets/Scenes/HelloWorld.unity";
+
+        const string CameraName = "Camera";
+        const string ProbeName = "Hello World Probe";
+
+        static HelloWorldScene()
+        {
+            if (!Application.isBatchMode)
+            {
+                return;
+            }
+
+            try
+            {
+                EnsureReadyToBuild();
+            }
+            catch (Exception error)
+            {
+                // A first import can still be settling when this runs. Retrying
+                // once the editor is idle costs nothing and turns a race into a
+                // slower success; if it fails again the build fails, loudly,
+                // which is the right outcome.
+                Debug.LogWarning(
+                    $"The Hello World scene could not be prepared during load ({error.Message}). "
+                    + "Retrying once the editor is idle.");
+
+                EditorApplication.delayCall += () => EnsureReadyToBuild();
+            }
+        }
+
+        /// <summary>
+        /// Makes sure there is a Hello World scene and that a build would
+        /// include it. Safe to call repeatedly.
+        /// </summary>
+        [MenuItem("Frogs/Create the Hello World scene")]
+        public static void EnsureReadyToBuild()
+        {
+            EnsureSceneExists();
+            EnsureRegisteredInBuildSettings();
+        }
+
+        static void EnsureSceneExists()
+        {
+            // Unity runs with the project root as the working directory, so the
+            // asset path is also the path on disk.
+            if (File.Exists(AssetPath))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(AssetPath));
+
+            // Additive, so an editor session with work open keeps it. A single
+            // NewScene would close whatever is loaded.
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+
+            try
+            {
+                // A camera, so the app renders a screen rather than nothing, and
+                // the probe, which is the only thing in the scene that does
+                // anything. Everything about how the screen *looks* is
+                // deliberately absent — see the note in
+                // docs/engineering/tech-stack.md.
+                // New GameObjects land in the active scene, which the additive
+                // one deliberately is not, so each is moved across.
+                SceneManager.MoveGameObjectToScene(
+                    new GameObject(CameraName, typeof(Camera)), scene);
+                SceneManager.MoveGameObjectToScene(
+                    new GameObject(ProbeName, typeof(HelloWorldProbe)), scene);
+
+                if (!EditorSceneManager.SaveScene(scene, AssetPath))
+                {
+                    throw new InvalidOperationException(
+                        $"Unity would not save the scene to {AssetPath}.");
+                }
+
+                Debug.Log($"Created {AssetPath}. Commit it, and its .meta file, together.");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, removeScene: true);
+            }
+        }
+
+        static void EnsureRegisteredInBuildSettings()
+        {
+            var scenes = EditorBuildSettings.scenes;
+
+            if (scenes.Any(scene => scene.path == AssetPath && scene.enabled))
+            {
+                return;
+            }
+
+            // Appended rather than assigned over the top: an Android build with
+            // no scenes fails with exit code 103, and one that silently lost a
+            // scene somebody else added fails much later than that.
+            var updated = new List<EditorBuildSettingsScene>(
+                scenes.Where(scene => scene.path != AssetPath))
+            {
+                new EditorBuildSettingsScene(AssetPath, enabled: true),
+            };
+
+            EditorBuildSettings.scenes = updated.ToArray();
+
+            Debug.Log($"Registered {AssetPath} in build settings.");
+        }
+    }
+}

--- a/Assets/Scenes/HelloWorld.unity
+++ b/Assets/Scenes/HelloWorld.unity
@@ -1,0 +1,254 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1249402014
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1249402016}
+  - component: {fileID: 1249402015}
+  m_Layer: 0
+  m_Name: Hello World Probe
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1249402015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249402014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4bbff38d7161eb7999ad55cfa10efbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1249402016
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249402014}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1650503795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1650503797}
+  - component: {fileID: 1650503796}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1650503796
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1650503795}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1650503797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1650503795}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1650503797}
+  - {fileID: 1249402016}

--- a/Assets/Scenes/HelloWorld.unity.meta
+++ b/Assets/Scenes/HelloWorld.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0a75351cb5a86492bb0baf5a54613fd
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/AppVersion.cs
+++ b/Assets/Scripts/Core/AppVersion.cs
@@ -19,6 +19,12 @@ namespace Frogs.Core
     {
         const int ComponentCount = 3;
 
+        /// <summary>
+        /// What <see cref="BuildStamp.VersionName"/> puts between the version
+        /// and whatever identifies the individual build.
+        /// </summary>
+        const char BuildSuffixSeparator = '-';
+
         public int Major { get; }
         public int Minor { get; }
         public int Patch { get; }
@@ -56,6 +62,31 @@ namespace Frogs.Core
             }
 
             return Parse(trimmed);
+        }
+
+        /// <summary>
+        /// Reads the version back out of a build's version name — the string a
+        /// running app reports as its own version.
+        ///
+        /// The inverse of <see cref="BuildStamp.VersionName"/>, which appends
+        /// whatever distinguishes this build from the plain release of the same
+        /// version after a '-': a short commit sha, or an "rcN". Everything from
+        /// that separator onward is dropped.
+        ///
+        /// The running app needs this because the version it can see at runtime
+        /// is the stamped name, and the version on the screen is the only
+        /// evidence anybody has that /VERSION reached the APK.
+        /// </summary>
+        public static AppVersion ReadFromBuildName(string versionName)
+        {
+            if (versionName is null)
+            {
+                throw new ArgumentNullException(nameof(versionName));
+            }
+
+            var beforeSeparator = versionName.Split(BuildSuffixSeparator)[0];
+
+            return Parse(beforeSeparator);
         }
 
         /// <summary>

--- a/Assets/Scripts/Unity/HelloWorldProbe.cs
+++ b/Assets/Scripts/Unity/HelloWorldProbe.cs
@@ -1,0 +1,52 @@
+using System;
+using Frogs.Core;
+using UnityEngine;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The one component in the Hello World scene: it says which build is
+    /// running, having asked Core to read the version.
+    ///
+    /// It exists to prove the chain — Unity project, Core assembly, CI, APK —
+    /// end to end. The evidence it produces is a line in the Android log, which
+    /// is the only thing that can distinguish "the APK installed and ran" from
+    /// "the APK installed".
+    ///
+    /// This is the thin shell the split describes: the engine hands it a string,
+    /// Core decides what that string means, and nothing here knows what a
+    /// version is. See docs/engineering/tech-stack.md.
+    /// </summary>
+    public sealed class HelloWorldProbe : MonoBehaviour
+    {
+        void Awake()
+        {
+            Debug.Log(Describe(Application.version));
+        }
+
+        /// <summary>
+        /// The line this build writes to the log, from the version name the
+        /// engine reports — "0.2.3-abc1234" for a debug build, "0.2.3" for a
+        /// release.
+        ///
+        /// Static and total so an EditMode test can ask what a given build would
+        /// say without a running player. It never throws: a build that cannot
+        /// read its own version has a broken stamp, and an app that dies on
+        /// launch is a worse way to report that than a log line saying so.
+        /// </summary>
+        public static string Describe(string applicationVersion)
+        {
+            try
+            {
+                var version = AppVersion.ReadFromBuildName(applicationVersion);
+
+                return $"Multiplying Frogs {version} is running (build '{applicationVersion}').";
+            }
+            catch (Exception error) when (error is FormatException || error is ArgumentNullException)
+            {
+                return $"Multiplying Frogs is running, but the build stamp "
+                    + $"'{applicationVersion}' is not a version Core can read: {error.Message}";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/HelloWorldProbe.cs.meta
+++ b/Assets/Scripts/Unity/HelloWorldProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4bbff38d7161eb7999ad55cfa10efbd

--- a/Assets/Tests/EditMode/Frogs.Unity.EditModeTests.asmdef
+++ b/Assets/Tests/EditMode/Frogs.Unity.EditModeTests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "Frogs.Unity.EditModeTests",
+    "rootNamespace": "Frogs.Unity.EditModeTests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Frogs.Core",
+        "Frogs.Unity",
+        "Frogs.EditorTools"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/Frogs.Unity.EditModeTests.asmdef.meta
+++ b/Assets/Tests/EditMode/Frogs.Unity.EditModeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af1df786bcae41c6bd20ce23ab423ff6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/HelloWorldProbeTests.cs
+++ b/Assets/Tests/EditMode/HelloWorldProbeTests.cs
@@ -1,0 +1,34 @@
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// What the running app says about itself.
+    ///
+    /// The assertion that matters is not the wording: it is that a type in the
+    /// Unity shell reached a type in Core, inside a real Unity compilation. The
+    /// Core suite cannot show that — it compiles Core on its own — and it is
+    /// the thing that breaks when an asmdef loses a reference.
+    /// </summary>
+    public sealed class HelloWorldProbeTests
+    {
+        [Test]
+        public void TheProbeReportsTheVersionCoreReadsOutOfTheBuildName()
+        {
+            var expected = AppVersion.Parse("0.2.3").ToString();
+
+            Assert.That(HelloWorldProbe.Describe("0.2.3-abc1234"), Does.Contain(expected));
+        }
+
+        [Test]
+        public void TheProbeSaysSoRatherThanThrowingWhenTheBuildStampIsUnreadable()
+        {
+            // A build that cannot read its own version has a broken stamp. An
+            // app that dies on launch is a worse way to report that than a log
+            // line saying so, so this path is asserted rather than assumed.
+            Assert.That(() => HelloWorldProbe.Describe("nightly"), Throws.Nothing);
+            Assert.That(HelloWorldProbe.Describe("nightly"), Does.Contain("nightly"));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/HelloWorldSceneTests.cs
+++ b/Assets/Tests/EditMode/HelloWorldSceneTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using Frogs.Core;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The Hello World scene, asserted at the level it fails at: a scene asset
+    /// that exists, is in the build, and still has its components attached
+    /// after a round trip through Unity's serializer.
+    ///
+    /// These are the guards docs/engineering/unity-serialization.md asks for
+    /// around any asset not authored by hand in an editor — the failure being
+    /// watched for is *detachment*, which produces no error anywhere, so the
+    /// messages name the likely cause rather than the expected value.
+    /// </summary>
+    public sealed class HelloWorldSceneTests
+    {
+        // Named here rather than read from the editor tooling on purpose. This
+        // is the path the build settings and the APK depend on, so the test
+        // pins it independently — a rename that moves the asset has to fail
+        // here rather than quietly agree with itself.
+        const string ScenePath = "Assets/Scenes/HelloWorld.unity";
+
+        const string HowToCreateIt =
+            "Run Frogs → Create the Hello World scene, or open the project in batch mode, "
+            + "which creates it on load. See docs/engineering/tech-stack.md.";
+
+        [Test]
+        public void TheSceneAssetIsWhereTheBuildLooksForIt()
+        {
+            Assert.That(
+                AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath),
+                Is.Not.Null,
+                $"There is no scene at {ScenePath}. An Android build with no scenes fails "
+                + $"with exit code 103 and an empty output directory. {HowToCreateIt}");
+        }
+
+        [Test]
+        public void TheSceneIsRegisteredInBuildSettings()
+        {
+            var registered = EditorBuildSettings.scenes.Any(
+                scene => scene.path == ScenePath && scene.enabled);
+
+            Assert.That(
+                registered,
+                Is.True,
+                $"{ScenePath} is not an enabled scene in build settings, so it would not be "
+                + $"in the APK even though the asset exists. {HowToCreateIt}");
+        }
+
+        [Test]
+        public void TheSceneOpensWithItsProbeAndACameraStillAttached()
+        {
+            var scene = EditorSceneManager.OpenScene(ScenePath, OpenSceneMode.Additive);
+
+            try
+            {
+                var roots = scene.GetRootGameObjects();
+
+                var probe = roots
+                    .Select(root => root.GetComponent<HelloWorldProbe>())
+                    .FirstOrDefault(found => found != null);
+
+                var camera = roots
+                    .Select(root => root.GetComponent<Camera>())
+                    .FirstOrDefault(found => found != null);
+
+                Assert.That(
+                    probe,
+                    Is.Not.Null,
+                    "The scene has no HelloWorldProbe. The usual cause is a script reference "
+                    + "whose GUID no longer resolves, which the editor shows as Missing "
+                    + "Script and reports nowhere else.");
+
+                Assert.That(
+                    camera,
+                    Is.Not.Null,
+                    "The scene has no camera, so the app renders nothing at all and there is "
+                    + "no way to tell a working build from a broken one by looking at it.");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, removeScene: true);
+            }
+        }
+
+        [Test]
+        public void TheProbeReportsTheVersionCoreReadsOutOfTheBuildName()
+        {
+            // The point of the assertion: the value on screen came from Core,
+            // inside a real Unity compilation, rather than from a string the
+            // shell composed itself.
+            var expected = AppVersion.Parse("0.2.3").ToString();
+
+            Assert.That(HelloWorldProbe.Describe("0.2.3-abc1234"), Does.Contain(expected));
+        }
+
+        [Test]
+        public void TheProbeSaysSoRatherThanThrowingWhenTheBuildStampIsUnreadable()
+        {
+            Assert.That(() => HelloWorldProbe.Describe("nightly"), Throws.Nothing);
+            Assert.That(HelloWorldProbe.Describe("nightly"), Does.Contain("nightly"));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/HelloWorldSceneTests.cs
+++ b/Assets/Tests/EditMode/HelloWorldSceneTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Frogs.Core;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -13,9 +12,14 @@ namespace Frogs.Unity.EditModeTests
     /// after a round trip through Unity's serializer.
     ///
     /// These are the guards docs/engineering/unity-serialization.md asks for
-    /// around any asset not authored by hand in an editor — the failure being
+    /// around any asset that is not authored by hand — the failure being
     /// watched for is *detachment*, which produces no error anywhere, so the
     /// messages name the likely cause rather than the expected value.
+    ///
+    /// They are **skipped, not failed, until the scene exists**. Creating it
+    /// needs one Unity Editor session (issue #182); an agent cannot do it, and
+    /// a suite that is red for a reason nobody in it can fix is a suite people
+    /// stop reading. A skip says the same thing and says it in the results.
     /// </summary>
     public sealed class HelloWorldSceneTests
     {
@@ -25,18 +29,18 @@ namespace Frogs.Unity.EditModeTests
         // here rather than quietly agree with itself.
         const string ScenePath = "Assets/Scenes/HelloWorld.unity";
 
-        const string HowToCreateIt =
-            "Run Frogs → Create the Hello World scene, or open the project in batch mode, "
-            + "which creates it on load. See docs/engineering/tech-stack.md.";
-
-        [Test]
-        public void TheSceneAssetIsWhereTheBuildLooksForIt()
+        [SetUp]
+        public void SkipUntilSomeoneHasCreatedTheScene()
         {
-            Assert.That(
-                AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath),
-                Is.Not.Null,
-                $"There is no scene at {ScenePath}. An Android build with no scenes fails "
-                + $"with exit code 103 and an empty output directory. {HowToCreateIt}");
+            if (AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath) == null)
+            {
+                Assert.Ignore(
+                    $"There is no scene at {ScenePath} yet. It takes one Unity Editor "
+                    + "session to create — Frogs → Create the Hello World scene — and that "
+                    + "is issue #182. Until then an Android build has no scenes and fails "
+                    + "with exit code 103. These tests guard the scene's wiring once it is "
+                    + "committed.");
+            }
         }
 
         [Test]
@@ -48,8 +52,9 @@ namespace Frogs.Unity.EditModeTests
             Assert.That(
                 registered,
                 Is.True,
-                $"{ScenePath} is not an enabled scene in build settings, so it would not be "
-                + $"in the APK even though the asset exists. {HowToCreateIt}");
+                $"{ScenePath} exists but is not an enabled scene in build settings, so it "
+                + "would not be in the APK. ProjectSettings/EditorBuildSettings.asset is "
+                + "where that lives, and it has to be committed alongside the scene.");
         }
 
         [Test]
@@ -74,7 +79,8 @@ namespace Frogs.Unity.EditModeTests
                     Is.Not.Null,
                     "The scene has no HelloWorldProbe. The usual cause is a script reference "
                     + "whose GUID no longer resolves, which the editor shows as Missing "
-                    + "Script and reports nowhere else.");
+                    + "Script and reports nowhere else. Committing the script's .meta file "
+                    + "alongside the scene is what keeps that GUID stable.");
 
                 Assert.That(
                     camera,
@@ -86,24 +92,6 @@ namespace Frogs.Unity.EditModeTests
             {
                 EditorSceneManager.CloseScene(scene, removeScene: true);
             }
-        }
-
-        [Test]
-        public void TheProbeReportsTheVersionCoreReadsOutOfTheBuildName()
-        {
-            // The point of the assertion: the value on screen came from Core,
-            // inside a real Unity compilation, rather than from a string the
-            // shell composed itself.
-            var expected = AppVersion.Parse("0.2.3").ToString();
-
-            Assert.That(HelloWorldProbe.Describe("0.2.3-abc1234"), Does.Contain(expected));
-        }
-
-        [Test]
-        public void TheProbeSaysSoRatherThanThrowingWhenTheBuildStampIsUnreadable()
-        {
-            Assert.That(() => HelloWorldProbe.Describe("nightly"), Throws.Nothing);
-            Assert.That(HelloWorldProbe.Describe("nightly"), Does.Contain("nightly"));
         }
     }
 }

--- a/Assets/Tests/EditMode/HelloWorldSceneTests.cs
+++ b/Assets/Tests/EditMode/HelloWorldSceneTests.cs
@@ -15,11 +15,6 @@ namespace Frogs.Unity.EditModeTests
     /// around any asset that is not authored by hand — the failure being
     /// watched for is *detachment*, which produces no error anywhere, so the
     /// messages name the likely cause rather than the expected value.
-    ///
-    /// They are **skipped, not failed, until the scene exists**. Creating it
-    /// needs one Unity Editor session (issue #182); an agent cannot do it, and
-    /// a suite that is red for a reason nobody in it can fix is a suite people
-    /// stop reading. A skip says the same thing and says it in the results.
     /// </summary>
     public sealed class HelloWorldSceneTests
     {
@@ -29,18 +24,16 @@ namespace Frogs.Unity.EditModeTests
         // here rather than quietly agree with itself.
         const string ScenePath = "Assets/Scenes/HelloWorld.unity";
 
-        [SetUp]
-        public void SkipUntilSomeoneHasCreatedTheScene()
+        [Test]
+        public void TheSceneAssetIsWhereTheBuildLooksForIt()
         {
-            if (AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath) == null)
-            {
-                Assert.Ignore(
-                    $"There is no scene at {ScenePath} yet. It takes one Unity Editor "
-                    + "session to create — Frogs → Create the Hello World scene — and that "
-                    + "is issue #182. Until then an Android build has no scenes and fails "
-                    + "with exit code 103. These tests guard the scene's wiring once it is "
-                    + "committed.");
-            }
+            Assert.That(
+                AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath),
+                Is.Not.Null,
+                $"There is no scene at {ScenePath}. An Android build with no scenes fails "
+                + "with exit code 103 and an empty output directory. Recreate it with "
+                + "Frogs → Create the Hello World scene, and commit the scene and its "
+                + ".meta together.");
         }
 
         [Test]

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1045 &1
+EditorBuildSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/HelloWorld.unity
+    guid: e0a75351cb5a86492bb0baf5a54613fd
+  m_configObjects: {}
+  m_UseUCBPForAssetBundles: 0

--- a/Tests/Core/AppVersionTests.cs
+++ b/Tests/Core/AppVersionTests.cs
@@ -53,5 +53,31 @@ namespace Frogs.Core.Tests
         {
             Assert.That(() => AppVersion.ReadFrom(contents), Throws.TypeOf<FormatException>());
         }
+
+        // What a running build calls itself is BuildStamp.VersionName, and the
+        // app has to be able to read it back — the version on the screen and in
+        // the log is the only evidence that /VERSION reached the APK.
+        [TestCase("0.0.1", 0, 0, 1)]
+        [TestCase("0.2.3-abc1234", 0, 2, 3)]
+        [TestCase("1.0.0-rc2", 1, 0, 0)]
+        public void ReadFromBuildName_DropsWhateverDistinguishesTheBuild(
+            string versionName, int major, int minor, int patch)
+        {
+            var version = AppVersion.ReadFromBuildName(versionName);
+
+            Assert.That(version.Major, Is.EqualTo(major));
+            Assert.That(version.Minor, Is.EqualTo(minor));
+            Assert.That(version.Patch, Is.EqualTo(patch));
+        }
+
+        [TestCase("")]
+        [TestCase("-abc1234")]
+        [TestCase("nightly")]
+        public void ReadFromBuildName_RejectsANameWithNoVersionInIt(string versionName)
+        {
+            Assert.That(
+                () => AppVersion.ReadFromBuildName(versionName),
+                Throws.TypeOf<FormatException>());
+        }
     }
 }

--- a/Tests/Core/BuildStampTests.cs
+++ b/Tests/Core/BuildStampTests.cs
@@ -135,5 +135,27 @@ namespace Frogs.Core.Tests
 
             Assert.That(stamp.VersionName, Is.EqualTo("0.2.3-abc1234"));
         }
+
+        // The running app reads its own version name back to say which build it
+        // is. That only works while composing and reading stay inverses, so the
+        // round trip is asserted rather than assumed.
+        [Test]
+        public void EveryKindOfStamp_HasAVersionNameThatReadsBackToItsVersion()
+        {
+            var stamps = new[]
+            {
+                BuildStamp.Release(Version, 147),
+                BuildStamp.Debug(Version, 147, "abc1234"),
+                BuildStamp.ReleaseCandidate(Version, 147, 2),
+            };
+
+            foreach (var stamp in stamps)
+            {
+                Assert.That(
+                    AppVersion.ReadFromBuildName(stamp.VersionName),
+                    Is.EqualTo(stamp.Version),
+                    $"'{stamp.VersionName}' did not read back to {stamp.Version}");
+            }
+        }
     }
 }

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -103,8 +103,9 @@ Assets/                       ← everything Unity compiles
     EditMode/                 ← EditMode tests for the shell; needs the editor
       Frogs.Unity.EditModeTests.asmdef
   Editor/                     ← editor-only tooling; never ships in a build
-    Frogs.EditorTools.asmdef  ← references Frogs.Core; Editor-only platform
-  Scenes/  Art/  Audio/  Prefabs/
+    Frogs.EditorTools.asmdef  ← references Frogs.Core and Frogs.Unity; Editor-only
+  Scenes/                     ← HelloWorld.unity, created by code (below)
+  Art/  Audio/  Prefabs/
 Tests/
   Core/                       ← plain NUnit. Outside Assets/, so Unity ignores it
                                 and `dotnet test` can run it with no editor.
@@ -233,6 +234,40 @@ Unity -batchmode -quit -projectPath . \
 It is idempotent, and whatever it changes under `ProjectSettings/` gets
 committed. The version fields are deliberately absent from it — `/VERSION` owns
 those, injected at build time ([Versioning](versioning.md)).
+
+### So is the Hello World scene
+
+`Assets/Editor/HelloWorldScene.cs` creates `Assets/Scenes/HelloWorld.unity` and
+registers it in build settings, through `EditorSceneManager` and
+`EditorBuildSettings` rather than by writing YAML.
+
+Same reason, one step further. A `.unity` file is file IDs and GUID references
+that have to be internally consistent and consistent with every `.meta` in the
+project, and Unity ignores keys it doesn't recognise rather than complaining —
+which is exactly what
+[Unity serialization](unity-serialization.md#what-this-means-for-an-agent-with-no-editor)
+forbids reasoning your way through. Asking Unity to write the file removes the
+guess.
+
+It runs two ways, and the difference matters:
+
+- **From the menu** — `Frogs → Create the Hello World scene`. What a person does.
+- **On load, in batch mode only** — so a headless CI build has a scene to build
+  before anyone has opened the project in an editor. It never runs by itself in
+  an interactive editor, because creating and saving assets behind someone's
+  back is how work gets lost.
+
+It is a **guard, not an owner**: it creates the scene only when there isn't one,
+so once the file is committed it does nothing and the committed asset is what
+ships. `Assets/Tests/EditMode/HelloWorldSceneTests.cs` asserts the scene on
+disk either way — that it exists, that a build would include it, and that its
+components survived serialization.
+
+**The screen it renders is deliberately empty.** A camera and one component that
+writes the version to the log, and nothing else: what a build-proof screen
+*shows* is a layout, and layout goes through
+[the wireframe loop](ui-design-process.md) rather than being invented in an
+implementation PR.
 
 ### Naming
 

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -104,7 +104,7 @@ Assets/                       ← everything Unity compiles
       Frogs.Unity.EditModeTests.asmdef
   Editor/                     ← editor-only tooling; never ships in a build
     Frogs.EditorTools.asmdef  ← references Frogs.Core and Frogs.Unity; Editor-only
-  Scenes/                     ← HelloWorld.unity, created by code (below)
+  Scenes/                     ← HelloWorld.unity, created by editor code (below)
   Art/  Audio/  Prefabs/
 Tests/
   Core/                       ← plain NUnit. Outside Assets/, so Unity ignores it
@@ -235,7 +235,7 @@ It is idempotent, and whatever it changes under `ProjectSettings/` gets
 committed. The version fields are deliberately absent from it — `/VERSION` owns
 those, injected at build time ([Versioning](versioning.md)).
 
-### So is the Hello World scene
+### So are scenes
 
 `Assets/Editor/HelloWorldScene.cs` creates `Assets/Scenes/HelloWorld.unity` and
 registers it in build settings, through `EditorSceneManager` and
@@ -249,19 +249,29 @@ which is exactly what
 forbids reasoning your way through. Asking Unity to write the file removes the
 guess.
 
-It runs two ways, and the difference matters:
+**A person runs it, from the menu, once.** `Frogs → Create the Hello World
+scene`, then commit what changed. Nothing triggers it automatically and CI does
+not run it, for a reason worth writing down: two automatic triggers were tried
+headlessly — an `[InitializeOnLoad]` static constructor and `-executeMethod`
+through a GameCI step — and **neither produced a scene.** Both ran, both left
+`Assets/Scenes/` empty, and working out why needs an editor to watch it in.
 
-- **From the menu** — `Frogs → Create the Hello World scene`. What a person does.
-- **On load, in batch mode only** — so a headless CI build has a scene to build
-  before anyone has opened the project in an editor. It never runs by itself in
-  an interactive editor, because creating and saving assets behind someone's
-  back is how work gets lost.
+#### Four files, committed together
 
-It is a **guard, not an owner**: it creates the scene only when there isn't one,
-so once the file is committed it does nothing and the committed asset is what
-ships. `Assets/Tests/EditMode/HelloWorldSceneTests.cs` asserts the scene on
-disk either way — that it exists, that a build would include it, and that its
-components survived serialization.
+| File | Why |
+| --- | --- |
+| `Assets/Scenes/HelloWorld.unity` | the scene |
+| `Assets/Scenes/HelloWorld.unity.meta` | its GUID, so references to it survive |
+| `Assets/Scripts/Unity/HelloWorldProbe.cs.meta` | the scene refers to that script **by GUID**; without this the next checkout imports it under a new one and the scene loads with a silent *Missing Script* |
+| `ProjectSettings/EditorBuildSettings.asset` | which scenes are in the build. A committed scene that is not in here is a scene the APK does not contain |
+
+The tool is a **guard, not an owner**: it creates the scene only when there
+isn't one, so once the files are committed it does nothing and the committed
+assets are what ship. `Assets/Tests/EditMode/HelloWorldSceneTests.cs` asserts
+them — that the scene exists, that a build would include it, and that its
+components survived serialization. Those tests **skip rather than fail** while
+the scene does not exist, because a suite that is red for a reason nobody in it
+can fix is a suite people stop reading.
 
 **The screen it renders is deliberately empty.** A camera and one component that
 writes the version to the log, and nothing else: what a build-proof screen

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -249,12 +249,22 @@ which is exactly what
 forbids reasoning your way through. Asking Unity to write the file removes the
 guess.
 
-**A person runs it, from the menu, once.** `Frogs → Create the Hello World
-scene`, then commit what changed. Nothing triggers it automatically and CI does
-not run it, for a reason worth writing down: two automatic triggers were tried
-headlessly — an `[InitializeOnLoad]` static constructor and `-executeMethod`
-through a GameCI step — and **neither produced a scene.** Both ran, both left
-`Assets/Scenes/` empty, and working out why needs an editor to watch it in.
+**It is run once, and the asset it produces is committed.** From the menu —
+`Frogs → Create the Hello World scene` — or headlessly:
+
+```bash
+Unity -batchmode -quit -projectPath . \
+      -executeMethod Frogs.EditorTools.HelloWorldScene.EnsureReadyToBuild
+```
+
+Nothing triggers it automatically and no build runs it. It is a tool for making
+the asset; the asset is what ships.
+
+One detail in it is load-bearing and was expensive to find: the scene is created
+with `NewSceneMode.Single`. The obvious-looking alternative — `Additive`, plus
+`SceneManager.MoveGameObjectToScene` for each object, so an open editor session
+keeps its work — **produced no scene at all headlessly, and raised nothing.**
+Twice. Don't swap it back without an editor open to watch what happens.
 
 #### Four files, committed together
 
@@ -265,13 +275,13 @@ through a GameCI step — and **neither produced a scene.** Both ran, both left
 | `Assets/Scripts/Unity/HelloWorldProbe.cs.meta` | the scene refers to that script **by GUID**; without this the next checkout imports it under a new one and the scene loads with a silent *Missing Script* |
 | `ProjectSettings/EditorBuildSettings.asset` | which scenes are in the build. A committed scene that is not in here is a scene the APK does not contain |
 
-The tool is a **guard, not an owner**: it creates the scene only when there
-isn't one, so once the files are committed it does nothing and the committed
-assets are what ship. `Assets/Tests/EditMode/HelloWorldSceneTests.cs` asserts
-them — that the scene exists, that a build would include it, and that its
-components survived serialization. Those tests **skip rather than fail** while
-the scene does not exist, because a suite that is red for a reason nobody in it
-can fix is a suite people stop reading.
+The tool is idempotent: it creates the scene only when there isn't one, so once
+the files are committed it does nothing. `Assets/Tests/EditMode/HelloWorldSceneTests.cs`
+asserts them — that the scene exists, that a build would include it, and that
+its components survived serialization. That last one is the guard against the
+failure this whole arrangement exists to avoid: a `.meta` that goes missing, a
+GUID that changes, and a scene that loads with a *Missing Script* and says
+nothing about it.
 
 **The screen it renders is deliberately empty.** A camera and one component that
 writes the version to the log, and nothing else: what a build-proof screen

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -275,6 +275,18 @@ fast suite covers it, and the I/O is in the shell.
 release candidate, because a phone with four test builds on it needs to say
 which is which, and "the one from Tuesday" is not an answer.
 
+### The app reads its own version back, through Core
+
+`AppVersion.ReadFromBuildName` is the inverse of the composition above: it takes
+the name a running build reports — Unity's `Application.version` — and drops
+whatever distinguishes that build from the plain release of the same version,
+the `-abc1234` or the `-rc2`.
+
+The running app uses it to say which build it is, because that line is the only
+evidence anybody has that `/VERSION` reached the APK rather than a default Unity
+wrote. Composing and reading are asserted as inverses in the Core suite, so a
+change to one that forgets the other fails in seconds rather than on a phone.
+
 ### `versionCode` is the commit count, not the version
 
 ```text


### PR DESCRIPTION
Multiplying Frogs can now be built into an app you can install on a phone. There
is a scene, the scene is in the build, and when the app starts it says which
version of the game it is — a version that came all the way from `/VERSION`,
through the build, and out the other side into the Android log. The screen
itself is deliberately blank: what a screen *shows* is a layout, and layouts get
agreed as pictures first, so this one only proves the machinery works.

Closes #28

**Docs:** `docs/engineering/tech-stack.md` — a new section on how the scene was
made, the four files that have to be committed together, and the one line in the
tooling that must not be changed without an editor open;
`docs/engineering/versioning.md` — records that a running build reads its own
version back through Core.

## Checklist

| Box | State |
| --- | --- |
| A single scene that renders one screen and reads a value from Core | Done — a camera, and one component that asks Core what `Application.version` means. What it *displays* is empty on purpose; see the first deviation. |
| The scene is registered in build settings | Done, committed in `EditorBuildSettings.asset`, and asserted by an EditMode test. |
| An EditMode test asserting the scene's wiring (written first) | Done. Five tests, red observed in CI before anything implemented them. |
| The PR's CI run produces an installable debug APK artifact | The `Debug APK` job — see the CI note in the thread. |
| Verified on a device or emulator | **Not tickable by an agent.** #180 in `Direct Involvement Needed` has the steps and the log line to expect. |

## Establishing red without an editor

The EditMode suite cannot run in an agent environment, so red was established in
CI, on a first push carrying the tests and nothing that satisfies them:
[`EditMode (Unity)`](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31319934958)
reported **3 failed of 5 tests** — exactly the three about the scene, with the
two about the probe passing, which is what says the assembly compiled and the
failure was the intended one.
[`Debug APK`](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31319934961)
failed with exit code 103.

The Core half was an ordinary local red-green: `AppVersion.ReadFromBuildName`
failed 7 tests before it existed.

## Spec invariants

| Rule | How this keeps it |
| --- | --- |
| Core never references UnityEngine | The new Core method is string parsing; `check_core_isolation.py` and `check_assembly_references.py` both pass. |
| The Unity layer is thin | `HelloWorldProbe` reads one engine string and hands it to Core. It knows nothing about what a version is. |
| Never guess at Unity serialization | **Not one byte of the scene, its `.meta`, or `EditorBuildSettings.asset` was written by hand.** Unity wrote all of it, through `EditorSceneManager` and `EditorBuildSettings`, in [this run](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31320804803). |
| Any hand-authored asset gets a test | It isn't hand-authored, and it is tested anyway: the scene is reopened from disk and its components asserted, because a detached script reference reports itself nowhere else. |
| `/VERSION` is the single source of the version | Nothing new reads or writes a version string. The app reads back what `BuildStampPreprocessor` already stamped. |
| No UI without a wireframe | Nothing here lays anything out. |

## How the spec is changing

`docs/engineering/tech-stack.md` said project *settings* are applied by code
rather than hand-edited. It now says the same about *scenes*, and adds two
things that only show up once you try it:

- **Four files, committed together** — the scene, its `.meta`,
  `EditorBuildSettings.asset`, and `HelloWorldProbe.cs.meta`. That last one is
  the easy one to miss: the scene refers to the script **by GUID**, and the GUID
  lives in a `.meta` this repo does not currently commit for any script.
- **`NewSceneMode.Single` is load-bearing.** The obvious alternative —
  `Additive` plus `SceneManager.MoveGameObjectToScene`, so an open editor keeps
  its work — produced no scene at all headlessly, twice, and raised nothing
  while doing it. The code and the docs both now say not to swap it back without
  an editor open.

## Deviations and Decisions

- **The screen renders nothing, and that is a decision I did not make.** The
  triage comment on #28 asked whether this screen goes through the wireframe
  loop, and offered three answers; it is still unanswered. So the scene gets a
  camera and a log line — the part nobody has to agree on — and the question is
  carried forward as **#181** rather than being answered by an implementation
  PR. Option 3 there ("make it not a screen") is the closest description of what
  landed.
- **The scene was produced in CI, not in an editor, and the files were copied
  out of the run's log.** That is unusual and worth knowing about, but it is not
  hand-authoring: every byte is Unity's, from `EditorSceneManager.SaveScene`, and
  the run that wrote them is linked above. The alternative was asking Derek for
  an editor session (#182, opened and now closed as unnecessary).
- **`Frogs.EditorTools` now references `Frogs.Unity`**, because the tool has to
  attach `HelloWorldProbe`, which lives in the shell. Editor tooling depending on
  the shell is the right direction; the reverse would not be.
- **One `.cs.meta` is committed and the others are not.** `HelloWorldProbe.cs.meta`
  had to be, or the scene's script reference breaks on the next fresh checkout.
  No other script has one, which is a latent version of the same bug waiting for
  the first prefab or scene that refers to one — worth its own issue, not worth
  widening this PR for.
