### PR TITLE
docs: rewrite the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# connor-multiplying-frogs
-Using AI to build a game with my son
+# Multiplying Frogs
+
+Multiplying Frogs is a digital port of a multiplication board game from Connor's
+math class. It is pass-and-play: two to four players share one device and take
+turns. The board is four lanes of lily pads running from a Start log to an End
+log, with one frog per player in their own lane, and a turn is roll, draw,
+answer, move. The roll picks which of the three piles the card comes from; the
+card is a multiplication problem, worked out on screen in a working-out grid
+built for long multiplication. Reaching the End log is what winning means.
+
+Built by Derek and his son Connor — Connor decides the rules, because it is his
+game.
+
+## Docs
+
+**[The docs site](https://derekwinters.github.io/connor-multiplying-frogs/)** is
+the design contract: what the game is, how it is played, and how it is built.
+If the code and the docs disagree, that is a bug in one of them.
+
+- [`CLAUDE.md`](CLAUDE.md) — the durable rules for anyone, human or agent,
+  working on this repo.
+- [`CONTEXT.md`](CONTEXT.md) — the glossary. It fixes what the words mean.
+
+### Building the docs site locally
+
+```bash
+python -m pip install -r docs/requirements.txt
+mkdocs serve          # live preview on http://127.0.0.1:8000
+mkdocs build --strict # what CI runs
+```
+
+## Free, offline, and saved on the device
+
+- **Free.** No purchases, no premium currency, no paid unlocks, no ads.
+- **Offline.** No network calls, no telemetry, no analytics, no accounts and no
+  sign-in. The game does not know who is playing and does not need to.
+- **Saved locally.** A game in progress is saved on the device and nowhere else.
+
+These are not features to be traded away later. They are rules in
+[`CLAUDE.md`](CLAUDE.md), and the offline one is meant to be
+[enforced in CI](docs/adr/0003-network-boundary.md) rather than remembered.
+
+## How it is built
+
+Unity and C#, targeting an Android tablet, with the game logic in an engine-free
+`Core` assembly that is tested in a couple of seconds without an editor. The
+[engineering handbook](docs/engineering/index.md) has the details.


### PR DESCRIPTION
Closes #4

The README was two lines and said nothing about the game. It now opens with a paragraph explaining what Multiplying Frogs is — a digital port of the multiplication board game from Connor's math class, played pass-and-play by two to four people on one device — then points at the docs site and `CLAUDE.md`, gives the commands for previewing the docs site locally, and states plainly that the game is free, offline, and saves only on the device.

Everything in it was assembled from what the repo already says: the description from `CONTEXT.md`, the site link from `mkdocs.yml`'s `site_url`, the build commands from the header of `docs/requirements.txt`, and the free/offline/local-save lines from `CLAUDE.md` and ADRs 0003 and 0004. Nothing new was invented.

**Docs:** README.md — replaced the placeholder with a description of the game, docs links, local docs build instructions, and the free/offline/local-save statement. No page under `docs/` changed.

## Spec invariants

- **Frogs do not multiply.** `CONTEXT.md` is explicit that there is exactly one frog per player and it does not multiply; the name is about multiplication tables. The paragraph never says or implies frogs split or breed.
- **The roll selects a pile and does nothing else.** The README says the roll picks which pile the card comes from, and stops there. How far a frog moves is not written down anywhere yet, so the README does not say.
- **Vocabulary matches the glossary.** lane, lily pad, Start log, End log, frog, pile, card, roll, turn, working-out grid, pass-and-play — and none of `CONTEXT.md`'s listed _Avoid_ words.

## How the spec is changing

It isn't. `/docs` is untouched; this is repo furniture catching up with what the contract already says.

## Deviations and Decisions

- **`python -m pip install -r …`, not `pip install -r …`.** The issue's checklist suggested the bare `pip` form, but the header of `docs/requirements.txt` uses `python -m pip`. I followed the file so there is one form of the command in the repo rather than two.
- **No test.** This is prose in a file no code reads, so there is no behaviour a test could have caught failing. `mkdocs build --strict`, the Core isolation check, the geometry lint and the Python suite are all green; the README is not part of the docs site build.
- **Two links point at repo-relative paths rather than the published site** — `docs/adr/0003-network-boundary.md` and `docs/engineering/index.md`. The site is published with `mike`, which puts pages under a `/latest/` version alias, so a deep link built from the bare `site_url` would 404. The site link itself uses the `site_url` verbatim, as the checklist asks; the deep links resolve correctly in the GitHub file view.
- **Also linked `CONTEXT.md`**, which the checklist did not ask for. It is the glossary a new reader needs immediately after the description paragraph.
- **No `skip-docs` label.** `README.md` is on the docs gate's allow-list, so a README-only PR satisfies the reconciliation gate on its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_