### PR TITLE
fix(build): apply the project's own settings, and build for tablets in landscape

### DIFF
--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -40,7 +40,7 @@ namespace Frogs.EditorTools
         public void OnPreprocessBuild(BuildReport report)
         {
             // First, and before the profile below: the project's own identity —
-            // name, company, application id, minimum API, portrait-only. CI
+            // name, company, application id, minimum API, landscape-only. CI
             // builds from a container that has no ProjectSettings.asset, so
             // without this the app is called after the working directory.
             ProjectBootstrap.ApplyToBuild();

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -39,6 +39,12 @@ namespace Frogs.EditorTools
 
         public void OnPreprocessBuild(BuildReport report)
         {
+            // First, and before the profile below: the project's own identity —
+            // name, company, application id, minimum API, portrait-only. CI
+            // builds from a container that has no ProjectSettings.asset, so
+            // without this the app is called after the working directory.
+            ProjectBootstrap.ApplyToBuild();
+
             // Which kind of build this is, decided by which variable CI set.
             // An rc number wins over a sha: a release candidate is identified
             // by its position in the queue, because "is this newer than the one

--- a/Assets/Editor/ProjectBootstrap.cs
+++ b/Assets/Editor/ProjectBootstrap.cs
@@ -33,12 +33,34 @@ namespace Frogs.EditorTools
         [MenuItem("Frogs/Apply project settings")]
         public static void Apply()
         {
-            ApplyIdentity();
+            ApplyToBuild();
             ApplyAndroidTarget();
-            ApplyOrientation();
 
             AssetDatabase.SaveAssets();
             Debug.Log("Project settings applied. Commit the changes under ProjectSettings/.");
+        }
+
+        /// <summary>
+        /// The settings a build must have, applied by the build itself.
+        ///
+        /// <c>ProjectSettings/ProjectSettings.asset</c> is not in the repository,
+        /// so every CI build starts from whatever Unity generates in the
+        /// container — which named the first APK <c>workspace</c>, after the
+        /// working directory, and let it rotate. Relying on someone having run
+        /// the menu item above is what produced that.
+        ///
+        /// So <see cref="BuildStampPreprocessor"/> calls this on every build,
+        /// for the same reason it stamps the version there: a step that can be
+        /// forgotten will be.
+        ///
+        /// Architecture and scripting backend are deliberately NOT here — those
+        /// are the device/emulator profile's, and it runs after this.
+        /// </summary>
+        public static void ApplyToBuild()
+        {
+            ApplyIdentity();
+            ApplyMinimumApiLevel();
+            ApplyOrientation();
         }
 
         static void ApplyIdentity()
@@ -53,9 +75,13 @@ namespace Frogs.EditorTools
             // version — see docs/engineering/versioning.md.
         }
 
-        static void ApplyAndroidTarget()
+        static void ApplyMinimumApiLevel()
         {
             PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel24;
+        }
+
+        static void ApplyAndroidTarget()
+        {
             PlayerSettings.Android.targetArchitectures = AndroidArchitecture.ARM64;
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.Android, ScriptingImplementation.IL2CPP);
 

--- a/Assets/Editor/ProjectBootstrap.cs
+++ b/Assets/Editor/ProjectBootstrap.cs
@@ -93,14 +93,21 @@ namespace Frogs.EditorTools
 
         static void ApplyOrientation()
         {
-            // Portrait only. The game is played one-handed on a phone; letting
-            // it rotate would mean specifying a landscape layout for every
-            // screen, which is a second design nobody asked for.
-            PlayerSettings.defaultInterfaceOrientation = UIOrientation.Portrait;
-            PlayerSettings.allowedAutorotateToPortrait = true;
+            // Landscape only. The game is built for kids' tablets, which are
+            // held landscape — Derek's call, overriding the portrait-only rule
+            // this file used to carry. That rule's reason was one-handed play
+            // on a phone, which is not the device any more.
+            //
+            // Both landscape rotations, because a tablet gets picked up either
+            // way up and neither is upside down. Neither portrait rotation,
+            // because rotating into portrait needs a portrait layout and no
+            // wireframe specifies one — the same argument the old comment made,
+            // pointed the other way.
+            PlayerSettings.defaultInterfaceOrientation = UIOrientation.LandscapeLeft;
+            PlayerSettings.allowedAutorotateToLandscapeLeft = true;
+            PlayerSettings.allowedAutorotateToLandscapeRight = true;
+            PlayerSettings.allowedAutorotateToPortrait = false;
             PlayerSettings.allowedAutorotateToPortraitUpsideDown = false;
-            PlayerSettings.allowedAutorotateToLandscapeLeft = false;
-            PlayerSettings.allowedAutorotateToLandscapeRight = false;
         }
     }
 }

