### PR TITLE
refactor(skills): one shared recognizer for `Blocked by #N`

### DIFF
--- a/.claude/skills/issue-blockers/SKILL.md
+++ b/.claude/skills/issue-blockers/SKILL.md
@@ -18,11 +18,15 @@ python3 .claude/skills/issue-blockers/set_blocker.py audit  --issue 28
 
 **`Blocked by #42` written in an issue body is not a blocker.** It is a sentence.
 
-Everything that acts on blockers reads the *native* dependency graph: the
-nightly builder computing its ready queue, the dashboard's blocked section, and
-the sweep that wakes an issue when its blocker closes. None of them read prose.
-An issue "blocked" in a sentence is an issue the builder walks straight into and
-starts.
+Everything that acts on blockers — the nightly builder computing its ready
+queue, the dashboard's blocked section, the sweep that wakes an issue when its
+blocker closes — reads the *native* dependency graph and **unions** a structured
+`Blocked by #N` line into it. So prose is caught, but only as a safety net, and
+it is a thin one: the line is invisible to GitHub's own dependency view, it
+cannot be listed or removed with the commands above, `Blocked-by: #42` with a
+hyphen is not matched, and a dependency nobody wrote as a whole line on its own
+is not there at all. A blocker you can only find by reading the body is a
+blocker that gets missed.
 
 So when you discover a dependency — even on an issue that is not yours — record
 it natively, there and then. `audit` finds the ones already written as prose:
@@ -63,6 +67,27 @@ POST /repos/:owner/:repo/issues/28/dependencies/blocked_by
 number** if it cannot — a wrong id here does not fail, it creates a
 relationship pointing at whatever issue happens to have that internal id.
 
+## This skill owns the `Blocked by #N` recognizer
+
+`blocker_refs.py` holds the one definition of the pattern and the one way text
+and native blockers are merged. Every reader in the pipeline imports it — the
+sweep, the queue selector, the reconciler, the dashboard, the comment-event
+snapshot, and `audit` here.
+
+```python
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import blockers_of  # noqa: E402
+```
+
+**Widen the pattern here and nowhere else.** Six copies of it used to sit in six
+files, and a copy that drifts does not raise: the builder refuses an issue the
+sweep never wakes and the board still shows as ready. The module is stdlib-only
+and does nothing at import time, because every suite that touches it keeps it
+loaded for the rest of the test run.
+
 ## Verified
 
 Against this repo: `list --issue 28` reports `#82 [open] Derek: add the
@@ -75,5 +100,9 @@ and `list --issue 53` reports no blockers.
 python3 .github/scripts/run_python_tests.py issue-blockers
 ```
 
-13 tests. The API is injected as a callable, so every path — including that the
+28 tests. The API is injected as a callable, so every path — including that the
 issue *number* is never sent as the id — is asserted without a network call.
+
+The last of them is the one to keep: it widens `TEXT_BLOCKER` in `blocker_refs`
+and asserts all six readers across the pipeline see the change. While that
+passes, the copies cannot come back.

