### PR TITLE
fix(gatekeeper): recognise claude_code_session_url as a real fire

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/fire_routine.py
@@ -70,6 +70,20 @@ def fire_text(repository: str, issue_number) -> str:
     return f"Triage issue {issue_number} in {repository}."
 
 
+# The key the API actually uses, then the two this looked for first. Order is
+# most-likely-first; all three are kept so an endpoint returning either shape
+# still reads as a real fire.
+SESSION_URL_KEYS = ("claude_code_session_url", "session_url", "url")
+
+
+def _session_url(payload):
+    """The session URL out of a fire response, or None if there isn't one."""
+    if not isinstance(payload, dict):
+        return None
+
+    return next((payload[key] for key in SESSION_URL_KEYS if payload.get(key)), None)
+
+
 def interpret_fire_response(status: int, body: str) -> FireResult:
     """Classify the response **truthfully**.
 
@@ -94,7 +108,7 @@ def interpret_fire_response(status: int, body: str) -> FireResult:
             False, "unreadable",
             f"HTTP {status} with a body that is not JSON: {snippet}")
 
-    session = payload.get("session_url") or payload.get("url") if isinstance(payload, dict) else None
+    session = _session_url(payload)
 
     if not session:
         return FireResult(

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fire_routine.py
@@ -314,3 +314,43 @@ class RequiredHeaderTests(unittest.TestCase):
     def test_the_version_is_a_named_constant_not_a_literal(self):
         # Tuning and protocol values get names, per the repo's constants rule.
         self.assertTrue(fire_routine.ANTHROPIC_VERSION)
+
+
+class SessionKeyTests(unittest.TestCase):
+    """The API names the session `claude_code_session_url`.
+
+    Looking only for `session_url`/`url` made the success path unreachable, so a
+    healthy fire was annotated as an error — see #240. An error annotation that
+    fires on every good run is as useless as a green line nobody believes.
+    """
+
+    REAL_RESPONSE = (
+        '{"claude_code_session_id":"session_01VW2xgbD4WTT48QSA2QLXwr",'
+        '"claude_code_session_url":"https://claude.ai/code/session_01VW2xgbD4WTT48QSA2QLXwr",'
+        '"type":"routine_fire"}')
+
+    def test_a_real_routine_fire_response_is_a_success(self):
+        result = fire_routine.interpret_fire_response(200, self.REAL_RESPONSE)
+
+        self.assertTrue(result.fired)
+        self.assertEqual("fired", result.outcome)
+
+    def test_the_session_url_reaches_the_detail(self):
+        result = fire_routine.interpret_fire_response(200, self.REAL_RESPONSE)
+
+        self.assertIn("https://claude.ai/code/session_01VW2xgbD4WTT48QSA2QLXwr",
+                      result.detail)
+
+    def test_the_older_key_still_works(self):
+        result = fire_routine.interpret_fire_response(
+            200, '{"session_url": "https://x/s/1"}')
+
+        self.assertTrue(result.fired)
+
+    def test_a_response_with_no_session_at_all_is_still_refused(self):
+        # The guard is the point of the check: a bare 200 means the endpoint
+        # answered, not that the Routine ran.
+        result = fire_routine.interpret_fire_response(200, '{"type": "ok"}')
+
+        self.assertFalse(result.fired)
+        self.assertEqual("no-session", result.outcome)

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -576,6 +576,13 @@ as fired would hide a misconfigured Routine behind a green log line for weeks.
 Everything else logs the status and a bounded snippet of the body, and a `401`
 says the secret is wrong rather than just failing.
 
+The API names that field **`claude_code_session_url`**. The older `session_url`
+and `url` are still accepted, but looking for only those made the success path
+unreachable and annotated every healthy fire as an error
+([#240](https://github.com/derekwinters/connor-multiplying-frogs/issues/240)) —
+which is the same failure as a green line nobody believes, pointing the other
+way. An annotation that fires on every good run is one people stop reading.
+
 #### The endpoint is the Anthropic API, so `anthropic-version` is required
 
 `AI_TRIAGE_URL` points at an Anthropic API endpoint, and that API requires an


### PR DESCRIPTION
The fire now lands. The endpoint answered `200` and a real triage session
started:

```json
{"claude_code_session_id":"session_01VW2xgbD4WTT48QSA2QLXwr",
 "claude_code_session_url":"https://claude.ai/code/session_01VW2xgbD4WTT48QSA2QLXwr",
 "type":"routine_fire"}
```

And we called it a failure, because the classifier looks for `session_url` or
`url` and the API returns `claude_code_session_url`. The success path was
unreachable.

## Why this is worth its own fix rather than a shrug

An `::error::` on every healthy run is the same defect as a green line nobody
believes, pointing the other way — and it lands on the annotation that the three
previous PRs existed to make trustworthy. Two rounds of crying wolf and nobody
reads it, at which point the fire is unobservable again.

It also leaves the feature looking broken at the exact moment it started
working, which is the confusion this whole sequence has been about.

## Spec invariants this had to keep true

- **A bare `200` is still not a success.** The guard is the entire point of the
  check: the endpoint answering does not mean the Routine ran. There is a test
  asserting a `200` with no session anywhere still reports `no-session`.
- **The older keys still work.** `session_url` and `url` are still accepted, so
  this narrows nothing.
- **The URL and secret still never reach the log.** Unchanged.

## How the spec is changing

`docs/engineering/issue-pipeline.md` said success requires "a session URL"
without naming the field. It now names `claude_code_session_url` as the one the
API actually uses, notes the other two are still accepted, and records why
getting this wrong mattered: an annotation that fires on every good run is one
people stop reading.

## Testing

Four new tests, written first, one red for the right reason — the other three
guard behaviour that must not regress. The red one uses the **real response body
captured from the live endpoint**, not an invented shape.

`python3 .github/scripts/run_python_tests.py` — all 12 suites pass, 224 tests in
the gatekeeper suite.

After merge I will dispatch a sweep and confirm the log reads `fired` with a
session URL and no error annotation.

## Deviations and Decisions

- **All three keys are kept, most-likely-first**, rather than swapping one for
  another. The two older names cost nothing to accept and I have no evidence
  about which shapes the endpoint returns in other modes.
- **`_session_url` became a named helper** rather than a longer inline
  expression, because the original one-liner already mixed an `isinstance`
  guard with a two-way fallback and was where the bug hid.
- **The 400-era guard stays exactly as strict.** It would have been tempting to
  relax "must carry a session" now that fires succeed; that check is what would
  catch the next misconfigured Routine.

**Docs:** `docs/engineering/issue-pipeline.md` — named
`claude_code_session_url` as the field the API returns, recorded that the older
keys are still accepted, and why a false error annotation is as damaging as a
false green one.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016bCR3yEzkwoPiabxjhSkpS)_