### PR TITLE
fix(gatekeeper): return the triage endpoint's error body instead of raising

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/fire_routine.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.error
 import urllib.request
 
 BODY_SNIPPET_LIMIT = 300
@@ -99,12 +100,26 @@ def interpret_fire_response(status: int, body: str) -> FireResult:
 
 
 def _post(url: str, headers: dict, body: bytes):
+    """POST and return `(status, body)` — including for a 4xx or 5xx.
+
+    `urlopen` **raises** `HTTPError` on any error status rather than returning
+    it, so without this every one of them reached `fire`'s catch-all and was
+    reported as a failure to reach the endpoint. That threw away the response
+    body — which, for a `400`, is the only thing that says what the endpoint
+    rejected — and made `interpret_fire_response`'s error branches unreachable.
+
+    `HTTPError` is itself a response: it carries the status and is readable. So
+    it is caught and returned, and only genuine transport failures raise.
+    """
     request = urllib.request.Request(url, data=body, method="POST")
     for name, value in headers.items():
         request.add_header(name, value)
 
-    with urllib.request.urlopen(request, timeout=30) as response:
-        return response.status, response.read().decode(errors="replace")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, response.read().decode(errors="replace")
+    except urllib.error.HTTPError as answered:
+        return answered.code, answered.read().decode(errors="replace")
 
 
 def announce(issue_number: int) -> None:

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
@@ -197,3 +197,83 @@ def _capture(action) -> list:
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
         action()
     return [line for line in (out.getvalue() + err.getvalue()).splitlines() if line]
