### PR TITLE
docs: write the docs site landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,97 @@
 # Multiplying Frogs
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #9](https://github.com/derekwinters/connor-multiplying-frogs/issues/9).
+Multiplying Frogs is a digital port of a multiplication board game from
+Connor's math class. It is pass-and-play: two to four players share one tablet
+and take turns. The board is four lanes of lily pads running from a Start log
+to an End log, with one frog per player in their own lane, and a turn is roll,
+draw, answer, move — the roll picks which of the three piles the card comes
+from, the card is a multiplication problem, and the problem is worked out on
+screen in a grid built for long multiplication. Reaching the End log is what
+winning means. Derek is building it with his son Connor, and Connor decides the
+rules, because it is his game.
 
-The landing page for the docs site: what the game is, and where to start reading.
+## What this documentation is
+
+This site is the **design contract**. It is the single description of what the
+game is and how it is built — not a pile of notes, not a changelog, and not
+somewhere to think out loud. Behaviour that is not written down here is
+behaviour nobody has decided yet, and the right response to finding a gap is to
+ask rather than to fill it in.
+
+!!! warning "Code that disagrees with the docs is a bug in one of them"
+
+    Which one is a **decision, not an assumption**. Whoever finds the code and
+    a page here saying different things stops and says so — in a comment on the
+    issue — rather than quietly editing the code to match the page, or the page
+    to match the code. A human decides which side moves, and the PR that
+    resolves it says which one was treated as authoritative and why.
+
+    The same rule, spelled out for agents, is in `CLAUDE.md` at the repo root
+    and in [Agent workflow](engineering/agent-workflow.md).
+
+The other half of the contract is that docs land with the change they describe.
+A page here is meant to be true of the build you are holding, so a behaviour
+change and its doc update are the same PR — never a follow-up issue.
+
+### Who each section is for
+
+The site has two audiences, and every section belongs to one of them. The
+**Introduction** and **Specs** are for anyone who wants to know what the game
+is; **Decisions**, **Engineering**, and **Tools** are for whoever is building
+it.
+
+| Section | It answers | Read it when |
+| --- | --- | --- |
+| [Introduction](intro/index.md) | What is this game, and what is it trying to be? | You are new here, or explaining the game to someone |
+| [Specs](specs/index.md) | Exactly how does it behave? | You are about to build, test, or argue about a rule |
+| [Decisions](adr/index.md) | Why is it built that way? | Something looks odd and you want the trade-off behind it |
+| [Engineering](engineering/index.md) | How does the work get done? | You are writing code, tests, CI, or a PR |
+| [Tools](tools/index.md) | What automation runs this repo? | You are working on the skills or the issue pipeline |
+
+The split that matters most is **Specs versus Decisions**. A spec page says what
+is true now and is edited whenever that changes; an ADR says what was chosen
+once, at a point in time, and is never rewritten — it is superseded by a later
+ADR that says so.
+
+## Where decisions live
+
+**Decisions are made in GitHub.** An issue body, a comment thread, a PR review —
+that is where a thing gets argued out and settled, and that record keeps its
+dates, its alternatives, and the reasons the losing options lost.
+
+**This site is the distillation.** It is the settled shape of those decisions,
+written up so nobody has to reconstruct the current rules from a fifty-comment
+thread. Two things follow:
+
+- **When this site and GitHub disagree, GitHub wins.** A comment from Derek
+  three days ago beats a paragraph here from three weeks ago, and the fix is to
+  update the page in the PR where you noticed it.
+- **A decision that only exists on this site was never made.** If it was not
+  agreed in an issue, write the issue first.
+
+**`#NN` points at the deciding issue.** When a page here says a rule was
+settled, it links the issue that settled it — like
+[issue #7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7),
+the design conversation the four
+[architectural decisions](adr/index.md) came out of. The number is not
+decoration: it is how you get from "the rule is X" to "here is the conversation
+where X won", which is the only thing that tells you whether X is still right.
+
+What this site deliberately does **not** record is live state — no milestone
+lists, no issue counts, no "we are currently working on…". That is queried from
+GitHub, because a page that mixes conventions with state is a page that is
+always slightly out of date.
+
+## Where to start
+
+- **Curious about the game** — [Vision](intro/vision.md), then
+  [How to play](intro/how-to-play.md).
+- **About to build something** — `CLAUDE.md` at the repo root first, then
+  [Agent workflow](engineering/agent-workflow.md) and
+  [Conventions](intro/conventions.md).
+- **Looking for a specific rule** — [Specs](specs/index.md), and the
+  [glossary](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CONTEXT.md)
+  if a word is doing more work than you expected.
+
+The [repo](https://github.com/derekwinters/connor-multiplying-frogs) is public,
+and its README covers building the game and the site locally.


### PR DESCRIPTION
Closes #9

The docs site's front page was a stub. It now says what Multiplying Frogs is in one paragraph, explains that this site is the design contract rather than a pile of notes, says who each of the five sections is for, and spells out that decisions are made in GitHub issues while the site is the tidy version of them — so a `#NN` in a page is a pointer back to the conversation that settled the rule.

**Docs:** `docs/index.md` — replaced the "not written yet" stub with the real landing page (pitch, what the documentation is, who each section is for, where decisions live, where to start). No other page changed, and no rule changed.

## Spec invariants

Nothing here changes behaviour, but the page restates rules that live elsewhere, so it had to agree with them word for word in substance:

| Rule it had to keep true | Where it comes from | How I know |
| --- | --- | --- |
| Code disagreeing with `/docs` is a bug in one of them, and which one is a decision, not an assumption | `CLAUDE.md` § The contract; `docs/engineering/agent-workflow.md` step 2 | The page's warning admonition states it in those terms and points at both |
| When the site and GitHub disagree, GitHub wins; a decision that only exists on the site was never made | `docs/intro/conventions.md` § GitHub is the source of truth | Restated in "Where decisions live", not contradicted |
| The site never records live state (no milestone lists, no issue counts) | same page | Explicitly stated, and the page contains no state |
| Docs land in the same PR as the change they describe | `CLAUDE.md` rule 9 | Stated in "What this documentation is" |
| Specs are edited as the game changes; ADRs are superseded, never rewritten | `docs/adr/index.md` | Called out as "the split that matters most" |
| The game's pitch matches the README merged in #4 | `README.md` | Same facts, same vocabulary from `CONTEXT.md` — lanes, lily pads, logs, piles, cards, rolls |

The only automated check that applies is `mkdocs build --strict`, which fails on a dead internal link. I confirmed it actually catches one — added a deliberate broken link first and watched the build abort — then removed it and confirmed the page builds clean.

## Deviations and Decisions

- **The checklist asked the page to say "the spec wins when code and spec disagree". It does not say that.** `CLAUDE.md` and `agent-workflow.md` say the opposite — a mismatch is a bug in one of them, you stop and flag rather than picking a winner. Triage on #9 raised this and the question was never answered, so rather than settle a repo-wide rule by accident in the most-read page we have, the page states the rule that already exists. I have opened #243 to keep the question alive; if the answer turns out to be "the spec wins", it is a couple of paragraphs here plus the two files that currently disagree.
- **The page describes five sections, not two audiences.** The checklist framed the site as Introduction vs. Specs, but the nav has had Decisions, Engineering and Tools since #8. The page keeps the two-audience idea — "what the game is" versus "how it gets built" — and sorts all five sections under it, rather than describing a site we do not have.
- **The pitch stays factual and leaves the aspiration to #10.** `docs/intro/vision.md` is the page that says what the game is *trying* to be; duplicating that here would give us two vision statements to keep in sync. The landing page links to it instead.
- **Links to `CLAUDE.md` and `CONTEXT.md` are absolute GitHub URLs.** They live outside `docs/`, so a relative link to them fails `mkdocs build --strict`. This follows what `docs/intro/conventions.md` already does for `.github/labels.yml`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_