--- a/Assets/Tests/EditMode/ProjectIdentityTests.cs
+++ b/Assets/Tests/EditMode/ProjectIdentityTests.cs
@@ -1,0 +1,121 @@
+using System;
+using Frogs.EditorTools;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// What the app calls itself, and which way up it sits.
+    ///
+    /// `ProjectBootstrap` has always held the right answers — "Multiplying
+    /// Frogs", portrait only, com.derekwinters.multiplyingfrogs — but nothing
+    /// ran it, so no build ever had them. The first APK installed on a phone
+    /// was called *workspace*, after the CI container's working directory, and
+    /// it rotated freely.
+    ///
+    /// The settings therefore have to be applied by the build itself, the same
+    /// way the version is. These tests assert that they are, by running the
+    /// pre-processor over a deliberately wrong project state.
+    /// </summary>
+    public sealed class ProjectIdentityTests
+    {
+        const string BuildShaVariable = "FROGS_BUILD_SHA";
+        const string VersionCodeVariable = "FROGS_VERSION_CODE";
+
+        string previousSha;
+        string previousVersionCode;
+
+        [SetUp]
+        public void StampADebugBuildWithoutTouchingGit()
+        {
+            // The pre-processor stamps a version before anything else, and the
+            // debug path reads both of these from the environment. Set, so the
+            // stamp cannot shell out to git — a shallow CI checkout has no
+            // history to count, and this test is not about the version anyway.
+            previousSha = Environment.GetEnvironmentVariable(BuildShaVariable);
+            previousVersionCode = Environment.GetEnvironmentVariable(VersionCodeVariable);
+
+            Environment.SetEnvironmentVariable(BuildShaVariable, "abc1234");
+            Environment.SetEnvironmentVariable(VersionCodeVariable, "1");
+        }
+
+        [TearDown]
+        public void RestoreTheEnvironment()
+        {
+            Environment.SetEnvironmentVariable(BuildShaVariable, previousSha);
+            Environment.SetEnvironmentVariable(VersionCodeVariable, previousVersionCode);
+        }
+
+        [Test]
+        public void ABuildIsNamedAfterTheGameRatherThanItsBuildDirectory()
+        {
+            PlayerSettings.productName = "workspace";
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.That(PlayerSettings.productName, Is.EqualTo(ProjectBootstrap.ProductName));
+        }
+
+        [Test]
+        public void ABuildCarriesTheCompanyName()
+        {
+            PlayerSettings.companyName = "DefaultCompany";
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.That(PlayerSettings.companyName, Is.EqualTo(ProjectBootstrap.CompanyName));
+        }
+
+        [Test]
+        public void ABuildStaysInPortrait()
+        {
+            // Not just the default orientation: the three rotations we do not
+            // want have to be off, or Android rotates anyway. This is the check
+            // that would have caught the first APK, which auto-rotated.
+            PlayerSettings.allowedAutorotateToLandscapeLeft = true;
+            PlayerSettings.allowedAutorotateToLandscapeRight = true;
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    PlayerSettings.defaultInterfaceOrientation,
+                    Is.EqualTo(UIOrientation.Portrait));
+                Assert.That(PlayerSettings.allowedAutorotateToPortrait, Is.True);
+                Assert.That(PlayerSettings.allowedAutorotateToPortraitUpsideDown, Is.False);
+                Assert.That(PlayerSettings.allowedAutorotateToLandscapeLeft, Is.False);
+                Assert.That(PlayerSettings.allowedAutorotateToLandscapeRight, Is.False);
+            });
+        }
+
+        [Test]
+        public void AnAndroidBuildUsesTheRealApplicationIdentifier()
+        {
+            // Without this the identifier is com.DefaultCompany.workspace, which
+            // is what a second app installing over the first looks like.
+            PlayerSettings.SetApplicationIdentifier(
+                NamedBuildTarget.Android, "com.DefaultCompany.workspace");
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.That(
+                PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.Android),
+                Does.StartWith(ProjectBootstrap.ApplicationIdentifier));
+        }
+
+        [Test]
+        public void AnAndroidBuildTargetsTheMinimumApiLevelTheDocsPromise()
+        {
+            PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel23;
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.That(
+                PlayerSettings.Android.minSdkVersion,
+                Is.EqualTo(AndroidSdkVersions.AndroidApiLevel24));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ProjectIdentityTests.cs
+++ b/Assets/Tests/EditMode/ProjectIdentityTests.cs
@@ -69,13 +69,17 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
-        public void ABuildStaysInPortrait()
+        public void ABuildStaysInLandscape()
         {
-            // Not just the default orientation: the three rotations we do not
-            // want have to be off, or Android rotates anyway. This is the check
-            // that would have caught the first APK, which auto-rotated.
-            PlayerSettings.allowedAutorotateToLandscapeLeft = true;
-            PlayerSettings.allowedAutorotateToLandscapeRight = true;
+            // Not just the default orientation: the rotations we do not want
+            // have to be off, or Android rotates anyway. This is the check that
+            // would have caught the first APK, which auto-rotated.
+            //
+            // Both landscape rotations are allowed, because a tablet gets
+            // picked up either way up and neither is upside down. Both portrait
+            // rotations are off until a portrait layout exists to rotate into.
+            PlayerSettings.allowedAutorotateToPortrait = true;
+            PlayerSettings.allowedAutorotateToPortraitUpsideDown = true;
 
             new BuildStampPreprocessor().OnPreprocessBuild(null);
 
@@ -83,11 +87,11 @@ namespace Frogs.Unity.EditModeTests
             // inside the Unity Test Framework has no Assert.Multiple.
             Assert.That(
                 PlayerSettings.defaultInterfaceOrientation,
-                Is.EqualTo(UIOrientation.Portrait));
-            Assert.That(PlayerSettings.allowedAutorotateToPortrait, Is.True);
+                Is.EqualTo(UIOrientation.LandscapeLeft));
+            Assert.That(PlayerSettings.allowedAutorotateToLandscapeLeft, Is.True);
+            Assert.That(PlayerSettings.allowedAutorotateToLandscapeRight, Is.True);
+            Assert.That(PlayerSettings.allowedAutorotateToPortrait, Is.False);
             Assert.That(PlayerSettings.allowedAutorotateToPortraitUpsideDown, Is.False);
-            Assert.That(PlayerSettings.allowedAutorotateToLandscapeLeft, Is.False);
-            Assert.That(PlayerSettings.allowedAutorotateToLandscapeRight, Is.False);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/ProjectIdentityTests.cs
+++ b/Assets/Tests/EditMode/ProjectIdentityTests.cs
@@ -79,16 +79,15 @@ namespace Frogs.Unity.EditModeTests
 
             new BuildStampPreprocessor().OnPreprocessBuild(null);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(
-                    PlayerSettings.defaultInterfaceOrientation,
-                    Is.EqualTo(UIOrientation.Portrait));
-                Assert.That(PlayerSettings.allowedAutorotateToPortrait, Is.True);
-                Assert.That(PlayerSettings.allowedAutorotateToPortraitUpsideDown, Is.False);
-                Assert.That(PlayerSettings.allowedAutorotateToLandscapeLeft, Is.False);
-                Assert.That(PlayerSettings.allowedAutorotateToLandscapeRight, Is.False);
-            });
+            // Sequential rather than Assert.Multiple: the NUnit that ships
+            // inside the Unity Test Framework has no Assert.Multiple.
+            Assert.That(
+                PlayerSettings.defaultInterfaceOrientation,
+                Is.EqualTo(UIOrientation.Portrait));
+            Assert.That(PlayerSettings.allowedAutorotateToPortrait, Is.True);
+            Assert.That(PlayerSettings.allowedAutorotateToPortraitUpsideDown, Is.False);
+            Assert.That(PlayerSettings.allowedAutorotateToLandscapeLeft, Is.False);
+            Assert.That(PlayerSettings.allowedAutorotateToLandscapeRight, Is.False);
         }
 
         [Test]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,15 @@ No UI code is written before there is an agreed wireframe for it. UI is the part
 Connor has the strongest opinions about and the part that is most expensive to
 redo, so the layout gets settled as a cheap picture first.
 
