### PR TITLE
docs: replace the stale pond and splitting examples with real game words

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -120,7 +120,7 @@ Closes #12
 Two or three sentences saying what changed and why, in language Connor could
 follow. No file list, no implementation tour.
 
-**Docs:** docs/specs/frogs.md — the splitting rule now caps at 32.
+**Docs:** docs/specs/ui/game-board.md — a lane is now nine positions, not eight.
 
 ## Deviations and Decisions
 

--- a/.claude/skills/core-unity-split/SKILL.md
+++ b/.claude/skills/core-unity-split/SKILL.md
@@ -17,8 +17,9 @@ This is the short answer.
 >
 > Yes → `Frogs.Core`. No → `Frogs.Unity`.
 
-A splitting rule can be wrong with no screen attached. A sprite being in the
-right place cannot. That one question settles almost every case.
+Where a frog lands after a wrong answer can be wrong with no screen attached. A
+sprite being in the right place cannot. That one question settles almost every
+case.
 
 Two ways to check yourself:
 
@@ -26,8 +27,8 @@ Two ways to check yourself:
   frames, it belongs in Core.** If the only test you can imagine is "it looks
   right", it belongs in the shell — or it is a decision, not code, and belongs
   in a wireframe.
-- **If a `MonoBehaviour` contains a rule** — how fast a frog moves, when it
-  splits, what scores — that rule is in the wrong assembly.
+- **If a `MonoBehaviour` contains a rule** — how far a frog moves, what a wrong
+  answer costs, what winning means — that rule is in the wrong assembly.
 
 ## The layout
 