--- a/.claude/skills/issue-blockers/blocker_refs.py
+++ b/.claude/skills/issue-blockers/blocker_refs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The one definition of `Blocked by #N`, and the one way blockers are merged.
+
+Six modules across five skills used to carry their own copy of this pattern,
+and five of them their own copy of the union. They are not independent — they
+are several readings of the same thing at several points in one pipeline — and
+when they disagree nothing raises: the queue selector reads a line as a blocker
+and refuses to build the issue, the sweep does not and so never wakes it, the
+dashboard shows it as ready. The issue simply stops moving.
+
+`issue-blockers` owns this because it is the skill that documents the format,
+on the same "the side that writes the format owns the recognizer" rule that put
+`has_analysis_signature` in `triage-issue`. See #65 and #147.
+
+Importing it from another skill is a `sys.path` insertion and a plain import:
+
+    _BLOCKERS = Path(__file__).resolve().parents[1] / "issue-blockers"
+    if str(_BLOCKERS) not in sys.path:
+        sys.path.insert(0, str(_BLOCKERS))
+
+    from blocker_refs import blockers_of  # noqa: E402
+
+**Stdlib only, and nothing happens at import time.** The test runner's
+per-suite teardown only evicts modules living under the suite it just ran, so
+this module stays in `sys.modules` for the whole run once any suite has
+imported it. That is harmless for a module that only defines things, and only
+for one.
+
+See docs/engineering/issue-pipeline.md.
+"""
+
+from __future__ import annotations
+
+import re
+
+# "Blocked by #42", "blocked by: #42". Structured only, and deliberately NOT
+# "Depends on: #42" — that is soft ordering with no native form, and reading it
+# as a blocker would turn a preference into a hard gate the builder refuses to
+# pass. "This is similar to #42" is not a dependency either.
+TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def text_blockers(body) -> set[int]:
+    """Issue numbers named as blockers in a body — which is the wrong place."""
+    return {int(number) for number in TEXT_BLOCKER.findall(body or "")}
+
+
+def union_blockers(body, native) -> list[int]:
+    """Text lines **unioned** with native edges, sorted.
+
+    Union rather than either-or: an issue can have one dependency recorded
+    natively and another still written in prose, and reading one source alone
+    releases work that is still half-blocked.
+
+    `native` is whatever the caller managed to find out. A caller that could not
+    reach the dependency API passes an empty set and gets the text blockers it
+    does know about — a smaller list, which is the safe direction.
+    """
+    return sorted(text_blockers(body) | {int(number) for number in (native or [])})
+
+
+def blockers_of(issue) -> list[int]:
+    """Every issue this one waits on, for an issue dict carrying its natives.
+
+    The shape four of the five readers have: a snapshot where the dependency
+    edges were fetched up front and left on the issue as `native_blockers`. The
+    fifth fetches them at the moment it needs them and calls `union_blockers`.
+    """
+    return union_blockers((issue or {}).get("body"), (issue or {}).get("native_blockers"))

--- a/.claude/skills/issue-blockers/set_blocker.py
+++ b/.claude/skills/issue-blockers/set_blocker.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """Read and write **native** GitHub blocked-by relationships.
 
-A blocker written as prose — `Blocked by #42` in an issue body — is invisible to
-everything that matters. The nightly builder computes its ready queue from the
-real dependency graph, the dashboard's blocked section reads the same graph, and
-the revisit sweep watches it to know when to wake an issue up. None of them read
-prose. An issue "blocked" in a sentence is an issue the builder walks straight
-into.
+A blocker written as prose — `Blocked by #42` in an issue body — is a sentence,
+not a relationship. The nightly builder, the dashboard's blocked section and the
+revisit sweep all read the real dependency graph and **union** a structured
+`Blocked by #N` line into it, so prose is honoured on a best-effort basis and
+nothing more: it is invisible to GitHub's own dependency view, it cannot be
+listed or removed, and one typo makes it vanish with nothing reporting it.
+Record it natively; `audit` finds the ones still written as prose.
+
+The recognizer for that line lives in `blocker_refs.py` beside this file, and
+every reader in the pipeline imports it from there.
 
     python3 set_blocker.py list   --issue 28
     python3 set_blocker.py add    --issue 28 --blocked-by 82
@@ -21,15 +25,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import sys
 import urllib.error
 import urllib.request
 
-# "Blocked by #42", "blocked by: #42". Deliberately NOT "Depends on: #42" —
-# that is soft ordering with no native form, and converting it would turn a
-# preference into a hard gate the builder refuses to pass.
-PROSE_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+# The one definition of the format this skill documents. Its sibling, so a
+# plain import — every other reader in the pipeline inserts this directory on
+# sys.path and imports the same names.
+from blocker_refs import text_blockers
 
 
 class BlockerError(Exception):
