### PR TITLE
feat(gatekeeper): replay comment commands the comment workflow missed

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/SKILL.md
+++ b/.claude/skills/pipeline-gatekeeper/SKILL.md
@@ -20,8 +20,8 @@ python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --events-only < state.js
 ## In production this is two workflows, with no model in the loop
 
 `gatekeeper-comment.yml` on every `issue_comment`, and `gatekeeper-sweep.yml`
-every fifteen minutes. Both run these scripts directly. **Nothing here asks a
-model anything.**
+on issue/PR events plus a six-hourly cron. Both run these scripts directly.
+**Nothing here asks a model anything.**
 
 That is the whole point of the design. The gatekeeper is what turns Derek
 typing `/approve` into an issue the builder will pick up — it is the boundary
@@ -78,10 +78,11 @@ redundancy is deliberate: a script that is safe only because the workflow's
 An applied comment gets an `eyes` reaction from the bot, and a comment already
 carrying one is never reconsidered.
 
-This is what makes the fifteen-minute sweep safe. The sweep re-reads recent
-comments to catch anything the event path missed — a dropped webhook, a
-workflow that failed to start — and without a marker it would re-apply every
-command it found, every time.
+This is what makes the sweep's **comment replay** safe. On its six-hourly cron
+the sweep re-reads the last seven days of comments to catch anything
+`gatekeeper-comment` missed — a dropped webhook, a workflow that failed to
+start — and without a marker it would re-apply every command it found, every
+time.
 
 Two details matter:
 
@@ -89,7 +90,7 @@ Two details matter:
   silence a command.
 - **A refused comment is watermarked too** — except a stranger's. It was
   considered and answered; without the mark the sweep would re-post the same
-  refusal every fifteen minutes forever.
+  refusal on every run forever.
 
 If a reaction lookup fails, the comment is treated as **already watermarked**.
 Re-applying a command is worse than skipping one, and the next sweep retries.
@@ -134,9 +135,10 @@ internally, so every decision is reachable in a test without a network call.
 - `run_comment_event.py` — an `issue_comment` webhook payload. Snapshot →
   parse → gate → apply → write labels, ack, reaction → re-render the dashboard
   **once**, after all label writes.
-- `run_sweep.py` — a state snapshot. Revisits cleared blockers, then reconciles.
-  `--events-only` drops reconcile's two cron-only fixes; use it when simulating
-  the fifteen-minute pass.
+- `run_sweep.py` — a state snapshot. Replays comment commands the comment
+  workflow missed, revisits cleared blockers, then reconciles — and re-renders
+  the board **once** for all of it. `--events-only` drops the replay and
+  reconcile's two cron-only fixes; use it when simulating the event path.
 
 Authentication is `GITHUB_TOKEN`, never a PAT.
 
