### PR TITLE
fix(triage): wire up reactive triage, and make the hand-back a write that cannot be skipped

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/fire_routine.py
@@ -32,6 +32,7 @@ See docs/engineering/issue-pipeline.md.
 from __future__ import annotations
 
 import json
+import os
 import urllib.request
 
 BODY_SNIPPET_LIMIT = 300
@@ -104,6 +105,23 @@ def _post(url: str, headers: dict, body: bytes):
 
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.status, response.read().decode(errors="replace")
+
+
+def fire_from_env(issue_number: int) -> FireResult:
+    """`fire`, with the endpoint read from the environment.
+
+    The one place the three environment variables are read, so both entry
+    points — `run_comment_event` and `run_sweep` — poke the same Routine the
+    same way. Never raises: the label move has already landed by this point,
+    and a few hours of extra latency is not a reason to report the command as
+    failed.
+    """
+    return fire(
+        issue_number,
+        os.environ.get("GITHUB_REPOSITORY", ""),
+        os.environ.get("AI_TRIAGE_URL"),
+        os.environ.get("AI_TRIAGE_SECRET"),
+    )
 
 
 def fire(issue_number: int, repository: str, url: str, secret: str, post=None) -> FireResult:

--- a/.claude/skills/pipeline-gatekeeper/run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/run_comment_event.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import apply_actions  # noqa: E402
 import fetch_comment_event  # noqa: E402
