### PR TITLE
fix(gatekeeper): log the reactive-triage fire instead of discarding it

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/fire_routine.py
@@ -107,6 +107,52 @@ def _post(url: str, headers: dict, body: bytes):
         return response.status, response.read().decode(errors="replace")
 
 
+def announce(issue_number: int) -> None:
+    """Say the fire is about to go out, **before** the POST.
+
+    Before, specifically. If the request hangs until the job times out, or the
+    runner dies mid-flight, a line printed afterwards is a line nobody ever
+    sees — and the log then stops at the label move, which reads as "the fire
+    was never attempted" rather than "the fire was attempted and went nowhere".
+    """
+    print(f"Sending triage webhook for issue #{issue_number}...", flush=True)
+
+
+def report(result: FireResult, issue_number: int) -> None:
+    """Print what came back, as an annotation the job summary surfaces.
+
+    The endpoint and the secret are never printed. `AI_TRIAGE_URL` is itself a
+    secret, and GitHub masks only exact matches — a host fragment reconstructed
+    into a log line is a leak nothing would catch.
+    """
+    detail = f" {result.detail}" if result.detail else ""
+
+    if result.fired:
+        print(f"Triage webhook for issue #{issue_number}: {result.outcome}.{detail}",
+              flush=True)
+        return
+
+    # Not configured is a choice not yet made, not a fault. Annotating it as an
+    # error would train everyone to ignore the annotation that matters.
+    level = "error" if result.is_error else "notice"
+    print(f"::{level}::Triage webhook for issue #{issue_number}: "
+          f"{result.outcome}.{detail}", flush=True)
+
+
+def fire_and_report(issue_number: int, repository: str, url: str, secret: str,
+                    post=None) -> FireResult:
+    """`fire`, with the outcome logged either side of it. Never raises.
+
+    The one entry point every caller should use. `fire` classifies the outcome
+    truthfully precisely so a misconfigured Routine cannot hide behind a green
+    log line — which only works if the classification is printed. See #231.
+    """
+    announce(issue_number)
+    result = fire(issue_number, repository, url, secret, post=post)
+    report(result, issue_number)
+    return result
+
+
 def fire_from_env(issue_number: int) -> FireResult:
     """`fire`, with the endpoint read from the environment.
 
@@ -116,7 +162,7 @@ def fire_from_env(issue_number: int) -> FireResult:
     and a few hours of extra latency is not a reason to report the command as
     failed.
     """