+
+
+class HttpErrorTests(unittest.TestCase):
+    """An HTTP error is an answer, not a failure to reach.
+
+    `urlopen` raises `HTTPError` on 4xx/5xx, so before #236 every one of them
+    propagated to `fire`'s catch-all and was reported as a transport failure —
+    discarding the response body, which for a 400 is the only thing that says
+    what the endpoint rejected.
+    """
+
+    def test_post_returns_an_http_error_instead_of_raising(self):
+        body = '{"error": {"message": "unexpected field: text"}}'
+
+        with _urlopen_raising(_http_error(400, body)):
+            status, returned = fire_routine._post("https://x", {}, b"{}")
+
+        self.assertEqual(400, status)
+        self.assertIn("unexpected field: text", returned)
+
+    def test_the_endpoints_own_words_reach_the_reported_detail(self):
+        # The whole point: a 400 must say what the endpoint disliked.
+        with _urlopen_raising(_http_error(400, '{"error": "no such trigger"}')):
+            result = fire_routine.fire(42, "owner/repo", "https://x", "s")
+
+        self.assertFalse(result.fired)
+        self.assertEqual("http-error", result.outcome)
+        self.assertIn("no such trigger", result.detail)
+
+    def test_a_401_now_says_the_secret_is_wrong(self):
+        # This branch of `interpret_fire_response` was unreachable before.
+        with _urlopen_raising(_http_error(401, "unauthorized")):
+            result = fire_routine.fire(42, "owner/repo", "https://x", "s")
+
+        self.assertEqual("unauthorized", result.outcome)
+        self.assertIn("AI_TRIAGE_SECRET", result.detail)
+
+    def test_a_genuine_transport_failure_is_still_unreachable(self):
+        import urllib.error
+
+        with _urlopen_raising(urllib.error.URLError("connection refused")):
+            result = fire_routine.fire(42, "owner/repo", "https://x", "s")
+
+        self.assertFalse(result.fired)
+        self.assertEqual("error", result.outcome)
+        self.assertIn("Could not reach", result.detail)
+
+    def test_a_long_error_body_stays_bounded(self):
+        with _urlopen_raising(_http_error(400, "x" * 5000)):
+            result = fire_routine.fire(42, "owner/repo", "https://x", "s")
+
+        self.assertLess(len(result.detail), fire_routine.BODY_SNIPPET_LIMIT + 200)
+
+
+def _http_error(status, body):
+    import io
+    import urllib.error
+
+    return urllib.error.HTTPError(
+        "https://x", status, "Bad Request", {}, io.BytesIO(body.encode()))
+
+
+def _urlopen_raising(error):
+    """Patch the module's `urlopen` so nothing touches the network."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def patched():
+        real = fire_routine.urllib.request.urlopen
+
+        def fake(*args, **kwargs):
+            raise error
+
+        fire_routine.urllib.request.urlopen = fake
+        try:
+            yield
+        finally:
+            fire_routine.urllib.request.urlopen = real
+
+    return patched()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -576,6 +576,21 @@ as fired would hide a misconfigured Routine behind a green log line for weeks.
 Everything else logs the status and a bounded snippet of the body, and a `401`
 says the secret is wrong rather than just failing.
 
+#### An error status is an answer, not a failure to reach
+
+`urlopen` raises on any 4xx or 5xx rather than returning it, so an error status
+has to be caught and turned back into a `(status, body)` pair. Skipping that
+step costs three things at once, and
+[#236](https://github.com/derekwinters/connor-multiplying-frogs/issues/236) cost
+all three: the response body is discarded, which for a `400` is the only thing
+that names the field the endpoint rejected; the classification above becomes
+unreachable on every error path, so the "your secret is wrong" message can never
+print; and every HTTP error reports as *"could not reach the Routine"*, which
+sends you looking at networking while the endpoint is up and answering.
+
+Only a genuine transport failure — a refused connection, a timeout, DNS — is
+reported as unreachable.
+
 #### And the classification is printed
 
 Classifying an outcome nobody prints buys nothing. Every fire writes two lines


### PR DESCRIPTION
With the previous fix in, the log finally said something about the triage
webhook — and what it said was wrong:

```
##[error]Triage webhook for issue #234: error. Could not reach the Routine: HTTP Error 400: Bad Request
```

We reached the Routine perfectly well. It answered, with a `400` and a body
explaining what it disliked about the request. We were throwing that body away
and blaming the network.

## What was wrong

`urlopen` raises `HTTPError` on any 4xx or 5xx instead of returning it, so every
error status flew straight past the classifier into `fire`'s catch-all. Three
consequences, all of them live:

1. **The response body was discarded.** For this `400` it is the only thing that
   names the field the endpoint rejected — the difference between fixing the
   payload and guessing at it.
2. **`interpret_fire_response` was dead code on every error path.** Its
   `status >= 400` and `401`/`403` branches cannot be reached when `urlopen`
   raises instead of returning, so the carefully written *"the AI_TRIAGE_SECRET
   is missing or wrong"* message has never once been printable.
3. **The message actively misled.** "Could not reach the Routine" sends you to
   networking and secrets while the endpoint is up and authenticating fine.

`HTTPError` is itself a response object — it carries `.code` and is readable —
so it is caught and returned as `(status, body)`. Only a genuine transport
failure still raises.

## Spec invariants this had to keep true

- **`fire` never raises past itself.** Unchanged, and still pinned by a test: a
  refused connection is still caught and still reported as unreachable.
- **A failed fire never fails the command.** The label move has already landed.
- **The URL and the secret never reach the log.** Unchanged, still tested.
- **The body stays bounded.** `interpret_fire_response` already truncates to
  `BODY_SNIPPET_LIMIT`, and there is now a test that a 5,000-character error
  body does not blow up the log line.

## How the spec is changing

`docs/engineering/issue-pipeline.md` described the classification as though it
applied to error responses. It never did, because none of them arrived as
responses. The page now states the rule explicitly — an error status is an
answer and gets classified; only a transport failure is "unreachable" — and
records why it matters, since this is the second bug in a row where the
diagnosis was available and being discarded.

## What this does NOT fix

**The `400` itself.** Triage still will not fire until the payload matches what
the endpoint expects, and this change is what makes that knowable: the next fire
will log the endpoint's own words instead of `HTTP Error 400: Bad Request`.

For the record, the Routine is not the problem. `Multiplying Frogs Issue Triage`
(`trig_01C1zmuqc8v8gedseSpeJ3uy`) is enabled, and its prompt correctly reads the
issue number out of the payload and runs `triage-issue`. The fault is on our
side of the request.

## Testing

Five new tests, written first, three of them red for the right reason (the other
two guard behaviour that must not regress): `_post` returns a `400` rather than
raising, the endpoint's words reach the reported detail, a `401` now reports the
secret as wrong — the previously unreachable branch — a real `URLError` is still
reported as unreachable, and a long error body stays bounded.

`python3 .github/scripts/run_python_tests.py` — all 12 suites pass, 217 tests in
the gatekeeper suite.

## Deviations and Decisions

- **I did not guess at the payload.** It would have been easy to try renaming
  `text` and re-firing until something stuck. Changing a contract by trial and
  error, with no way to read the rejection, is how you end up with a shape that
  happens to work and nobody can explain. One more fire will tell us the answer.
- **I could not fire the Routine from here to shortcut the diagnosis.** It was
  created via the HTTP API, and agents may only fire Routines they created
  themselves, so `fire_trigger` refuses it.
- **`mkdocs build --strict` was not run locally** — mkdocs is unavailable in
  this environment; `docs-test` covers it.

**Docs:** `docs/engineering/issue-pipeline.md` — added "An error status is an
answer, not a failure to reach" to the reactive-triage section: why an error
status has to be caught and returned, the three things lost when it is not, and
that only a genuine transport failure counts as unreachable.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS)_