### PR TITLE
docs: write the vision page

### DIFF
--- a/docs/intro/vision.md
+++ b/docs/intro/vision.md
@@ -1,8 +1,146 @@
 # Vision
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #10](https://github.com/derekwinters/connor-multiplying-frogs/issues/10).
+Multiplying Frogs is the multiplication board game from Connor's math class, on
+a tablet. Two to four players share one device: roll, draw a card, and answer a
+long-multiplication problem to move your frog up its lane. First frog to the End
+log wins.
 
-What Multiplying Frogs is trying to be, and who it is for.
+That is the whole game, and it is deliberately the whole game. Everything on
+this page is either something that was settled in
+[issue #7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7),
+the founding design conversation, or something that was deliberately left open
+there.
+
+## A port, not a new game
+
+The classroom game already exists. It is cardboard, it has eight frog pawns and
+a handwritten rules card, and Connor plays it at school. This project is a port
+of that game and nothing more ambitious than that.
+
+So the classroom game is **the authority on every rule** —
+[ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) draws the line.
+How far a frog moves, what a wrong answer costs, how many players there are,
+what winning means: those belong to the board, and changing one needs Connor.
+Layout, animation, and how something is tapped are ours to design, because
+cardboard never had an opinion about them.
+
+The board itself is photographed and transcribed in
+[reference material](../specs/reference/index.md), so any claim about the game
+can be checked against the artifact rather than against somebody's memory of it.
+
+## Who it is for
+
+**Connor first, kids like him second.** He is eight, he already knows this game,
+and he breaks ties on taste. Designing for a hypothetical median eight-year-old
+instead is how the game quietly stops being his — which would remove the reason
+for building it.
+
+The practical version of that rule: when something is a matter of taste, the
+answer is to ask Connor, not to reason it out. When something is a rule of the
+classroom game, the answer is to look at the board.
+
+## What it feels like to play
+
+**A slow, thinky game.** The rules card says 15–45 minutes, and that is right,
+because the cards are multi-digit long multiplication — `331 × 41`, not
+`7 × 8`. A turn is two to five minutes of actual arithmetic, done properly, on
+screen.
+
+This is the single most important thing to know before designing anything for
+it. **It is not a snappy game and must not be built like one.** Nothing in the
+classroom game rewards speed and nothing here should either; the pace of the
+game is the pace of a child working out a three-digit multiplication. A screen
+that hurries the player is a screen that has misunderstood the game.
+
+The other half of the feel is that a turn asks you for exactly one thing: the
+answer. You do not choose which problem you get and you do not choose where to
+move — the roll decides which pile your card comes from, and a right answer
+moves you along. Whether the problem in front of you is an easy one is luck, and
+that is how the classroom game works.
+
+The rules themselves are on [how to play](how-to-play.md), and the edges of
+what v1 includes are in [product scope](../specs/product-scope.md). This page
+does not restate either — there should only ever be one copy of a rule to keep
+true.
+
+## Two places v1 differs from the classroom game
+
+Both are Derek's calls, both are permitted by
+[ADR-0001](../adr/0001-rules-sacred-presentation-ours.md), and both are written
+here rather than left to be discovered. They are worth telling Connor about
+rather than presenting as already done.
+
+**Four players, where the card says 2–8.** The physical board has eight lanes
+and the box has eight frogs. v1 caps at four, because two-to-five-minute turns
+and one shared screen means eight players spend half an hour waiting. At a table
+that is fine — everyone can see the board and think at the same time. One device
+takes that away. Five to eight players is
+[parked, not dropped](../specs/future-ideas.md#five-to-eight-players).
+
+**A working-out grid, which the classroom game has no equivalent of.** At school
+the working happens on paper next to the board. On a tablet there is no paper,
+so the game provides a structured grid with carry boxes to do the long
+multiplication in —
+[ADR-0002](../adr/0002-structured-working-out-grid.md). It is a workspace and
+nothing else: nothing written in it is marked, and only the answer moves a frog.
+
+## What this game is not
+
+**Nothing multiplies on screen.** The frog is a playing piece, there is one per
+player, and the title stays a pun. Frogs that visibly multiply on a correct
+answer was proposed and declined by Connor; it is
+[parked](../specs/future-ideas.md#frogs-that-visibly-multiply).
+
+**No computer frogs.** Every frog belongs to a person in the room. The intended
+direction is toward *more* real people playing together, not a synthetic
+opponent, and the cost of that is real and accepted: Connor cannot play alone.
+[Parked](../specs/future-ideas.md#computer-frogs).
+
+**No accounts, no ads, no purchases, no network.** The game does not know who is
+playing, does not cost anything, and does not talk to the internet — v1 ships
+with no network permission at all, and
+[ADR-0003](../adr/0003-network-boundary.md) says why the internet is out
+permanently. These are not features waiting to be traded away in a later
+version.
+
+And four things that are simply out of v1, each parked rather than dropped:
+
+| Not in v1 | Where it went |
+| --- | --- |
+| Sound and music | [Parked](../specs/future-ideas.md#sound-and-music) |
+| Any arithmetic but multiplication | [Parked](../specs/future-ideas.md#other-kinds-of-arithmetic) |
+| More than one board | [Parked](../specs/future-ideas.md#more-than-one-board) |
+| An in-app tutorial | [Parked](../specs/future-ideas.md#an-in-app-tutorial) |
+
+"Parked" means exactly what [future ideas](../specs/future-ideas.md) says it
+means: the idea is written down with the reason it is not being built, and it
+stays out of scope until somebody deliberately promotes it. It is not a no.
+
+## What it looks like is not decided yet
+
+There is no art direction on this page, and that is deliberate rather than an
+omission. The founding conversation ticked six of its seven boxes and left this
+one open on purpose — writing a line about the look to satisfy a checklist would
+be inventing a decision nobody made.
+
+What was decided is how to keep the question cheap to answer later: placeholder
+shapes for now, every placeholder dimension a named constant, so a later
+re-skin is a change of values rather than a rebuild. Art direction gets its own
+issue, and Connor gets to have opinions in it.
+
+## Where all of this was settled
+
+Nothing on this page was decided here. It is a distillation, and every claim
+should be walkable back to the conversation that settled it:
+
+| What | Settled in |
+| --- | --- |
+| The pitch, the audience, the pace, and what is out of v1 | [#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7) |
+| The rules the photograph could not settle, answered by Connor | [#170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170) |
+| Rules sacred, presentation ours | [ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) |
+| The working-out grid | [ADR-0002](../adr/0002-structured-working-out-grid.md) |
+| The network boundary | [ADR-0003](../adr/0003-network-boundary.md) |
+| The classroom game itself | [Reference material](../specs/reference/index.md) |
+
+If this page and one of those disagree, the source wins, and the fix is to
+correct this page in the pull request where you noticed it.


### PR DESCRIPTION
Closes #10

`docs/intro/vision.md` was a "Not written yet" stub, and it is the page the docs
landing page sends anyone curious about the game to first. It now says what
Multiplying Frogs is: the multiplication board game from Connor's math class, on
a tablet — a port, not a new game — who it is for, and what it feels like to
play, which is slow and thinky rather than snappy. It also says out loud the two
places v1 differs from the classroom game (four players where the card says 2–8,
and the working-out grid), and what the game deliberately is not.

Nothing on the page is decided by the page. Every claim is distilled from the
founding design conversation in #7 and Connor's answers in #170, and the last
section is a table pointing each claim back at where it was settled.

**Docs:** `docs/intro/vision.md` — the stub is replaced with the real page: the
pitch, the audience, the pace, the port-not-a-new-game framing, the two v1
deviations, the "what this game is not" list, and a traceability table. No other
docs page changed.

## Spec invariants

This is a docs-only change, so the invariants it had to keep are about not
quietly moving the contract:

- **No mechanic is invented.** Every sentence traces to #7, #170, an ADR, or
  `docs/specs/reference/index.md`; the page's closing table is the mapping.
- **Vision is the pitch, not the rulebook.** No roll → pile table, no movement
  rule, no restatement of the win condition beyond the one line of the pitch.
  The page links [how to play](docs/intro/how-to-play.md) and
  [product scope](docs/specs/product-scope.md) instead, so each rule still has
  exactly one home.
- **Art direction stays deferred.** #7 left that box unticked deliberately, so
  the page says the look is not decided yet and describes no visual style.
- **Vocabulary matches `CONTEXT.md`** — lane, End log, pile, card, roll, frog as
  a playing piece, the classroom game.
- **It does not contradict the merged README or `docs/index.md`.** Same pitch,
  same player count, same free/offline/no-accounts position.
- `mkdocs build --strict` passes, and every `future-ideas.md` anchor the page
  links to was checked against the built HTML.

## How the spec is changing

It isn't. The contract gains a page it always intended to have; no rule that was
already written down changed meaning.

## Deviations and Decisions

- **"On a tablet", where #7's pitch says "on a phone".** The merged `README.md`,
  `docs/index.md` and `CLAUDE.md` (rule 8, mockups at 1920 × 1200) all treat a
  kids' Android tablet as the target device, so the page follows them rather
  than #7's earlier wording. This is a wording swap, not a decision — but #7
  also reasons about portrait layout in places, so the phone/tablet language
  across the older issues is worth a tidy-up at some point.
- **No test failed first.** This is a prose page; the only executable check is
  `mkdocs build --strict`, which passed before the change as well. The
  substantive verification was the checklist in the triage comment, ticked
  item by item, plus the anchor check above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_