### PR TITLE
docs(specs): end the game on its own once every frog is home

### DIFF
--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -140,5 +140,17 @@ particular player was never enforceable — what protects a game in progress is
 that the confirm names the cost before it acts. See
 [end-game confirm](../ui/end-game-confirm.md).
 
-One thing this still leaves for whoever specifies it: whether the game also ends
-*on its own* once every frog is home. Same issue; not settled.
+**The game also ends on its own once every frog is home.** The last frog to
+reach its End log finishes the game, and the results appear without anyone
+choosing to stop. Derek's call in the same issue.
+
+Together those two decisions describe the whole of how a game finishes:
+
+| How a game ends | Who caused it |
+| --- | --- |
+| Every frog reaches its End log | Nobody — the game ends itself |
+| Somebody ends it early, with a confirm | Any player, on any turn |
+
+There is no third way, and in particular there is no state where a finished
+game sits waiting to be dismissed. That is what makes the ordinary two-player
+game work without anyone ever opening the settings.

--- a/docs/specs/ui/end-game-confirm.md
+++ b/docs/specs/ui/end-game-confirm.md
@@ -52,7 +52,12 @@ right.
     | --- | --- |
     | Some frogs still going | `Three frogs are still swimming. Ending it now stops the game for all four players and shows the results.` |
     | Only one frog left going | `One frog is still swimming. Ending it now stops the game for all four players and shows the results.` |
-    | Every frog home | `Everybody is home. Ending it now shows the results.` |
+
+    There is no everybody-is-home wording, and there does not need to be:
+    [the game ends itself](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open)
+    the moment the last frog lands on its End log, so this dialog can never open
+    on a finished game. At least one frog is always still swimming when it
+    appears — which is exactly why it has something to warn about.
 
 - **`End the game`** — destructive [button](shared-components.md#button). Goes
   to [game over](game-over.md) with the standings as they are.
@@ -91,7 +96,4 @@ specific every time.
 
 ## Open questions
 
-- **Does the game also end on its own when every frog is home?** Still
-  [issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
-  If yes, the everybody-is-home body sentence above is a state almost nobody
-  will see, because the game will have ended itself first.
+None.

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -162,6 +162,10 @@ changes, one of the others has to move with it.
   [the reference material](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open),
   not something the classroom board says.
 - A frog that is home is skipped in turn order.
+- **When the last frog gets home, the game ends itself.** The hop finishes, and
+  [game over](game-over.md) follows with no input from anybody — see
+  [how a game ends](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open).
+  A finished game never sits on this screen waiting to be dismissed.
 - Hardware back opens the [settings dialog](settings-dialog.md). It does not
   quit, and it never quits without the confirm.
 

--- a/docs/specs/ui/game-over.md
+++ b/docs/specs/ui/game-over.md
@@ -75,9 +75,16 @@ through the title screen.
 
 ## Behaviour
 
-- Reached two ways: every frog home (if that ends the game — see the open
-  question), or `End the game` confirmed from
-  [end-game confirm](end-game-confirm.md).
+- Reached two ways, and only two:
+
+    | Route | What the headline says |
+    | --- | --- |
+    | The last frog reaches its End log, and the game ends itself | `<Colour> frog wins!` |
+    | `End the game` confirmed from [end-game confirm](end-game-confirm.md) | `<Colour> frog wins!` if anyone got home, otherwise `Game over` |
+
+    The first route needs no input from anybody. When the last frog lands on its
+    End log, the hop finishes, and this screen follows — see
+    [how a game ends](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open).
 - Entering: rows appear in place, top to bottom, over `StandingsRevealDuration`
   (0.4 s total). No suspense reveal — everyone watched it happen.
 - Hardware back does what `Back to the title` does.
@@ -93,10 +100,6 @@ one that has to look fair.
 
 ## Open questions
 
-- **Does the game end itself once every frog is home?**
-  [Issue #186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
-  This screen works either way; what changes is how often it is reached without
-  anyone choosing to end anything.
 - **Is finishing order the right ranking for frogs that did not finish?**
   Ranking by lily pads is the only fact available, and ties are possible. Two
   frogs on the same pad currently share a place number. Say if they should be


### PR DESCRIPTION
When the last frog hops onto its End log, the game finishes by itself and the results come up — nobody has to decide to stop. That was the final open question about how a game of Multiplying Frogs ends, and with it answered there are now exactly two ways one can finish: everybody gets home, or somebody ends it early and confirms.

It also quietly removes a dialog state. The confirm used to have wording for "everybody is home", and that can no longer happen — the game will have ended itself before anyone could open the settings — so the sentence is gone and the spec says why.

**Docs:** `docs/specs/reference/index.md` — recorded that the game ends itself, with a table of the two ways a game can end. `docs/specs/ui/game-board.md` — added the self-end to the board's behaviour. `docs/specs/ui/game-over.md` — the two entry routes and what the headline says on each; open question removed. `docs/specs/ui/end-game-confirm.md` — dropped the unreachable everybody-is-home body wording; its open questions section is now "None."

Closes #186

## Spec invariants this had to keep true

- **Play still continues past the first frog home.** The winner is the first one there; the others keep taking turns and finishing. Self-ending is about the *last* frog, not the first, and nothing here shortens a game that is still going.
- **A frog that is home is still skipped in turn order.** Unchanged — that is what makes "the last frog gets home" a state the game can reach at all.
- **The confirm still names the cost from live state.** It just has one fewer case to name, and the remaining ones are the only ones reachable.

## How the spec is changing

**`docs/specs/reference/index.md` has no unsettled questions left about how a game ends.** It previously said the classroom board settles neither whether the game self-ends nor who may quit; both are now recorded as v1 decisions, filed under "where v1 fills a gap the board leaves open" because they are ours rather than the board's. What remains unknown there is only what Connor's class itself does after the first frog finishes, which is a fact about the classroom game and not a decision we need.

**One dialog state stops existing.** The old rule left open the possibility of opening the confirm on a finished game, so the dialog carried a third body sentence for it. The new rule makes that unreachable: at least one frog is always still swimming when the confirm appears. That is a strictly better contract — the dialog now has exactly one job, warning you about frogs you are about to stop, and no case where it warns about nothing.

## Deviations and Decisions

- **Removed the everybody-is-home wording rather than leaving it as dead text.** A body sentence for a state the rules make impossible is a trap for whoever implements it — they would write it, test it, and never be able to reach it. It is gone, with a note saying why so it is not re-added as a missing case.
- **Wrote the two ways a game ends as a table in the reference material.** Both halves of #186 were answered across two conversations; stating them together is what makes "there is no third way" checkable rather than something a reader has to infer from two paragraphs.
- **No mockup changed.** The game-over and confirm mockups were already drawn for these states — the confirm is drawn with three frogs still swimming, which is now the only kind of state it can be in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Scj5WXsLitxyZVJBrqfjs5)_