@@ -146,8 +148,9 @@ Authentication is `GITHUB_TOKEN`, never a PAT.
 python3 .github/scripts/run_python_tests.py pipeline-gatekeeper
 ```
 
-158 tests. The parser, the gates, the label planning, the revisit rules, and
-the I/O ordering — none of them touch the network.
+The parser, the gates, the label planning, the revisit rules, the replay's
+watermark rule, and the I/O ordering — none of them touch the network. The
+count is deliberately not written down here; it went stale twice.
 
 ## See also
 

--- a/.claude/skills/pipeline-gatekeeper/run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/run_comment_event.py
@@ -34,9 +34,16 @@ from _github_api import (  # noqa: E402
 
 
 class Result:
-    def __init__(self, applied: bool, detail: str = "") -> None:
+    def __init__(self, applied: bool, detail: str = "", labels=None) -> None:
         self.applied = applied
         self.detail = detail
+        # The label set the issue ends this pass with, or **None** when the
+        # pass never got as far as computing one. The sweep's replay writes it
+        # back onto its in-memory snapshot, which reconcile then reads — see
+        # `run_sweep.replay_comments`. `None` rather than "the labels
+        # unchanged", so a caller with its own copy leaves it alone instead of
+        # overwriting it with a guess.
+        self.labels = list(labels) if labels is not None else None
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
         return f"Result(applied={self.applied!r}, {self.detail!r})"
@@ -97,7 +104,9 @@ def run(event: dict, api, owner: str, rerender=None, fire=None) -> Result:
         rerender = rerender or (lambda **kwargs: rerender_dashboard(api, **kwargs))
         rerender(focus_override=plan.focus, cap_override=plan.cap)
 
-    return Result(bool(actions), acknowledgement)
+    # `sorted(set(...))` because that is what `set_labels` actually wrote, and
+    # the caller's snapshot should match the repository rather than the plan.
+    return Result(bool(actions), acknowledgement, sorted(set(plan.labels)))
 
 
 def _apply_gates(outcome, issue):

--- a/.claude/skills/pipeline-gatekeeper/run_sweep.py
+++ b/.claude/skills/pipeline-gatekeeper/run_sweep.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""The board-wide sweep: catch missed comments, wake cleared blockers, reconcile.
+"""The board-wide sweep: replay missed comments, wake cleared blockers, reconcile.
 
-Runs every 15 minutes from the sweep workflow, and nightly from the reconcile
-Routine. The difference between those two is one flag, and it matters:
+Two paths, and the difference between them is one flag:
 
     run_sweep.py                  # cron — everything
-    run_sweep.py --events-only    # the 15-minute pass
+    run_sweep.py --events-only    # the issue/PR event path
 
-**`--events-only` omits reconcile's two requeue fixes**, because the drift they
-detect is indistinguishable from work in flight. An issue the builder picked up
-ten seconds ago has `in-progress` and no PR — exactly a stall's shape — and
-requeuing it would yank the work out from under a running agent.
+**`--events-only` omits the comment replay and reconcile's two requeue fixes.**
+
+The requeue fixes, because the drift they detect is indistinguishable from work
+in flight: an issue the builder picked up ten seconds ago has `in-progress` and
+no PR — exactly a stall's shape — and requeuing it would yank the work out from
+under a running agent.
+
+The replay, because the event path fires on `issues: [labeled]` and an applied
+command *changes a label*. Replaying there would wake this workflow up to
+re-apply the very comment `gatekeeper-comment` is applying at that moment, and
+nothing serialises the two — they are in different concurrency groups.
 
 See docs/engineering/issue-pipeline.md.
 """
@@ -18,7 +24,9 @@ See docs/engineering/issue-pipeline.md.
 from __future__ import annotations
 
 import os
+import re
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -31,12 +39,146 @@ import apply_actions  # noqa: E402
 import check_revisits  # noqa: E402
 import fire_routine  # noqa: E402
 import reconcile  # noqa: E402
+import run_comment_event  # noqa: E402
 from _github_api import (  # noqa: E402
     comment as post_comment,
     github_api,
     rerender_dashboard,
     set_labels,
 )
+
+# How far back the replay looks. The cron is six-hourly, so anything past about
+# twelve hours already covers a single dropped webhook; a week covers a
+# multi-day Actions outage as well. Widening costs almost nothing — a comment
+# that was applied carries the 👀 and re-reading it is a no-op — but it is
+# bounded rather than unlimited, because an unbounded scan of the repository's
+# whole comment history is both slow and a far larger surface for a watermark
+# bug to act on.
+REPLAY_WINDOW_DAYS = 7
+
+_ISSUE_URL_NUMBER = re.compile(r"/issues/(\d+)$")
+
+
+def comments_query(now=None) -> str:
+    """The one call that gathers the replay's candidates.
+
+    Repo-wide and `since`-filtered, so it is a single paged request rather than
+    one per open issue. Ascending by creation date, so two `/focus` commands in
+    the same window are replayed in the order they were typed and the later one
+    wins — which is what would have happened had both webhooks arrived.
+    """
+    since = (now or datetime.now(timezone.utc)) - timedelta(days=REPLAY_WINDOW_DAYS)
+
+    return (f"/issues/comments?since={since.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            "&per_page=100&sort=created&direction=asc")
+
+
+class CollectedRender:
+    """Stands in for the dashboard render while comments are being replayed.
+
+    `run_comment_event.run` re-renders after its own label writes, which is
+    right for one webhook and wrong for a sweep: six replayed commands would
+    publish six boards, five of them describing a half-finished sweep. So the
+    replay records what each command wanted and the sweep renders once, at the
+    end, with the last override to arrive.
+    """
+
+    def __init__(self) -> None:
+        self.focus = None
+        self.cap = None
+        self.wanted = False
+
+    def __call__(self, focus_override=None, cap_override=None) -> None:
+        self.wanted = True
+        if focus_override is not None:
+            self.focus = focus_override
+        if cap_override is not None:
+            self.cap = cap_override
+
+
+def _issue_number(comment: dict):
+    match = _ISSUE_URL_NUMBER.search((comment.get("issue_url") or "").split("?")[0])
+    return int(match.group(1)) if match else None
+
+
+def _as_event(issue: dict, comment: dict) -> dict:
+    """The snapshot issue plus one raw comment, in webhook shape.
+
+    `fetch_comment_event.build` reads GitHub's JSON, so the replay hands it
+    GitHub's JSON rather than teaching it a second shape to understand.
+    """
+    return {
+        "issue": {
+            "number": issue["number"],
+            "labels": [{"name": name} for name in issue.get("labels") or []],
+            "body": issue.get("body") or "",
+            "milestone": {"title": issue["milestone"]} if issue.get("milestone") else None,
+        },
+        "comment": comment,
+    }
+
+
+def replay_comments(api, state, owner, render, fire=None) -> tuple[list, list]:
+    """Re-apply comment commands the comment workflow never saw.
+
+    `gatekeeper-comment` fires on `issue_comment: created`. A dropped delivery,
+    a workflow that fails to start, a run cancelled mid-flight — and the command
+    is simply lost: Derek types `/approve`, nothing happens, and nothing
+    anywhere reports that nothing happened.
+
+    **Every command goes back through `run_comment_event.run`**, the same
+    function the live workflow calls, so the gates, the owner re-check, the
+    acknowledgement and above all the watermark rule are inherited rather than
+    re-derived. That rule — a failed reaction lookup counts as *already*
+    watermarked — is what keeps the failure direction safe, and a second
+    implementation that got it backwards would re-apply every command in the
+    window on every sweep, six times a day, forever.
+
+    Returns the issues whose commands applied, and the issues whose replay
+    raised.
+    """
+    if not owner:
+        # An empty owner would match an empty author, and nothing here could be
+        # attributed to Derek anyway. Skip rather than guess.
+        return [], []
+
+    open_issues = {
+        issue["number"]: issue
+        for issue in state.get("issues") or []
+        if issue.get("state", "open") == "open"
+    }
+
+    replayed: list = []
+    failed: list = []
+
+    for raw in state.get("recent_comments") or []:
+        issue = open_issues.get(_issue_number(raw))
+        if issue is None:
+            # A closed issue, a pull request, or something the snapshot does
+            # not have. `/issues/comments` is repo-wide and returns all three.
+            continue
+
+        try:
+            result = run_comment_event.run(
+                _as_event(issue, raw), api, owner, rerender=render, fire=fire)
+        except Exception:  # noqa: BLE001 - one comment, not the whole sweep
+            # Reconcile is the backstop for the entire board. Losing it because
+            # one comment blew up would trade a missed command for a missed
+            # sweep, which is the more expensive of the two.
+            failed.append(issue["number"])
+            continue
+
+        # Back onto the snapshot, before reconcile reads it. Reconcile derives
+        # its fixes from `issue["labels"]`, so a stale list here has it "fix"
+        # the state the command just set — silently undoing the very command
+        # the replay existed to honour, and reporting a success while doing it.
+        if result.labels is not None:
+            issue["labels"] = list(result.labels)
+
+        if result.applied:
+            replayed.append(issue["number"])
+
+    return replayed, failed
 
 
 def apply_revisits(api, issues, snapshot, fire=None) -> list:
@@ -96,10 +238,11 @@ def apply_fixes(api, findings, issues, fire=None) -> list:
 
 
 def run(state: dict, api, events_only: bool = False, rerender=None,
-        fire=None) -> dict:
+        fire=None, owner=None) -> dict:
     """One sweep. Returns what it did, for the workflow log."""
     issues = state.get("issues") or []
     snapshot = state.get("snapshot") or {}
+    owner = owner if owner is not None else state.get("owner")
 
     # **At most one fire per issue per sweep.** A revisit wakes an issue into
     # `ai-triage` without updating the in-memory copy reconcile then reads, so
@@ -114,6 +257,18 @@ def run(state: dict, api, events_only: bool = False, rerender=None,
         already_fired.add(number)
         sink(number)
 
+    # First, and cron-only. First because everything after it reasons about
+    # `issue["labels"]`, and a replayed command is the newest thing anyone said
+    # about that issue; cron-only because of the race described at the top of
+    # this file.
+    collected = CollectedRender()
+    replayed: list = []
+    replay_errors: list = []
+
+    if not events_only:
+        replayed, replay_errors = replay_comments(
+            api, state, owner, collected, fire=fire_once)
+
     woken = apply_revisits(api, issues, snapshot, fire=fire_once)
 
     findings = reconcile.process({
@@ -126,21 +281,23 @@ def run(state: dict, api, events_only: bool = False, rerender=None,
 
     fixed = apply_fixes(api, findings, issues, fire=fire_once)
 
-    # Once, at the end. The board should describe the state the sweep left
-    # behind, not one of the states it passed through.
-    if woken or fixed:
+    # Once, at the end, for the whole sweep — replay included. The board should
+    # describe the state the sweep left behind, not one of the states it passed
+    # through.
+    if woken or fixed or collected.wanted:
         rerender = rerender or (lambda **kwargs: rerender_dashboard(api, **kwargs))
-        rerender()
+        rerender(focus_override=collected.focus, cap_override=collected.cap)
 
-    return {"woken": woken, "fixed": fixed, "findings": findings}
+    return {"replayed": replayed, "replay_errors": replay_errors,
+            "woken": woken, "fixed": fixed, "findings": findings}
 
 
 def fetch_state(api, focus=None) -> dict:  # pragma: no cover - network shape
     """Build the sweep's snapshot from the API.
 
-    Separate from the dashboard's fetch because the sweep needs three things
-    the renderer does not: open PRs, recent merged commits on `main`, and the
-    state of every issue named as a blocker.
+    Separate from the dashboard's fetch because the sweep needs four things the
+    renderer does not: open PRs, recent merged commits on `main`, the state of
+    every issue named as a blocker, and the recent comments to replay.
     """
     from _github_api import paged  # noqa: PLC0415
 
@@ -183,6 +340,10 @@ def fetch_state(api, focus=None) -> dict:  # pragma: no cover - network shape
             {"body": c.get("commit", {}).get("message", "")}
             for c in api("GET", "/commits?sha=main&per_page=100") or []
         ],
+        # The replay's candidates: one repo-wide, `since`-filtered, paged call
+        # rather than one request per open issue. Raw, exactly as GitHub
+        # returned them, because `fetch_comment_event.build` reads that shape.
+        "recent_comments": get_all(comments_query()),
         # Every issue's own record doubles as the blocker snapshot.
         "snapshot": by_number,
         "focus": focus,
@@ -197,9 +358,12 @@ def _blocked_by(api, number) -> list:  # pragma: no cover - network shape
     return [edge["number"] for edge in edges if isinstance(edge.get("number"), int)]
 
 
-def _comments(api, number) -> list:  # pragma: no cover - network shape
+def _comments(api, number) -> list:
+    # `id` is carried because the watermark is keyed on it — dropping it here
+    # left the sweep holding comments it could not have claimed.
     return [
-        {"body": c.get("body") or "",
+        {"id": c.get("id"),
+         "body": c.get("body") or "",
          "author": (c.get("user") or {}).get("login", ""),
          "created_at": c.get("created_at", "")}
         for c in api("GET", f"/issues/{number}/comments?per_page=100") or []
@@ -220,10 +384,17 @@ def main(argv=None) -> int:  # pragma: no cover - the workflow entry point
     else:
         state = json.load(sys.stdin)
 
-    result = run(state, api, events_only="--events-only" in argv)
+    result = run(state, api, events_only="--events-only" in argv,
+                 owner=os.environ.get("PIPELINE_OWNER", ""))
 
-    print(f"woke {len(result['woken'])}, fixed {len(result['fixed'])}, "
+    print(f"replayed {len(result['replayed'])} "
+          f"({len(result['replay_errors'])} failed), "
+          f"woke {len(result['woken'])}, fixed {len(result['fixed'])}, "
           f"flagged {sum(1 for f in result['findings'] if f['action'] == 'flag')}")
+
+    for number in result["replay_errors"]:
+        print(f"  replay of a comment on #{number} raised — see the run log")
+
     return 0
 
 

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
@@ -147,6 +147,32 @@ class WatermarkTests(unittest.TestCase):
         self.assertFalse(result.applied)
 
 
+class ResultingLabelsTests(unittest.TestCase):
+    """The sweep's replay writes these back onto its in-memory snapshot.
+
+    Reconcile runs next and derives its fixes from that snapshot, so a replay
+    that could not report the labels it left behind would have reconcile "fix"
+    the state the command just set.
+    """
+
+    def test_an_applied_command_reports_the_labels_it_left(self):
+        result = runner.run(event(), RecordingApi(), owner=OWNER,
+                            rerender=lambda **kw: None)
+        self.assertEqual(result.labels, ["ready-for-work"])
+
+    def test_a_refused_command_reports_no_labels_at_all(self):
+        """Not "the labels unchanged" — nothing, so the caller leaves its own
+        copy alone rather than overwriting it with a guess."""
+        api = RecordingApi(reactions=[
+            {"content": "eyes", "user": {"login": "github-actions[bot]"}}])
+        result = runner.run(event(), api, owner=OWNER, rerender=lambda **kw: None)
+        self.assertIsNone(result.labels)
+
+    def test_a_stranger_reports_no_labels(self):
+        result = runner.run(event(author="a-stranger"), RecordingApi(), owner=OWNER)
+        self.assertIsNone(result.labels)
+
+
 class ReactiveTriageTests(unittest.TestCase):
     """The fire is wired in, not merely implemented.
 

--- a/.claude/skills/pipeline-gatekeeper/tests/test_sweep_replay.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_sweep_replay.py
@@ -1,0 +1,323 @@
+"""Tests for the sweep's replay of comment commands the webhook never delivered.
+
+`gatekeeper-comment` fires on `issue_comment: created`. When that delivery is
+dropped the command is lost silently. The replay is the second pass the 👀
+watermark was designed for, so the tests that matter here are the ones about
+*not* acting twice.
+"""
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import run_sweep  # noqa: E402
+
+OWNER = "derekwinters"
+BOT = "github-actions[bot]"
+
+# What `reconcile.has_analysis` recognises as "triage analyzed this". Present on
+# every issue in these tests so `requeue_triage` — which is about un-analyzed
+# issues, not about the replay — stays out of the way.
+ANALYSIS = {"body": "## Build checklist\n\n- [ ] x", "author": BOT,
+            "created_at": "2026-08-08T10:00:00Z"}
+
+
+class RecordingApi:
+    """Records every call, answers the reads the replay makes."""
+
+    def __init__(self, reactions=None, reactions_raise=False, raise_on=None):
+        self.calls = []
+        self._reactions = reactions or {}
+        self._reactions_raise = reactions_raise
+        self._raise_on = raise_on or ()
+
+    def __call__(self, method, path, body=None):
+        self.calls.append((method, path, body))
+
+        for method_fragment, path_fragment in self._raise_on:
+            if method == method_fragment and path_fragment in path:
+                raise RuntimeError("the API said no")
+
+        if path.endswith("/reactions") and method == "GET":
+            if self._reactions_raise:
+                raise RuntimeError("reactions are unreadable")
+            comment_id = int(path.split("/issues/comments/")[1].split("/")[0])
+            return self._reactions.get(comment_id, [])
+        if path.endswith("/blocked_by"):
+            return []
+        return {}
+
+    @property
+    def label_writes(self):
+        return [(p, b) for m, p, b in self.calls if m == "PUT" and p.endswith("/labels")]
+
+    @property
+    def posted_comments(self):
+        return [b for m, p, b in self.calls
+                if m == "POST" and p.endswith("/comments")]
+
+    @property
+    def watermarks(self):
+        return [p for m, p, _ in self.calls
+                if m == "POST" and p.endswith("/reactions")]
+
+
+def issue(number=10, state="open", labels=("pending-approval",), body="",
+          milestone="v0.0.1", comments=(ANALYSIS,)):
+    return {
+        "number": number, "state": state, "labels": list(labels), "body": body,
+        "milestone": milestone, "native_blockers": [], "comments": list(comments),
+    }
+
+
+def raw_comment(identifier=999, body="/approve", author=OWNER, on=10,
+                kind="User"):
+    """A comment as `/issues/comments` returns it, not as the snapshot holds it."""
+    return {
+        "id": identifier,
+        "body": body,
+        "user": {"login": author, "type": kind},
+        "issue_url": f"https://api.github.com/repos/derekwinters/frogs/issues/{on}",
+        "created_at": "2026-08-09T09:00:00Z",
+    }
+
+
+def state(issues, comments=()):
+    return {"issues": list(issues), "recent_comments": list(comments),
+            "focus": "v0.0.1"}
+
+
+def sweep(api, issues, comments=(), **kwargs):
+    kwargs.setdefault("owner", OWNER)
+    kwargs.setdefault("rerender", lambda **kw: None)
+    return run_sweep.run(state(issues, comments), api, **kwargs)
+
+
+class ReplayTests(unittest.TestCase):
+    def test_an_owner_command_in_the_window_is_applied(self):
+        api = RecordingApi()
+        result = sweep(api, [issue()], [raw_comment()])
+
+        self.assertEqual(result["replayed"], [10])
+        self.assertEqual(api.label_writes,
+                         [("/issues/10/labels", {"labels": ["ready-for-work"]})])
+
+    def test_the_replay_acknowledges_exactly_as_the_live_path_does(self):
+        api = RecordingApi()
+        sweep(api, [issue()], [raw_comment()])
+
+        self.assertEqual(len(api.posted_comments), 1)
+        self.assertIn("`/approve`", api.posted_comments[0]["body"])
+
+    def test_a_replayed_command_leaves_the_eyes(self):
+        api = RecordingApi()
+        sweep(api, [issue()], [raw_comment()])
+        self.assertEqual(api.watermarks, ["/issues/comments/999/reactions"])
+
+    def test_the_event_pass_replays_nothing(self):
+        """The event path fires on `issues: [labeled]`, and an applied command
+        changes a label — so replaying there would race `gatekeeper-comment`
+        applying the very same comment, in a different concurrency group."""
+        api = RecordingApi()
+        result = sweep(api, [issue()], [raw_comment()], events_only=True)
+
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+        self.assertEqual(api.posted_comments, [])
+
+
+class IdempotencyTests(unittest.TestCase):
+    """The whole risk. A replay that mis-reads the watermark re-applies every
+    command it finds, six times a day, forever."""
+
+    def test_a_watermarked_comment_is_not_replayed(self):
+        api = RecordingApi(reactions={999: [{"content": "eyes",
+                                             "user": {"login": BOT}}]})
+        result = sweep(api, [issue()], [raw_comment()])
+
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+        self.assertEqual(api.posted_comments, [])
+        self.assertEqual(api.watermarks, [])
+
+    def test_a_humans_eyes_do_not_count_as_the_watermark(self):
+        api = RecordingApi(reactions={999: [{"content": "eyes",
+                                             "user": {"login": "a-passer-by"}}]})
+        self.assertEqual(sweep(api, [issue()], [raw_comment()])["replayed"], [10])
+
+    def test_an_unreadable_reaction_lookup_counts_as_watermarked(self):
+        """Unknown is not "unclaimed" — the safe direction is to skip."""
+        api = RecordingApi(reactions_raise=True)
+        result = sweep(api, [issue()], [raw_comment()])
+
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+        self.assertEqual(api.watermarks, [])
+
+
+class ScopeTests(unittest.TestCase):
+    def test_a_comment_on_a_closed_issue_is_ignored(self):
+        api = RecordingApi()
+        result = sweep(api, [issue(state="closed", labels=())],
+                       [raw_comment()])
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.posted_comments, [])
+
+    def test_a_comment_on_an_issue_outside_the_snapshot_is_ignored(self):
+        api = RecordingApi()
+        result = sweep(api, [issue(10)], [raw_comment(on=4242)])
+        self.assertEqual(result["replayed"], [])
+
+    def test_a_strangers_command_is_refused_and_not_watermarked(self):
+        """Reacting to it would itself be letting a stranger make the bot act."""
+        api = RecordingApi()
+        result = sweep(api, [issue()], [raw_comment(author="a-stranger")])
+
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+        self.assertEqual(api.watermarks, [])
+
+    def test_a_bot_comment_is_ignored(self):
+        api = RecordingApi()
+        result = sweep(api, [issue()], [raw_comment(author=BOT, kind="Bot")])
+        self.assertEqual(result["replayed"], [])
+
+    def test_without_a_configured_owner_nothing_is_replayed(self):
+        api = RecordingApi()
+        result = sweep(api, [issue()], [raw_comment()], owner="")
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+
+
+class SnapshotWriteBackTests(unittest.TestCase):
+    def test_reconcile_does_not_revert_a_just_replayed_command(self):
+        """Reconcile derives its fixes from `issue["labels"]`. Read stale, it
+        "fixes" the state the replayed command just set — undoing the command
+        it was replayed to honour, and reporting a success while doing it."""
+        api = RecordingApi()
+        result = sweep(api, [issue(labels=("in-progress",))],
+                       [raw_comment(body="/park")])
+
+        self.assertEqual(result["replayed"], [10])
+        self.assertEqual(api.label_writes,
+                         [("/issues/10/labels", {"labels": ["parked"]})])
+        self.assertEqual([f["kind"] for f in result["findings"]
+                          if f["action"] == "auto-fix"], [])
+
+    def test_a_refused_command_leaves_the_snapshot_alone(self):
+        """`/focus` off the dashboard is refused, so reconcile must still see
+        the labels the issue really has."""
+        api = RecordingApi()
+        board = state([issue(labels=("pending-approval",))],
+                      [raw_comment(body="/focus v0.0.2")])
+
+        result = run_sweep.run(board, api, owner=OWNER, rerender=lambda **kw: None)
+
+        self.assertEqual(result["replayed"], [])
+        self.assertEqual(api.label_writes, [])
+        self.assertIn("not applied", api.posted_comments[0]["body"])
+        self.assertEqual(board["issues"][0]["labels"], ["pending-approval"])
+
+
+class RenderTests(unittest.TestCase):
+    def test_two_replayed_commands_render_the_board_once(self):
+        """`run_comment_event` renders after its own writes, which is right for
+        one webhook and wrong for a sweep — six replays would publish six
+        boards, five of them describing a half-finished sweep."""
+        renders = []
+        api = RecordingApi()
+
+        run_sweep.run(
+            state([issue(10), issue(11)],
+                  [raw_comment(999, on=10), raw_comment(1000, on=11)]),
+            api, owner=OWNER, rerender=lambda **kw: renders.append(kw))
+
+        self.assertEqual(len(renders), 1)
+
+    def test_the_last_focus_override_wins(self):
+        """What would have happened had both webhooks arrived in order."""
+        renders = []
+        api = RecordingApi()
+        board = issue(20, labels=("dashboard",), comments=())
+
+        run_sweep.run(
+            state([board],
+                  [raw_comment(1, body="/focus v0.0.1", on=20),
+                   raw_comment(2, body="/focus v0.0.2", on=20)]),
+            api, owner=OWNER, rerender=lambda **kw: renders.append(kw))
+
+        self.assertEqual(len(renders), 1)
+        self.assertEqual(renders[0].get("focus_override"), "v0.0.2")
+
+    def test_a_sweep_that_replayed_nothing_still_does_not_render(self):
+        renders = []
+        run_sweep.run(state([issue(10, labels=("ai-triage",), comments=())], []),
+                      RecordingApi(), owner=OWNER,
+                      rerender=lambda **kw: renders.append(kw))
+        self.assertEqual(renders, [])
+
+
+class ReactiveTriageTests(unittest.TestCase):
+    def test_a_replayed_admit_fires_triage(self):
+        fired = []
+        sweep(RecordingApi(), [issue(labels=(), comments=())],
+              [raw_comment(body="/admit")], fire=fired.append)
+        self.assertEqual(fired, [10])
+
+    def test_a_replayed_approve_does_not(self):
+        fired = []
+        sweep(RecordingApi(), [issue()], [raw_comment()], fire=fired.append)
+        self.assertEqual(fired, [])
+
+
+class ResilienceTests(unittest.TestCase):
+    def test_one_failing_comment_does_not_take_the_rest_of_the_sweep_with_it(self):
+        """Reconcile is the backstop for the whole board. Losing it because one
+        comment blew up would trade a missed command for a missed sweep."""
+        api = RecordingApi(raise_on=[("PUT", "/issues/10/labels")])
+        result = sweep(api, [issue(10), issue(11)],
+                       [raw_comment(999, on=10), raw_comment(1000, on=11)])
+
+        self.assertEqual(result["replay_errors"], [10])
+        self.assertEqual(result["replayed"], [11])
+        self.assertIn("/issues/11/labels", [p for p, _ in api.label_writes])
+
+
+class WindowTests(unittest.TestCase):
+    def test_the_window_is_a_named_constant(self):
+        self.assertIsInstance(run_sweep.REPLAY_WINDOW_DAYS, int)
+        self.assertGreater(run_sweep.REPLAY_WINDOW_DAYS, 0)
+
+    def test_the_query_asks_only_for_comments_inside_the_window(self):
+        now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+        since = (now - timedelta(days=run_sweep.REPLAY_WINDOW_DAYS))
+
+        query = run_sweep.comments_query(now)
+
+        self.assertTrue(query.startswith("/issues/comments?"), query)
+        self.assertIn(f"since={since.strftime('%Y-%m-%dT%H:%M:%SZ')}", query)
+        self.assertIn("per_page=100", query)
+
+    def test_the_query_is_ascending_so_the_later_command_lands_later(self):
+        self.assertIn("direction=asc", run_sweep.comments_query())
+
+    def test_the_candidates_come_from_that_one_repo_wide_call(self):
+        source = (Path(__file__).resolve().parents[1] / "run_sweep.py").read_text()
+        self.assertIn("get_all(comments_query())", source)
+
+
+class CommentIdTests(unittest.TestCase):
+    def test_the_per_issue_comments_carry_the_id(self):
+        """The watermark is keyed on it."""
+        def api(method, path, body=None):
+            return [{"id": 7, "body": "x", "user": {"login": OWNER},
+                     "created_at": "2026-08-01T00:00:00Z"}]
+
+        self.assertEqual(run_sweep._comments(api, 10)[0]["id"], 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/gatekeeper-sweep.yml
+++ b/.github/workflows/gatekeeper-sweep.yml
@@ -1,13 +1,26 @@
 name: gatekeeper-sweep
 
-# The board-wide sweep: wake issues whose blockers cleared, and fix drift.
+# The board-wide sweep: replay missed comment commands, wake issues whose
+# blockers cleared, and fix drift.
 #
 # Two paths, and the difference between them is the whole design:
 #
 #   event path   — runs on the events that can actually change the board.
 #                  `strip_labels` only.
 #   cron path    — every six hours, plus manual dispatch. Everything, including
-#                  the two requeue fixes.
+#                  the comment replay and the two requeue fixes.
+#
+# WHY THE COMMENT REPLAY IS CRON-ONLY
+#
+# `gatekeeper-comment` can lose a command outright — a webhook never delivered,
+# a workflow that fails to start — so the cron re-reads the last week of
+# comments and re-applies anything not already carrying the bot's 👀.
+#
+# It cannot run on the event path, because this workflow triggers on
+# `issues: [labeled]` and an applied command CHANGES A LABEL. The replay would
+# wake up and re-apply the very comment `gatekeeper-comment` is applying at
+# that moment, and nothing serialises them — the two workflows are in different
+# concurrency groups.
 #
 # WHY `requeue` AND `requeue_triage` ARE CRON-ONLY
 #
@@ -79,9 +92,9 @@ jobs:
           # not the cron or a deliberate dispatch takes the event path.
           if [ "${{ github.event_name }}" = "schedule" ] \
             || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Cron path — all fixes, including requeue."
+            echo "Cron path — comment replay and all fixes, including requeue."
             python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --fetch
           else
-            echo "Event path — strip_labels only."
+            echo "Event path — strip_labels only, no replay."
             python3 .claude/skills/pipeline-gatekeeper/run_sweep.py --fetch --events-only
           fi

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -686,7 +686,7 @@ does; this is where the workflows live.
 | Workflow | Trigger | Does |
 | --- | --- | --- |
 | `gatekeeper-comment` | issue comment created | parses commands (`/approve`, `/park`, …), applies label changes, acknowledges with a reaction |
-| `gatekeeper-sweep` | issue/PR events, 6-hourly cron, dispatch | auto-revisits blockers that have cleared, and applies reconcile's fixes |
+| `gatekeeper-sweep` | issue/PR events, 6-hourly cron, dispatch | replays comment commands the comment workflow missed, auto-revisits blockers that have cleared, and applies reconcile's fixes |
 | `dashboard` | human label changes, daily schedules, dispatch | rewrites the live dashboard issue |
 | `pipeline-tests` | PR/push touching the pipeline skills | runs the pipeline scripts' own unit tests |
 
@@ -723,12 +723,23 @@ Runs on the events that can actually change the board picture — an issue
 closed or labelled, a PR closed — plus a six-hourly cron and manual dispatch.
 
 **Two paths, and the difference is the point.** The event path applies
-`strip_labels` only. The cron path applies everything, including reconcile's
-two requeue fixes.
+`strip_labels` only. The cron path applies everything: the comment replay, and
+reconcile's two requeue fixes.
 
-Those two are cron-only because **the drift they detect is indistinguishable
-from work in flight**. An issue the builder picked up ten seconds ago has
-`in-progress` and no PR yet — exactly a stall's shape — and requeuing it on the
+**The comment replay is cron-path only, and for a different reason from the
+other two.** `gatekeeper-comment` can lose a command outright — a webhook that
+is never delivered, a workflow that fails to start — so the cron re-reads the
+last week of comments and re-applies anything not already carrying the bot's
+👀. It cannot run on the event path, because this workflow's event triggers
+include `issues: [labeled]` and an applied command *changes a label*: the
+replay would wake up and re-apply the very comment `gatekeeper-comment` is
+applying at that moment. The two are in different concurrency groups, so
+nothing serialises them. See
+[Issue pipeline](issue-pipeline.md#replaying-the-comments-the-webhook-lost).
+
+The two requeue fixes are cron-only because **the drift they detect is
+indistinguishable from work in flight**. An issue the builder picked up ten
+seconds ago has `in-progress` and no PR yet — exactly a stall's shape — and requeuing it on the
 event path would yank the issue out from under a running agent. Triage's
 comment-before-label ordering creates the mirror-image window for
 `requeue_triage`. By the six-hourly run those transients have resolved.

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -196,6 +196,82 @@ dependency lookup in particular does not lose the event: the command is
 probably `/park`, which does not care, and the gates that *do* care see a
 smaller blocker list and refuse — which is the safe direction.
 
+## Replaying the comments the webhook lost
+
+`gatekeeper-comment` fires on `issue_comment: created`. When that delivery is
+dropped — a webhook that never arrives, a workflow that fails to start, a run
+cancelled mid-flight — the command is simply gone. Derek types `/approve`,
+nothing happens, and **nothing anywhere reports that nothing happened.**
+
+So the sweep re-reads recent comments and feeds anything unclaimed back through
+the ordinary path. This is the second pass the 👀 watermark was designed for.
+
+Four properties, and every one of them is load-bearing:
+
+- **It reuses `run_comment_event.run`, the same function the live workflow
+  calls.** Not a second implementation of parse → gate → apply. The owner
+  re-check, the gates, the acknowledgement wording and above all the watermark
+  rule are *inherited* rather than re-derived — and a second copy that got the
+  watermark's failure direction backwards would re-apply every command in the
+  window on every sweep, six times a day, forever.
+- **It is cron-path only.** See below.
+- **The window is bounded** — seven days, `REPLAY_WINDOW_DAYS` in
+  `run_sweep.py`, gathered by one repo-wide `since`-filtered call rather than
+  one request per open issue. Seven days is far more than the six-hourly cron
+  needs for a single dropped webhook; the width is there for a multi-day
+  Actions outage, and costs nothing because re-reading a claimed comment is a
+  no-op. It is bounded rather than unlimited because an unbounded scan of the
+  whole comment history is both slow and a far larger surface for a watermark
+  bug to act on.
+- **A replayed command updates the sweep's own snapshot** before reconcile
+  reads it, and the board is re-rendered **once**, at the end of the sweep.
+
+### Why the replay is cron-only
+
+`gatekeeper-sweep` has two triggers, and on the event path one of them is
+`issues: [labeled]`. An applied command *changes a label*. So an event-path
+replay would wake this workflow up to re-apply the very comment
+`gatekeeper-comment` is applying at that moment — and nothing serialises the
+two, because they are in different concurrency groups.
+
+The six-hourly cron has no such relationship to the comment workflow, which is
+why the replay lives there, alongside reconcile's two cron-only fixes.
+
+### Why the replay writes its labels back
+
+Reconcile runs after the replay, and derives its fixes from the labels on the
+sweep's in-memory snapshot. If the replay moved an issue from `in-progress` to
+`parked` and reconcile then read the pre-replay list, it would see an
+`in-progress` issue with no open PR, call it a stall, and requeue it to
+`ready-for-work` — **silently undoing the command it was replayed to honour**,
+and reporting a successful auto-fix while doing it.
+
+So `run_comment_event.Result` carries the label set the command left behind,
+and the replay writes it onto the snapshot issue. A refused command reports no
+labels at all, rather than "the labels unchanged", so the snapshot is left
+exactly as it was instead of being overwritten with a guess.
+
+### One render, last override wins
+
+`run_comment_event.run` re-renders the dashboard itself, which is right for one
+webhook and wrong for a sweep: six replayed commands would publish six boards,
+five of them describing a half-finished sweep. The replay hands it a collector
+instead, and the sweep renders once at the end.
+
+If two replayed comments both set a `/focus`, **the later one wins** — the
+candidates are fetched oldest-first for exactly that reason. Refusing both as
+ambiguous was the alternative; last-wins is what would have happened had the
+webhooks arrived normally, and matching the undropped case is the less
+surprising rule.
+
+### When a replay raises
+
+One malformed comment does not take the sweep down with it. The failure is
+counted, named in the workflow log, and the sweep carries on — reconcile is the
+backstop for the entire board, and losing it because a single comment blew up
+trades a missed command for a missed sweep, which is the more expensive of the
+two.
+
 ## The approval gates
 
 Both gates **refuse and explain**. Neither ever fixes the problem itself.
@@ -434,7 +510,7 @@ to normalise and hope.
 | Runs | When | Does |
 | --- | --- | --- |
 | `gatekeeper-comment` workflow | on `issue_comment` created | parse and apply commands, immediately |
-| `gatekeeper-sweep` workflow | every 15 minutes | catch missed comments; auto-revisit cleared blockers |
+| `gatekeeper-sweep` workflow | issue/PR events, and a six-hourly cron | auto-revisit cleared blockers, apply reconcile's fixes; on the cron, also replay missed comments |
 | `pipeline-analysis` routine | nightly, 02:00 UTC | triage everything untriaged |
 | reactive triage | fired on demand by the gatekeeper | triage one issue, now |
 | `pipeline-dev` routine | nightly, 03:00 UTC | build and work the ready queue |
@@ -743,13 +819,15 @@ thin modules wire those pieces to GitHub:
 | --- | --- |
 | `_github_api.py` | REST helpers, and the shared dashboard re-render |
 | `run_comment_event.py` | one `issue_comment` event, end to end |
-| `run_sweep.py` | the board-wide revisit + reconcile pass |
+| `run_sweep.py` | the board-wide replay + revisit + reconcile pass |
 
 `run_comment_event.py` is: snapshot → parse → gate → apply → write labels, ack,
 and reaction → **re-render the dashboard once, after every label write.**
 Rendering in between would publish a board describing a half-applied command.
 `run_sweep.py` re-renders once at the end for the same reason, and takes
-`--events-only` to drop reconcile's two cron-only fixes on the 15-minute pass.
+`--events-only` to drop the comment replay and reconcile's two cron-only fixes
+on the **event path**. That flag names the trigger, not a clock: both paths run
+the same script, and the cron is six-hourly.
 
 **Authentication is `GITHUB_TOKEN`, never a PAT.** The workflow token is scoped
 to this repository and expires with the job; a personal access token would
@@ -769,12 +847,19 @@ rehearsing a sweep possible without waiting for a trigger:
 | Entry point | Expects on stdin |
 | --- | --- |
 | `run_comment_event.py` | an `issue_comment` webhook payload |
-| `run_sweep.py` | a state snapshot — issues, pulls, merged commits, focus |
+| `run_sweep.py` | a state snapshot — issues, pulls, merged commits, recent comments, focus |
 
-`run_sweep.py --events-only` simulates the fifteen-minute pass by dropping
-reconcile's two cron-only fixes. Running it *without* that flag outside the
-nightly window will requeue whatever the builder currently has in flight, which
-is the one way to do real damage with these scripts by hand.
+`run_sweep.py --events-only` simulates the **event path** by dropping the
+comment replay and reconcile's two cron-only fixes. Running it *without* that
+flag outside the nightly window will requeue whatever the builder currently has
+in flight, which is the one way to do real damage with these scripts by hand.
+
+The rehearsal snapshot's `recent_comments` are raw `/issues/comments` items,
+exactly as GitHub returns them — the replay hands them to the same
+`fetch_comment_event.build` the live path uses, so it must be given the same
+shape rather than a second one. `PIPELINE_OWNER` names the account whose
+comments count; without it the replay does nothing at all, because an empty
+owner would match an empty author.
 
 ### Applying an action
 


### PR DESCRIPTION
Closes #161

When you type `/approve` on an issue, a workflow wakes up and applies it. If GitHub drops that notification — it happens: a webhook that never arrives, a workflow that fails to start, a run cancelled halfway — the command is simply lost. Nothing retries it, and nothing anywhere tells you it went missing. You just come back later and find the issue sitting exactly where you left it.

The board-wide sweep already runs every six hours. It now also re-reads the last week of comments and re-applies anything the comment workflow never got to. It is safe to run over and over because an applied comment carries the bot's 👀 and is skipped on sight — which is what that 👀 was put there for in the first place.

**Docs:** `docs/engineering/issue-pipeline.md` — new "Replaying the comments the webhook lost" section (why it is cron-only, why the window is bounded, why the replay writes its labels back, one-render/last-wins), and its "every 15 minutes" / "the fifteen-minute pass" claims corrected to the six-hourly cron and the event path. `docs/engineering/ci-cd.md` — the `gatekeeper-sweep` section now names the replay as a cron-path-only step, with the race against `gatekeeper-comment` as the reason.

## Spec invariants this had to keep true

| Invariant (from `/docs`) | How it is held | Test |
| --- | --- | --- |
| A watermarked comment is never re-applied | the replay calls `run_comment_event.run`, which returns `"already applied"` before touching anything | `IdempotencyTests.test_a_watermarked_comment_is_not_replayed` |
| An unreadable reactions lookup counts as **already** watermarked | inherited from the same function, not re-derived | `test_an_unreadable_reaction_lookup_counts_as_watermarked` |
| Only the bot's own 👀 counts | ditto | `test_a_humans_eyes_do_not_count_as_the_watermark` |
| Only the owner's comments are honoured, and a stranger's is **not** watermarked | ditto | `ScopeTests.test_a_strangers_command_is_refused_and_not_watermarked` |
| Reactive triage fires only when `ai-triage` is newly present, at most once per issue per sweep | the replay shares the sweep's existing `fire_once` sink | `ReactiveTriageTests` |
| The board is re-rendered **once**, after all label writes | `run_comment_event`'s render is collected, not performed | `RenderTests.test_two_replayed_commands_render_the_board_once` |
| Two requeue fixes stay cron-only | untouched; the replay joins them behind the same flag | `ReplayTests.test_the_event_pass_replays_nothing` |

## How the spec is changing

**Old rule:** `gatekeeper-sweep` runs "every 15 minutes" and `--events-only` is "the 15-minute pass".

**New rule:** the sweep runs on issue/PR events *and* a six-hourly cron; `--events-only` names the *event trigger*, not a clock.

**Why:** the old text was wrong on both counts and always has been — the workflow's cron is `17 */6 * * *`, and `ci-cd.md` and the workflow header already described it correctly. This is not a drive-by tidy. This change's central decision is "cron path, not event path", and that cannot be documented on top of a page describing the two paths as two different clocks.

**Old rule:** the sweep is a revisit + reconcile pass.

**New rule:** it is a replay + revisit + reconcile pass, and the replay runs first.

**Why:** reconcile derives its auto-fixes from the labels on the sweep's in-memory snapshot. If a replayed `/park` moved an issue off `in-progress` and reconcile then read the pre-replay list, it would see an `in-progress` issue with no open PR, call it a stall, and requeue it to `ready-for-work` — silently undoing the command it was replayed to honour, and logging a successful auto-fix while doing it. So `run_comment_event.Result` now carries the label set the command left behind, and the replay writes it onto the snapshot before reconcile reads it.

## Deviations and Decisions

- **A replay that raises is caught per comment, not per sweep.** Not on the issue's checklist. Feeding live comments through `run_comment_event.run` inside the sweep means a single malformed comment could take reconcile down with it, and reconcile is the backstop for the whole board — that trades a missed command for a missed sweep, which is worse. Failures are counted, returned as `replay_errors`, and named in the workflow log rather than swallowed. Tested (`ResilienceTests`).
- **Found a live bug on the comment path, and did not fix it here: #196.** `run_comment_event._apply_gates` reads `verdict.detail`, which `gates.Verdict` does not have — so *every* gate refusal raises instead of explaining itself. `/approve` with no milestone has never posted its refusal. It is unrelated to this change (it predates it, and is reachable from the live workflow today), it needs its own red test, and fixing it here would have made this PR close two issues. The per-comment guard above means it degrades to a log line rather than a dead sweep. One of my tests had to be rewritten to route around it, which is how it was found.
- **Also corrected the same "fifteen-minute" fiction in `.claude/skills/pipeline-gatekeeper/SKILL.md`**, and dropped its hardcoded test count, which had already gone stale twice. The issue named only the two docs pages, but leaving the skill file asserting a schedule the workflow does not have is the exact drift this repo treats as a bug.
- **Left `_github_api.set_milestone` and `fire_routine.py` alone**, as the triage comment asked — both noted there as out of scope.
- **The branch's remote head had already been deleted upstream**, so the push created it fresh rather than force-updating; nothing was clobbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYrHXJn6XAZh7DRfWmhdQz


---
_Generated by [Claude Code](https://claude.ai/code/session_01UYrHXJn6XAZh7DRfWmhdQz)_