### PR TITLE
fix(ci): drop package-name so release-please can tag releases

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -10,7 +10,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "multiplying-frogs",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {

--- a/.github/scripts/tests/test_release_please_config.py
+++ b/.github/scripts/tests/test_release_please_config.py
@@ -1,0 +1,179 @@
+"""The release-please config must stay component-free, in both halves at once.
+
+release-please decides whether a merged release PR may be tagged by comparing
+two things that are configured in different places:
+
+* the component it parses out of the release branch name
+  (`release-please--branches--main` → no component at all), and
+* `getBranchComponent()`, which is `component` if set, else a normalized
+  `package-name`.
+
+If those disagree, `buildRelease` logs `PR component: undefined does not match
+configured component: …` and returns without building anything. No tag, no
+release, no APK — and the run still reports success. Worse, release-please then
+refuses to open any *further* release PR while a merged-but-untagged one is
+outstanding, so one mismatched key stops every release, not just the one.
+
+This is a single root package with `separate-pull-requests: false`, so the
+branch never carries a component. Therefore nothing in the config may produce
+one. This test asserts both halves together, so they cannot drift apart again:
+declaring a component while the patterns interpolate none is the exact failure,
+and it is invisible in the config file itself.
+
+See docs/engineering/versioning.md and issue #205.
+"""
+
+import json
+import unittest
+from pathlib import Path
+
+CONFIG_PATH = (Path(__file__).resolve().parents[3]
+               / ".github" / "release-please" / "config.json")
+
+# Keys release-please turns into a branch component. `component` is used
+# directly; `package-name` is normalized into one when `component` is absent.
+COMPONENT_KEYS = ("component", "package-name")
+
+# The interpolation release-please expands into the component when writing a
+# branch name, a tag, or a PR title.
+COMPONENT_TOKEN = "${component}"
+
+
+def load_config():
+    return json.loads(CONFIG_PATH.read_text())
+
+
+def component_producing_keys(config):
+    """Every place in `config` that gives release-please a branch component.
+
+    Returned as `"<where>.<key>"` so a failure names the line to delete.
+    """
+    found = []
+
+    for key in COMPONENT_KEYS:
+        if config.get(key):
+            found.append(f"(root).{key}")
+
+    for name, package in (config.get("packages") or {}).items():
+        for key in COMPONENT_KEYS:
+            if package.get(key):
+                found.append(f"{name}.{key}")
+
+    if config.get("include-component-in-tag"):
+        found.append("(root).include-component-in-tag")
+
+    return sorted(found)
+
+
+def patterns_using_component(config, path="(root)"):
+    """Every string in `config` that interpolates `${component}`.
+
+    Recursive rather than a list of known pattern keys: release-please has
+    several (`pull-request-title-pattern`, its group variant, and more added
+    between versions), and a check that only knows today's names would quietly
+    stop seeing tomorrow's.
+    """
+    found = []
+
+    if isinstance(config, dict):
+        for key, value in config.items():
+            found.extend(patterns_using_component(value, f"{path}.{key}"))
+    elif isinstance(config, list):
+        for index, value in enumerate(config):
+            found.extend(patterns_using_component(value, f"{path}[{index}]"))
+    elif isinstance(config, str) and COMPONENT_TOKEN in config:
+        found.append(path)
+
+    return sorted(found)
+
+
+class RealConfigTests(unittest.TestCase):
+    """The config as it stands in this repo."""
+
+    def setUp(self):
+        self.config = load_config()
+
+    def test_the_root_package_is_configured(self):
+        """Guards against the rest of this suite passing on an empty config."""
+        self.assertIn(".", self.config.get("packages", {}))
+
+    def test_nothing_declares_a_component(self):
+        declared = component_producing_keys(self.config)
+
+        self.assertEqual(
+            declared, [],
+            "The release branch is `release-please--branches--main`, which "
+            "carries no component, so release-please will refuse to tag any "
+            f"release while these are set: {declared}.")
+
+    def test_no_pattern_interpolates_a_component(self):
+        self.assertEqual(patterns_using_component(self.config), [])
+
+    def test_the_two_halves_agree(self):
+        """The invariant. Either both sides have a component, or neither does."""
+        declared = component_producing_keys(self.config)
+        interpolated = patterns_using_component(self.config)
+
+        self.assertEqual(
+            bool(declared), bool(interpolated),
+            f"declared {declared} but interpolated {interpolated} — a config "
+            "that names a component the patterns never use is the shape that "
+            "silently stops every release from being tagged.")
+
+
+class ComponentDetectionTests(unittest.TestCase):
+    """The detectors see the bad shapes, so a clean result means something."""
+
+    def test_a_package_name_is_a_component(self):
+        config = {"packages": {".": {"package-name": "multiplying-frogs"}}}
+        self.assertEqual(component_producing_keys(config),
+                         ["..package-name"])
+
+    def test_an_explicit_component_is_a_component(self):
+        config = {"packages": {".": {"component": "frogs"}}}
+        self.assertEqual(component_producing_keys(config), ["..component"])
+
+    def test_a_root_level_key_counts_too(self):
+        self.assertEqual(component_producing_keys({"package-name": "frogs"}),
+                         ["(root).package-name"])
+
+    def test_include_component_in_tag_counts(self):
+        self.assertEqual(component_producing_keys(
+            {"include-component-in-tag": True}),
+            ["(root).include-component-in-tag"])
+
+    def test_an_empty_value_is_not_a_component(self):
+        config = {"packages": {".": {"package-name": ""}}}
+        self.assertEqual(component_producing_keys(config), [])
+
+    def test_a_clean_package_declares_nothing(self):
+        config = {"include-component-in-tag": False,
+                  "packages": {".": {"release-type": "simple"}}}
+        self.assertEqual(component_producing_keys(config), [])
+
+
+class PatternDetectionTests(unittest.TestCase):
+    def test_a_title_pattern_using_the_component_is_seen(self):
+        config = {"pull-request-title-pattern":
+                  "chore(${component}): release ${version}"}
+        self.assertEqual(patterns_using_component(config),
+                         ["(root).pull-request-title-pattern"])
+
+    def test_a_pattern_nested_in_a_package_is_seen(self):
+        config = {"packages": {".": {"tag-format": "${component}-v${version}"}}}
+        self.assertEqual(patterns_using_component(config),
+                         ["(root).packages...tag-format"])
+
+    def test_a_pattern_inside_a_list_is_seen(self):
+        config = {"extra-files": [{"path": "${component}/VERSION"}]}
+        self.assertEqual(patterns_using_component(config),
+                         ["(root).extra-files[0].path"])
+
+    def test_patterns_without_the_token_are_not_seen(self):
+        config = {"pull-request-title-pattern":
+                  "chore(${branch}): release ${version}"}
+        self.assertEqual(patterns_using_component(config), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -174,10 +174,60 @@ manifest-file: .github/release-please/manifest.json
   false`** — plain semver, as described above.
 - **`include-component-in-tag: false`** — one package, so tags are `v0.2.0`
   rather than `multiplying-frogs-v0.2.0`.
+- **No component, and no `package-name` either** — see below. This one is not a
+  preference; setting either stops every release from being tagged.
 - **The manifest** (`.github/release-please/manifest.json`) records the last
   released version per package — `{".": "0.0.1"}`. It is generated:
   release-please updates it in its own release PR, and a hand edit tells the
   tool it already released something it didn't.
+
+### The config carries no component — and must not
+
+This is one root package with `separate-pull-requests: false`, so release-please
+names the release branch `release-please--branches--main`, with no
+`--components--` suffix. **Nothing in the config may declare a component**, and
+that means no `component` key, no `package-name` key, and
+`include-component-in-tag` left `false`.
+
+The reason is a guard inside release-please's `buildRelease`. Before tagging a
+merged release PR it compares the component it parsed out of the branch name
+against the one the config declares:
+
+| | Source | Value here |
+| --- | --- | --- |
+| `branchName.component` | the release branch name | none |
+| `getBranchComponent()` | `component`, else a normalized `package-name` | whatever you set |
+
+If those two disagree it logs `PR component: undefined does not match
+configured component: …` and **returns without building the release**. The
+release PR merges, `/VERSION`, the manifest and `CHANGELOG.md` all update — and
+then there is no tag, no GitHub release, and no APK. The workflow reports
+success, because nothing failed; the release simply was not built.
+
+!!! danger "One wrong key wedges *all* releases, not just one"
+    release-please refuses to open or update a release PR while a merged but
+    untagged one is outstanding — `There are untagged, merged release PRs
+    outstanding - aborting`. So a mismatch does not cost you one release. It
+    costs you every release after it, until the config is fixed.
+
+    It does self-heal: tagging runs before that abort, so the first push to
+    `main` after the fix tags the outstanding release retroactively, at the
+    commit its PR was merged at. **Do not make the tag by hand** — a hand-made
+    tag with no matching release and no `autorelease: tagged` label leaves
+    release-please trying to release the same version again.
+
+`include-component-in-tag: false` does **not** rescue a stray `package-name`.
+That flag is only read when composing the tag; the branch guard calls
+`getBranchComponent()`, which never looks at it.
+
+`.github/scripts/tests/test_release_please_config.py` asserts both halves of
+this at once — that nothing declares a component, *and* that no branch, tag or
+title pattern interpolates `${component}` — so the two can never fall out of
+step again. It runs in the `scripts` suite:
+
+```bash
+python3 .github/scripts/run_python_tests.py scripts
+```
 
 ### The guard test
 


### PR DESCRIPTION
Closes #205

When we merged the 0.1.0 release PR, the version number moved but no tag, no
GitHub release and no APK ever appeared — and after that, release-please
stopped being able to open a release PR at all. The cause was one line of
config naming the package `multiplying-frogs`, which made release-please look
for that name in the release branch's name, not find it, and quietly decline to
finish the release. This deletes that line and adds a test so the same mistake
cannot come back unnoticed.

Merging this is what unblocks the release: the next push to `main` makes
release-please go back and tag `v0.1.0` at the commit the release PR was merged
at, retroactively. No tag is created by hand here.

**Docs:** `docs/engineering/versioning.md` — new "The config carries no
component — and must not" section recording that the config declares no
`component` / `package-name`, the `buildRelease` guard that makes that
mandatory, that a mismatch wedges every subsequent release rather than one, and
that it self-heals rather than needing a hand-made tag. The config summary
gains a matching bullet.

## Spec invariants

| Rule kept true | How |
| --- | --- |
| Tags are `v0.2.0`, not `multiplying-frogs-v0.2.0` (`include-component-in-tag: false`) | Unchanged; removing `package-name` only removes a name that was never in the tag |
| The PR title pattern stays `chore(${branch}): release ${version}` | `test_no_pattern_interpolates_a_component` |
| `/VERSION` and the manifest still agree | Neither file touched; `Tests/Core/VersionDriftTests.cs` still covers it |
| `release-type: simple` and the `extra-files` generic updater for `/VERSION` | Untouched — `package-name` fed neither |

## How the spec is changing

- **Old rule:** the config summary documented `include-component-in-tag: false`
  as the whole of the component story, and `package-name` sat in the config
  unexplained.
- **New rule:** the config declares **no** component at all — no `component`,
  no `package-name`, `include-component-in-tag` false — because
  `getBranchComponent()` derives a component from `package-name` and compares it
  against the release branch name, which for a single root package with
  `separate-pull-requests: false` carries none.
- **Why it is better:** the old wording implied `include-component-in-tag`
  controlled this. It does not — that flag is only read when composing the tag,
  while the guard that blocks the release reads `getBranchComponent()`, which
  never looks at it. The docs now say which key matters and what breaks, so the
  next person to add a package name reads why not first.

## Test

`.github/scripts/tests/test_release_please_config.py`, in the existing `scripts`
suite. It asserts **both halves together** — that nothing in the config produces
a branch component, and that no branch, tag or title pattern interpolates
`${component}` — so the two can never disagree again. That pairing is the point:
either half alone is a valid config, and only the combination is broken.

Seen red before the fix, failing for the intended reason:

```
AssertionError: Lists differ: ['..package-name'] != []
 : … release-please will refuse to tag any release while these are set: ['..package-name'].

AssertionError: True != False : declared ['..package-name'] but interpolated [] —
a config that names a component the patterns never use is the shape that silently
stops every release from being tagged.
```

Verified: `python3 .github/scripts/run_python_tests.py` (all 12 suites) and
`mkdocs build --strict` both pass.

## Deviations and Decisions

- **The test is a test, not a new CI check script.** Every other file in
  `.github/scripts/tests/` covers a script that runs as its own gate. This one
  has no script: the assertion is over a static config file, so a test in the
  `scripts` suite (already run by `docs-test`, `geometry-lint` and
  `pipeline-tests`) covers it with nothing new to wire up. `run_python_tests.py`
  discovers it unmodified.
- **The pattern half of the test scans every string in the config recursively**
  rather than a fixed list of pattern keys. release-please has several and has
  added more between versions, and a check that only knew today's names would
  quietly stop seeing tomorrow's.
- **`include-component-in-tag: true` is counted as declaring a component** by
  the test, even though it is not what broke this. It produces a component in
  the tag, so flipping it alone would be the mirror-image mismatch.
- **Four checklist boxes are not tickable from here** — they are all
  post-merge observations, listed in the thread below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYrHXJn6XAZh7DRfWmhdQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYrHXJn6XAZh7DRfWmhdQz)_