@@ -79,8 +80,9 @@ sealed class UnityClock : IClock {
 
 Core declares what it needs in the game's vocabulary; the shell provides it;
 tests substitute a fake and control it exactly. That last part is the point —
-`IClock` is not ceremony, it is what makes "what happens if two splits land in
-the same tick" a test rather than a thing you find out on a phone.
+`IClock` is not ceremony, it is what makes "what happens if `Roll` is tapped
+while the frog's hop is still playing" a test rather than a thing you find out
+on a tablet.
 
 ### Specific cases
 
@@ -88,7 +90,7 @@ the same tick" a test rather than a thing you find out on a phone.
 | --- | --- |
 | `Time.deltaTime` | an `IClock`, or pass elapsed seconds into the tick |
 | `Random` | an interface Core owns, seeded in tests |
-| `Vector3` | a Core type in the game's own vocabulary — a pond position, a lily index |
+| `Vector3` | a Core type in the game's own vocabulary — a position in a lane, a lily pad index |
 | `Debug.Log` | return the fact, or an interface the shell logs through |
 | `MonoBehaviour` lifecycle | a plain method the shell calls from `Update` |
 

--- a/.claude/skills/scaffold-core/SKILL.md
+++ b/.claude/skills/scaffold-core/SKILL.md
@@ -6,8 +6,8 @@ description: Create a new Core type and its failing test, following the project'
 # scaffold-core
 
 ```bash
-python3 .claude/skills/scaffold-core/scaffold.py Pond
-python3 .claude/skills/scaffold-core/scaffold.py SplitRule --subfolder Rules
+python3 .claude/skills/scaffold-core/scaffold.py Lane
+python3 .claude/skills/scaffold-core/scaffold.py Card --subfolder Cards
 ```
 
 ## Run this before any logic exists
@@ -29,8 +29,8 @@ someone who already knows the answer.
 
 Namespaces and layout follow
 [tech-stack.md](../../../docs/engineering/tech-stack.md): a subfolder becomes a
-namespace segment, so `--subfolder Rules` gives `Frogs.Core.Rules` and
-`Frogs.Core.Tests.Rules`.
+namespace segment, so `--subfolder Cards` gives `Frogs.Core.Cards` and
+`Frogs.Core.Tests.Cards`.
 
 ### Three decisions worth knowing
 
@@ -43,8 +43,8 @@ passing suite right after scaffolding tells you nothing. Running the suite
 immediately after this must go red. The failure message says what to do next:
 
 ```text
-Failed Pond_DoesTheThingTheIssueAskedFor
-  Write the first real test for Pond.
+Failed Lane_DoesTheThingTheIssueAskedFor
+  Write the first real test for Lane.
 ```
 
 **The test file gets no `.meta`.** `Tests/Core` is outside `Assets/`, so Unity
@@ -76,5 +76,5 @@ dotnet test Tests/Core/Frogs.Core.Tests.csproj
 python3 .github/scripts/run_python_tests.py scaffold-core
 ```
 
-23 tests. Everything that generates text is a pure function, and the writing is
+24 tests. Everything that generates text is a pure function, and the writing is
 tested against a temporary directory.

--- a/.claude/skills/scaffold-core/scaffold.py
+++ b/.claude/skills/scaffold-core/scaffold.py
@@ -4,8 +4,8 @@
 Run this **before** writing any logic. It leaves you at the *start* of the red
 phase: an empty class, and a test that fails.
 
-    python3 .claude/skills/scaffold-core/scaffold.py Pond
-    python3 .claude/skills/scaffold-core/scaffold.py Pond --subfolder Rules
+    python3 .claude/skills/scaffold-core/scaffold.py Lane
+    python3 .claude/skills/scaffold-core/scaffold.py Card --subfolder Cards
 
 What it writes, following docs/engineering/tech-stack.md:
 
@@ -44,7 +44,7 @@ def validate_type_name(name: str) -> str:
     if not TYPE_NAME.match(trimmed):
         raise ValueError(
             f"'{name}' is not a usable type name. Use PascalCase with no dots or "
-            "spaces — `Pond`, `FrogColony`, `SplitRule`."
+            "spaces — `Lane`, `LilyPad`, `Card`."
         )
 
     return trimmed

--- a/.claude/skills/scaffold-core/tests/test_scaffold.py
+++ b/.claude/skills/scaffold-core/tests/test_scaffold.py
@@ -12,28 +12,42 @@ import scaffold  # noqa: E402
 
 class NameTests(unittest.TestCase):
     def test_a_plain_name_is_accepted(self):
-        self.assertEqual("Pond", scaffold.validate_type_name("Pond"))
+        self.assertEqual("Lane", scaffold.validate_type_name("Lane"))
 
     def test_whitespace_is_trimmed(self):
-        self.assertEqual("Pond", scaffold.validate_type_name("  Pond  "))
+        self.assertEqual("Lane", scaffold.validate_type_name("  Lane  "))
 
     def test_a_lowercase_name_is_rejected(self):
         # C# types are PascalCase, and a scaffolder that silently "fixes" the
         # name produces a file whose name does not match what was asked for.
         with self.assertRaises(ValueError):
-            scaffold.validate_type_name("pond")
+            scaffold.validate_type_name("lilypad")
 
     def test_a_name_with_a_space_is_rejected(self):
         with self.assertRaises(ValueError):
-            scaffold.validate_type_name("Frog Colony")
+            scaffold.validate_type_name("Lily Pad")
 
     def test_a_name_with_a_dot_is_rejected(self):
         with self.assertRaises(ValueError):
-            scaffold.validate_type_name("Frogs.Pond")
+            scaffold.validate_type_name("Frogs.Lane")
 
     def test_an_empty_name_is_rejected(self):
         with self.assertRaises(ValueError):
             scaffold.validate_type_name("")
+
+    def test_the_rejection_message_suggests_this_game_s_type_names(self):
+        # This message is read at the moment a type gets its name, so the
+        # examples in it seed the domain model. They have to be words from
+        # CONTEXT.md, not from a game we are not building.
+        with self.assertRaises(ValueError) as raised:
+            scaffold.validate_type_name("lane")
+
+        message = str(raised.exception)
+
+        self.assertIn("`Lane`", message)
+        self.assertNotIn("Pond", message)
+        self.assertNotIn("Colony", message)
+        self.assertNotIn("Split", message)
 
 
 class NamespaceTests(unittest.TestCase):
@@ -41,13 +55,13 @@ class NamespaceTests(unittest.TestCase):
         self.assertEqual("Frogs.Core", scaffold.namespace_for(""))
 
     def test_a_subfolder_becomes_a_namespace_segment(self):
-        self.assertEqual("Frogs.Core.Rules", scaffold.namespace_for("Rules"))
+        self.assertEqual("Frogs.Core.Cards", scaffold.namespace_for("Cards"))
 
     def test_nested_subfolders_nest_the_namespace(self):
-        self.assertEqual("Frogs.Core.Rules.Splitting", scaffold.namespace_for("Rules/Splitting"))
+        self.assertEqual("Frogs.Core.Cards.Piles", scaffold.namespace_for("Cards/Piles"))
 
     def test_the_test_namespace_mirrors_it(self):
-        self.assertEqual("Frogs.Core.Tests.Rules", scaffold.test_namespace_for("Rules"))
+        self.assertEqual("Frogs.Core.Tests.Cards", scaffold.test_namespace_for("Cards"))
 
 
 class GuidTests(unittest.TestCase):
@@ -70,13 +84,13 @@ class GuidTests(unittest.TestCase):
 
 class GeneratedSourceTests(unittest.TestCase):
     def test_the_class_is_in_the_right_namespace(self):
-        source = scaffold.class_source("Pond", "Frogs.Core.Rules")
+        source = scaffold.class_source("Card", "Frogs.Core.Cards")
 
-        self.assertIn("namespace Frogs.Core.Rules", source)
-        self.assertIn("public sealed class Pond", source)
+        self.assertIn("namespace Frogs.Core.Cards", source)
+        self.assertIn("public sealed class Card", source)
 
     def test_the_class_does_not_reference_unity(self):
-        source = scaffold.class_source("Pond", "Frogs.Core")
+        source = scaffold.class_source("Lane", "Frogs.Core")
 
         self.assertNotIn("UnityEngine", source)
         self.assertNotIn("MonoBehaviour", source)
@@ -85,14 +99,14 @@ class GeneratedSourceTests(unittest.TestCase):
         # The scaffolder leaves you at the START of the red phase. A class with
         # a plausible implementation already in it is an invitation to skip
         # writing the test that should have driven it.
-        source = scaffold.class_source("Pond", "Frogs.Core")
+        source = scaffold.class_source("Lane", "Frogs.Core")
 
         self.assertNotIn("return", source)
 
 
 class GeneratedTestTests(unittest.TestCase):
     def source(self):
-        return scaffold.test_source("Pond", "Frogs.Core", "Frogs.Core.Tests")
+        return scaffold.test_source("Lane", "Frogs.Core", "Frogs.Core.Tests")
 
     def test_it_is_a_failing_test_not_an_empty_stub(self):
         # The whole point: running the suite immediately after scaffolding must
@@ -102,7 +116,7 @@ class GeneratedTestTests(unittest.TestCase):
         self.assertIn("Assert.Fail", source)
 
     def test_it_names_the_type_under_test(self):
-        self.assertIn("PondTests", self.source())
+        self.assertIn("LaneTests", self.source())
 
     def test_it_uses_the_test_namespace_and_imports_the_type(self):
         source = self.source()
@@ -118,11 +132,11 @@ class WritingTests(unittest.TestCase):
     def test_it_writes_four_files_in_the_right_places(self):
         with TemporaryDirectory() as directory:
             root = Path(directory)
-            written = scaffold.scaffold(root, "Pond", subfolder="Rules")
+            written = scaffold.scaffold(root, "Card", subfolder="Cards")
 
-            self.assertTrue((root / "Assets/Scripts/Core/Rules/Pond.cs").is_file())
-            self.assertTrue((root / "Assets/Scripts/Core/Rules/Pond.cs.meta").is_file())
-            self.assertTrue((root / "Tests/Core/Rules/PondTests.cs").is_file())
+            self.assertTrue((root / "Assets/Scripts/Core/Cards/Card.cs").is_file())
+            self.assertTrue((root / "Assets/Scripts/Core/Cards/Card.cs.meta").is_file())
+            self.assertTrue((root / "Tests/Core/Cards/CardTests.cs").is_file())
             self.assertEqual(3, len(written))
 
     def test_the_test_file_gets_no_meta(self):
@@ -130,17 +144,17 @@ class WritingTests(unittest.TestCase):
         # there would be a file nothing reads.
         with TemporaryDirectory() as directory:
             root = Path(directory)
-            scaffold.scaffold(root, "Pond")
+            scaffold.scaffold(root, "Lane")
 
-            self.assertFalse((root / "Tests/Core/PondTests.cs.meta").exists())
+            self.assertFalse((root / "Tests/Core/LaneTests.cs.meta").exists())
 
     def test_it_refuses_to_overwrite(self):
         with TemporaryDirectory() as directory:
             root = Path(directory)
-            scaffold.scaffold(root, "Pond")
+            scaffold.scaffold(root, "Lane")
 
             with self.assertRaises(FileExistsError):
-                scaffold.scaffold(root, "Pond")
+                scaffold.scaffold(root, "Lane")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -65,9 +65,10 @@ Read the issue, then pick exactly one. Most of the skill is knowing which.
 Diagnose the **root cause**, not the symptom. Then: the fix approach, a
 `## Build checklist`, the milestone, `type:bug`, `pending-approval`.
 
-A bug report says "the frogs kept splitting past 32". The diagnosis says which
-code path skipped the check and why. A plan written against the symptom fixes
-the one case in the report and leaves the other three.
+A bug report says "my frog went backwards off the bottom of its lane". The
+diagnosis says which code path skipped the Start-log floor and why. A plan
+written against the symptom fixes the one case in the report and leaves the
+other three.
 
 #### When the root cause is a missing rule
 
@@ -79,10 +80,10 @@ That is a **spec gap**, and patching the code alone guarantees the same class of
 bug returns somewhere else. The plan proposes the missing **invariant** in
 plain English, and the checklist gets an item that tests it:
 
-> **Proposed invariant:** a frog never splits when the pond is at its cap,
-> whatever caused the split — timer, tap, or another frog landing on it.
+> **Proposed invariant:** a frog never moves below the Start log, whatever
+> moved it back — a wrong answer, or a turn that resolves twice.
 >
-> - [ ] Test: a tap on a frog at cap produces no new frog
+> - [ ] Test: a wrong answer on the Start log leaves the frog on the Start log
 
 Proposing an invariant is not inventing a mechanic: it is writing down the rule
 the existing behaviour already implies, so it can be agreed or corrected. If the
@@ -110,11 +111,11 @@ survive into the build because it was already written down.
 Ask one concrete question:
 
 ```markdown
-❓ **Needs from Derek/Connor:** when the pond is full and Connor taps a frog,
-should nothing happen, or should the frog wiggle to show it heard the tap?
+❓ **Needs from Derek/Connor:** when a wrong answer moves a frog back a lily
+pad, should the frog hop backwards, or just appear on the lower pad?
 
-Either is easy to build. I've not guessed because it changes how the game feels
-when you're winning.
+Either is easy to build. I've not guessed because it changes how it feels to
+get one wrong.
 ```
 
 Concrete means answerable with a sentence. "How should this work?" hands the

--- a/.claude/skills/triage-issue/tests/test_hand_back.py
+++ b/.claude/skills/triage-issue/tests/test_hand_back.py
@@ -18,17 +18,17 @@ import hand_back  # noqa: E402
 import parse_commands  # noqa: E402
 
 ANALYSIS = """\
-Frogs keep multiplying past the limit when you tap them quickly.
+A wrong answer on the Start log moves the frog off the bottom of its lane.
 
 ## Build checklist
 
-- [ ] Check the cap at the moment the frog is added
+- [ ] Clamp a back move at the Start log
 """
 
 QUESTION = """\
 This one needs a decision before it can be planned.
 
-❓ **Needs from Derek/Connor:** should a tap on a full pond do nothing?
+❓ **Needs from Derek/Connor:** should a frog hop backwards on a wrong answer?
 """
 
 PENDING = "pending-approval"

--- a/.claude/skills/triage-issue/tests/test_triage_repair.py
+++ b/.claude/skills/triage-issue/tests/test_triage_repair.py
@@ -11,18 +11,18 @@ import triage_repair as repair  # noqa: E402
 BOT = "github-actions[bot]"
 
 CHECKLIST_BODY = """\
-Frogs keep multiplying past the limit when you tap them quickly.
+A wrong answer on the Start log moves the frog off the bottom of its lane.
 
 ## Build checklist
 
-- [ ] Check the cap at the moment the frog is added
+- [ ] Clamp a back move at the Start log
 """
 
 QUESTION_BODY = """\
 This one needs a decision before it can be planned.
 
-❓ **Needs from Derek/Connor:** should a tap on a full pond do nothing, or
-should the frog wiggle?
+❓ **Needs from Derek/Connor:** should a frog hop backwards on a wrong answer,
+or just appear on the lower pad?
 """
 
 

--- a/.github/scripts/lint_pr_title.py
+++ b/.github/scripts/lint_pr_title.py
@@ -9,7 +9,7 @@ merge succeeds, and the version silently does not move.
 So the title is a required check rather than a matter of discipline.
 
 Usage:
-    python3 .github/scripts/lint_pr_title.py --title "feat(frogs): add the pond"
+    python3 .github/scripts/lint_pr_title.py --title "feat(frogs): add the lane"
     PR_TITLE="fix: ..." python3 .github/scripts/lint_pr_title.py
 
 Exits 0 when the title conforms, 1 with one line per problem when it does not.
@@ -77,7 +77,7 @@ def validate(title: str) -> list[str]:
     if not match:
         return problems + [
             f"'{title}' is not a Conventional Commit. Expected `type(scope): subject`, "
-            f"for example `feat(frogs): add the pond`. Allowed types: "
+            f"for example `feat(frogs): add the lane`. Allowed types: "
             f"{', '.join(ALLOWED_TYPES)}."
         ]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ by three PRs is not a contract.
 Every PR body carries a `**Docs:**` line stating what happened:
 
 ```
-**Docs:** docs/specs/frogs.md — updated the splitting rule to cap at 32.
+**Docs:** docs/specs/ui/game-board.md — a lane is now nine positions, not eight.
 **Docs:** None — no behaviour the docs describe was changed.
 ```
 

--- a/docs/engineering/agent-workflow.md
+++ b/docs/engineering/agent-workflow.md
@@ -110,11 +110,11 @@ list of squashed changes, one per issue.
 
 **Every PR body opens with two or three sentences saying what changed and why,
 in language Connor could follow.** Before any technical detail. No file list, no
-implementation tour, no "refactored `FrogColony` to extract an interface".
+implementation tour, no "refactored `Lane` to extract an interface".
 
-> Frogs now stop splitting once there are 32 of them, instead of filling the
-> pond until the game slows down. The cap is a number we can change later if 32
-> turns out to be too few.
+> A wrong answer while your frog is still on the Start log now leaves it where
+> it is, instead of sliding it off the bottom of the lane. The Start log is the
+> floor of a lane, so the worst a wrong answer can do down there is nothing.
 
 ### Why this and not a summary of the diff
 
@@ -158,35 +158,37 @@ Invariants are stated as their own line, marked, so they can be quoted and
 found:
 
 ```markdown
-**Invariant:** a pond never contains more than `MaxColonySize` frogs.
-**Invariant:** splitting never produces a frog outside the pond bounds.
+**Invariant:** a frog never moves below the Start log.
+**Invariant:** a turn moves one frog, by exactly one position.
 ```
 
 ### Worked example
 
-An issue says: *"Frogs should split every few seconds until the pond is full."*
+An issue says: *"A wrong answer moves the frog back one lily pad."*
 
-Outcome-only, the spec would say "frogs split until the pond is full", and this
-implementation satisfies it:
+Outcome-only, the spec would say exactly that, and this implementation
+satisfies it:
 
 ```csharp
-if (colony.Count < MaxColonySize) colony.Add(Frog.SplitFrom(parent));
+if (!correct) position -= 1;
 ```
 
-…which is wrong when a split would produce two frogs and the colony is at
-`MaxColonySize - 1`, and wrong again if two splits resolve in the same tick.
-Neither case is in the outcome, so neither is caught.
+…which is wrong on the Start log, where `position` becomes `-1` and the frog
+drops off the bottom of its lane. The outcome says nothing about the bottom of
+a lane, so nothing catches it.
 
 With invariants, the spec says:
 
-> **Invariant:** a pond never contains more than `MaxColonySize` frogs.
-> **Invariant:** a split either adds all of its offspring or none of them.
+> **Invariant:** a frog never moves below the Start log — a wrong answer there
+> leaves it where it is.
+> **Invariant:** a turn moves one frog, by exactly one position.
 
 Now the boundary cases are specified, the tests write themselves, and the PR
 can say:
 
-> **Spec invariants kept:** colony size never exceeds `MaxColonySize`
-> (`SplitStopsAtCap`), and a split is all-or-nothing (`PartialSplitRejected`).
+> **Spec invariants kept:** a wrong answer on the Start log moves nothing
+> (`WrongAnswerOnStartLogStaysPut`), and no turn moves a frog by more than one
+> position (`TurnMovesExactlyOnePosition`).
 
 Naming the test next to the invariant is what makes the claim checkable. "I kept
 the invariants" is not a claim; "this test asserts it" is.
@@ -196,10 +198,11 @@ the invariants" is not a claim; "this test asserts it" is.
 When a change **moves the contract** — the old rule was X, the new rule is Y —
 the PR body carries a blockquote note saying so:
 
-> **How the spec is changing:** previously a frog could split at any colony
-> size and the pond simply grew. From this change, splitting stops at 32,
-> because past roughly forty frogs the pond stops being readable on a phone
-> screen and the game stops being fun.
+> **How the spec is changing:** the spec used to leave the top of a lane open —
+> seven lily pads, and "first one to the end wins". From this change a lane is
+> nine positions and a frog wins by *landing on* the End log, because the Start
+> log is already a real space a frog sits on and both ends of a lane should
+> behave the same way.
 
 Three sentences: what the old rule was, what the new one is, why the new one is
 better.

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -223,8 +223,8 @@ Run it before pushing. CI runs it too ([CI/CD](ci-cd.md)).
 
 **The Unity layer is thin.** It reads input, hands it to Core, asks Core what the
 world looks like now, and draws that. A `MonoBehaviour` that contains a rule —
-how fast a frog moves, when it splits, what scores — is a rule in the wrong
-assembly.
+how far a frog moves, what a wrong answer costs, what winning means — is a rule
+in the wrong assembly.
 
 ### Why
 
@@ -341,51 +341,58 @@ Use the `scaffold-core` skill to create a Core type; it applies all of this and
 leaves you with a failing test, which is where a new type should start.
 
 ```bash
-python3 .claude/skills/scaffold-core/scaffold.py SplitRule --subfolder Rules
+python3 .claude/skills/scaffold-core/scaffold.py Card --subfolder Cards
 ```
 
 - Assemblies and their folders share a name: `Frogs.Core`, `Frogs.Unity`.
 - A subfolder under `Assets/Scripts/Core/` becomes a namespace segment:
-  `Rules/` is `Frogs.Core.Rules`, and its tests are `Frogs.Core.Tests.Rules`.
-- Core types are named for the game, not the engine — `Pond`, `FrogColony`,
-  `SplitRule`. If a type name only makes sense to someone who knows Unity, it
-  probably belongs in the shell.
+  `Cards/` is `Frogs.Core.Cards`, and its tests are `Frogs.Core.Tests.Cards`.
+- Core types are named for the game, not the engine — `Lane`, `LilyPad`,
+  `Card`. The words come from [`CONTEXT.md`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CONTEXT.md),
+  which is the glossary for exactly this reason. If a type name only makes sense
+  to someone who knows Unity, it probably belongs in the shell.
 - Unity-layer types that exist to display a Core type are named `<Thing>View`
   (`FrogView`), and ones that exist to feed input in are `<Thing>Input`.
 - One public type per file, file named for the type.
 
 ## Geometry, layout, and tuning values are named variables
 
-**Every size, offset, margin, spacing, duration, speed, delay, threshold, count,
-and payout is a named constant or a serialized field. Never a bare literal in a
+**Every size, offset, margin, spacing, duration, speed, delay, threshold, and
+count is a named constant or a serialized field. Never a bare literal in a
 method body.**
 
 ```csharp
 // No.
 transform.position = new Vector3(1.5f, 0.25f, 0f);
-if (colony.Count > 32) { … }
+if (position == 8) { … }
 yield return new WaitForSeconds(0.4f);
 
 // Yes.
-const int MaxColonySize = 32;
-[SerializeField] float _spawnHeight = 0.25f;
-[SerializeField] float _splitAnimationSeconds = 0.4f;
+const int LaneWinningPosition = 8;
+[SerializeField] float _lanePositionGap = 48f;
+[SerializeField] float _frogHopDuration = 0.4f;
 ```
+
+None of those three names is invented here. `LaneWinningPosition`,
+`LanePositionGap` and `FrogHopDuration` are what
+[the game board spec](../specs/ui/game-board.md) already calls those numbers,
+and a constant in the code keeps the name the spec page gave it so the two can
+be checked against each other.
 
 ### Why this is a rule and not a preference
 
-- **Tuning is the game.** Whether a frog splits after three seconds or four is
-  the difference between fun and not, and it is a question for Connor. A number
-  with a name is a number he can be asked about; `0.4f` on line 118 of a method
-  is not.
+- **Tuning is the game.** Whether a wrong answer costs a lily pad or costs
+  nothing is the difference between fun and not, and it is a question for
+  Connor. A number with a name is a number he can be asked about; `0.4f` on
+  line 118 of a method is not.
 - **A named value can be found.** Changing "the gap between lily pads" means
   finding one constant, not grepping for `1.5f` and guessing which of the eleven
   matches is the gap.
-- **A named value can be tested.** `MaxColonySize` can be asserted against;
-  `> 32` buried in a branch can only be re-typed into the test, where it will
-  agree with a bug just as happily as with correct code.
-- **The name is the documentation.** `_splitAnimationSeconds = 0.4f` says what
-  0.4 *is*. No comment required, and no comment to go stale.
+- **A named value can be tested.** `LaneWinningPosition` can be asserted
+  against; `== 8` buried in a branch can only be re-typed into the test, where
+  it will agree with a bug just as happily as with correct code.
+- **The name is the documentation.** `_frogHopDuration = 0.4f` says what 0.4
+  *is*. No comment required, and no comment to go stale.
 
 ### This includes graybox
 
@@ -401,7 +408,7 @@ Deliberately narrow:
   `count + 1` is fine; `width * 1` was never fine.
 - Loop bounds derived from a collection — `for (var i = 0; i < frogs.Count; i++)`.
 - Values inside a test that *are* the test's subject — a test asserting a frog
-  splits at 32 should say `32` where the reader can see it.
+  wins on position 8 should say `8` where the reader can see it.
 - Unity's own required literals in serialization or attribute arguments, where a
   constant is not permitted by the language.
 

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -42,7 +42,8 @@ only then fix it. A bug fix without a reproducing test is a bug that comes back.
 Say so. The PR body should be able to answer "what did the test say before the
 fix?" — usually one line:
 
-> `SplitsAtThreshold` failed with `Expected: 32, But was: 16` before the change.
+> `WrongAnswerOnStartLogStaysPut` failed with `Expected: 0, But was: -1` before
+> the change.
 
 An agent that cannot say this did not do step 2.
 

--- a/docs/intro/conventions.md
+++ b/docs/intro/conventions.md
@@ -256,7 +256,7 @@ GITHUB_TOKEN=... GITHUB_REPOSITORY=derekwinters/connor-multiplying-frogs \
 Every issue body ends with a line naming the pages in `/docs` it affects:
 
 ```
-**Spec pages touched:** docs/specs/frogs.md, docs/specs/ui/hud.md
+**Spec pages touched:** docs/specs/reference/index.md, docs/specs/ui/game-board.md
 **Spec pages touched:** none — repo config.
 ```
 
@@ -304,10 +304,10 @@ because nobody reads a closed issue's thread. Close it with a comment stating
 what was decided, in one sentence, so the thread has an answer at the bottom.
 
 **It stays open when** the decision is made but nothing has been written down
-yet, when it was answered partially ("splitting caps at 32" — but not what
-happens at the cap), or when the answer was "not yet". A question that was
-answered "not now" is a question that gets asked again later, and reopening a
-closed issue loses the thread.
+yet, when it was answered partially ("a wrong answer moves you back one" — but
+not what happens on the Start log), or when the answer was "not yet". A question
+that was answered "not now" is a question that gets asked again later, and
+reopening a closed issue loses the thread.
 
 **It becomes a task** — closed as a duplicate, with the task linked — when the
 answer turns out to be small enough to just build. Do not quietly retitle a

--- a/docs/specs/ui/index.md
+++ b/docs/specs/ui/index.md
@@ -31,7 +31,7 @@ See [target platform](../../engineering/tech-stack.md#target-platform).
 
 ## Shared components
 
-Reusable atomic pieces — a primary button, the score readout, a confirm dialog —
+Reusable atomic pieces — a primary button, a player chip, a confirm dialog —
 are specified once in [Shared components](shared-components.md) and
 **referenced** by screen pages, never re-specified in them.
 
@@ -56,21 +56,21 @@ Things that must always be true of this screen, stated as
 `**Invariant:** …` lines so they can be quoted in a PR and asserted in a test.
 
 ```markdown
-**Invariant:** the pause screen never covers the score readout.
+**Invariant:** whose turn it is is stated in words, not only shown by a highlight.
 **Invariant:** every destructive action confirms before it acts.
 ```
 
 ### 3. Regions
 
 The screen broken into its named areas, top to bottom. A region is a box with a
-name and a job — `header`, `playfield`, `controls`. Naming them is what lets
-everything else say *where* without re-describing the layout each time.
+name and a job. Naming them is what lets everything else say *where* without
+re-describing the layout each time. The [game board](game-board.md)'s three:
 
 | Region | Job |
 | --- | --- |
-| `header` | score and pause button |
-| `playfield` | the pond; everything interactive |
-| `controls` | the two action buttons |
+| `header` | whose turn it is, and the settings button |
+| `pond` | the lanes — one per frog in the game |
+| `controls` | the `Roll` button |
 
 ### 4. Anchors
 
@@ -89,8 +89,8 @@ radius, and duration on the screen, named and valued.
 
 | Element | Constant | Value |
 | --- | --- | --- |
-| Panel width | `PausePanelWidth` | 280 dp |
-| Gap between buttons | `PauseButtonSpacing` | 12 dp |
+| `Roll` button width | `RollButtonWidth` | 480 px |
+| Gap between positions in a lane | `LanePositionGap` | 48 px |
 
 Same names in the code. See
 [named constants are the origin](../../engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought).


### PR DESCRIPTION
Closes #174

The engineering handbook and the agent skills were teaching their rules with
examples from a game we are not building — a pond of frogs that split into
colonies until it filled up. Those pages are the ones an agent reads right
before it names something, so the wrong words were seeding the wrong game.
Every example is now written in this game's own words: lanes, lily pads, the
Start log, cards, and a frog that moves one space at a time.

**Docs:** `docs/engineering/tech-stack.md` — the naming and tuning examples now
use `Lane`, `LilyPad`, `Card`, `LaneWinningPosition`, `LanePositionGap` and
`FrogHopDuration`; `docs/engineering/agent-workflow.md` — the plain-English
lead, the invariant convention, the worked example and the "how the spec is
changing" example are rewritten around the Start-log floor and the End log;
`docs/engineering/testing.md` — the "seen to fail" example names a real test;
`docs/intro/conventions.md` — the example spec-page paths now resolve, and the
partially-answered-question example is a real one; `docs/specs/ui/index.md` —
the per-screen template's illustrative invariant, region and constant examples
are taken from the committed game board page. No behaviour and no rule changed;
these are all illustrations.

## Spec invariants

Nothing in this PR moves the contract, so the invariants it had to keep are the
ones about *not* moving it:

- **Every replacement term appears in `CONTEXT.md` or names a real part of this
  game.** Checked by reading `tech-stack.md`, `agent-workflow.md`,
  `core-unity-split` and `scaffold-core` end to end, and by a final repo grep
  for `pond`, `colony`, `split`, `MaxColonySize`, `FrogColony` and `SplitRule`
  that returns only the fixtures listed below and the live `pond` region.
- **Every replacement value is already written down somewhere.** `8`, `9`, `7`,
  `48 px` and `0.4 s` all come from
  `docs/specs/ui/game-board.md` § Named constants and § Behaviour, or from
  `docs/specs/reference/index.md`. No number was chosen here.
- **Every example file path resolves to a file that exists.** The phantom
  `docs/specs/frogs.md` and `docs/specs/ui/hud.md` are gone from `CLAUDE.md`,
  `.claude/agents/dev.md` and `docs/intro/conventions.md`.
- **No undecided rule got written down as though it were decided.** In
  particular the top-of-lane behaviour that #201 flags as unsettled is not used
  as an example anywhere.

The one behaviour change is in the scaffolder, and it has a test:
`test_the_rejection_message_suggests_this_game_s_type_names` failed with
`'`Lane`' not found in "… — `Pond`, `FrogColony`, `SplitRule`."` before the
change.

## Deviations and Decisions

- **Triage said to fix `docs/specs/ui/index.md` because "`playfield` = the
  board, not the pond". The current docs say otherwise, and the docs win.**
  `docs/specs/ui/game-board.md` — an agreed wireframe merged after that triage
  note was written — names the middle region of the board screen `pond`. So
  `pond` is live, decided vocabulary for a screen region, not a stale example,
  and renaming it would be changing an agreed wireframe rather than fixing a
  stale one. `game-board.md` is untouched. What I fixed in `ui/index.md`
  instead is the *template*, whose example regions were `playfield` and a
  `header` holding "score and pause button" — a screen this game does not have.
  The template's examples now come from the real board page.
- **Two example blocks in `docs/specs/ui/index.md` beyond the grep hit.** While
  fixing that region table I also replaced the invariant example ("the pause
  screen never covers the score readout"), the named-constants example
  (`PausePanelWidth` in dp) and one mention of "the score readout" — same
  disease, same table, and nothing in this game is scored or paused. Every real
  spec page measures in px, so the example does too.
- **Two Tier-2 strings fixed that triage said to leave.** `lint_pr_title.py`'s
  usage line and its failure message suggested `feat(frogs): add the pond` —
  read by whoever's PR title just failed lint, so it teaches. Now `add the
  lane`. Its 15 test fixtures still say "pond" and were left alone.
- **`CLAUDE.md` was edited** — the `**Docs:**` line example, which named
  `docs/specs/frogs.md`. Triage asked for an explicit yes on this; the approved
  checklist includes it, so I took the approval as given. It is one line and
  changes no rule.
- **Tier 2 left alone, as the grep box asks me to justify.** Sample strings that
  only need to be *a* string, in files whose tests assert on their exact text:
  `test_lint_pr_title.py` (15×), `test_docs_reconciliation_gate.py`'s
  `Assets/Scripts/Core/Pond.cs` path (9×), the `pipeline-dashboard` fixture
  issue titles, `test_run_comment_event.py`'s `/revise wrong pond`, and
  `ci_watch.py`'s `Failed SplitsAtThreshold` regex comment plus its fixture.
  None of them teaches vocabulary. I did update the `triage-issue` fixtures,
  because those mirror the prose examples in that skill's `SKILL.md` and would
  have drifted from them.
- **Tier 3 left alone:** the `core-unity-split` skill name, "the Core/Unity
  split" as prose, `.Split('#')` in `AppVersion.cs`, `splitlines()`, and
  `type:epic`'s "gets split into tasks".
- **The lane-count conflict triage flagged is still open and still not mine.**
  `CONTEXT.md` says four lanes and two-to-four players; `docs/specs/reference/index.md`
  says eight lanes and the rules card says 2–8. I have not resolved it and have
  not opened an issue for it — but none of the examples in this PR names a lane
  or player count, so nothing here depends on the answer. Worth its own issue.
- **`payout` dropped** from the list of things that must be named constants in
  `tech-stack.md`. Nothing in this game pays out, and monetization is banned
  outright by `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_