-    return fire(
+    return fire_and_report(
         issue_number,
         os.environ.get("GITHUB_REPOSITORY", ""),
         os.environ.get("AI_TRIAGE_URL"),

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
@@ -108,3 +108,92 @@ def _explode(url, headers, body):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ReportingTests(unittest.TestCase):
+    """The fire must say what it did.
+
+    `interpret_fire_response` classifies the outcome truthfully so a
+    misconfigured Routine cannot hide behind a green log line. That only works
+    if somebody prints the classification — see issue #231, where every call
+    site discarded it and a failed fire looked exactly like a working one.
+    """
+
+    def test_the_send_is_announced_before_the_post_goes_out(self):
+        # Ordering matters: a POST that hangs or crashes the job must already
+        # have said it was about to happen, or the log stops at the label move
+        # and the fire looks like it was never attempted.
+        def post(url, headers, body):
+            print("POSTED")
+            return 200, '{"session_url": "https://x/s/1"}'
+
+        lines = _capture(lambda: fire_routine.fire_and_report(
+            42, "owner/repo", "https://x", "s", post=post))
+
+        announced = next(i for i, l in enumerate(lines) if "Sending triage webhook" in l)
+        posted = lines.index("POSTED")
+        self.assertLess(announced, posted, lines)
+        self.assertIn("42", lines[announced])
+
+    def test_a_successful_fire_reports_the_session(self):
+        lines = _capture(lambda: fire_routine.report(
+            fire_routine.FireResult(True, "fired", "Triage session: https://x/s/1"), 42))
+
+        self.assertTrue(any("fired" in line for line in lines), lines)
+        self.assertFalse(any(line.startswith("::error::") for line in lines), lines)
+
+    def test_a_failed_fire_is_an_actions_error_annotation(self):
+        lines = _capture(lambda: fire_routine.report(
+            fire_routine.FireResult(False, "no-session", "the endpoint answered"), 42))
+
+        self.assertTrue(any(line.startswith("::error::") for line in lines), lines)
+        self.assertTrue(any("no-session" in line for line in lines), lines)
+
+    def test_not_configured_is_a_notice_not_an_error(self):
+        # A choice not yet made is not a fault. Erroring on it would train
+        # everyone to ignore the annotation.
+        lines = _capture(lambda: fire_routine.report(
+            fire_routine.FireResult(False, "not-configured", "secrets are not set"), 42))
+
+        self.assertTrue(any(line.startswith("::notice::") for line in lines), lines)
+        self.assertFalse(any(line.startswith("::error::") for line in lines), lines)
+
+    def test_it_never_prints_the_url_or_the_secret(self):
+        # The endpoint is a secret and GitHub masks only exact matches, so a
+        # host fragment in the log is a leak that nothing would catch.
+        def post(url, headers, body):
+            return 200, '{"session_url": "https://x/s/1"}'
+
+        lines = _capture(lambda: fire_routine.fire_and_report(
+            42, "owner/repo", "https://routine.example.internal/hook", "s3cret", post=post))
+
+        joined = "\n".join(lines)
+        self.assertNotIn("routine.example.internal", joined)
+        self.assertNotIn("s3cret", joined)
+
+    def test_fire_and_report_returns_the_result_and_never_raises(self):
+        def post(url, headers, body):
+            raise OSError("connection refused")
+
+        result = None
+
+        def go():
+            nonlocal result
+            result = fire_routine.fire_and_report(
+                42, "owner/repo", "https://x", "s", post=post)
+
+        lines = _capture(go)
+
+        self.assertFalse(result.fired)
+        self.assertTrue(any(line.startswith("::error::") for line in lines), lines)
+
+
+def _capture(action) -> list:
+    """Run `action`, returning everything it wrote to stdout and stderr."""
+    import contextlib
+    import io
+
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        action()
+    return [line for line in (out.getvalue() + err.getvalue()).splitlines() if line]

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -576,6 +576,36 @@ as fired would hide a misconfigured Routine behind a green log line for weeks.
 Everything else logs the status and a bounded snippet of the body, and a `401`
 says the secret is wrong rather than just failing.
 
+#### And the classification is printed
+
+Classifying an outcome nobody prints buys nothing. Every fire writes two lines
+to the job log: one **before** the request saying it is about to go out, and one
+after saying what came back.
+
+Before, specifically. A line printed only afterwards is a line nobody sees when
+the request hangs until the job times out — and the log then stops at the label
+move, which reads as *the fire was never attempted* rather than *the fire was
+attempted and went nowhere*.
+
+A failed fire is a GitHub Actions `::error::` annotation. `not-configured` is a
+`::notice::`, because a secret nobody has set yet is a choice not yet made
+rather than a fault, and annotating it as an error trains everyone to ignore the
+annotation that matters.
+
+**Neither line contains the endpoint or the secret.** `AI_TRIAGE_URL` is itself
+a secret, and GitHub masks only exact matches — a host fragment reassembled into
+a log line is a leak nothing would catch.
+
+This was [#231](https://github.com/derekwinters/connor-multiplying-frogs/issues/231):
+the classification above was implemented and then discarded at every call site,
+so a Routine that never ran produced a log identical to one that worked. The
+page described the intended behaviour and the code did not deliver it; the code
+is what changed.
+
+A failed fire still never fails the command. The label move has already landed
+by then, and the nightly round will pick the issue up — the cost is latency, not
+correctness.
+
 #### The payload is not a place to put instructions
 
 The POST body's freeform text names **only the repository and the issue


### PR DESCRIPTION
When you comment `/revise` on an issue, the gatekeeper moves the label and then
pokes a Routine so triage runs straight away instead of waiting for the nightly
round. That poke has been going out into silence: the code worked out exactly
what happened to it — sent, refused, unreachable, answered-but-never-ran — and
then threw that away without printing a word. So a Routine that never ran looked
exactly like one that worked, and there was no way to tell which you had.

Now every poke says what it is doing. One line before it goes out, one line
after saying what came back.

## Spec invariants this had to keep true

- **A failed fire never fails the command.** The label move has already landed
  by the time the fire runs; a network failure costs latency, not correctness,
  and the nightly round still picks the issue up. `fire` still never raises, and
  the new wrapper does not change that — there is a test pinning it.
- **The payload is still not a place to put instructions.** Nothing about the
  POST body changed; `fire_text` still refuses a non-integer issue number.
- **The endpoint and the secret stay out of the log.** `AI_TRIAGE_URL` is itself
  a secret, and GitHub masks only exact matches — a host fragment reassembled
  into a log line is a leak nothing would catch. There is a test asserting
  neither appears in the output.
- **At most one fire per issue per sweep.** Untouched: the fix routes through
  `fire_from_env`, which sits below `run_sweep`'s `fire_once` de-duplication.

## How the spec is changing

`docs/engineering/issue-pipeline.md` already said the outcome is "classified
truthfully" and that everything logs its status and a snippet of the body. That
was a description of intent, not of behaviour — the classification existed and
nothing printed it.

The old rule was, in effect, *classify the outcome*. The new rule is **classify
it and print it, before and after the request**. Before matters: a line printed
only afterwards is a line nobody sees when the request hangs until the job times
out, and the log then stops at the label move, which reads as *the fire was
never attempted* rather than *the fire was attempted and went nowhere*.

The page also now states the annotation levels — a failure is `::error::`, and
`not-configured` is `::notice::` because an unset secret is a choice nobody has
made yet rather than a fault. Annotating that as an error is how people learn to
ignore the annotation that matters.

## What was actually wrong

`fire_routine.fire()` returns a `FireResult` distinguishing `not-configured`,
`unauthorized`, `http-error`, `unreadable`, `no-session` and `fired`, and it
carries an `is_error` property clearly meant for reporting. Every call site
called it as a bare statement and bound nothing:

- `run_comment_event.py`, after the label write
- `run_sweep.py`, in the revisit path, the auto-fix path, and `fire_once`

All four already share one seam — `fire_from_env` — so the fix lands there and
no call site needed touching.

## Testing

Six new tests, written first and watched fail for the right reason (six errors,
all "module has no attribute"): the announce line precedes the POST, a success
reports the session, a failure is an `::error::`, `not-configured` is a
`::notice::`, neither the URL nor the secret is ever printed, and the wrapper
returns its result without raising when the transport blows up.

`python3 .github/scripts/run_python_tests.py` — 212 gatekeeper tests and all 12
suites pass. `check_core_isolation.py` passes.

## Deviations and Decisions

- **The fix went in at `fire_from_env` rather than at the four call sites.**
  Every caller already reaches the Routine through it, so one change covers all
  four paths and no future caller can forget to log. The call sites still
  discard the return value, which is now correct — there is nothing left in it
  they need.
- **`not-configured` is a notice, not an error.** The repo has the secrets set,
  so this path should not arise here; it is annotated gently anyway because the
  module's own docstring calls it "a choice not yet made".
- **I could not run `mkdocs build --strict` locally** — mkdocs is not installed
  in this environment and could not be fetched. The `docs-test` workflow covers
  it; the change is prose plus one absolute link.
- **This does not prove the webhook now succeeds.** It makes the outcome
  visible, which is what was asked for and what was missing. If the next
  `/revise` reports `no-session` or `unauthorized`, that is a real Routine
  misconfiguration and a separate fix — but it will now say so in words.

**Docs:** `docs/engineering/issue-pipeline.md` — added "And the classification
is printed" under the reactive-triage section: the two log lines and why the
first comes before the request, the `::error::` / `::notice::` split and why,
and that the endpoint and secret are never printed. Corrected the neighbouring
claim that everything "logs the status", which the code did not do.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS)_