+import fire_routine  # noqa: E402
 import gates  # noqa: E402
 import parse_commands  # noqa: E402
 from _github_api import (  # noqa: E402
@@ -41,7 +42,7 @@ class Result:
         return f"Result(applied={self.applied!r}, {self.detail!r})"
 
 
-def run(event: dict, api, owner: str, rerender=None) -> Result:
+def run(event: dict, api, owner: str, rerender=None, fire=None) -> Result:
     """One comment, one pass. Never raises on an ordinary refusal."""
     snapshot = fetch_comment_event.build(event, api, owner)
 
@@ -75,6 +76,13 @@ def run(event: dict, api, owner: str, rerender=None) -> Result:
 
     if changed_labels:
         set_labels(api, issue["number"], plan.labels)
+
+    # After the label write, never before: triage reads the issue's labels, and
+    # firing first would hand it one that is not in `ai-triage` yet. Only when
+    # `ai-triage` is NEWLY present, or a replay turns one stuck comment into a
+    # triage run on every sweep.
+    if apply_actions.fires_triage(issue["labels"], plan.labels):
+        (fire or fire_routine.fire_from_env)(issue["number"])
 
     acknowledgement = apply_actions.acknowledgement(actions, skips)
     if acknowledgement:

--- a/.claude/skills/pipeline-gatekeeper/run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/run_sweep.py
@@ -27,7 +27,9 @@ _RECONCILE_SKILL = Path(__file__).resolve().parents[1] / "pipeline-reconcile"
 if str(_RECONCILE_SKILL) not in sys.path:
     sys.path.insert(0, str(_RECONCILE_SKILL))
 
+import apply_actions  # noqa: E402
 import check_revisits  # noqa: E402
+import fire_routine  # noqa: E402
 import reconcile  # noqa: E402
 from _github_api import (  # noqa: E402
     comment as post_comment,
@@ -37,7 +39,7 @@ from _github_api import (  # noqa: E402
 )
 
 
-def apply_revisits(api, issues, snapshot) -> list:
+def apply_revisits(api, issues, snapshot, fire=None) -> list:
     """Wake issues whose blockers have all cleared.
 
     A state-derived transition, not a command — nothing else would ever wake an
@@ -54,12 +56,19 @@ def apply_revisits(api, issues, snapshot) -> list:
 
         set_labels(api, revisit.issue_number, labels)
         post_comment(api, revisit.issue_number, revisit.comment)
+
+        # A woken issue lands back in `ai-triage` and needs analyzing. Without
+        # this it waits for the next scheduled round, which is the whole
+        # latency the reactive fire exists to remove.
+        if apply_actions.fires_triage(issue.get("labels") or [], labels):
+            (fire or fire_routine.fire_from_env)(revisit.issue_number)
+
         woken.append(revisit.issue_number)
 
     return woken
 
 
-def apply_fixes(api, findings, issues) -> list:
+def apply_fixes(api, findings, issues, fire=None) -> list:
     """Apply the auto-fix findings. Flags are left for the dashboard."""
     fixed = []
 
@@ -77,17 +86,35 @@ def apply_fixes(api, findings, issues) -> list:
         labels |= set(finding.get("add_labels") or [])
 
         set_labels(api, number, sorted(labels))
+
+        if apply_actions.fires_triage(issue.get("labels") or [], sorted(labels)):
+            (fire or fire_routine.fire_from_env)(number)
+
         fixed.append(number)
 
     return fixed
 
 
-def run(state: dict, api, events_only: bool = False, rerender=None) -> dict:
+def run(state: dict, api, events_only: bool = False, rerender=None,
+        fire=None) -> dict:
     """One sweep. Returns what it did, for the workflow log."""
     issues = state.get("issues") or []
     snapshot = state.get("snapshot") or {}
 
-    woken = apply_revisits(api, issues, snapshot)
+    # **At most one fire per issue per sweep.** A revisit wakes an issue into
+    # `ai-triage` without updating the in-memory copy reconcile then reads, so
+    # the same issue can look newly-triageable twice in one pass. Two fires are
+    # two triage sessions racing on one issue, each posting its own plan.
+    sink = fire or fire_routine.fire_from_env
+    already_fired = set()
+
+    def fire_once(number):
+        if number in already_fired:
+            return
+        already_fired.add(number)
+        sink(number)
+
+    woken = apply_revisits(api, issues, snapshot, fire=fire_once)
 
     findings = reconcile.process({
         "issues": issues,
@@ -97,7 +124,7 @@ def run(state: dict, api, events_only: bool = False, rerender=None) -> dict:
         "events_only": events_only,
     })["findings"]
 
-    fixed = apply_fixes(api, findings, issues)
+    fixed = apply_fixes(api, findings, issues, fire=fire_once)
 
     # Once, at the end. The board should describe the state the sweep left
     # behind, not one of the states it passed through.

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
@@ -147,6 +147,48 @@ class WatermarkTests(unittest.TestCase):
         self.assertFalse(result.applied)
 
 
+class ReactiveTriageTests(unittest.TestCase):
+    """The fire is wired in, not merely implemented.
+
+    `fires_triage` and `fire_routine.fire` were both written and both tested,
+    and nothing called either — so reactive triage never fired once, and every
+    issue waited for the scheduled round. These tests assert the call site
+    exists, which is the part that was missing.
+    """
+
+    def _fired(self, **kwargs):
+        fired = []
+        api = RecordingApi()
+        runner.run(event(**kwargs), api, owner=OWNER,
+                   rerender=lambda **kw: None, fire=fired.append)
+        return fired
+
+    def test_admitting_an_issue_fires_triage(self):
+        self.assertEqual(self._fired(body="/admit", labels=()), [10])
+
+    def test_revise_fires_triage(self):
+        """`/revise` returns the issue to `ai-triage` — it needs analyzing again."""
+        self.assertEqual(self._fired(body="/revise wrong pond", labels=("pending-approval",)), [10])
+
+    def test_approve_does_not_fire_triage(self):
+        """`/approve` moves to `ready-for-work`. Nothing to triage."""
+        self.assertEqual(self._fired(body="/approve", labels=("pending-approval",)), [])
+
+    def test_re_admitting_an_already_admitted_issue_does_not_fire(self):
+        """An idempotent re-add is not a new admission — or one stuck comment
+        becomes a triage run on every sweep."""
+        self.assertEqual(self._fired(body="/admit", labels=("ai-triage",)), [])
+
+    def test_a_refused_command_does_not_fire(self):
+        self.assertEqual(
+            self._fired(body="/admit", labels=("type:epic",)), [])
+
+    def test_the_runner_imports_the_fire(self):
+        """The regression itself: the module never imported `fire_routine`."""
+        source = (Path(__file__).resolve().parents[1] / "run_comment_event.py").read_text()
+        self.assertIn("import fire_routine", source)
+
+
 class TokenTests(unittest.TestCase):
     def test_the_api_helper_uses_the_workflow_token_not_a_pat(self):
         source = (Path(__file__).resolve().parents[1] / "_github_api.py").read_text()

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_sweep.py
@@ -115,5 +115,77 @@ class FlagTests(unittest.TestCase):
         self.assertEqual(api.label_writes, [])
 
 
+
+class ReactiveTriageTests(unittest.TestCase):
+    """The sweep fires too, on both of its paths.
+
+    Neither path was wired. A blocker clearing at 09:00, or a stalled issue
+    requeued at 02:00, added `ai-triage` and then waited for the *next*
+    scheduled round to notice.
+    """
+
+    def test_waking_a_blocked_issue_fires_triage(self):
+        fired = []
+        state = {
+            "issues": [issue(10, labels=("needs-clarification",), body="Blocked by #42")],
+            "snapshot": {42: {"state": "closed", "labels": []}},
+            "focus": "v0.0.1",
+        }
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: None,
+                      fire=fired.append)
+        self.assertEqual(fired, [10])
+
+    def test_requeuing_to_triage_fires_triage(self):
+        fired = []
+        state = {"issues": [issue(10, labels=("pending-approval",), comments=[])],
+                 "focus": "v0.0.1"}
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: None,
+                      fire=fired.append)
+        self.assertEqual(fired, [10])
+
+    def test_a_fix_that_does_not_reach_triage_does_not_fire(self):
+        """A stalled `in-progress` issue goes to `ready-for-work`, not triage."""
+        fired = []
+        analysis = {"body": "## Build checklist\n\n- [ ] x",
+                    "author": "github-actions[bot]",
+                    "created_at": "2026-08-08T10:00:00Z"}
+        state = {"issues": [issue(10, labels=("in-progress",), comments=[analysis])],
+                 "focus": "v0.0.1"}
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: None,
+                      fire=fired.append)
+        self.assertEqual(fired, [])
+
+    def test_a_quiet_sweep_fires_nothing(self):
+        fired = []
+        analysis = {"body": "## Build checklist\n\n- [ ] x",
+                    "author": "github-actions[bot]",
+                    "created_at": "2026-08-08T10:00:00Z"}
+        state = {"issues": [issue(10, labels=("pending-approval",), comments=[analysis])],
+                 "focus": "v0.0.1"}
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: None,
+                      fire=fired.append)
+        self.assertEqual(fired, [])
+
+    def test_an_issue_woken_and_requeued_in_one_sweep_fires_once(self):
+        """Two fires are two triage sessions racing, each posting its own plan.
+
+        A revisit does not update the in-memory issue reconcile then reads, so
+        without the guard this exact state fires twice.
+        """
+        fired = []
+        state = {
+            "issues": [issue(10, labels=("needs-clarification",), body="Blocked by #42")],
+            "snapshot": {42: {"state": "closed", "labels": []}},
+            "focus": "v0.0.1",
+        }
+        run_sweep.run(state, RecordingApi(), rerender=lambda **kw: None,
+                      fire=fired.append)
+        self.assertEqual(fired, [10])
+
+    def test_the_sweep_imports_the_fire(self):
+        source = (Path(__file__).resolve().parents[1] / "run_sweep.py").read_text()
+        self.assertIn("import fire_routine", source)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/pipeline-reconcile/SKILL.md
+++ b/.claude/skills/pipeline-reconcile/SKILL.md
@@ -121,13 +121,19 @@ board's current state, and a comment would outlive the state it described.
 python3 .github/scripts/run_python_tests.py pipeline-reconcile
 ```
 
-37 tests. Two are worth knowing about: one asserts no finding can ever close an
-issue, and one reads this module's source to assert it does not define its own
-`has_analysis_signature` — that recognizer is imported from `triage-issue`,
-because two copies drift into a requeue↔repair loop that reports no error.
+40 tests. Three are worth knowing about: one asserts no finding can ever close an
+issue, and two read this module's source to assert it defines neither its own
+`has_analysis_signature` nor its own triage-author set — both are imported from
+`triage-issue`, because two copies drift into a requeue↔repair loop that reports
+no error.
+
+The author guard is the one that was earned. Both modules kept
+`TRIAGE_AUTHOR = "github-actions[bot]"` while every real triage comment came
+from `claude[bot]`, so `has_analysis` answered "no analysis" for the whole board
+— and because the two copies agreed with each other, nothing looked wrong.
 
 ## See also
 
-- `triage-issue` — owns `has_analysis_signature`
+- `triage-issue` — owns `has_analysis_signature` and `is_triage_author`
 - `pipeline-dashboard` — renders the flags
 - `docs/engineering/issue-pipeline.md` — the stage and the schedule

--- a/.claude/skills/pipeline-reconcile/reconcile.py
+++ b/.claude/skills/pipeline-reconcile/reconcile.py
@@ -34,7 +34,7 @@ _TRIAGE_SKILL = Path(__file__).resolve().parents[1] / "triage-issue"
 if str(_TRIAGE_SKILL) not in sys.path:
     sys.path.insert(0, str(_TRIAGE_SKILL))
 
-from triage_repair import has_analysis_signature  # noqa: E402
+from triage_repair import has_analysis_signature, is_triage_author  # noqa: E402
 
 TRIAGE_LABEL = "ai-triage"
 READY_LABEL = "ready-for-work"
@@ -56,8 +56,6 @@ STATE_LABELS = {
 # overrule a human.
 ANALYZED_STATES = {"pending-approval", "needs-clarification", READY_LABEL,
                    IN_PROGRESS_LABEL}
-
-TRIAGE_AUTHOR = "github-actions[bot]"
 
 TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
                           re.IGNORECASE | re.MULTILINE)
@@ -113,7 +111,7 @@ def has_open_pr(issue_number: int, pulls) -> bool:
 def has_analysis(issue) -> bool:
     """Did triage analyze this issue — by triage's own hand?"""
     return any(
-        (comment.get("author") or "").lower() == TRIAGE_AUTHOR.lower()
+        is_triage_author(comment.get("author"))
         and has_analysis_signature(comment.get("body"))
         for comment in issue.get("comments") or []
     )

--- a/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
+++ b/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
@@ -282,6 +282,24 @@ class ShapeTests(unittest.TestCase):
         source = (Path(__file__).resolve().parents[1] / "reconcile.py").read_text()
         self.assertNotIn("def has_analysis_signature", source)
 
+    def test_the_triage_author_set_is_imported_not_redefined(self):
+        """The copy that actually drifted: both sides said `github-actions[bot]`
+        while every real triage comment came from `claude[bot]`."""
+        source = (Path(__file__).resolve().parents[1] / "reconcile.py").read_text()
+        self.assertNotIn("TRIAGE_AUTHOR =", source)
+        self.assertNotIn("TRIAGE_AUTHORS =", source)
+
+    def test_a_claude_app_analysis_is_seen(self):
+        """The regression itself: this read as "no analysis" and requeued forever."""
+        issue = {"labels": ["pending-approval"], "comments": [
+            {"author": "claude[bot]", "body": "## Build checklist\n\n- [ ] x"}]}
+        self.assertTrue(reconcile.has_analysis(issue))
+
+    def test_a_human_analysis_is_still_not_seen(self):
+        issue = {"labels": ["pending-approval"], "comments": [
+            {"author": "derekwinters", "body": "## Build checklist\n\n- [ ] x"}]}
+        self.assertFalse(reconcile.has_analysis(issue))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
+++ b/.claude/skills/pipeline-reconcile/tests/test_reconcile.py
@@ -128,12 +128,22 @@ class RequeueTriageTests(unittest.TestCase):
             findings([issue(10, labels=("pending-approval",), comments=[comment()])],
                      kind="requeue_triage"), [])
 
-    def test_a_human_comment_carrying_a_checklist_does_not_count(self):
+    def test_an_outsiders_comment_carrying_a_checklist_does_not_count(self):
         found = findings(
             [issue(10, labels=("pending-approval",),
-                   comments=[comment(author="derekwinters")])],
+                   comments=[comment(author="a-passing-contributor")])],
             kind="requeue_triage")
         self.assertEqual(len(found), 1)