+**Every layout and every dialog gets its own wireframe.** Not only the big
+screens — a confirm box, a toast, an end-of-turn panel each get one. A dialog
+is the easiest thing to slip in without a wireframe, and being small, the
+easiest to get wrong in a way nobody notices until Connor is holding it.
+
+**Mockups are drawn at 1920 × 1200, landscape.** That is the target device, a
+kids' Android tablet, and it is the one canvas every layout is designed
+against. A mockup at some other size is a mockup of a screen nobody has.
+
 A UI issue starts as a `type:wireframe` issue with a mockup in
 `docs/specs/ui/`. Only once that is agreed does an implementation issue get
 opened against it. Finding yourself writing a layout without a wireframe to

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -52,21 +52,34 @@ guessed at now.
 
 ## Target platform
 
-**Android phones.** That is the platform, singular. Connor plays on a phone;
-that is who the game is for.
+**Android tablets, held landscape.** Phones still run it — same OS, same
+architecture, same APK — but the tablet is the device the game is designed
+around, because that is what kids play on.
 
 | | |
 | --- | --- |
-| Primary target | Android, ARM64 (`arm64-v8a`) |
+| Primary target | Android tablets, ARM64 (`arm64-v8a`) |
+| Also runs on | Android phones |
 | Scripting backend | IL2CPP for device builds |
 | Minimum API level | 24 (Android 7.0) |
