### PR TITLE
docs: write the specs overview page

### DIFF
--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -1,8 +1,118 @@
 # Specs
 
-!!! note "Not written yet"
-    This page is a stub so the docs site builds and the navigation reflects
-    what the contract will cover. It is filled in by
-    [issue #13](https://github.com/derekwinters/connor-multiplying-frogs/issues/13).
+**These pages are the implementation contract.** They say what Multiplying
+Frogs does — the rules it plays by, the edges of the product, and the layout of
+every screen — precisely enough that code is built from them and a pull request
+can be held against them.
 
-An overview of the specification pages and how to read them.
+The [site as a whole](../index.md) is the design contract; this section is the
+part of it a build is checked against line by line. The
+[introduction](../intro/index.md) explains the game to a person and is allowed
+to be friendly about it. These pages are not friendly, on purpose: where the
+two describe the same rule, this section is the one the code follows.
+
+!!! warning "The code and a page here cannot quietly disagree"
+
+    When they disagree, one of them is a bug, and **which one moves is a
+    decision, not an assumption**. Say so on the issue and let a human pick the
+    side that changes. Editing whichever was easier to change is how a contract
+    stops being one.
+
+## A gap is a stop, not an invitation
+
+Behaviour these pages do not describe is behaviour nobody has decided yet. The
+response is to open a `type:question` issue naming the choice and the options,
+and to go and work on something else — never to pick the sensible-looking
+answer and leave a note about it in the pull request. A guessed mechanic that
+ships is the game drifting away from being Connor's, which is the whole reason
+for building it this way.
+
+### Telling a rule gap from a presentation gap
+
+[ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) draws the line this
+section is organised around, and it is the fastest way to work out what a
+particular gap costs.
+
+| The gap is in | Whose answer it is | What to do |
+| --- | --- | --- |
+| A **rule** — how far a frog moves, what a wrong answer costs, how many players there are, what winning means | Connor's, via the classroom game | Check [reference material](reference/index.md) first; the board may already settle it. If it does not, open the question and stop. |
+| **Presentation** — layout, animation, what is tapped, what the screen shows and when | The project's | Design it. For anything with a layout, that means an agreed wireframe first, not a layout invented in code. |
+
+A presentation gap is ours to fill, which is not the same as ours to skip. UI
+structure starts as a wireframe under the
+[UI design process](../engineering/ui-design-process.md) and becomes a page
+under [UI](ui/index.md) before any of it becomes code.
+
+Why a page here says what it says is often one level down, in
+[Decisions](../adr/index.md): a spec page states what is true now, an ADR
+records what was chosen once and why.
+
+## What the first complete release covers
+
+**v1 is the classroom game on one tablet.** Two to four players share an
+Android tablet held landscape and pass it around: roll the die, draw a card
+from the pile the roll names, work the multiplication out on screen, and hop
+one lily pad up your own lane — or one back if you got it wrong. The first frog
+onto its End log wins. That is the whole of it.
+
+It costs nothing, has no accounts and no advertising, makes no network calls,
+and keeps everything it stores on the device. Those are permanent product
+invariants rather than v1 defaults. [Product scope](product-scope.md) is the
+authority on the product's edges and states them in the form a pull request can
+be held against; what is deliberately *out* of v1 — sound, other kinds of
+arithmetic, a second board, a tutorial, players five to eight — is listed once
+in [the vision](../intro/vision.md#what-this-game-is-not), and each item is
+parked rather than dropped.
+
+!!! danger "One page in this section is not the contract"
+
+    [Future ideas](future-ideas.md) is the exact opposite of one. Everything on
+    it is deliberately out of scope, and finding an idea there is not
+    permission to build it. It sits in this section because the ideas are about
+    the game, not because any of them are agreed.
+
+## Pages
+
+Grouped by what they describe. **The list grows as spec pages land** — a system
+with no page here is a system whose contract has not been written yet, which is
+worth knowing in itself.
+
+### The game
+
+| Page | What it settles |
+| --- | --- |
+| [Reference material](reference/index.md) | The classroom board, photographed and transcribed: the rules card verbatim, the three card piles and the rolls that reach them, the nine positions in a lane, and the handful of things the board leaves open. |
+
+The precise rules spec — every rule stated edge case by edge case for the code
+to be built against — is
+[issue #199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199)
+and does not exist yet. Until it lands, reference material is where the rules
+are recorded, and [how to play](../intro/how-to-play.md) is the same rules in
+the friendly form.
+
+### The product
+
+| Page | What it settles |
+| --- | --- |
+| [Product scope](product-scope.md) | The five invariants, the target device, how you get hold of the game, where the network boundary sits, and what the save is allowed to be. |
+
+### The screens
+
+[UI](ui/index.md) is the layout contract: one page per screen and per dialog,
+each carrying its invariants, regions, anchors and named constants, with a 1:1
+HTML [mockup](ui/mockups/index.md) alongside it.
+
+| Page | What it settles |
+| --- | --- |
+| [UI overview](ui/index.md) | The nine screens of v1 in the order a game meets them, and the template every screen page follows. |
+| [Shared components](ui/shared-components.md) | The pieces used on more than one screen — buttons, the player chip, the confirm dialog — specified once and referenced everywhere else. |
+| [Mockups](ui/mockups/index.md) | The rendered 1920 × 1200 mockups the screen pages link to. |
+
+The individual screen pages are listed on the
+[UI overview](ui/index.md#screens) rather than repeated here.
+
+### Not the contract
+
+| Page | What it is |
+| --- | --- |
+| [Future ideas](future-ideas.md) | The parking lot. Ideas deliberately not being built, each with the reason it was set aside and what it would take to promote it. |


### PR DESCRIPTION
Closes #13

`docs/specs/index.md` was a one-line stub. It is now the front door of the specs section: it says these pages are what the code gets built from, that a gap in them is a question for Connor rather than something to fill in, and it lists what is in the section so a reader lands on the right page. It also says plainly that future ideas is the one page in there that is *not* the contract, so the section does not look like it contradicts itself on its own second page.

**Docs:** `docs/specs/index.md` — replaced the "Not written yet" stub with the full overview: the contract framing, the stop-and-flag rule, ADR-0001's rule-versus-presentation split as the test for what a gap costs, a short v1 scope paragraph deferring to product scope, and a Pages list grouped by system. No other file changed.

## Spec invariants

Docs-only, so the invariants at stake are the ones about where a rule is allowed to live. Each was kept by pointing at the owning page rather than restating it:

- **One rule, one home.** The v1 scope paragraph is three sentences and a link — [product scope](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/product-scope.md) stays the authority on the product's edges, and the vision stays the single out-of-v1 list. Nothing on the new page re-decides either.
- **The classroom game is the authority on rules** (ADR-0001) — the rule-gap row sends you to reference material first, then to a `type:question`.
- **Wireframe before UI code** — the presentation-gap row says a presentation gap is ours to fill but still starts as a wireframe, so the page cannot be read as licence to invent a layout in code.
- **`mkdocs build --strict` passes with every internal link resolving** — verified, along with the three Python validators.

## How the spec is changing

It isn't. Nothing on this page decides anything new; every statement records a decision already made in `CLAUDE.md`, ADR-0001, the vision, or product scope, and links to it.

## Deviations and Decisions

- **No link to `docs/specs/rules.md`.** The triage plan assumed the rules spec would be linkable; it is #199 and comes later in this milestone, and the nav does not expect it yet. I confirmed empirically that adding the link aborts `mkdocs build --strict` (*"contains a link 'rules.md', but the target 'specs/rules.md' is not found"*), so the page refers to #199 by issue URL — the same pattern [how to play](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/intro/how-to-play.md) already uses — and names reference material as where the rules live until then.
- **Product scope is cited as the authority on the product's edges, not as "the authoritative in/out list".** Triage predates the page. Product scope, as written, explicitly declines to carry the out-of-v1 list and points at [the vision](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/intro/vision.md#what-this-game-is-not) instead. The docs are authoritative over the triage note, so the overview follows the split the pages actually use: product scope for the invariants and the hard edges, the vision for what is out of v1.
- **The Pages list covers more than triage listed, and does not enumerate the screens.** Triage was written when the section held four pages; it now holds product scope, future ideas, reference material, the UI overview, shared components, mockups and nine screen pages. Listing all nine here would be a second copy of the [UI overview's table](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/index.md#screens) to keep true, so the overview links that table instead of duplicating it.
- **The ADRs are mentioned in one line, not listed.** They live under `Decisions`, not under `specs/`, and `adr/index.md` already links back here. One sentence on the specs-versus-decisions difference seemed the most that could be said without duplicating either index.
- **The "Added to `mkdocs.yml` nav" box was a verification, not work** — `specs/index.md` was already the section's nav entry, so `mkdocs.yml` is unchanged.
- **The Core suite was not run: `dotnet` is not installed in this environment.** No code changed, so it is not affected. `mkdocs build --strict`, `check_core_isolation.py`, `check_geometry_literals.py` and `run_python_tests.py` all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_