+
+    def test_the_owners_own_comment_does_count(self):
+        """Triage runs under Derek's account, so his analyses are triage's.
+
+        The accepted cost: a checklist he writes by hand reads as one too.
+        """
+        self.assertEqual(
+            findings([issue(10, labels=("pending-approval",),
+                            comments=[comment(author="derekwinters")])],
+                     kind="requeue_triage"), [])
 
     def test_requeue_triage_is_omitted_on_the_event_path(self):
         """A just-triaged issue transiently has the label but not yet the comment."""
@@ -295,10 +305,17 @@ class ShapeTests(unittest.TestCase):
             {"author": "claude[bot]", "body": "## Build checklist\n\n- [ ] x"}]}
         self.assertTrue(reconcile.has_analysis(issue))
 
-    def test_a_human_analysis_is_still_not_seen(self):
+    def test_an_outsiders_analysis_is_not_seen(self):
+        issue = {"labels": ["pending-approval"], "comments": [
+            {"author": "a-passing-contributor",
+             "body": "## Build checklist\n\n- [ ] x"}]}
+        self.assertFalse(reconcile.has_analysis(issue))
+
+    def test_the_owners_analysis_is_seen(self):
+        """Triage posted as `derekwinters` on #83 and #169, not only as a bot."""
         issue = {"labels": ["pending-approval"], "comments": [
             {"author": "derekwinters", "body": "## Build checklist\n\n- [ ] x"}]}
-        self.assertFalse(reconcile.has_analysis(issue))
+        self.assertTrue(reconcile.has_analysis(issue))
 
 
 if __name__ == "__main__":

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -161,7 +161,37 @@ issues.
 
 See `docs/engineering/agent-workflow.md` for the lead's full rationale.
 
+### The footer is added for you
+
+`hand_back.py` appends the commands that make sense **on the route taken** —
+`/approve`, `/revise`, `/park` on a plan; `/revise <answer>` and `/park` on a
+question. Do not write one by hand and do not paste the whole command list: a
+`needs-clarification` hand-back that offers `/approve` invites approving a plan
+that was never written.
+
+The wording comes from `render_dashboard.COMMANDS`, so there is one description
+of each command rather than a third copy drifting quietly out of date.
+
 ## Write ordering: comment first, then the label