-| Orientation | Portrait |
+| Orientation | Landscape (both ways up) |
 | Output | `.apk` for direct install; `.aab` only if the game is ever published |
+
+This page previously said *"Android phones. That is the platform, singular"*
+and specified portrait, on the reasoning that the game is played one-handed on
+a phone. **Derek changed it**: the game is primarily for kids' tablets, and a
+tablet is held in landscape. The old rule's reasoning did not survive the
+change of device, so both the device and the orientation moved together.
+
+Portrait is not ruled out forever — but supporting it means designing a second
+layout for every screen, which is the same argument the portrait-only rule used
+to make in reverse. It stays off until a wireframe specifies one.
 
 ### Two build profiles
 
-**Device build** — ARM64, IL2CPP, what actually gets installed on a phone. This
-is what the release build produces, and what an RC build has to prove works.
+**Device build** — ARM64, IL2CPP, what actually gets installed on a tablet or a
+phone. This is what the release build produces, and what an RC build has to
+prove works.
 
 **Emulator build** — x86_64, Mono. IL2CPP cross-compiling to x86_64 is slow and
 buys nothing for a smoke test, so the emulator profile trades fidelity for a
@@ -88,14 +101,14 @@ starts as whatever Unity happens to default to.
 
 That is not theoretical. The first APK ever installed on a phone was called
 **`workspace`**, after the container's working directory, and it rotated freely