@@ -99,7 +102,7 @@ def remove_blocker(api, blocked: int, blocked_by: int):
 
 def prose_blockers(body: str) -> list[int]:
     """Issue numbers named as blockers in prose — which is the wrong place."""
-    return [int(match) for match in PROSE_BLOCKER.findall(body or "")]
+    return sorted(text_blockers(body))
 
 
 def audit(api, issue_number: int) -> list[str]:

--- a/.claude/skills/issue-blockers/tests/test_blocker_refs.py
+++ b/.claude/skills/issue-blockers/tests/test_blocker_refs.py
@@ -1,0 +1,173 @@
+"""Tests for the one shared `Blocked by #N` recognizer.
+
+The last test in this file is the reason the module exists: it widens the
+pattern in one place and checks that every reader in the pipeline sees the
+change. While that passes, the six copies cannot come back.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SKILLS = Path(__file__).resolve().parents[2]
+
+sys.path.insert(0, str(SKILLS / "issue-blockers"))
+
+import blocker_refs  # noqa: E402
+
+
+class TextBlockers(unittest.TestCase):
+    def test_a_structured_line_is_a_blocker(self):
+        self.assertEqual({42}, blocker_refs.text_blockers("Blocked by #42"))
+
+    def test_the_colon_form_and_case_are_both_accepted(self):
+        self.assertEqual({42}, blocker_refs.text_blockers("blocked by: #42"))
+
+    def test_every_line_in_a_body_is_read(self):
+        body = "Some context.\n\nBlocked by #42\nBlocked by #43\n\nMore context."
+        self.assertEqual({42, 43}, blocker_refs.text_blockers(body))
+
+    def test_depends_on_is_not_a_blocker(self):
+        # Soft ordering with no native form. Reading it as a hard blocker turns
+        # a preference into a gate the builder refuses to pass.
+        self.assertEqual(set(), blocker_refs.text_blockers("Depends on: #42"))
+
+    def test_a_mention_in_ordinary_prose_is_not_a_blocker(self):
+        self.assertEqual(set(), blocker_refs.text_blockers("This is similar to #42."))
+
+    def test_no_body_is_no_blockers(self):
+        self.assertEqual(set(), blocker_refs.text_blockers(None))
+
+
+class UnionBlockers(unittest.TestCase):
+    def test_text_and_native_are_unioned(self):
+        self.assertEqual([20, 21], blocker_refs.union_blockers("Blocked by #20", {21}))
+
+    def test_the_same_blocker_from_both_sources_is_counted_once(self):
+        self.assertEqual([20], blocker_refs.union_blockers("Blocked by #20", {20}))
+
+    def test_natives_that_could_not_be_fetched_leave_the_text_ones(self):
+        # `fetch_comment_event.py` degrades to an empty set when the dependency
+        # lookup fails, rather than losing the whole event. The union has to
+        # keep working on what it does know.
+        self.assertEqual([20], blocker_refs.union_blockers("Blocked by #20", set()))
+
+    def test_no_sources_at_all_is_no_blockers(self):
+        self.assertEqual([], blocker_refs.union_blockers(None, None))
+
+
+class BlockersOf(unittest.TestCase):
+    def test_an_issue_dict_unions_its_body_with_its_native_edges(self):
+        issue = {"body": "Blocked by #43", "native_blockers": [42]}
+        self.assertEqual([42, 43], blocker_refs.blockers_of(issue))
+
+    def test_an_issue_with_neither_is_not_blocked(self):
+        self.assertEqual([], blocker_refs.blockers_of({}))
+
+
+class ImportIsInert(unittest.TestCase):
+    def test_importing_the_module_reads_no_environment_and_touches_nothing(self):
+        # Every suite that imports this keeps it cached in sys.modules for the
+        # rest of the run, so importing it has to be free of side effects.
+        result = subprocess.run(
+            [sys.executable, "-c", "import blocker_refs"],
+            cwd=str(SKILLS / "issue-blockers"),
+            env={"PATH": os.environ.get("PATH", "")},
+            capture_output=True, text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+
+
+# A pattern one character wider than the real one: it also accepts the hyphen
+# form somebody writes by hand.
+WIDER = re.compile(r"^\s*blocked[\s-]+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+HAND_WRITTEN = "Blocked-by: #42"
+
+
+READER_SKILLS = ("pipeline-dashboard", "pipeline-dev", "pipeline-gatekeeper",
+                 "pipeline-reconcile")
+
+
+def _every_reader() -> dict:
+    """Each module that recognizes a blocker, as name -> callable(body) -> list."""
+    import check_revisits
+    import fetch_comment_event
+    import reconcile
+    import render_dashboard
+    import select_queue
+    import set_blocker
+
+    def via_snapshot(body):
+        event = {"issue": {"number": 10, "labels": [], "body": body},
+                 "comment": {"id": 5, "body": "/approve",
+                             "user": {"login": "derekwinters", "type": "User"}}}
+        snapshot = fetch_comment_event.build(event, _NoApi(), owner="derekwinters")
+        return snapshot["issue"]["blockers"]
+
+    return {
+        "set_blocker.prose_blockers":
+            lambda body: set_blocker.prose_blockers(body),
+        "check_revisits.blockers_of":
+            lambda body: check_revisits.blockers_of({"body": body}),
+        "select_queue.blockers_of":
+            lambda body: select_queue.blockers_of({"body": body}),
+        "render_dashboard.blockers_of":
+            lambda body: render_dashboard.blockers_of({"body": body}),
+        "reconcile._text_blockers":
+            lambda body: reconcile._text_blockers({"body": body}),
+        "fetch_comment_event.build":
+            via_snapshot,
+    }
+
+
+class _NoApi:
+    """Every lookup fails — the snapshot still has to be built."""
+
+    def __call__(self, method, path, payload=None):
+        raise RuntimeError("no network in a unit test")
+
+
+class OneDefinitionReachesEveryReader(unittest.TestCase):
+    """The regression this module exists to prevent.
+
+    Six copies of this pattern used to sit in six files. Widening one and not
+    the other five does not raise: the queue selector refuses to build an issue
+    the dashboard shows as ready, and nothing logs a reason.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Reaching the other skills is the point of the test, but the paths go
+        # back afterwards: a suite that leaves them behind would let the next
+        # one import across skills without saying so, which is how a missing
+        # path insertion passes here and fails in CI.
+        cls._added = [str(SKILLS / skill) for skill in READER_SKILLS
+                      if str(SKILLS / skill) not in sys.path]
+        for directory in cls._added:
+            sys.path.insert(0, directory)
+
+    @classmethod
+    def tearDownClass(cls):
+        for directory in cls._added:
+            if directory in sys.path:
+                sys.path.remove(directory)
+
+    def test_the_hand_written_form_is_not_a_blocker_today(self):
+        for name, read in _every_reader().items():
+            with self.subTest(reader=name):
+                self.assertEqual([], read(HAND_WRITTEN))
+
+    def test_widening_the_shared_pattern_is_visible_from_every_reader(self):
+        with mock.patch.object(blocker_refs, "TEXT_BLOCKER", WIDER):
+            for name, read in _every_reader().items():
+                with self.subTest(reader=name):
+                    self.assertEqual([42], read(HAND_WRITTEN))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -24,6 +24,17 @@ import os
 import re
 import sys
 import urllib.request
