### PR TITLE
fix(gatekeeper): send the anthropic-version header the triage endpoint requires

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/fire_routine.py
@@ -38,6 +38,12 @@ import urllib.request
 
 BODY_SNIPPET_LIMIT = 300
 
+# `AI_TRIAGE_URL` is an Anthropic API endpoint, and that API requires this
+# header on every request. Omit it and the fire is refused at header validation
+# with a `400` — before the token or the payload is looked at, which is why a
+# missing version reads as a malformed request rather than an auth failure.
+ANTHROPIC_VERSION = "2023-06-01"
+
 
 class FireResult:
     def __init__(self, fired: bool, outcome: str, detail: str = "") -> None:
@@ -203,6 +209,7 @@ def fire(issue_number: int, repository: str, url: str, secret: str, post=None) -
     headers = {
         "Authorization": f"Bearer {secret}",
         "Content-Type": "application/json",
+        "anthropic-version": ANTHROPIC_VERSION,
     }
 
     try:

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
@@ -277,3 +277,40 @@ def _urlopen_raising(error):
             fire_routine.urllib.request.urlopen = real
 
     return patched()
+
+
+class RequiredHeaderTests(unittest.TestCase):
+    """`AI_TRIAGE_URL` is an Anthropic API endpoint, and that API requires the
+    `anthropic-version` header on every request. Without it the fire is refused
+    at header validation with a 400, before the token or the payload is ever
+    looked at — see #238, which is why every fire since the feature shipped has
+    been rejected.
+    """
+
+    def test_the_anthropic_version_header_is_sent(self):
+        sent = {}
+
+        def post(url, headers, body):
+            sent.update(headers)
+            return 200, '{"session_url": "https://x/s/1"}'
+
+        fire_routine.fire(42, "owner/repo", "https://x", "s", post=post)
+
+        self.assertIn("anthropic-version", sent)
+        self.assertTrue(sent["anthropic-version"])
+
+    def test_it_does_not_displace_the_other_headers(self):
+        sent = {}
+
+        def post(url, headers, body):
+            sent.update(headers)
+            return 200, '{"session_url": "https://x/s/1"}'
+
+        fire_routine.fire(42, "owner/repo", "https://x", "s3cret", post=post)
+
+        self.assertEqual("Bearer s3cret", sent["Authorization"])
+        self.assertEqual("application/json", sent["Content-Type"])
+
+    def test_the_version_is_a_named_constant_not_a_literal(self):
+        # Tuning and protocol values get names, per the repo's constants rule.
+        self.assertTrue(fire_routine.ANTHROPIC_VERSION)

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -576,6 +576,21 @@ as fired would hide a misconfigured Routine behind a green log line for weeks.
 Everything else logs the status and a bounded snippet of the body, and a `401`
 says the secret is wrong rather than just failing.
 
+#### The endpoint is the Anthropic API, so `anthropic-version` is required
+
+`AI_TRIAGE_URL` points at an Anthropic API endpoint, and that API requires an
+`anthropic-version` header on **every** request. Without it the fire is refused
+at header validation with a `400`, before the token or the payload is examined —
+which is why a missing version reads as a malformed request rather than an auth
+failure, and why a `400` here never meant the secret was wrong.
+
+That cost real time in
+[#238](https://github.com/derekwinters/connor-multiplying-frogs/issues/238):
+because the URL is a secret, nobody could see it was an `api.anthropic.com`
+endpoint, so nobody thought to ask what headers that API demands. If the fire
+ever starts failing at header validation again, the endpoint's own message names
+the header — which is the whole reason the two fixes above exist.
+
 #### An error status is an answer, not a failure to reach
 
 `urlopen` raises on any 4xx or 5xx rather than returning it, so an error status


### PR DESCRIPTION
This is the actual reason reactive triage has never fired. With the previous two
fixes in, the endpoint finally told us in its own words:

```
##[error]Triage webhook for issue #235: http-error. HTTP 400:
{"error":{"message":"anthropic-version: header is required","type":"invalid_request_error"}}
```

`AI_TRIAGE_URL` is an Anthropic API endpoint, and that API requires an
`anthropic-version` header on every request. We were sending `Authorization` and
`Content-Type` and nothing else, so every fire was refused at header validation.

One line to fix, after two PRs to be able to see it.

## What this rules out, for the record

- **The secret is not wrong.** A bad token is a `401`. We got a `400`, from
  header validation, which happens before the token is examined.
- **The Routine is not misconfigured.** `Multiplying Frogs Issue Triage`
  (`trig_01C1zmuqc8v8gedseSpeJ3uy`) is enabled, and its prompt correctly reads
  the issue number out of the payload and runs `triage-issue`.
- **The payload shape was never the problem.** I nearly went looking there,
  since a `400` reads like a malformed body. It was refused before the body was
  parsed.

## Spec invariants this had to keep true

- **`Authorization` and `Content-Type` are unchanged** — there is a test pinning
  both, because "fixed the 400 by rewriting all the headers" is how you trade a
  known failure for an unknown one.
- **The payload is unchanged.** Still `fire_text`, still naming only the
  repository and the issue number, still refusing a non-integer.
- **The version is a named constant**, not a literal at the call site, per the
  repo's constants rule — with a test asserting it exists.

## How the spec is changing

`docs/engineering/issue-pipeline.md` never said what kind of endpoint
`AI_TRIAGE_URL` is, so it never said what that endpoint requires. It does now:
the fire targets the Anthropic API, `anthropic-version` is mandatory, and a
missing version surfaces as a `400` rather than a `401` — which is the detail
that made this look like an auth problem for as long as it did.

The page also records why it stayed hidden: the URL is a secret, so nobody could
see it was an `api.anthropic.com` endpoint and think to ask what headers it
demands.

## Testing

Three new tests, written first, two red for the right reason: the header is
sent, the other two headers are untouched, and the version is a named constant.

`python3 .github/scripts/run_python_tests.py` — all 12 suites pass, 220 tests in
the gatekeeper suite.

Unit tests cannot prove this against the real endpoint, so after merge I will
dispatch `gatekeeper-sweep` and read the log. The fire must report `fired` with
a session URL — which is exactly the verification #83 asked for and never got. I
will not call this done until that line appears.

## Deviations and Decisions

- **`2023-06-01` as the version.** It is the long-standing stable value for this
  header. If the endpoint wants a newer one it will say so, in words, in the log
  — which is now a thing that happens.
- **I did not touch the auth scheme.** `Authorization: Bearer` got us past auth
  to a header-validation error, so it is accepted. Changing it while fixing
  something else would muddy the next diagnosis.
- **Three PRs for a one-line fix, and I think that was right.** The first made
  the outcome visible, the second made the endpoint's explanation visible, and
  this one acts on it. Guessing at header combinations after PR&nbsp;1 might have
  landed sooner and would have left nobody able to say why.

**Docs:** `docs/engineering/issue-pipeline.md` — added "The endpoint is the
Anthropic API, so `anthropic-version` is required": what the header is, that a
missing one is a `400` and not a `401`, and why a secret URL made this expensive
to find.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS)_