-in spite of this page promising portrait.
+in spite of this page promising a fixed orientation.
 
 So `ProjectBootstrap.ApplyToBuild()` applies them, and
 `BuildStampPreprocessor` calls it on **every** build — the same mechanism, and
 the same reasoning, as the version stamp: a step that can be forgotten will be.
 The order inside that pre-processor matters and is deliberate:
 
-1. `ProjectBootstrap.ApplyToBuild()` — identity, minimum API, portrait-only.
+1. `ProjectBootstrap.ApplyToBuild()` — identity, minimum API, landscape-only.
 2. The `.debug` application-id suffix, so it appends to the real id rather than
    to `com.DefaultCompany.workspace`.
 3. The device/emulator profile, so it can still override architecture and

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -62,7 +62,8 @@ around, because that is what kids play on.
 | Also runs on | Android phones |
 | Scripting backend | IL2CPP for device builds |
 | Minimum API level | 24 (Android 7.0) |
-| Orientation | Landscape (both ways up) |
+| Orientation | Landscape only (both ways up) |
+| Reference resolution | 1920 × 1200 (16:10) |
 | Output | `.apk` for direct install; `.aab` only if the game is ever published |
 
 This page previously said *"Android phones. That is the platform, singular"*
@@ -74,6 +75,12 @@ change of device, so both the device and the orientation moved together.
 Portrait is not ruled out forever — but supporting it means designing a second
 layout for every screen, which is the same argument the portrait-only rule used
 to make in reverse. It stays off until a wireframe specifies one.
+
+**1920 × 1200 is the resolution every layout is designed at.** It is 16:10,
+which is the common kids'-tablet shape, and it is the viewport every UI mockup
+is drawn at — see [the UI design process](ui-design-process.md). Devices that
+are not exactly this still run the game; the number exists so that layouts are
+designed against one agreed canvas instead of each being guessed at separately.
 
 ### Two build profiles
 

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -79,6 +79,32 @@ emulator-targeted asset is attached alongside it so the release can be tried on
 a desktop without rebuilding. A bug that reproduces only under the emulator is a
 bug in the profile until proven otherwise.
 
+### The settings above are applied by the build, not stored in the repo
+
+`ProjectSettings/ProjectSettings.asset` is **not committed**. Unity generates a
+default one in the CI container on every build, which means every value in the
+tables above — product name, application id, minimum API level, orientation —
+starts as whatever Unity happens to default to.
+
+That is not theoretical. The first APK ever installed on a phone was called
+**`workspace`**, after the container's working directory, and it rotated freely
+in spite of this page promising portrait.
+
+So `ProjectBootstrap.ApplyToBuild()` applies them, and
+`BuildStampPreprocessor` calls it on **every** build — the same mechanism, and
+the same reasoning, as the version stamp: a step that can be forgotten will be.
+The order inside that pre-processor matters and is deliberate:
+
+1. `ProjectBootstrap.ApplyToBuild()` — identity, minimum API, portrait-only.
+2. The `.debug` application-id suffix, so it appends to the real id rather than
+   to `com.DefaultCompany.workspace`.
+3. The device/emulator profile, so it can still override architecture and
+   scripting backend. Those two are deliberately *not* in `ApplyToBuild`.
+
+Committing a reviewed `ProjectSettings.asset` is still worth doing — it would
+make the settings a diffable source file rather than something reconstructed
+each build — but it needs an editor session to generate honestly.
+
 ### What is explicitly not a target
 
 iOS, desktop, console, web. Not "not yet" in a way that shapes decisions today —

--- a/docs/engineering/ui-design-process.md
+++ b/docs/engineering/ui-design-process.md
@@ -2,6 +2,11 @@
 
 **No UI gets built without an approved wireframe. Not even graybox.**
 