+
+**Do not do this by hand. Call `hand_back.py`.**
+
+```python
+import hand_back
+hand_back.apply(api, 47, analysis, labels, "pending-approval")
+```
+
+One call, both writes, in the right order — or neither. It appends the route's
+footer, removes `ai-triage`, adds exactly one state label, and keeps every
+`area:`, `type:` and `skip-docs` label untouched.
+
+It **refuses before writing anything** if you pass a state triage may not set
+(`ready-for-work` is Derek's, via `/approve`) or an analysis the recognizer
+would not match. Both refusals leave the issue exactly as it was.
+
+This used to be an instruction in this file rather than code, and it was skipped
+in practice — sixteen issues sat on `ai-triage` carrying finished plans, because
+a missing label fails nothing and the posted comment made the run look done.
 
 **Post the analysis comment. Then set the state label. Always that order.**
 
@@ -257,15 +287,28 @@ Only comments authored by the bot count. Derek pasting a checklist by hand is
 not a triage run, and treating it as one would let a helpful comment suppress
 the analysis the issue is actually waiting for.
 
+`is_triage_author` is that gate, and it is shared the same way — `reconcile.py`
+imports it too. Both surfaces count: `claude[bot]` when triage runs as the App,
+`github-actions[bot]` when it runs from a workflow. Accepting only the second
+was a real bug and a quiet one: the gate runs *before* the recognizer, so every
+analysis on the board read as absent while both modules agreed with each other.
+
 ## Running the tests
 
 ```bash
 python3 .github/scripts/run_python_tests.py triage-issue
 ```
 
-23 tests over `triage_repair.py`: what the recognizer matches and — more
-importantly — what it refuses to match, and the four repair outcomes. No
-network in any of them.
+57 tests over `triage_repair.py` and `hand_back.py`: what the recognizer matches
+and — more importantly — what it refuses to match, the four repair outcomes, and
+the hand-back write. No network in any of them; `apply` takes an `api` callable,
+so its ordering is asserted against a fake that records calls.
+
+Two are worth knowing about because they pin a rule rather than a behaviour:
+one asserts the footer never names a command `parse_commands` would refuse (the
+test that catches a `/retriage`), and one asserts a comment still reads as an
+analysis *after* the footer is appended — a footer that broke the recognizer
+would send every triaged issue back round the loop.
 
 ## See also
 

--- a/.claude/skills/triage-issue/hand_back.py
+++ b/.claude/skills/triage-issue/hand_back.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""The hand-back write: post the analysis, then move the state label.
+
+Triage's last step used to be prose in a skill file — "remove `ai-triage` in the
+same write that adds the new state" — performed by a model at the end of a long
+analysis. When it was skipped nothing failed: the comment was posted, so the run
+looked successful from outside, and the issue sat on `ai-triage` waiting for a
+round that would analyze it all over again.
+
+So the step is code now. `apply()` either does both writes, in the right order,
+or refuses and does neither.
+
+    python3 hand_back.py --issue 47 --state pending-approval --analysis plan.md
+
+**Comment first, then the label. Always.** If a run dies between the two writes:
+
+| Order | Dies halfway | Recoverable? |
+| --- | --- | --- |
+| comment → label | a plan sitting on `ai-triage` | yes — the next run redoes it |
+| label → comment | `pending-approval` with no plan | no — it waits on nothing |
+
+The second is silent: Derek opens an issue awaiting approval and there is
+nothing to approve, while the pipeline believes it is handled.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SKILLS = Path(__file__).resolve().parents[1]
+for _sibling in ("pipeline-dashboard", "pipeline-gatekeeper"):
+    _path = str(_SKILLS / _sibling)
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from render_dashboard import COMMANDS  # noqa: E402
+
+from triage_repair import (  # noqa: E402
+    HAND_BACK_STATES,
+    STATE_LABELS,
+    has_analysis_signature,
+)
+
+PENDING = "pending-approval"
+CLARIFY = "needs-clarification"
+
+# What to offer on each route, in the order a reader should consider them.
+#
+# **Route-aware, not the whole vocabulary.** A `needs-clarification` hand-back
+# has no plan on it, so `/approve` would be approving nothing — offering it
+# invites a click that means something different from what it looks like.
+OFFERED = {
+    PENDING: ("/approve", "/revise <notes>", "/park"),
+    CLARIFY: ("/revise <notes>", "/park"),
+}
+
+# How each route's footer opens — what state the issue is actually in.
+LEAD = {
+    PENDING: "**This is waiting on you.** Reply on this issue with:",
+    CLARIFY: ("**This needs an answer before it can be planned.** Reply with the "
+              "answer, then:"),
+}
+
+# The glosses come from the dashboard's list rather than a third copy of them.
+# `render_dashboard.COMMANDS` pairs `/approve` with "the plan is right — build
+# it"; repeating that here is how two descriptions of one command drift.
+_GLOSS = dict(COMMANDS)
+
+# The exception, and it is a real one rather than a convenience.
+#
+# `/revise` is glossed "the plan is not right, here is why" — true on the
+# `pending-approval` route, and false on the other one, where triage wrote no
+# plan at all. The command is doing double duty: it is the only way back to
+# `ai-triage` that carries a note, so it is also how an answered question gets
+# re-triaged. Reusing its usual gloss there would tell Derek he is rejecting
+# something that does not exist.
+#
+# This is worth saying out loud rather than only working around: the vocabulary
+# has no verb for "here is the answer, look again". `docs/engineering/
+# issue-pipeline.md` twice named a `/retriage` for this, which has never
+# existed — `parse_commands.COMMANDS` has no such entry and typing it earns the
+# unknown-command reaction.
+ROUTE_GLOSS = {
+    (CLARIFY, "/revise"): "send it back to triage with your answer attached",
+}
+
+
+def _gloss(offer: str, state: str) -> str:
+    """What this command does *on this route*, in the dashboard's words by default."""
+    name = offer.split()[0]
+
+    override = ROUTE_GLOSS.get((state, name))
+    if override:
+        return override
+
+    return _GLOSS.get(offer) or _GLOSS[name]
+
+
+def footer(state: str) -> str:
+    """The commands that make sense on this route, and what each one does."""
+    if state not in OFFERED:
+        raise ValueError(
+            f"no footer for {state!r} — triage only hands back to "
+            f"{', '.join(HAND_BACK_STATES)}")
+
+    # A colon rather than a dash: several glosses contain an em-dash of their
+    # own, and `/approve — the plan is right — build it` is a line nobody parses.
+    lines = [LEAD[state], ""]
+    lines += [f"- `{offer}`: {_gloss(offer, state)}" for offer in OFFERED[state]]
+
+    return "\n".join(lines)
+
+
+def build_comment(analysis: str, state: str) -> str:
+    """The analysis with its footer, ready to post.
+
+    Refuses an analysis the recognizer would not match. A hand-back comment that
+    does not read as one is the state `triage_repair` cannot repair and
+    `pipeline-reconcile` requeues — better to fail here, loudly, than to write
+    an issue into it.
+    """
+    if state not in OFFERED:
+        raise ValueError(f"{state!r} is not a hand-back state")
+
+    if not has_analysis_signature(analysis):
+        raise ValueError(
+            "this analysis carries neither a `## Build checklist` heading nor "
+            "the `❓ Needs from Derek/Connor:` marker, so nothing downstream "
+            "will recognize it as a triage analysis")
+
+    return f"{analysis.rstrip()}\n\n---\n\n{footer(state)}\n"
+
+
+def plan_labels(labels, state: str) -> list:
+    """The label set after the hand-back — one state label, everything else kept.
+
+    A *replacement*, never an addition. An issue carrying both `ai-triage` and
+    `pending-approval` is one the next analysis round picks up and triages
+    again, while it sits waiting for Derek.
+    """
+    if state not in OFFERED:
+        raise ValueError(
+            f"triage may not set {state!r} — only {', '.join(HAND_BACK_STATES)}. "
+            "`ready-for-work` is Derek's, via `/approve`.")
+
+    kept = [label for label in labels or [] if label not in STATE_LABELS]
+
+    return sorted(set(kept) | {state})
+
+
+def apply(api, issue_number: int, analysis: str, labels, state: str) -> str:
+    """Post the hand-back comment, then move the label. Returns the body posted.
+
+    Both refusals happen before either write, so a rejected hand-back leaves the
+    issue exactly as it was rather than half-written.
+    """
+    body = build_comment(analysis, state)
+    planned = plan_labels(labels, state)
+
+    api("POST", f"/issues/{issue_number}/comments", {"body": body})
+    api("PUT", f"/issues/{issue_number}/labels", {"labels": planned})
+
+    return body
+
+
+def main(argv=None) -> int:  # pragma: no cover - the command-line entry point
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument("--state", required=True, choices=list(HAND_BACK_STATES))
+    parser.add_argument("--analysis", required=True,
+                        help="path to the analysis markdown, or - for stdin")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print the comment and the label set, write nothing")
+    args = parser.parse_args(argv)
+
+    analysis = (sys.stdin.read() if args.analysis == "-"
+                else Path(args.analysis).read_text(encoding="utf-8"))
+
+    from _github_api import github_api  # local: the network half
+
+    if args.dry_run:
+        print(build_comment(analysis, args.state))
+        print("labels:", ", ".join(plan_labels([], args.state)))
+        return 0
+
+    api = github_api()
+    issue = api("GET", f"/issues/{args.issue}")
+    labels = [label["name"] for label in issue.get("labels") or []]
+
+    apply(api, args.issue, analysis, labels, args.state)
+    print(f"#{args.issue} handed back: {args.state}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.claude/skills/triage-issue/tests/test_hand_back.py
+++ b/.claude/skills/triage-issue/tests/test_hand_back.py
@@ -1,0 +1,217 @@
+"""Tests for the hand-back write — the comment, its footer, and the label move.
+
+The whole point of this module is that the hand-back is not a judgement the
+agent makes at the end of a long analysis. It is one call that either does both
+writes, in order, or refuses.
+"""
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SKILLS = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(SKILLS / "pipeline-gatekeeper"))
+
+import hand_back  # noqa: E402
+import parse_commands  # noqa: E402
+
+ANALYSIS = """\
+Frogs keep multiplying past the limit when you tap them quickly.
+
+## Build checklist
+
+- [ ] Check the cap at the moment the frog is added
+"""
+
+QUESTION = """\
+This one needs a decision before it can be planned.
+
+❓ **Needs from Derek/Connor:** should a tap on a full pond do nothing?
+"""
+
+PENDING = "pending-approval"
+CLARIFY = "needs-clarification"
+
+
+class FakeApi:
+    """Records every call so ordering can be asserted."""
+
+    def __init__(self, fail_on=None):
+        self.calls = []
+        self.fail_on = fail_on
+
+    def __call__(self, method, path, body=None):
+        self.calls.append((method, path, body))
+        if self.fail_on and self.fail_on in path and method == self.fail_on_method:
+            raise RuntimeError("the label write failed")
+        return {}
+
+    fail_on_method = "PUT"
+
+    @property
+    def methods(self):
+        return [method for method, _, _ in self.calls]
+
+
+class LabelPlanTests(unittest.TestCase):
+    """`plan_labels` — exactly one state label, and the rest untouched."""
+
+    def test_ai_triage_comes_off_and_the_new_state_goes_on(self):
+        result = hand_back.plan_labels(["ai-triage", "area:ai", "type:bug"], PENDING)
+        self.assertEqual(sorted(result), ["area:ai", PENDING, "type:bug"])
+
+    def test_the_issue_never_carries_both(self):
+        result = hand_back.plan_labels(["ai-triage"], PENDING)
+        self.assertNotIn("ai-triage", result)
+        self.assertIn(PENDING, result)
+
+    def test_a_different_prior_state_is_replaced_not_stacked(self):
+        result = hand_back.plan_labels(["needs-clarification", "area:ui"], PENDING)
+        self.assertEqual(sorted(result), ["area:ui", PENDING])
+
+    def test_area_type_and_skip_docs_survive(self):
+        labels = ["ai-triage", "area:gameplay", "type:task", "skip-docs"]
+        result = hand_back.plan_labels(labels, CLARIFY)
+        self.assertEqual(
+            sorted(result), ["area:gameplay", CLARIFY, "skip-docs", "type:task"])
+
+    def test_exactly_one_state_label_survives(self):
+        messy = ["ai-triage", "pending-approval", "parked", "area:ai"]
+        result = hand_back.plan_labels(messy, CLARIFY)
+        states = [label for label in result if label in hand_back.STATE_LABELS]
+        self.assertEqual(states, [CLARIFY])
+
+    def test_it_is_idempotent(self):
+        once = hand_back.plan_labels(["ai-triage", "area:ai"], PENDING)
+        twice = hand_back.plan_labels(once, PENDING)
+        self.assertEqual(sorted(once), sorted(twice))
+
+    def test_a_state_triage_may_not_set_is_refused(self):
+        for state in ("ready-for-work", "in-progress", "parked", "nonsense"):
+            with self.assertRaises(ValueError):
+                hand_back.plan_labels(["ai-triage"], state)
+
+
+class FooterTests(unittest.TestCase):
+    """The footer names what to type next, and only commands that exist."""
+
+    def _commands_in(self, text):
+        return set(re.findall(r"(?<![\w/])/([a-z]+)", text))
+
+    def test_a_pending_approval_footer_offers_approve_and_revise(self):
+        footer = hand_back.footer(PENDING)
+        self.assertIn("/approve", footer)
+        self.assertIn("/revise", footer)
+
+    def test_a_needs_clarification_footer_does_not_offer_approve(self):
+        """There is no plan on this route, so there is nothing to approve."""
+        self.assertNotIn("/approve", hand_back.footer(CLARIFY))
+
+    def test_a_needs_clarification_footer_says_how_to_send_it_back(self):
+        self.assertIn("/revise", hand_back.footer(CLARIFY))
+
+    def test_every_command_named_is_a_real_command(self):
+        """The regression this test exists for: `/retriage` does not exist."""
+        for state in hand_back.HAND_BACK_STATES:
+            for command in self._commands_in(hand_back.footer(state)):
+                self.assertIn(
+                    command, parse_commands.COMMANDS,
+                    f"{state} footer names /{command}, which the parser refuses")
+
+    def test_the_clarification_route_does_not_claim_there_is_a_plan(self):
+        """`/revise`'s usual gloss is about rejecting a plan. This route has none."""
+        self.assertNotIn("plan is not right", hand_back.footer(CLARIFY))
+
+    def test_the_clarification_route_asks_for_the_answer(self):
+        self.assertIn("answer", hand_back.footer(CLARIFY).lower())
+
+    def test_no_line_stacks_two_dashes(self):
+        """`- /approve — the plan is right — build it` is a sentence nobody parses."""
+        for state in hand_back.HAND_BACK_STATES:
+            for line in hand_back.footer(state).splitlines():
+                self.assertLessEqual(line.count("—"), 1, line)
+
+    def test_the_glosses_come_from_the_dashboard_list(self):
+        """One definition of what a command means, not a third copy."""
+        sys.path.insert(0, str(SKILLS / "pipeline-dashboard"))
+        import render_dashboard  # noqa: E402
+
+        glosses = dict(render_dashboard.COMMANDS)
+        self.assertIn(glosses["/approve"], hand_back.footer(PENDING))
+
+    def test_an_unknown_state_has_no_footer(self):
+        with self.assertRaises(ValueError):
+            hand_back.footer("ready-for-work")
+
+
+class CommentTests(unittest.TestCase):
+    """`build_comment` — the analysis, then the footer, in that order."""
+
+    def test_the_analysis_comes_first_and_is_unchanged(self):
+        body = hand_back.build_comment(ANALYSIS, PENDING)
+        self.assertTrue(body.startswith(ANALYSIS.rstrip()))
+
+    def test_the_footer_is_appended(self):
+        body = hand_back.build_comment(ANALYSIS, PENDING)
+        self.assertIn("/approve", body)
+
+    def test_the_result_still_reads_as_an_analysis(self):
+        """The footer must not break the recognizer that repair depends on."""
+        import triage_repair  # noqa: E402
+
+        for analysis, state in ((ANALYSIS, PENDING), (QUESTION, CLARIFY)):
+            body = hand_back.build_comment(analysis, state)
+            self.assertTrue(triage_repair.has_analysis_signature(body))
+
+    def test_an_analysis_with_no_signature_is_refused(self):
+        """A hand-back with no plan is the silent bad state — refuse to write it."""
+        with self.assertRaises(ValueError):
+            hand_back.build_comment("Looks tricky, will think about it.", PENDING)
+
+
+class ApplyTests(unittest.TestCase):
+    """`apply` — comment first, then the label. Always that order."""
+
+    def test_it_posts_the_comment_before_setting_labels(self):
+        api = FakeApi()
+        hand_back.apply(api, 47, ANALYSIS, ["ai-triage", "area:ai"], PENDING)
+        self.assertEqual(api.methods, ["POST", "PUT"])
+
+    def test_the_comment_carries_the_footer(self):
+        api = FakeApi()
+        hand_back.apply(api, 47, ANALYSIS, ["ai-triage"], PENDING)
+        _, path, body = api.calls[0]
+        self.assertIn("/comments", path)
+        self.assertIn("/approve", body["body"])
+
+    def test_the_label_write_sends_the_planned_set(self):
+        api = FakeApi()
+        hand_back.apply(api, 47, ANALYSIS, ["ai-triage", "area:ai"], PENDING)
+        _, path, body = api.calls[1]
+        self.assertIn("/labels", path)
+        self.assertEqual(sorted(body["labels"]), ["area:ai", PENDING])
+
+    def test_a_failed_label_write_still_leaves_the_comment_posted(self):
+        """The recoverable half: a plan on `ai-triage` is what the next run redoes."""
+        api = FakeApi(fail_on="/labels")
+        with self.assertRaises(RuntimeError):
+            hand_back.apply(api, 47, ANALYSIS, ["ai-triage"], PENDING)
+        self.assertEqual(api.methods, ["POST", "PUT"])
+
+    def test_a_refused_state_writes_nothing_at_all(self):
+        api = FakeApi()
+        with self.assertRaises(ValueError):
+            hand_back.apply(api, 47, ANALYSIS, ["ai-triage"], "ready-for-work")
+        self.assertEqual(api.calls, [])
+
+    def test_a_refused_analysis_writes_nothing_at_all(self):
+        api = FakeApi()
+        with self.assertRaises(ValueError):
+            hand_back.apply(api, 47, "no plan here", ["ai-triage"], PENDING)
+        self.assertEqual(api.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/triage-issue/tests/test_triage_repair.py
+++ b/.claude/skills/triage-issue/tests/test_triage_repair.py
@@ -87,9 +87,17 @@ class AnalysisCommentTimesTests(unittest.TestCase):
         comments = [comment("thanks!"), comment(CHECKLIST_BODY, created_at="2026-08-02T09:00:00Z")]
         self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-02T09:00:00Z"])
 
-    def test_a_human_comment_carrying_a_checklist_is_not_triage(self):
-        """Derek pasting a checklist by hand must not read as a triage run."""
+    def test_the_owners_own_login_counts(self):
+        """Triage runs under Derek's account too, so his login is a triage author.
+
+        The cost is deliberate and accepted: a checklist he writes by hand now
+        reads as a triage analysis. See the note on `TRIAGE_AUTHORS`.
+        """
         comments = [comment(CHECKLIST_BODY, author="derekwinters")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-08T10:00:00Z"])
+
+    def test_any_other_human_is_not_triage(self):
+        comments = [comment(CHECKLIST_BODY, author="a-passing-contributor")]
         self.assertEqual(repair.analysis_comment_times(comments), [])
 
     def test_the_claude_app_is_a_triage_author(self):
@@ -116,8 +124,16 @@ class TriageAuthorTests(unittest.TestCase):
     def test_the_actions_bot_is_recognized(self):
         self.assertTrue(repair.is_triage_author("github-actions[bot]"))
 
-    def test_a_human_is_not(self):
-        self.assertFalse(repair.is_triage_author("derekwinters"))
+    def test_the_owner_is_recognized(self):
+        """Triage sessions run under Derek's own account, not only as a bot."""
+        self.assertTrue(repair.is_triage_author("derekwinters"))
+
+    def test_any_other_human_is_not(self):
+        self.assertFalse(repair.is_triage_author("a-passing-contributor"))
+
+    def test_the_accepted_set_is_exactly_three(self):
+        """Widening this set is a decision, not a convenience — pin the size."""
+        self.assertEqual(len(repair.TRIAGE_AUTHORS), 3)
 
     def test_another_app_is_not(self):
         self.assertFalse(repair.is_triage_author("dependabot[bot]"))

--- a/.claude/skills/triage-issue/tests/test_triage_repair.py
+++ b/.claude/skills/triage-issue/tests/test_triage_repair.py
@@ -92,6 +92,40 @@ class AnalysisCommentTimesTests(unittest.TestCase):
         comments = [comment(CHECKLIST_BODY, author="derekwinters")]
         self.assertEqual(repair.analysis_comment_times(comments), [])
 
+    def test_the_claude_app_is_a_triage_author(self):
+        """The App posts triage's comments — this is the login that actually writes them."""
+        comments = [comment(CHECKLIST_BODY, author="claude[bot]")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-08T10:00:00Z"])
+
+    def test_the_actions_bot_is_still_a_triage_author(self):
+        """A workflow-run triage posts under the Actions token, and older comments exist."""
+        comments = [comment(CHECKLIST_BODY, author="github-actions[bot]")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-08T10:00:00Z"])
+
+    def test_the_author_match_ignores_case(self):
+        comments = [comment(CHECKLIST_BODY, author="Claude[Bot]")]
+        self.assertEqual(repair.analysis_comment_times(comments), ["2026-08-08T10:00:00Z"])
+
+
+class TriageAuthorTests(unittest.TestCase):
+    """`is_triage_author` — the one definition of "triage wrote this"."""
+
+    def test_the_claude_app_is_recognized(self):
+        self.assertTrue(repair.is_triage_author("claude[bot]"))
+
+    def test_the_actions_bot_is_recognized(self):
+        self.assertTrue(repair.is_triage_author("github-actions[bot]"))
+
+    def test_a_human_is_not(self):
+        self.assertFalse(repair.is_triage_author("derekwinters"))
+
+    def test_another_app_is_not(self):
+        self.assertFalse(repair.is_triage_author("dependabot[bot]"))
+
+    def test_an_empty_or_missing_login_is_not(self):
+        self.assertFalse(repair.is_triage_author(""))
+        self.assertFalse(repair.is_triage_author(None))
+
     def test_times_come_back_oldest_first(self):
         comments = [
             comment(QUESTION_BODY, created_at="2026-08-05T09:00:00Z"),

--- a/.claude/skills/triage-issue/triage_repair.py
+++ b/.claude/skills/triage-issue/triage_repair.py
@@ -50,13 +50,26 @@ STATE_LABELS = {
 # hand is not a triage run, and treating it as one would let a well-meaning
 # comment suppress the analysis the issue is actually waiting for.
 #
-# **Both, because triage has two surfaces.** Run as the Claude GitHub App it
-# posts as `claude[bot]`; run from a workflow holding `GITHUB_TOKEN` it posts as
-# `github-actions[bot]`. Accepting only one is not a stricter rule, it is a
-# broken one: this set read `github-actions[bot]` alone while every real triage
-# comment came from the App, so `has_analysis_signature` was never reached and
-# the pipeline believed no issue had ever been analyzed.
-TRIAGE_AUTHORS = frozenset({"claude[bot]", "github-actions[bot]"})
+# **All three, because triage has three surfaces**, confirmed against the board:
+#
+# | Login | When |
+# | --- | --- |
+# | `claude[bot]` | triage running as the Claude GitHub App — #4, #147 |
+# | `derekwinters` | triage running in a session under Derek's own account — #83, #169 |
+# | `github-actions[bot]` | triage running from a workflow holding `GITHUB_TOKEN` |
+#
+# All three posted analyses in the same round on 9 Aug. Accepting only one is
+# not a stricter rule, it is a broken one: this set read `github-actions[bot]`
+# alone while no analysis had ever come from it, so `has_analysis_signature` was
+# never reached and the pipeline believed no issue had been analyzed at all.
+#
+# **The cost of including the owner, stated plainly.** A `## Build checklist`
+# Derek writes by hand now reads as a triage analysis, and will suppress the
+# analysis the issue is actually waiting for. That is accepted deliberately —
+# triage genuinely runs under his account, so excluding him would leave a third
+# of hand-backs invisible, which is the worse failure. Derek's call, taken
+# knowing the trade.
+TRIAGE_AUTHORS = frozenset({"claude[bot]", "derekwinters", "github-actions[bot]"})
 
 
 def is_triage_author(login) -> bool:

--- a/.claude/skills/triage-issue/triage_repair.py
+++ b/.claude/skills/triage-issue/triage_repair.py
@@ -46,10 +46,28 @@ STATE_LABELS = {
     "parked",
 }
 
-# Comments this login authored are triage's. A human pasting a checklist by hand
-# is not a triage run, and treating it as one would let a well-meaning comment
-# suppress the analysis the issue is actually waiting for.
-TRIAGE_AUTHOR = "github-actions[bot]"
+# Comments these logins authored are triage's. A human pasting a checklist by
+# hand is not a triage run, and treating it as one would let a well-meaning
+# comment suppress the analysis the issue is actually waiting for.
+#
+# **Both, because triage has two surfaces.** Run as the Claude GitHub App it
+# posts as `claude[bot]`; run from a workflow holding `GITHUB_TOKEN` it posts as
+# `github-actions[bot]`. Accepting only one is not a stricter rule, it is a
+# broken one: this set read `github-actions[bot]` alone while every real triage
+# comment came from the App, so `has_analysis_signature` was never reached and
+# the pipeline believed no issue had ever been analyzed.
+TRIAGE_AUTHORS = frozenset({"claude[bot]", "github-actions[bot]"})
+
+
+def is_triage_author(login) -> bool:
+    """Did triage write this, by its own hand?
+
+    The one definition. `pipeline-reconcile` imports it rather than keeping a
+    copy — the same rule, and the same reason, as `has_analysis_signature`
+    below: two copies of "was this triage" drift, and the drift is a cycle
+    neither side reports.
+    """
+    return (login or "").lower() in TRIAGE_AUTHORS
 
 # An owner note that objects to the plan. Repairing the label would apply the
 # state the rejected plan asked for and drop the objection on the floor.
@@ -87,7 +105,7 @@ def analysis_comment_times(comments) -> list:
     times = [
         comment.get("created_at") or ""
         for comment in comments or []
-        if (comment.get("author") or "").lower() == TRIAGE_AUTHOR.lower()
+        if is_triage_author(comment.get("author"))
         and has_analysis_signature(comment.get("body"))
     ]
 

--- a/.github/workflows/gatekeeper-comment.yml
+++ b/.github/workflows/gatekeeper-comment.yml
@@ -35,11 +35,22 @@ jobs:
     # costs nothing. The script re-checks the author itself as defense in
     # depth — a script that is safe only because this `if:` filtered for it is
     # one careless edit away from not being safe at all.
+    #
+    # **No filter on the body.** There was a `startsWith(…body, '/')` here, and
+    # it was stricter than the contract it was filtering for: a command has to
+    # start its *line*, not the comment, precisely so you can explain yourself
+    # in the same comment. Under that filter this was silently dropped —
+    #
+    #     Looks right to me.
+    #     /approve
+    #
+    # — with no run, no reaction and no ack, which is indistinguishable from
+    # the pipeline being broken. `parse_commands` already ignores a comment
+    # with no command in it, at the cost of one cheap job.
     if: >-
       github.event.comment.user.login == github.repository_owner &&
       github.event.comment.user.type != 'Bot' &&
-      !github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/')
+      !github.event.issue.pull_request
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/gatekeeper-sweep.yml
+++ b/.github/workflows/gatekeeper-sweep.yml
@@ -66,6 +66,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PIPELINE_OWNER: ${{ github.repository_owner }}
+          # The sweep fires triage too: a cleared blocker wakes an issue into
+          # `ai-triage`, and so does a requeue. Without these the sweep's fire
+          # is a permanent `not-configured` no-op and those issues wait for the
+          # next scheduled round. See issue #83.
+          AI_TRIAGE_URL: ${{ secrets.AI_TRIAGE_URL }}
+          AI_TRIAGE_SECRET: ${{ secrets.AI_TRIAGE_SECRET }}
         run: |
           set -euo pipefail
 

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -37,15 +37,23 @@ Exactly one state label per open issue.
 | State | Meaning | Set by | Leaves when |
 | --- | --- | --- | --- |
 | *(none)* | brand new, not yet seen | issue creation | triage picks it up |
-| `ai-triage` | queued for automated triage | analysis, `/retriage` | triage finishes |
+| `ai-triage` | queued for automated triage | `/admit`, `/propose`, `/revise`, `/unpark` | triage finishes |
 | `pending-approval` | triaged; waiting on a human | triage | `/approve`, `/park` |
-| `needs-clarification` | triage could not proceed without an answer | triage | `/retriage` after the answer |
+| `needs-clarification` | triage could not proceed without an answer | triage | `/revise <answer>`, `/park`, or the blocker sweep |
 | `ready-for-work` | approved and eligible for the builder | `/approve` | the builder picks it up |
 | `in-progress` | an agent is building it right now | the builder | its PR merges, or it fails |
 | `parked` | deliberately set aside | `/park` | `/unpark` |
 
 Plus `dashboard`, which is not a state — it marks the one live dashboard issue,
 which the pipeline never triages or works.
+
+**There is no `/retriage`.** This table named one twice, and it has never
+existed: `parse_commands.COMMANDS` has no such entry, so typing it earns the
+unknown-command reaction rather than a re-triage. The way back to `ai-triage`
+from a question is `/revise <your answer>` — the one command that returns an
+issue to triage *with a note attached*, which is exactly what an answer is. The
+verb reads oddly on that route and the hand-back footer says so in plainer
+words; see [the footer](#the-hand-back-footer).
 
 **Invariant:** `ready-for-work` ⇒ the issue has a milestone. Enforced at the
 `/approve` gate and re-checked by the reconciler. See
@@ -570,6 +578,58 @@ believes the issue is handled and it waits on a human who has nothing to read.
 rests in exactly one state. An issue carrying both gets triaged again by the
 next analysis round while it sits waiting for Derek.
 
+##### The write is code, not an instruction
+
+`hand_back.py` performs both writes. This used to be prose in the skill file —
+"remove `ai-triage` in the same write that adds the new state" — carried out by
+a model at the end of a long analysis, and it was skipped in practice: sixteen
+issues sat on `ai-triage` with finished plans on them, waiting for an approval
+queue they had never reached.
+
+Nothing failed when it was skipped, which is the whole problem. The comment was
+posted, so the run looked successful from outside; only the label was missing,
+and no exit code, artifact, or test reports a missing label.
+
+So it is one call that does both writes or neither:
+
+```python
+hand_back.apply(api, 47, analysis, labels, "pending-approval")
+```
+
+It **refuses before it writes** in two cases, so a rejected hand-back leaves the
+issue exactly as it was rather than half-written:
+
+- a state triage may not set — `ready-for-work` is Derek's, via `/approve`;
+- an analysis the recognizer would not match, which is the state
+  `triage_repair` cannot repair and the reconciler requeues forever.
+
+This follows the same principle as the gatekeeper: *the component that can
+change state is a parser with a fixed vocabulary, not a model.* Triage was the
+one stage where a model applied its own label, and it was the one stage that
+silently stopped doing it.
+
+##### The hand-back footer
+
+The comment ends with the commands that make sense **on the route it took** —
+not the whole vocabulary:
+
+| Route | Offers |
+| --- | --- |
+| `pending-approval` | `/approve`, `/revise <notes>`, `/park` |
+| `needs-clarification` | `/revise <answer>`, `/park` |
+
+`/approve` is deliberately absent from the second: there is no plan on that
+route, so approving would approve nothing, and an offered command that means
+something other than it appears to is worse than no footer.
+
+The glosses come from `render_dashboard.COMMANDS` rather than a second copy —
+one description of what each command does. The single exception is `/revise` on
+the clarification route, where the canonical gloss ("the plan is not right") is
+false, because triage wrote no plan. That override is the visible edge of a real
+gap in the vocabulary: there is no verb for *here is the answer, look again*,
+and `/revise` is doing that job because it is the only route back to `ai-triage`
+that carries a note.
+
 #### Re-fire repair
 
 Triage runs twice more often than you would think: a sweep catches a comment
@@ -608,6 +668,19 @@ returns the issue to `ai-triage`, triage finds the analysis it wrote and repairs
 the label instead, reconcile returns it again. Neither side is wrong on its own
 terms, so nothing surfaces as an error — the issue just cycles. The side that
 writes the format owns the recognizer.
+
+**The author test is shared for the same reason, and it was the one that broke.**
+`is_triage_author` lives beside the recognizer and is imported the same way. Both
+modules previously kept their own `TRIAGE_AUTHOR = "github-actions[bot]"`, while
+every real triage comment was posted by the Claude App as `claude[bot]` — so the
+author filter ran *before* the recognizer and rejected every analysis on the
+board. Two copies, both stale in the same direction, so nothing looked
+inconsistent.
+
+Triage has two surfaces and both are accepted: `claude[bot]` when it runs as the
+App, `github-actions[bot]` when it runs from a workflow holding `GITHUB_TOKEN`.
+A human's comment still never counts, which is the point of having the gate at
+all — Derek pasting a checklist is not a triage run.
 
 ### The I/O layer
 

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -116,7 +116,12 @@ want.
 
 Two parsing rules worth knowing:
 
-- **A command must start its line.** "see /approve for details" is a mention.
+- **A command must start its line** — its *line*, not the comment. "see
+  /approve for details" is a mention; a sentence of explanation above
+  `/approve` is not, and applies normally. The workflow briefly filtered on
+  `startsWith(body, '/')`, which dropped exactly that case with no run, no
+  reaction and no acknowledgement — a silence indistinguishable from the
+  pipeline being broken.
 - **A command inside a code fence is ignored**, or writing up this table in a
   comment would execute it.
 
@@ -439,6 +444,34 @@ clean no-op** — the nightly run still picks the issue up, so a missing secret
 costs latency rather than correctness, and never fails the command that caused
 it. A network error is swallowed for the same reason: the label move has
 already succeeded by then.
+
+#### Both entry points fire, and each issue fires once
+
+`run_comment_event.py` fires after its label write; `run_sweep.py` fires from
+both of its paths, because a cleared blocker and a requeue each land an issue in
+`ai-triage` without anyone typing a command.
+
+The sweep fires **at most once per issue per pass**. A revisit does not update
+the in-memory issue that reconcile then reads, so the same issue can look newly
+triageable twice in one sweep — and two fires are two triage sessions racing on
+one issue, each posting its own plan for Derek to choose between.
+
+`fire_from_env` is the single place the environment variables are read, so both
+entry points poke the same Routine the same way.
+
+!!! warning "This was described here for weeks before it was true"
+
+    `fires_triage` and `fire_routine.fire` were both written, both unit-tested
+    — and called from nowhere. The workflow passed the two secrets to a step
+    that never read them, so **reactive triage never fired once**, on any
+    issue, and everything waited for the scheduled round.
+
+    Nothing surfaced it. Tests passed, because each half was correct in
+    isolation; the log was green, because nothing had failed; and the fallback
+    it was designed around — the nightly round — did the work quietly, which is
+    exactly what it is there for. A feature whose absence looks identical to
+    its fallback needs a test that the call site exists, and both entry points
+    now have one.
 
 #### The outcome is classified truthfully
 


### PR DESCRIPTION
Triage was broken in four separate places at once, and each one hid the next. Issues got a plan but never reached your approval queue; the check for "has this been triaged?" answered no for the whole board; the comment never told you what to type; and the thing that is supposed to triage an issue the moment you admit it has **never run, not once**.

Closes #190
Closes #191
Closes #192

## 1. Reactive triage was never wired up

This is the one behind "comments aren't triggering triage".

`apply_actions.fires_triage` and `fire_routine.fire` were both written. Both unit-tested. **Neither was called from anywhere.** `run_comment_event.py` never imported `fire_routine`, and no Python file read `AI_TRIAGE_URL` or `AI_TRIAGE_SECRET` — the workflow handed both secrets to a step that ignored them.

Your secrets are fine. Run `31288147708` shows both masked, which only happens for a registered value. It was the call site that didn't exist.

Nothing surfaced this, and that is the part worth keeping in mind. Each half passed its own tests. No log line failed. And the fallback it was designed around — the nightly round — did the work quietly, which is exactly its job. **A feature whose absence looks identical to its fallback needs a test that the call site exists**, and both entry points now have one.

Wired at the three places that need it: after the comment path's label write, and on both of the sweep's paths, since a cleared blocker and a requeue each land an issue in `ai-triage` with nobody typing a command. `gatekeeper-sweep.yml` now passes the two secrets — without them the sweep's fire would be a permanent `not-configured` no-op.

**One fire per issue per sweep.** A revisit doesn't update the in-memory issue reconcile then reads, so one issue can look newly-triageable twice in a single pass. I hit this in my own tests: two fires are two triage sessions racing, each posting its own plan for you to choose between.

## 2. Commands with a sentence in front of them were dropped

The comment workflow filtered on `startsWith(github.event.comment.body, '/')`. The contract is that a command starts its **line** — the docs say so explicitly, so you can explain yourself in the same comment. So this:

```
Looks right to me.
·/·a·pprove
```

produced no run, no 👀, no acknowledgement. Silence indistinguishable from a broken pipeline. Filter removed; `parse_commands` already ignores a comment with no command in it.

Not in upstream, for what it's worth — this was added here.

## 3. The hand-back label move was prose (#191)

`SKILL.md` said "remove `ai-triage` in the same write that adds the new state". Nothing performed or checked it, and skipping it fails nothing — the comment gets posted, so the run looks successful. Sixteen issues are sitting on `ai-triage` with finished plans on them.

`hand_back.py` now does both writes or neither, refusing *before writing anything* on a state triage may not set (`ready-for-work` stays yours) or an analysis the recognizer wouldn't match.

## 4. The author gate answered "no analysis" for the whole board (#190)

Both `triage_repair.py` and `reconcile.py` kept `TRIAGE_AUTHOR = "github-actions[bot]"`. The gate runs *before* the signature check, so nothing read as triaged — and the two stale copies agreed with each other, so nothing looked wrong.

Now one shared `is_triage_author`, imported rather than copied, accepting the three logins triage actually posts under:

| Login | Evidence |
| --- | --- |
| `claude[bot]` | #4, #147 |
| `derekwinters` | #83, #169 — triage running in a session under your account |
| `github-actions[bot]` | workflow-run triage |

All three appeared in the same round on 9 Aug. **Your call, and the cost is real:** a `## Build checklist` you write by hand now reads as a triage analysis and will suppress the analysis that issue is waiting for. Recorded in the code and in two tests so nobody quietly widens the set later.

## 5. The footer (#192)

Route-aware — `/approve`, `/revise <notes>`, `/park` on a plan; `/revise <answer>` and `/park` on a question, where `/approve` would approve a plan that was never written. Glosses come from `render_dashboard.COMMANDS`.

Writing it turned up that **`/retriage` does not exist** — the docs named it twice as the way out of `needs-clarification`, and `parse_commands` has no such entry. Corrected, with a test asserting the footer can only name commands the parser accepts.

## Spec invariants

- **Comment before label, always** — asserted against a fake API recording call order.
- **Exactly one state label** — `plan_labels` replaces rather than adds, is idempotent, preserves `area:`/`type:`/`skip-docs`.
- **Fire only when `ai-triage` is newly present** — an idempotent re-add must not fire, or one stuck comment becomes a triage run every sweep.
- **One implementation of "triage wrote this"** — `has_analysis_signature` and `is_triage_author` both imported by reconcile, each guarded by a test reading reconcile's source.
- **The footer must not break the recognizer** — a comment still reads as an analysis after the footer is appended.

Verified: 12 suites green (`pipeline-gatekeeper` 172 → 178, `triage-issue` 23 → 60, `pipeline-reconcile` 37 → 41), both cross-importing suites green standalone, `check_core_isolation.py` clean, `mkdocs build --strict` builds, both workflow YAMLs parse. Every new test seen red first, including the ones written after their fix, which I re-ran against the pre-fix module to confirm they failed for the right reason.

**Docs:** `docs/engineering/issue-pipeline.md` — new "Both entry points fire, and each issue fires once" section with a warning box on the never-wired fire; the command-parsing rule now says *line, not comment* and records the filter that broke it; states table corrected (`/retriage` removed); new sections on the enforced hand-back write and the footer; shared-recognizer section extended to the author gate. `.claude/skills/triage-issue/SKILL.md` — `hand_back.py`, the footer, the three authors, updated test count. `.claude/skills/pipeline-reconcile/SKILL.md` — the new source-reading guard.

## Deviations and Decisions

- **Four fixes in one PR, three issues closed, against rule 10.** #190 and #191 cannot land apart — #191 alone starts the requeue loop #190's bug was masking. The fire wiring and the `startsWith` filter have no issues at all; they were found while investigating why comments weren't triggering triage, and both are small. Happy to split any of it out if you'd rather review them separately.
- **`derekwinters` added to the triage-author set at your instruction**, with the hand-written-checklist cost accepted. I'd argued for removing the gate entirely; you decided otherwise and this implements that.
- **The owner's login is hardcoded** in `TRIAGE_AUTHORS` rather than read from `PIPELINE_OWNER`. `triage_repair.py` is a pure module with no import-time environment reads, and threading an owner argument through `reconcile.has_analysis(issue)` would change a signature four call sites depend on. One constant, one place, matching how the repo already treats label strings.
- **`fire_from_env` added** so both entry points read the environment in one place rather than each growing its own copy.
- **The sweep's stale in-memory labels are not fixed**, only guarded against. `apply_fixes` computes from the pre-revisit issue dict, which produces the same label set here and so is harmless — but it is why the double-fire existed, and it is a wider change than this PR should make.
- **The 16 stuck issues are still untouched.** They need a repair-mode run per issue against live issues, with this merged first. Yours to authorise.