+from pathlib import Path
+
+# One recognizer for `Blocked by #N`, and one union of it with the native
+# edges, shared with the skill that documents the format. A copy here that
+# drifted would show the board as ready while the builder refuses to build —
+# the failure Derek would see first and be least able to explain. See #147.
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import blockers_of  # noqa: E402
 
 DEFAULT_CAP = 3
 
@@ -40,9 +51,6 @@ STATE_LABELS = PLANNING_LABELS | ACTIVE_LABELS | {PARKED}
 
 FOCUS_MARKER = re.compile(r"<!--\s*pipeline-focus:\s*(.+?)\s*-->")
 CAP_MARKER = re.compile(r"<!--\s*pipeline-cap:\s*(.+?)\s*-->")
-
-TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
-                          re.IGNORECASE | re.MULTILINE)
 
 COMMANDS = [
     ("/admit", "bring an issue into the pipeline"),
@@ -157,13 +165,6 @@ def ready_queue(data: dict, focus=None) -> list:
     focus = focus or resolve_focus(data)
 
     return _sorted_rows(_active(data, focus, READY), data)
-
-
-def blockers_of(issue) -> list:
-    """Hard blockers — native edges unioned with `Blocked by #N` lines."""
-    from_native = {int(n) for n in (issue.get("native_blockers") or [])}
-    from_text = {int(n) for n in TEXT_BLOCKER.findall(issue.get("body") or "")}
-    return sorted(from_native | from_text)
 
 
 def _open_issues(data) -> dict:

--- a/.claude/skills/pipeline-dev/select_queue.py
+++ b/.claude/skills/pipeline-dev/select_queue.py
@@ -19,6 +19,17 @@ from __future__ import annotations
 import json
 import re
 import sys
+from pathlib import Path
+
+# One recognizer for `Blocked by #N`, and one union of it with the native
+# edges, shared with the skill that documents the format. A copy here that
+# drifted from the sweep's would refuse to build an issue nothing would ever
+# wake, with nothing reporting a reason. See #147.
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import blockers_of  # noqa: E402
 
 READY_LABEL = "ready-for-work"
 PARKED_LABEL = "parked"
@@ -29,12 +40,9 @@ EPIC_LABEL = "type:epic"
 # the only thing standing between a quiet night and thirty open PRs.
 DEFAULT_CAP = 3
 
-# A hard blocker, written in prose. Structured only — "this is similar to #42"
-# is not a dependency, and treating it as one would stall issues at random.
-TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
-                          re.IGNORECASE | re.MULTILINE)
-
-# Soft ordering. Does not gate the issue — it sequences it.
+# Soft ordering. Does not gate the issue — it sequences it. It has no native
+# form and exactly one reader, so unlike the blocker pattern there is nothing
+# here for it to drift from.
 TEXT_DEPENDS = re.compile(r"^\s*depends\s+on\s*:?\s*#(\d+)\s*$",
                           re.IGNORECASE | re.MULTILINE)
 