+**Every layout and every dialog.** Not just the big screens — a confirm box, a
+toast, an end-of-turn panel each get their own wireframe. A dialog is the
+easiest thing to slip in without one and, being small, the easiest to get
+wrong in a way nobody notices until Connor is holding it.
+
 UI is the part of this game Connor has the strongest opinions about and the part
 that is most expensive to redo. A layout argued about as a picture costs an
 evening; the same argument had about working code costs the code.
@@ -55,10 +60,14 @@ Vertical stack, centred, over a dimmed copy of the playfield.
 A **1:1 HTML mockup**: a static page sized to the target device, laying out the
 real elements at the real proportions.
 
+- **1920 × 1200, landscape.** That is the target device — a kids' Android
+  tablet — and it is the viewport every mockup is drawn at. See
+  [target platform](tech-stack.md#target-platform).
 - 1:1 because "roughly this" is how a button ends up too small for an
-  eight-year-old's thumb. Sized to a real phone viewport, in the real units.
-- HTML because it opens in a browser on a phone. Connor can look at the actual
-  thing at the actual size, on the device he plays on, and say it's wrong.
+  eight-year-old's thumb. Real viewport, real units.
+- HTML because it opens in a browser on the tablet itself. Connor can look at
+  the actual thing at the actual size, on the device he plays on, and say it's
+  wrong.
 - Static. No behaviour, no framework, no build step. It is a picture that
   happens to be made of divs.
 


### PR DESCRIPTION
The first APK installed on a tablet was called **workspace** and spun round when you tilted the device. Neither was a bug in the app: the settings that say what the game is called and which way up it sits had never been applied to any build at all. This makes the build apply them itself, so it cannot be forgotten again — and changes what they say, because the game is for kids' tablets held in landscape, not phones held in portrait.

## What was wrong

`ProjectSettings/ProjectSettings.asset` is **not committed to this repository**. It isn't gitignored; it was simply never added. So Unity generates a default one inside the CI container on every build, and `productName` defaults to the name of the project's directory — which in Actions is `/github/workspace`.

Everything `tech-stack.md` specifies as contract was in the same position: minimum API level, application identifier, orientation. None of it was reaching a build. Derek confirmed on-device that the app auto-rotated, which is Unity's default rather than the fixed orientation this repo documents.

`Assets/Editor/ProjectBootstrap.cs` has held the correct values all along:

```csharp
public const string CompanyName = "Derek Winters";
public const string ProductName = "Multiplying Frogs";
public const string ApplicationIdentifier = "com.derekwinters.multiplyingfrogs";
```

…behind a `[MenuItem]` that nothing has ever clicked, and no workflow invokes.

## The fix

`ProjectBootstrap.ApplyToBuild()` — identity, minimum API level, landscape-only — called from `BuildStampPreprocessor.OnPreprocessBuild`, which already stamps the version on every build. That pre-processor's own docstring gives the reason, and it applies just as well here:

> This runs as a build pre-processor rather than as a step CI remembers to call, because a stamping step that can be forgotten will be.

The mechanism is proven: the APK Derek installed reads `0.0.1-7e2ae71` because of it.

**Order inside the pre-processor is deliberate and load-bearing:**

1. `ProjectBootstrap.ApplyToBuild()` — identity, min API, orientation.
2. `ApplyApplicationIdSuffix()` — so `.debug` appends to `com.derekwinters.multiplyingfrogs`, not to `com.DefaultCompany.workspace`. Side-by-side install is preserved.
3. `ApplyAndroidProfile()` — architecture and scripting backend are deliberately **not** in `ApplyToBuild`, so the emulator profile can still switch to x86_64/Mono.

## How the spec is changing

Three contract changes, all Derek's calls, all recorded rather than done quietly.

**The device and the orientation moved together.**

- **Old rule:** *"Android phones. That is the platform, singular. Connor plays on a phone; that is who the game is for."* Orientation portrait, because the game is played one-handed on a phone.
- **New rule:** Android tablets, held landscape. Phones still run the same APK; they are no longer what the game is designed around. Landscape only, both ways up.
- **Why it is better:** the portrait rule's stated reasoning was about the device, and the device changed. Keeping portrait would have meant keeping a conclusion whose premise had gone.

Portrait is not ruled out forever, but supporting it means a second layout for every screen — the same argument the portrait-only rule used to make in reverse. It stays off until a wireframe specifies one.

**1920 × 1200 (16:10) is now the reference resolution.** Every layout is designed at it, and every UI mockup is drawn at it. `ui-design-process.md` previously told people to size mockups to "a real phone viewport", which was the old device.

**Rule 8 gained the two things it left to be re-derived:** whether a dialog counts as UI needing a wireframe (it does — every layout and every dialog), and what size to draw one at. Both were living in a chat message; they now live in `CLAUDE.md`.

## Spec invariants kept

- **`/VERSION` stays the only source of the version.** `ApplyToBuild` sets no `bundleVersion` and no `bundleVersionCode`.
- **Debug builds still install alongside release builds.** The `.debug` suffix now appends to a real identifier, which is what that feature always meant to do.
- **The emulator profile still works.** Architecture and backend are untouched here and still applied afterwards.
- **The editor's own Build button keeps working.** `Apply()` still does everything it did, including the build-target switch that has no business running inside a build.

## Verification

Test-first, with the red observed in CI rather than claimed — twice.

| Commit | CI result | What it proved |
| --- | --- | --- |
| `a1cc5a4` tests only | compile error, then `5 tests` | the tests exist and bite |
| `2cf4808` fix | — | `ApplyToBuild` wired in |
| `30a97be` | — | Unity's bundled NUnit has no `Assert.Multiple` |
| `1d0aad6` landscape test only | **`1 failed of 10 tests`** | the orientation test bites; the other four identity tests **pass**, so name, company, application id and API level are genuinely fixed |
| `e98c65d` landscape fix | — | orientation flipped |

The EditMode suite cannot run in an agent environment ([why](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/testing.md)), so red and green are both observed in CI. Locally: `check_assembly_references.py`, `check_core_isolation.py`, 139 script tests, `mkdocs build --strict`.

**Docs:** docs/engineering/tech-stack.md — rewrote the target platform section for tablets and landscape, added the 1920 × 1200 reference resolution, and added "The settings above are applied by the build, not stored in the repo" explaining why the first APK was called `workspace`. docs/engineering/ui-design-process.md — mockups are drawn at 1920 × 1200 landscape, not a phone viewport, and every dialog needs its own wireframe. CLAUDE.md — rule 8 now states both.

## Deviations and Decisions

- **This PR closes no issue, which breaks rule 10.** It exists because Derek said "fix it now" after installing the APK, so there was never an issue to close. Flagging it rather than opening one retroactively just to satisfy the keyword — but it means this work will not appear in the issue history, and that is a real cost.
- **It carries three of Derek's contract changes, not only the bug fix.** Landscape, 1920 × 1200, and the wireframe rule arrived while this branch was open. They belong to the same section of the same docs and would have conflicted as a second PR; folding them in was the smaller evil, and each is called out above.
- **I recommended committing `ProjectSettings.asset` and then did something else.** Reading `BuildStampPreprocessor` changed my mind: the repo already had a mechanism for exactly this, with a written rationale, and using it fixes the bug now rather than after an editor session. Committing a reviewed asset is still worth doing and is noted in the docs as outstanding.
- **Architecture and scripting backend are left alone.** `tech-stack.md` promises ARM64 + IL2CPP for device builds, and `pr-build` sets no profile, so PR APKs still use Unity's defaults. Forcing IL2CPP would make every PR build substantially slower — a trade worth deciding on its own.
- **Rebased onto `main` after #179 merged**, per rule 7, so this branch carries only its own seven commits.
