### PR TITLE
ci: re-run the docs gate when a PR's labels change

### DIFF
--- a/.github/scripts/tests/test_docs_gate_triggers.py
+++ b/.github/scripts/tests/test_docs_gate_triggers.py
@@ -1,0 +1,219 @@
+"""Adding `skip-docs` must actually re-run the docs reconciliation gate.
+
+`CLAUDE.md` rule 9, `docs/engineering/ci-cd.md`, and the gate's own failure
+message all tell a blocked human the same thing: add the label and the check
+re-runs, nothing needs pushing. That is the sentence someone reads at the
+moment they are stuck, so it is the worst one to have be false.
+
+It was false. The workflow carrying the gate triggered on a bare
+`pull_request:`, which is GitHub's default set — `opened`, `synchronize`,
+`reopened` — and a `labeled` event reaches none of those. Once the gate had
+failed, the label did nothing at all (issue #176).
+
+The invariant, stated once so it cannot rot back:
+
+    Every event that can change the gate's verdict must re-run the gate.
+
+The verdict has exactly two inputs — the PR's changed files and the PR's
+labels. `synchronize` covers the first. `labeled` covers the second, and it is
+the one that has to be asked for by name.
+
+Stdlib only, and regex rather than a YAML parse, for the same reason as
+`check_action_pins.py`: the `gate-tests` job runs `run_python_tests.py scripts`
+on nothing but the Python already on the runner, with no pip install to import
+`pyyaml` from. The shapes needed here are a nested mapping key and a short list.
+
+See docs/engineering/ci-cd.md and issue #176.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+
+# The gate is wherever this script is invoked from, rather than a hard-coded
+# workflow filename: moving the step to another workflow must move this check
+# with it, not quietly stop checking anything.
+GATE_SCRIPT = "docs_reconciliation_gate.py"
+
+# GitHub's implicit `types:` for a `pull_request` trigger, used whenever the key
+# is absent. `labeled` is deliberately not among them, which is the whole bug.
+DEFAULT_TYPES = ("opened", "synchronize", "reopened")
+
+# The label event is additional, and asking for it means spelling out the
+# defaults too — naming `types:` at all replaces them rather than adding to it.
+REQUIRED_TYPES = DEFAULT_TYPES + ("labeled",)
+
+BLANK_OR_COMMENT = re.compile(r"^\s*(#.*)?$")
+
+# `on:`, `"on":`, `'on':` — YAML 1.1 readers take a bare `on` for a boolean, so
+# either spelling is legitimate and both mean the trigger block.
+ON_KEY = re.compile(r"^(?:on|[\"']on[\"']):\s*(.*)$")
+
+LIST_ITEM = re.compile(r"^\s*-\s*(.+)$")
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def strip_inline_comment(value: str) -> str:
+    """Drop a trailing `# ...`, which YAML requires be preceded by whitespace."""
+    return re.split(r"\s+#", value, maxsplit=1)[0].strip()
+
+
+def block_under(lines: list[str], index: int) -> list[str]:
+    """The lines strictly inside the mapping opened at `lines[index]`."""
+    parent = indent_of(lines[index])
+    body: list[str] = []
+
+    for line in lines[index + 1:]:
+        if BLANK_OR_COMMENT.match(line):
+            continue
+        if indent_of(line) <= parent:
+            break
+        body.append(line)
+
+    return body
+
+
+def find_key(lines: list[str], key: str):
+    """`(index, inline value)` for `key:` in these lines, or None."""
+    pattern = re.compile(rf"^\s*{re.escape(key)}:\s*(.*)$")
+
+    for index, line in enumerate(lines):
+        if BLANK_OR_COMMENT.match(line):
+            continue
+        match = pattern.match(line)
+        if match:
+            return index, strip_inline_comment(match.group(1))
+
+    return None
+
+
+def parse_list(lines: list[str], index: int, inline: str) -> list[str]:
+    """A YAML list written either inline (`[a, b]`) or as `- ` items."""
+    if inline.startswith("["):
+        items = inline.strip("[]").split(",")
+        return [item.strip().strip("\"'") for item in items if item.strip()]
+
+    values = []
+    for line in block_under(lines, index):
+        match = LIST_ITEM.match(line)
+        if match:
+            values.append(strip_inline_comment(match.group(1)).strip("\"'"))
+
+    return values
+
+
+def pull_request_types(text: str):
+    """The `on: pull_request: types:` of a workflow.
+
+    None means the key is absent — which is not "no triggers" but GitHub's
+    defaults, and the distinction is exactly what this file is about.
+    """
+    lines = text.splitlines()
+
+    on_index = next(
+        (index for index, line in enumerate(lines)
+         if indent_of(line) == 0 and ON_KEY.match(line)),
+        None,
+    )
+    if on_index is None:
+        return None
+
+    triggers = block_under(lines, on_index)
+
+    found = find_key(triggers, "pull_request")
+    if found is None:
+        return None
+
+    pull_request_index, _ = found
+    types = find_key(block_under(triggers, pull_request_index), "types")
+    if types is None:
+        return None
+
+    body = block_under(triggers, pull_request_index)
+    types_index, inline = types
+    return parse_list(body, types_index, inline)
+
+
+def workflows_running_the_gate() -> list[Path]:
+    return sorted(
+        path for path in list(WORKFLOWS.glob("*.yml")) + list(WORKFLOWS.glob("*.yaml"))
+        if GATE_SCRIPT in path.read_text(encoding="utf-8")
+    )
+
+
+class TheGateRerunsWhenTheLabelChangesTests(unittest.TestCase):
+    def test_exactly_one_workflow_runs_the_gate(self):
+        # Without this the rest of the file passes vacuously the day the step
+        # is renamed out from under it.
+        self.assertEqual(
+            1, len(workflows_running_the_gate()),
+            f"expected exactly one workflow to run {GATE_SCRIPT}")
+
+    def test_a_label_event_reaches_the_gate(self):
+        for path in workflows_running_the_gate():
+            with self.subTest(workflow=path.name):
+                types = pull_request_types(path.read_text(encoding="utf-8"))
+
+                self.assertIsNotNone(
+                    types,
+                    f"{path.name} takes GitHub's default pull_request types, which "
+                    "exclude `labeled` — so adding `skip-docs` re-runs nothing, and "
+                    "the gate's own failure message is a lie.")
+                self.assertIn(
+                    "labeled", types,
+                    f"{path.name} must re-run when a label changes: the gate's verdict "
+                    "depends on the PR's labels.")
+
+    def test_naming_the_types_keeps_the_defaults(self):
+        # `types:` replaces GitHub's defaults rather than extending them, so
+        # adding `labeled` and nothing else would stop a pushed commit ever
+        # re-checking the gate — a much worse bug than the one being fixed.
+        for path in workflows_running_the_gate():
+            with self.subTest(workflow=path.name):
+                types = pull_request_types(path.read_text(encoding="utf-8")) or []
+
+                for expected in REQUIRED_TYPES:
+                    self.assertIn(expected, types, f"{path.name} must trigger on {expected}")
+
+
+class TriggerParsingTests(unittest.TestCase):
+    """The parser reads YAML with regexes, so it gets its own tests."""
+
+    def test_an_absent_types_key_is_not_an_empty_list(self):
+        self.assertIsNone(pull_request_types("on:\n  pull_request:\n  push:\n    branches: [main]\n"))
+
+    def test_an_inline_list_is_read(self):
+        self.assertEqual(
+            ["opened", "labeled"],
+            pull_request_types("on:\n  pull_request:\n    types: [opened, labeled]\n"))
+
+    def test_a_block_list_is_read(self):
+        self.assertEqual(
+            ["opened", "labeled"],
+            pull_request_types("on:\n  pull_request:\n    types:\n      - opened\n      - labeled\n"))
+
+    def test_a_trailing_comment_is_not_part_of_the_last_item(self):
+        self.assertEqual(
+            ["opened", "labeled"],
+            pull_request_types("on:\n  pull_request:\n    types: [opened, labeled]  # why\n"))
+
+    def test_a_quoted_on_key_is_still_the_trigger_block(self):
+        self.assertEqual(
+            ["labeled"],
+            pull_request_types('"on":\n  pull_request:\n    types: [labeled]\n'))
+
+    def test_another_triggers_types_is_not_mistaken_for_the_pull_requests(self):
+        self.assertIsNone(pull_request_types(
+            "on:\n  issues:\n    types: [labeled]\n  pull_request:\n"))
+
+    def test_a_workflow_with_no_pull_request_trigger_has_no_types(self):
+        self.assertIsNone(pull_request_types("on:\n  push:\n    branches: [main]\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -9,6 +9,15 @@ name: docs-test
 
 on:
   pull_request:
+    # `labeled` is the one that is not obvious, and it is load-bearing: do not
+    # tidy it away. The gate's verdict depends on the PR's labels as well as on
+    # its changed files, so a `skip-docs` label added to a PR that has already
+    # failed has to start a fresh run — that is what rule 9 and the gate's own
+    # failure message promise ("you do not need to push anything"). Naming
+    # `types:` at all replaces GitHub's defaults, so the other three are here to
+    # be kept, not to be added. Asserted by
+    # .github/scripts/tests/test_docs_gate_triggers.py.
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
   workflow_dispatch:

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -607,6 +607,12 @@ code-only PR is exactly what the reconciliation gate exists to catch. It is
 therefore also the one workflow here that is safe to mark required in branch
 protection.
 
+**And `types: [opened, synchronize, reopened, labeled]`.** The first three are
+GitHub's default set, spelled out because naming `types:` at all *replaces* the
+defaults rather than extending them. `labeled` is the addition, and it is the
+whole of [the escape hatch](#the-skip-docs-escape-hatch) working: see
+[Every input to the verdict re-runs the gate](#every-input-to-the-verdict-re-runs-the-gate).
+
 When docs changed, it builds with `mkdocs build --strict`, so a broken nav
 entry, a dead internal link, or a page missing from the nav fails the PR rather
 than shipping a broken site. No deploy — publishing is `docs-publish`'s job.
@@ -684,6 +690,32 @@ nothing else. It cannot reconcile docs, and there is nobody driving it to apply
 a label. Matched **both** by its head branch and by its `autorelease: pending`
 label, so a change to either does not silently start failing every release.
 
+#### Every input to the verdict re-runs the gate
+
+The verdict has exactly two inputs: the PR's **changed files** and the PR's
+**labels**. Both have to be able to start a fresh run, or the tick on the PR is
+answering a question nobody asked any more.
+
+| Input changes | What re-runs the gate |
+| --- | --- |
+| a commit is pushed | the `synchronize` trigger |
+| a label is added | the `labeled` trigger, or the grace poll if the run is still going |
+
+`labeled` is on the workflow for that reason and no other. It is not obvious
+from reading `docs-test.yml`, so it carries a comment saying so and
+`.github/scripts/tests/test_docs_gate_triggers.py` asserts it — the failure mode
+if it is tidied away is silent, and lands on whoever is already blocked.
+
+Because `docs-test` is grouped per PR with `cancel-in-progress: true`, a label
+applied while a run is in flight cancels that run and starts another. That is
+the right way round: the surviving run is the newer one, it is the one that saw
+the new label, and it is the one whose conclusion the branch ruleset reads.
+
+Removing a label does **not** re-run the gate, so a PR that passed on
+`skip-docs` keeps its green tick if the label is taken off again. That is a
+known gap rather than a decision — see
+[#250](https://github.com/derekwinters/connor-multiplying-frogs/issues/250).
+
 #### The grace poll
 
 A `skip-docs` label applied moments after the PR opens would otherwise produce a
@@ -695,6 +727,12 @@ So a would-be failure re-reads the PR's **live** labels for up to a minute
 inside that window is observed by the same run: **no failing run is produced at
 all.** A passing PR never waits.
 
+The poll is the pipeline's case, not a human's. `pipeline-dev` applies
+`skip-docs` in the same breath as opening the PR, so the label is always inside
+the window and a bot PR never flashes red. A person reads the failure first and
+labels afterwards, minutes later — that is the `labeled` trigger's job, and the
+poll is no substitute for it.
+
 If the label API cannot be read, the gate keeps failing. Unknown is not
 permission — a gate that passes when it cannot see the labels is a gate an
 outage switches off.
@@ -702,7 +740,9 @@ outage switches off.
 #### The `skip-docs` escape hatch
 
 For the genuinely doc-irrelevant PR — a dependency bump, a CI fix, a typo in a
-comment. Adding the label re-runs the check, so nothing needs pushing.
+comment. Adding the label re-runs the check, so nothing needs pushing: either
+the run still in flight sees it during the grace poll, or the `labeled` trigger
+starts a new one.
 
 Using it is a decision, so it goes in the PR's `## Deviations and Decisions`
 section with a reason. A `skip-docs` label with no justification is a review


### PR DESCRIPTION
Closes #176

When a pull request changes code but no documentation, CI blocks it and tells you to add a `skip-docs` label — promising that adding the label re-runs the check and you don't need to push anything. That promise was false. The check only ever re-ran when someone pushed a commit, so anyone who followed the instructions clicked the label and sat looking at a red tick that would never change. It now re-runs when a label is added, which is what everything already said it did.

**Docs:** `docs/engineering/ci-cd.md` — the reconciliation gate section gains "Every input to the verdict re-runs the gate", stating the rule the gate now keeps (both of the verdict's inputs, changed files *and* labels, can start a fresh run), what the `cancel-in-progress` concurrency does when a label lands mid-run, and the one case that still does not re-run. The grace-poll and escape-hatch subsections say which of the two mechanisms covers which case.

## Spec invariants

| Rule this had to keep true | How I know |
| --- | --- |
| `CLAUDE.md` rule 9: "adding it re-runs the check" | `test_a_label_event_reaches_the_gate` — the workflow that invokes `docs_reconciliation_gate.py` triggers on `labeled` |
| A pushed commit still re-checks the gate | `test_naming_the_types_keeps_the_defaults` — naming `types:` *replaces* GitHub's defaults, so dropping one would have been a worse bug than the one being fixed |
| The gate is still always on, with no path filter | `docs-test.yml`'s `on:` block is otherwise unchanged; the "no path filter" comment and the `push`/`workflow_dispatch` triggers are untouched |
| A bot PR never flashes red (the grace poll) | Untouched. `pipeline-dev` labels the moment it opens a PR, so the label still lands inside the poll's window and no failing run is produced at all |

## How the spec is changing

It isn't — this makes it true. `CLAUDE.md` rule 9 already claimed the label re-runs the check, and `ci-cd.md` already said "nothing needs pushing". Neither sentence changes; the code caught up to them. What `ci-cd.md` gains is the mechanism behind the claim, because the previous text described the grace poll as though it covered every case, and that reading is exactly how the gap survived being written down twice.

## Deviations and Decisions

- **Did not add `unlabeled`.** Triage asked whether *removing* `skip-docs` should also re-run the gate, recommended yes, and left it for you at `/approve`; no answer was given. Removing the label is not something any doc promises, so implementing it would have been my call to make rather than yours. Opened **#250** (`type:question`, `Direct Involvement Needed`) with both options and their costs, and `ci-cd.md` names the gap and links there rather than leaving it silent. The "Settle the `unlabeled` question" checklist box is therefore unticked.
- **Could not verify by hand on a throwaway PR.** The checklist asks for a PR that fails the gate and then passes once `skip-docs` is added. That needs a second PR, which the one-issue-one-PR rule rules out, and this PR touches docs so its own gate passes by the docs path. What is verifiable here is the trigger itself: a `labeled` event on this PR should start a fresh `docs-test` run. I confirmed that below in a comment.
- **Left #80 alone.** Triage noticed it names the required check as `docs-test / build` while the job is `name: Docs`. #80 has since been closed as completed, so the ruleset already exists and is presumably set from whatever GitHub actually listed — checking it is a repo-settings look, not a code change. Flagging it rather than acting on it.
- **`ci:` not `fix:`.** This is a genuine bug fix, but nothing in the shipped game changes, and `ci:` is the type that does not move `/VERSION`. A patch release whose entire changelog entry is a workflow trigger would be a worse outcome than an unlogged one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_