@@ -48,18 +56,6 @@ CLOSING_KEYWORD = re.compile(
 
 def _numbers(pattern, body) -> set:
     return {int(number) for number in pattern.findall(body or "")}
-
-
-def blockers_of(issue: dict) -> list:
-    """Every issue this one is *blocked by* — native edges unioned with text.
-
-    **One helper, both sources.** A dependency can be recorded natively while
-    another sits in prose in the same body, and reading only one source means
-    releasing an issue that is still half-blocked. Union is the only safe
-    merge, and doing it in one place is what stops the two readings drifting.
-    """
-    from_native = {int(number) for number in (issue.get("native_blockers") or [])}
-    return sorted(from_native | _numbers(TEXT_BLOCKER, issue.get("body")))
 
 
 def depends_on(issue: dict) -> list:

--- a/.claude/skills/pipeline-gatekeeper/check_revisits.py
+++ b/.claude/skills/pipeline-gatekeeper/check_revisits.py
@@ -13,7 +13,19 @@ See docs/engineering/issue-pipeline.md.
 
 from __future__ import annotations
 
-import re
+import sys
+from pathlib import Path
+
+# One recognizer for `Blocked by #N`, and one union of it with the native
+# edges, shared with the skill that documents the format. Six copies of the
+# pattern used to drift silently: this sweep would stop seeing a line the queue
+# selector still refused to build past, and the issue would never wake. See
+# #147.
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import blockers_of  # noqa: E402
 
 # The state a blocked issue is parked in by triage.
 BLOCKED_LABEL = "needs-clarification"
@@ -25,10 +37,6 @@ WIREFRAME_LABEL = "type:wireframe"
 # be built, and holding the dependent back until it closes costs a night for
 # nothing.
 SCHEDULED_LABELS = {"ready-for-work", "in-progress"}
-
-# Structured only. "This is similar to #42" is not a dependency, and treating it
-# as one would wake issues at random.
-TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
 
 
 class Revisit:
@@ -49,18 +57,6 @@ class Revisit:
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
         return f"Revisit(#{self.issue_number}, cleared={self.cleared})"
-
-
-def blockers_of(issue: dict) -> list[int]:
-    """Every issue this one waits on — text lines **unioned** with native edges.
-
-    Union rather than either-or: an issue can have one recorded natively and
-    another still written in prose, and waking it when only half have cleared
-    is worse than not waking it at all.
-    """
-    from_text = {int(number) for number in TEXT_BLOCKER.findall(issue.get("body") or "")}
-    from_native = {int(number) for number in (issue.get("native_blockers") or [])}
-    return sorted(from_text | from_native)
 
 
 def is_resolved(blocker: dict) -> bool:

--- a/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
@@ -19,20 +19,25 @@ See docs/engineering/issue-pipeline.md.
 
 from __future__ import annotations
 
-import re
+import sys
+from pathlib import Path
+
+# One recognizer for `Blocked by #N` and one union with the native edges,
+# shared with the skill that documents the format. See #147. This is the one
+# caller that fetches its natives live rather than reading them off a
+# pre-built snapshot, which is why it calls `union_blockers` directly.
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import union_blockers  # noqa: E402
 
 DASHBOARD_LABEL = "dashboard"
 WATERMARK = "eyes"
 
-TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
-
 
 def _labels(issue: dict) -> list[str]:
     return [label.get("name", "") for label in (issue.get("labels") or [])]
-
-
-def _text_blockers(body: str | None) -> set[int]:
-    return {int(number) for number in TEXT_BLOCKER.findall(body or "")}
 
 
 def _native_blockers(api, issue_number: int) -> set[int]:
@@ -95,8 +100,8 @@ def build(event: dict, api, owner: str, bot_login: str = "github-actions[bot]") 
             "labels": labels,
             "body": issue.get("body") or "",
             "milestone": (issue.get("milestone") or {}).get("title"),
-            "blockers": sorted(
-                _text_blockers(issue.get("body")) | _native_blockers(api, issue["number"])),
+            "blockers": union_blockers(
+                issue.get("body"), _native_blockers(api, issue["number"])),
             "is_dashboard": DASHBOARD_LABEL in labels,
         },
         "comment": {

--- a/.claude/skills/pipeline-reconcile/reconcile.py
+++ b/.claude/skills/pipeline-reconcile/reconcile.py
@@ -36,6 +36,16 @@ if str(_TRIAGE_SKILL) not in sys.path:
 
 from triage_repair import has_analysis_signature, is_triage_author  # noqa: E402
 
+# Same rule, same reason, for `Blocked by #N`: the skill that documents the
+# format owns the recognizer. A copy here that drifted would report an issue as
+# prose-only, or flag a cycle, on a reading nobody else in the pipeline shares.
+# See #147.
+_BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
+if str(_BLOCKERS_SKILL) not in sys.path:
+    sys.path.insert(0, str(_BLOCKERS_SKILL))
+
+from blocker_refs import blockers_of, text_blockers  # noqa: E402
+
 TRIAGE_LABEL = "ai-triage"
 READY_LABEL = "ready-for-work"
 IN_PROGRESS_LABEL = "in-progress"
@@ -56,9 +66,6 @@ STATE_LABELS = {
 # overrule a human.
 ANALYZED_STATES = {"pending-approval", "needs-clarification", READY_LABEL,
                    IN_PROGRESS_LABEL}
-
-TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$",
-                          re.IGNORECASE | re.MULTILINE)
 
 # Done-ness comes from a closing keyword in a commit **body**. Never a title:
 # a squash merge puts `(#148)` in the subject and that is a PR number, not a
@@ -84,7 +91,7 @@ def _labels(issue) -> set:
 
 
 def _text_blockers(issue) -> list:
-    return sorted({int(n) for n in TEXT_BLOCKER.findall(issue.get("body") or "")})
+    return sorted(text_blockers(issue.get("body")))
 
 
 def _closed_by_body(body: str) -> set:
@@ -127,8 +134,7 @@ def find_cycles(issues) -> list:
     graph = {}
     for issue in issues:
         number = issue["number"]
-        blockers = set(issue.get("native_blockers") or []) | set(_text_blockers(issue))
-        graph[number] = blockers
+        graph[number] = set(blockers_of(issue))
 
     cycles = []
     seen = set()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -296,6 +296,25 @@ is worse than not waking it at all.
 An unstructured mention — "this is similar to #42" — is not a dependency, and
 is deliberately not matched.
 
+#### One recognizer, shared
+
+Recognizing that line has exactly one implementation: `text_blockers` in
+`.claude/skills/issue-blockers/blocker_refs.py`, and the union has exactly two —
+`blockers_of` for a snapshot that already carries its native edges, and
+`union_blockers` for the one caller that fetches them live. Every reader in the
+pipeline imports them: the sweep, the queue selector, the reconciler, the
+dashboard, the comment-event snapshot, and `audit`.
+
+`issue-blockers` owns them because it is the skill that documents the format —
+the same "the side that writes the format owns the recognizer" rule that put
+`has_analysis_signature` in `triage-issue`.
+
+The pattern used to be written out in each reader, and the drift is silent in
+the worst way: the queue selector reads a line as a blocker and refuses to
+build the issue, the sweep does not and so never wakes it, and the dashboard
+shows it as ready the whole time. Nothing errors. The issue just stops moving,
+and no log anywhere says why.
+
 ### When a blocker resolves
 
 | Blocker state | Resolved? |
@@ -814,7 +833,9 @@ to have it.
 Two of those are narrower than they look.
 
 **Hard blockers are native edges unioned with `Blocked by #N` lines**, merged by
-one helper. An issue can have one dependency recorded natively and another still
+one helper — `blockers_of` in `.claude/skills/issue-blockers/blocker_refs.py`,
+the same one the sweep and the dashboard use. An issue can have one dependency
+recorded natively and another still
 written in prose, and reading either source alone releases work that is still
 half-blocked. A blocker the caller knows nothing about counts as unresolved:
 not knowing whether the thing you depend on is finished is precisely the case


### PR DESCRIPTION
Closes #147

Six different scripts each had their own copy of the rule for spotting a `Blocked by #42` line in an issue, and five had their own copy of how that gets combined with GitHub's real "blocked by" links. They all have to agree, because they are the same question asked at six points in the pipeline. When one of them was changed and the others were not, nothing broke loudly — the builder would refuse to start an issue, the sweep would never wake it up, and the board would keep showing it as ready. The issue just stopped moving and nothing said why.

There is now one copy, owned by the `issue-blockers` skill, and everything else imports it. Nothing about how blockers behave has changed: every copy was character-identical, so this is a move, not a rewrite.

**Docs:** `docs/engineering/issue-pipeline.md` — added a "One recognizer, shared" section naming `blocker_refs.py` and its three entry points, mirroring how the page already names `has_analysis_signature`, and named the same module on the "merged by one helper" line in the ready-queue section. `.claude/skills/issue-blockers/SKILL.md` — corrected the claim that nothing reads prose blockers (all three readers it named do union prose in), and documented that this skill now owns the recognizer.

## Spec invariants

| Rule in `/docs` this had to keep true | The test that asserts it |
| --- | --- |
| Hard blockers are native edges **unioned** with `Blocked by #N` lines, never either alone (`issue-pipeline.md`) | `UnionBlockers.test_text_and_native_are_unioned`, plus the existing per-reader union tests in all five suites |
| `Depends on: #42` is soft ordering and must **not** read as a blocker | `TextBlockers.test_depends_on_is_not_a_blocker`, and the pre-existing `test_a_soft_depends_on_line_is_not_a_blocker` |
| An unstructured mention — "this is similar to #42" — is not a dependency | `TextBlockers.test_a_mention_in_ordinary_prose_is_not_a_blocker` |
| A failed dependency lookup must not lose the whole comment event; the blockers list degrades to what is known | `UnionBlockers.test_natives_that_could_not_be_fetched_leave_the_text_ones`, and the pre-existing `test_a_failing_blockers_fetch_does_not_lose_the_snapshot` |

## How the spec is changing

The rule is not moving — `issue-pipeline.md` already said hard blockers are "merged by one helper", and the code had six recognizers and five mergers. **The code was the side that was wrong**, and this makes it true to the rule the docs already state. What the docs gain is the helper's name, so the next person adding a reader has somewhere to import from rather than a pattern to copy.

`SKILL.md` is the one genuine correction. It said the builder, the dashboard and the sweep read only native relationships and that "none of them read prose" — factually wrong about exactly the three readers it named, all of which union prose in. It now says prose is caught but only as a thin safety net, and lists what the net misses (invisible to GitHub's dependency view, cannot be listed or removed, `Blocked-by:` with a hyphen does not match). The advice it exists to give — record it natively — is unchanged and better supported.

## The test worth keeping

`OneDefinitionReachesEveryReader` widens the shared pattern to accept the hand-written `Blocked-by: #42`, then asserts all six readers see the change. Red before this PR with one failure per reader; a sibling test pins that the same input is *not* a blocker while the pattern is unpatched, so the test cannot pass by accident. Re-introducing a local copy in any one reader was confirmed to fail it, naming the reader that drifted.

## Deviations and Decisions

- **Scope was six copies, not the four in the issue body.** `pipeline-reconcile/reconcile.py` and `pipeline-dashboard/render_dashboard.py` carry the same pattern and were not in the issue's table. Leaving them would have made "no module keeps a local copy" untickable, and they are the two where the drift is most visible — the sweep that requeues and the board Derek reads. Approved in triage.
- **Two entry points rather than one.** `blockers_of(issue)` for the four readers whose snapshot already carries `native_blockers`, and `union_blockers(body, native)` underneath it for `fetch_comment_event.py`, which fetches natives live and deliberately degrades to an empty set. One signature would have meant either threading an `api` argument through a pure function or dropping that fallback. Approved in triage.
- **`TEXT_DEPENDS` stayed in `select_queue.py`.** One reader, no native form, nothing to drift from. Approved in triage.
- **`run_python_tests.py` is untouched.** The cross-skill import is the `sys.path` insertion the repo already uses four times, so the runner's per-suite path model did not need to move. Each of the five affected suites was verified to pass **alone** as well as together, and the new test restores the paths it inserts so it cannot mask a missing insertion in a later suite.
- **`set_blocker.py`'s module docstring was corrected too**, not just `SKILL.md`. It carried the same "none of them read prose" claim word for word, and fixing one copy of a wrong statement while leaving the other is the failure this whole PR is about.
- **`prose_blockers()` now returns sorted, de-duplicated numbers** rather than raw regex-match order. Its only caller is `audit`, which prints one line per number; a body naming the same blocker twice used to produce the same instruction twice. The existing tests pass unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYrHXJn6XAZh7DRfWmhdQz)_