### PR TITLE
docs(specs): settle the End log as the winning space, and who may end a game

### DIFF
--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -71,6 +71,18 @@ A player's entire state is therefore one number — how far up their own lane th
 are. There is no board state beyond that: no collisions, no blocking, no ordering
 between frogs.
 
+### The End log is the winning space
+
+A frog wins by **landing on the End log**, not by reaching the last lily pad.
+The lane is therefore **nine positions** — the Start log, seven lily pads, and
+the End log — and winning takes **eight correct answers** from the start.
+
+Confirmed by Derek in
+[issue #185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185),
+after the board wireframe needed the number of spaces in a lane and the
+photograph could not settle it. The logs are symmetric: both ends of a lane are
+real positions a frog occupies, one as the floor and one as the goal.
+
 ### The Start log is a floor, not a special space
 
 A wrong answer moves you back one lily pad, exactly as the rules card says. The
@@ -86,6 +98,15 @@ where you are.
 A clamp at the bottom rather than a special case. Worth stating precisely,
 because "move back one" written without a floor is an off-by-one waiting to
 happen.
+
+Two of the three rows above are about the ends of a lane, so they are worth
+reading together:
+
+| Position | What it is |
+| --- | --- |
+| Start log | Position 0. The floor — a wrong answer here moves nothing. |
+| Lily pads 1–7 | The ordinary spaces. |
+| End log | Position 8. The goal — landing on it wins. |
 
 ## Still unsettled
 
@@ -111,6 +132,13 @@ a session needs a way to stop that isn't "everyone eventually finishes": a quit
 or end-game flow. This is purely ours — a cardboard game ends when you close the
 box, so there is nothing to be faithful to.
 
-Two things this leaves for whoever specifies it: whether the game also ends *on
-its own* once every frog is home, and who may trigger a quit when four players
-share one device. Neither is settled here.
+**Anyone may end the game, and a confirm is the only thing in the way.** Derek's
+call in
+[issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
+The device cannot tell who is holding it, so restricting the exit to a
+particular player was never enforceable — what protects a game in progress is
+that the confirm names the cost before it acts. See
+[end-game confirm](../ui/end-game-confirm.md).
+
+One thing this still leaves for whoever specifies it: whether the game also ends
+*on its own* once every frog is home. Same issue; not settled.

--- a/docs/specs/ui/end-game-confirm.md
+++ b/docs/specs/ui/end-game-confirm.md
@@ -75,14 +75,23 @@ right.
 three-frogs-still-swimming state, which is the one where the confirm has
 something to lose.
 
+## Who may end a game
+
+**Anyone, on anyone's turn.** Derek's call in
+[issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
+
+The alternative was restricting it to the current player, and it was rejected
+because the tablet cannot tell who is holding it — the restriction would have
+been a guess dressed as a rule. What actually protects a game in progress is
+this dialog telling you, before you act, how many frogs you are about to stop.
+
+That is why the cost sentence is built from live state rather than being a fixed
+string. It is the whole of the protection, so it has to say something true and
+specific every time.
+
 ## Open questions
 
-- **Who may end a game, on a shared tablet?**
-  [Issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
-  This wireframe proposes *anyone, with a confirm that names the cost*, on the
-  grounds that the tablet cannot tell who is holding it and the confirm is the
-  real protection. If the answer is "only the current player", this dialog gains
-  a condition and the settings button gains a disabled state.
-- **Does the game also end on its own when every frog is home?** Same issue.
-  If yes, the third body sentence above is a state almost nobody will see,
-  because the game will already have ended itself.
+- **Does the game also end on its own when every frog is home?** Still
+  [issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
+  If yes, the everybody-is-home body sentence above is a state almost nobody
+  will see, because the game will have ended itself first.

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -93,6 +93,15 @@ lanes-across** after seeing both drawn.
 | `Roll` button height | `RollButtonHeight` | 144 px |
 | `Roll` label size | `RollButtonLabelSize` | 56 px |
 | Positions in a lane | `LanePositionCount` | 9 |
+| Correct answers needed to win | `LaneWinningPosition` | 8 |
+
+`LanePositionCount` is 9 because a lane is the Start log, seven lily pads, and
+the End log, and **the End log is the winning space** — a frog has to land on
+it. Confirmed by Derek in
+[issue #185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185);
+recorded in
+[the reference material](../reference/index.md#the-end-log-is-the-winning-space).
+That is what the `of 8` in every chip's pad count refers to.
 
 The lane:
 
@@ -169,11 +178,6 @@ decided against; keeping a mockup of a layout nobody is building is how a
 
 ## Open questions
 
-- **Nine positions or eight?** The mockups draw the End log as a space a frog
-  lands on, making a lane nine positions and a win eight correct answers.
-  Whether that is what the classroom game does is
-  [issue #185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185),
-  and it is a rule, so Connor answers it.
 - **Do the unused lanes show?** The classroom board always has eight lanes,
   whoever is playing. The mockups draw only the lanes in play, because empty
   lanes on a screen this size cost the ones in play their height. Presentation,

--- a/docs/specs/ui/game-over.md
+++ b/docs/specs/ui/game-over.md
@@ -8,6 +8,9 @@ Who won, and where everybody else got to.
 far it got. Nobody disappears off the bottom of the game they just played.
 **Invariant:** there is no score. The classroom game has no score — it has an
 order — and inventing one would be inventing a mechanic.
+**Invariant:** a frog is home when it **lands on the End log** — eight correct
+answers — not when it reaches the last lily pad. See
+[the End log is the winning space](../reference/index.md#the-end-log-is-the-winning-space).
 **Invariant:** the winner is the frog that reached the End log first, and
 finishing order is the order frogs got home. Frogs that did not finish are
 ranked by how many lily pads they made.


### PR DESCRIPTION
Two things the board photograph could not tell us, now answered by Derek and written into the contract. A frog wins by landing on the End log, so a lane is nine spaces and it takes eight right answers to get home. And anybody can end a game, whoever's turn it is — the tablet has no way of knowing who is holding it, so the dialog that says *"three frogs are still swimming"* is what protects a game in progress, not a rule about whose turn it is.

Neither answer changes a single pixel of the wireframes: both are what the mockups already drew. This PR is the docs catching up to the decision.

**Docs:** `docs/specs/reference/index.md` — added "The End log is the winning space" beside the Start-log floor rule, with a position table covering both ends of a lane, and recorded that anyone may end a game. `docs/specs/ui/game-board.md` — added `LaneWinningPosition`, explained why `LanePositionCount` is 9, removed the resolved open question. `docs/specs/ui/end-game-confirm.md` — replaced the open question with a "Who may end a game" section saying what was decided and what was rejected. `docs/specs/ui/game-over.md` — added the home-means-landing-on-the-End-log invariant.

Closes #185

## Spec invariants this had to keep true

- **The two logs stay symmetric.** The Start log was already a real position a frog occupies — the floor a wrong answer clamps against. The End log now has the matching status as the goal. That symmetry was the reason for guessing nine positions in the first place, and it turned out to be right.
- **`of 8` was already correct everywhere.** Every player chip, the standings rows, and the board mockup were drawn against a nine-position lane. Nothing had to be redrawn, and I checked rather than assumed.
- **The confirm still names the cost from live state.** With "anyone may end it" settled, that sentence is now the entire protection, so the spec says so explicitly instead of leaving it as a nicety.

## How the spec is changing

**`docs/specs/reference/index.md` loses one of its unsettled items and half of another.** It previously said the board did not show whether the End log is a space, and left both "who may quit" and "does the game self-end" for whoever specified them. The first is now a recorded rule of the classroom game; the second is now a recorded v1 decision that is ours rather than the board's, and it stays filed under "where v1 fills a gap the board leaves open" for exactly that reason.

**What is deliberately still open:** whether the game ends by itself once every frog is home. #186 stays open, narrowed to just that.

## Deviations and Decisions

- **#186 is not closed, only narrowed.** It asked two questions and one was answered. Closing it would lose the other; opening a fresh issue for the leftover half would lose the conversation. Its title and body now cover the remaining question only.
- **No mockup changed.** Worth stating as a decision rather than an absence: I checked the board, chips and standings against the nine-position answer before concluding nothing needed redrawing.
- **Recorded the rejected option, not just the chosen one.** "Only the current player may end it" is written into `end-game-confirm.md` with why it lost, so it is not re-proposed later as an obvious safety improvement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Scj5WXsLitxyZVJBrqfjs5)_