### PR TITLE
fix(build): pass the build's inputs on Unity's command line

### DIFF
--- a/.github/scripts/check_release_apks.py
+++ b/.github/scripts/check_release_apks.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""The two release APKs must be the two builds the docs promise.
+
+`release-build` runs Unity twice — ARM64/IL2CPP for the tablet, x86_64/Mono for
+a desktop emulator (docs/engineering/tech-stack.md). Running it twice is not
+the same as getting two builds: for `v0.1.0` the profile never reached Unity,
+both invocations built the same thing, and the release went out with two
+byte-identical assets under different names (issue #218).
+
+Nothing noticed, because everything that could have noticed was upstream of the
+APK. Both builds went green, both files existed, both were the right size for
+an APK. The only place the truth was visible was inside the archive.
+
+So this looks inside. An APK's native libraries sit under `lib/<abi>/`, and
+those ABI names are Android's, not Unity's — `arm64-v8a` and `x86_64` mean the
+same thing in every APK ever built. IL2CPP additionally ships `libil2cpp.so`,
+and a Mono build does not, so the scripting backend is readable from the same
+listing.
+
+Usage:
+    python3 .github/scripts/check_release_apks.py \\
+        --device build/device/Android/multiplying-frogs-0.2.0.apk \\
+        --emulator build/emulator/Android/multiplying-frogs-0.2.0-emulator.apk
+
+Exits non-zero, naming every problem, if the pair is not what it should be.
+Failing here is the point: an emulator APK that will not install is a failure
+that otherwise happens on someone else's machine, days later, with no build log
+anywhere near it.
+
+Stdlib only — the pipeline scripts run on the Python already on the runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import zipfile
+from collections import namedtuple
+from pathlib import Path
+
+# Android's own directory names, and Unity's own library name. Neither is
+# something this project chooses, which is what makes them safe to assert on.
+DEVICE_ABI = "arm64-v8a"
+EMULATOR_ABI = "x86_64"
+IL2CPP_LIBRARY = "libil2cpp.so"
+
+Apk = namedtuple("Apk", "name abis il2cpp digest")
+
+
+def inspect_apk(path):
+    """What an APK is, as far as the profile is concerned.
+
+    An APK is a zip, and the entry names carry everything needed here — no
+    need for `aapt`, which is not on the runner.
+    """
+    path = Path(path)
+
+    with zipfile.ZipFile(path) as archive:
+        entries = archive.namelist()
+
+    abis = {entry.split("/")[1] for entry in entries
+            if entry.startswith("lib/") and entry.count("/") >= 2}
+    il2cpp = any(entry.endswith(f"/{IL2CPP_LIBRARY}") for entry in entries)
+
+    return Apk(path.name, abis, il2cpp, sha256(path))
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
+def problems(device, emulator):
+    """Everything wrong with this pair, in plain sentences. Empty is a pass."""
+    found = []
+
+    # First, because it explains every other line that follows it. Two profiles
+    # cannot produce one file, so if they did, neither profile was applied.
+    if device.digest == emulator.digest:
+        found.append(
+            f"{device.name} and {emulator.name} are byte-for-byte identical "
+            f"(sha256 {device.digest[:16]}…). Two build profiles cannot "
+            f"produce one file, so neither profile reached Unity.")
+
+    found.extend(profile_problems(device, "device", DEVICE_ABI, il2cpp=True))
+    found.extend(profile_problems(emulator, "emulator", EMULATOR_ABI, il2cpp=False))
+
+    return found
+
+
+def profile_problems(apk, profile, abi, il2cpp):
+    """Whether one APK is the build its profile asked for."""
+    found = []
+
+    if apk.abis != {abi}:
+        listed = ", ".join(sorted(apk.abis)) if apk.abis else "no native libraries at all"
+        found.append(
+            f"{apk.name} is the '{profile}' profile, so it must contain {abi} "
+            f"and nothing else. It has {listed}.")
+
+    if il2cpp and not apk.il2cpp:
+        found.append(
+            f"{apk.name} is the '{profile}' profile, which is IL2CPP, but it "
+            f"has no {IL2CPP_LIBRARY}.")
+
+    if not il2cpp and apk.il2cpp:
+        found.append(
+            f"{apk.name} is the '{profile}' profile, which is Mono, but it "
+            f"ships {IL2CPP_LIBRARY} — it was built with IL2CPP.")
+
+    return found
+
+
+def describe(apk):
+    backend = "IL2CPP" if apk.il2cpp else "Mono"
+    abis = ", ".join(sorted(apk.abis)) or "none"
+    return f"{apk.name}: {abis}, {backend}, sha256 {apk.digest[:16]}…"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--device", required=True,
+                        help="the ARM64/IL2CPP APK, for the tablet")
+    parser.add_argument("--emulator", required=True,
+                        help="the x86_64/Mono APK, for a desktop emulator")
+    arguments = parser.parse_args(argv)
+
+    for path in (arguments.device, arguments.emulator):
+        if not Path(path).is_file():
+            print(f"::error::No APK at {path}. The build that should have "
+                  f"written it did not.")
+            return 1
+
+    device = inspect_apk(arguments.device)
+    emulator = inspect_apk(arguments.emulator)
+
+    print(describe(device))
+    print(describe(emulator))
+
+    found = problems(device, emulator)
+
+    if not found:
+        print("Both profiles produced the build they asked for.")
+        return 0
+
+    for problem in found:
+        print(f"::error::{problem}")
+
+    print("\nThe device and emulator APKs are not the two builds "
+          "docs/engineering/tech-stack.md specifies. Refusing to attach them: "
+          "an emulator APK that will not install is a failure that otherwise "
+          "surfaces on someone else's machine. See issue #218.")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_build_inputs_reach_unity.py
+++ b/.github/scripts/tests/test_build_inputs_reach_unity.py
@@ -1,0 +1,297 @@
+"""A value the Unity build needs must reach the Unity process.
+
+`game-ci/unity-builder` does not run Unity on the runner. It runs it inside a
+container, and it forwards a **fixed allow-list** of environment variables into
+that container — `UNITY_*`, `BUILD_*`, `ANDROID_*`, `CUSTOM_PARAMETERS`, a
+handful of `GITHUB_*`. Nothing else. Setting `FROGS_ANDROID_PROFILE` in a
+step's `env:` puts it in the runner's environment, where the Unity process
+never looks.
+
+That is silent by construction. Every reader of these variables treats "unset"
+as "not asked for" and returns early, so a build with none of them arrives
+looks exactly like a build that wanted none of them. It shipped two `v0.1.0`
+APKs — a device build and an emulator build — that were byte-for-byte the same
+file, both ARM64/IL2CPP, because the profile never reached Unity (issue #218).
+
+So the values go on Unity's own command line, via the action's
+`customParameters` input, which the container entrypoint appends verbatim to
+its `unity-editor` invocation. This asserts that they still do, and that none
+of them has drifted back into an `env:` block where it would do nothing.
+
+Stdlib only, and regex rather than a YAML parse, for the same reason as
+`test_build_output_paths.py`: the pipeline suites run on nothing but the Python
+already on the runner.
+
+See docs/engineering/ci-cd.md and issue #218.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+
+UNITY_BUILDER = re.compile(r"^\s*(?:-\s*)?uses:\s*game-ci/unity-builder@")
+
+LIST_ITEM = re.compile(r"^(\s*)-\s")
+
+# Anything this project passes into a build. The prefix is the point: it is
+# what marks a value as ours rather than the action's.
+FROGS_ENV = re.compile(r"^\s*(FROGS_[A-Z0-9_]+)\s*:")
+
+# The command-line spelling of the same thing: `-frogsAndroidProfile emulator`.
+FROGS_FLAG = re.compile(r"^-frogs[A-Za-z0-9]*$")
+
+# The versionCode every build has to carry. Absent, the editor falls back to
+# shelling out to git inside the container, which is not what the workflow
+# checked out and not something the build should depend on.
+VERSION_CODE_FLAG = "-frogsVersionCode"
+
+PROFILE_FLAG = "-frogsAndroidProfile"
+
+INLINE_COMMENT = re.compile(r"\s+#.*$")
+
+
+def indent_of(line):
+    return len(line) - len(line.lstrip())
+
+
+def step_block(lines, index):
+    """The lines of the list item containing `lines[index]`."""
+    start = index
+    while start >= 0 and not LIST_ITEM.match(lines[start]):
+        start -= 1
+    if start < 0:
+        return [lines[index]]
+
+    opening = len(LIST_ITEM.match(lines[start]).group(1))
+
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        if line.strip() and indent_of(line) <= opening:
+            break
+        end += 1
+
+    return lines[start:end]
+
+
+def scalar(block, key):
+    """The value of `key: value` in `block`, or None."""
+    pattern = re.compile(rf"^\s*(?:-\s*)?{re.escape(key)}:\s*(.+?)\s*$")
+    for line in block:
+        match = pattern.match(line)
+        if match:
+            return INLINE_COMMENT.sub("", match.group(1)).strip().strip("'\"")
+    return None
+
+
+def unity_build_steps(text):
+    """Every unity-builder step in one workflow, as (name, block)."""
+    lines = text.splitlines()
+    steps = []
+
+    for index, line in enumerate(lines):
+        if UNITY_BUILDER.match(line):
+            block = step_block(lines, index)
+            steps.append((scalar(block, "name") or "(unnamed step)", block))
+
+    return steps
+
+
+def frogs_environment_variables(block):
+    """The `FROGS_*` keys a step sets in its `env:`, sorted."""
+    return sorted({match.group(1) for match in
+                   (FROGS_ENV.match(line) for line in block) if match})
+
+
+def custom_parameters(block):
+    """A step's `customParameters`, split into words. Empty if it has none."""
+    value = scalar(block, "customParameters")
+    return value.split() if value else []
+
+
+def flag_values(block):
+    """`customParameters` read as {flag: value}.
+
+    A flag whose value is missing — the end of the string, or another flag —
+    maps to None rather than being dropped. `-frogsBuildSha -frogsVersionCode
+    412` would otherwise quietly pass the sha as "-frogsVersionCode" and lose
+    the version code entirely, which is the same shape of silent failure this
+    whole file exists to stop.
+    """
+    words = custom_parameters(block)
+    found = {}
+
+    for index, word in enumerate(words):
+        if not FROGS_FLAG.match(word):
+            continue
+        following = words[index + 1] if index + 1 < len(words) else None
+        found[word] = None if following is None or following.startswith("-") else following
+
+    return found
+
+
+def workflow_files():
+    return sorted(WORKFLOWS.glob("*.yml"))
+
+
+class RealWorkflowTests(unittest.TestCase):
+    """The workflows as they stand in this repo."""
+
+    def setUp(self):
+        self.building = [
+            (path, path.read_text()) for path in workflow_files()
+            if unity_build_steps(path.read_text())
+        ]
+
+    def test_the_unity_build_workflows_are_found(self):
+        """Guards against the rest of this suite passing on nothing at all."""
+        names = sorted(path.name for path, _ in self.building)
+        self.assertEqual(
+            names, ["pr-build.yml", "rc-build.yml", "release-build.yml"])
+
+    def test_no_build_passes_its_values_in_the_environment(self):
+        """The bug. An `env:` on the step never reaches the container."""
+        for path, text in self.building:
+            for name, block in unity_build_steps(text):
+                with self.subTest(workflow=path.name, step=name):
+                    self.assertEqual(
+                        frogs_environment_variables(block), [],
+                        f"{path.name}, step {name!r}, sets these in `env:`. "
+                        f"unity-builder forwards only its own allow-list of "
+                        f"variables into the container, so Unity never sees "
+                        f"them and every reader treats them as unset. Pass "
+                        f"them on the command line with `customParameters` "
+                        f"instead — see issue #218.")
+
+    def test_every_build_is_told_its_version_code(self):
+        """Otherwise the editor shells out to git inside the container."""
+        for path, text in self.building:
+            for name, block in unity_build_steps(text):
+                with self.subTest(workflow=path.name, step=name):
+                    self.assertIn(
+                        VERSION_CODE_FLAG, flag_values(block),
+                        f"{path.name}, step {name!r}, passes no "
+                        f"{VERSION_CODE_FLAG}. The Android versionCode is the "
+                        f"commit count, and a build that has to work it out "
+                        f"for itself is a build that can disagree with the "
+                        f"workflow that started it.")
+
+    def test_every_flag_passed_has_a_value(self):
+        """A flag swallowing the next flag is the failure mode, not an error."""
+        for path, text in self.building:
+            for name, block in unity_build_steps(text):
+                for flag, value in flag_values(block).items():
+                    with self.subTest(workflow=path.name, step=name, flag=flag):
+                        self.assertIsNotNone(
+                            value,
+                            f"{path.name}, step {name!r}, passes {flag} with "
+                            f"nothing after it. Unity would take the next flag "
+                            f"as its value and drop that flag's own.")
+
+    def test_two_builds_in_one_workflow_ask_for_different_profiles(self):
+        """Two Unity builds in a file are the device/emulator split.
+
+        If they cannot be told apart on the command line they cannot be told
+        apart in the APK either, which is exactly what #218 was.
+        """
+        for path, text in self.building:
+            steps = unity_build_steps(text)
+            if len(steps) < 2:
+                continue
+
+            profiles = [flag_values(block).get(PROFILE_FLAG) for _, block in steps]
+
+            with self.subTest(workflow=path.name):
+                self.assertEqual(
+                    len(set(profiles)), len(profiles),
+                    f"{path.name} runs {len(steps)} Unity builds but asks for "
+                    f"profiles {profiles}. Two builds that ask Unity for the "
+                    f"same thing produce the same APK twice.")
+
+
+class StepDetectionTests(unittest.TestCase):
+    """The detectors see the real shapes, so a clean result means something."""
+
+    STEPS = """\
+jobs:
+  build:
+    steps:
+      - name: Build the device APK
+        uses: game-ci/unity-builder@d829bfc # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FROGS_ANDROID_PROFILE: device
+        with:
+          targetPlatform: Android
+          customParameters: -frogsVersionCode 412 -frogsAndroidProfile device
+
+      - name: Build the emulator APK
+        uses: game-ci/unity-builder@d829bfc # v5.0.0
+        with:
+          targetPlatform: Android
+          customParameters: -frogsVersionCode 412 -frogsAndroidProfile emulator
+"""
+
+    def test_each_build_step_is_found(self):
+        self.assertEqual(
+            [name for name, _ in unity_build_steps(self.STEPS)],
+            ["Build the device APK", "Build the emulator APK"])
+
+    def test_a_frogs_variable_in_the_environment_is_seen(self):
+        _, block = unity_build_steps(self.STEPS)[0]
+        self.assertEqual(
+            frogs_environment_variables(block), ["FROGS_ANDROID_PROFILE"])
+
+    def test_the_licence_secrets_are_not_mistaken_for_ours(self):
+        """`UNITY_LICENSE` is on the action's allow-list and belongs in `env:`."""
+        _, block = unity_build_steps(self.STEPS)[0]
+        self.assertNotIn("UNITY_LICENSE", frogs_environment_variables(block))
+
+    def test_a_step_does_not_absorb_its_neighbours_parameters(self):
+        first, second = (block for _, block in unity_build_steps(self.STEPS))
+        self.assertEqual(flag_values(first)["-frogsAndroidProfile"], "device")
+        self.assertEqual(flag_values(second)["-frogsAndroidProfile"], "emulator")
+
+    def test_a_workflow_with_no_unity_build_yields_nothing(self):
+        self.assertEqual(unity_build_steps("jobs:\n  test:\n    steps:\n"
+                                           "      - run: dotnet test\n"), [])
+
+
+class FlagParsingTests(unittest.TestCase):
+    def block(self, parameters):
+        return [f"          customParameters: {parameters}"]
+
+    def test_a_flag_and_its_value_are_paired(self):
+        self.assertEqual(
+            flag_values(self.block("-frogsBuildSha abc1234")),
+            {"-frogsBuildSha": "abc1234"})
+
+    def test_several_flags_are_all_read(self):
+        self.assertEqual(
+            flag_values(self.block(
+                "-frogsVersionCode 412 -frogsApplicationIdSuffix .debug")),
+            {"-frogsVersionCode": "412", "-frogsApplicationIdSuffix": ".debug"})
+
+    def test_a_flag_at_the_end_with_no_value_is_reported(self):
+        self.assertEqual(flag_values(self.block("-frogsBuildSha")),
+                         {"-frogsBuildSha": None})
+
+    def test_a_flag_followed_by_another_flag_is_reported(self):
+        self.assertEqual(
+            flag_values(self.block("-frogsBuildSha -frogsVersionCode 412")),
+            {"-frogsBuildSha": None, "-frogsVersionCode": "412"})
+
+    def test_the_actions_own_parameters_are_left_alone(self):
+        """Only `-frogs…` flags are ours to check."""
+        self.assertEqual(
+            flag_values(self.block("-quit -batchmode -frogsVersionCode 412")),
+            {"-frogsVersionCode": "412"})
+
+    def test_a_step_with_no_custom_parameters_passes_nothing(self):
+        self.assertEqual(flag_values(["          targetPlatform: Android"]), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_check_release_apks.py
+++ b/.github/scripts/tests/test_check_release_apks.py
@@ -1,0 +1,161 @@
+"""The two release APKs have to be two different builds.
+
+`release-build` runs Unity twice, once per profile in
+docs/engineering/tech-stack.md: ARM64/IL2CPP for the tablet, x86_64/Mono for a
+desktop emulator. Nothing checked that the two invocations produced anything
+different, and for `v0.1.0` they did not — the profile never reached Unity, so
+both assets were the same ARM64 file under two names. An x86_64 emulator
+refuses to install an ARM64-only APK, so the failure surfaced on someone
+else's machine rather than in CI (issue #218).
+
+This is the check that would have caught it: not "did two builds run" but "are
+the two things they produced actually the two things the docs promise".
+
+See docs/engineering/ci-cd.md and issue #218.
+"""
+
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from check_release_apks import inspect_apk, problems  # noqa: E402
+
+# Enough of a Unity Android APK for the check to have an opinion about it.
+DEVICE_LIBS = [
+    "lib/arm64-v8a/libunity.so",
+    "lib/arm64-v8a/libil2cpp.so",
+    "lib/arm64-v8a/libmain.so",
+]
+EMULATOR_LIBS = [
+    "lib/x86_64/libunity.so",
+    "lib/x86_64/libmonobdwgc-2.0.so",
+    "lib/x86_64/libmain.so",
+]
+
+
+class ApkFixture(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+
+    def apk(self, name, entries, filler="x"):
+        path = Path(self.directory.name) / name
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("AndroidManifest.xml", filler)
+            for entry in entries:
+                archive.writestr(entry, filler)
+        return path
+
+    def good_pair(self):
+        return (inspect_apk(self.apk("device.apk", DEVICE_LIBS)),
+                inspect_apk(self.apk("emulator.apk", EMULATOR_LIBS, filler="y")))
+
+
+class InspectionTests(ApkFixture):
+    def test_the_abis_present_are_read_from_the_lib_directories(self):
+        apk = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
+        self.assertEqual(apk.abis, {"arm64-v8a"})
+
+    def test_an_apk_with_two_abis_reports_both(self):
+        apk = inspect_apk(self.apk("fat.apk", DEVICE_LIBS + EMULATOR_LIBS))
+        self.assertEqual(apk.abis, {"arm64-v8a", "x86_64"})
+
+    def test_il2cpp_is_recognised(self):
+        self.assertTrue(inspect_apk(self.apk("d.apk", DEVICE_LIBS)).il2cpp)
+
+    def test_a_mono_build_has_no_il2cpp(self):
+        self.assertFalse(inspect_apk(self.apk("e.apk", EMULATOR_LIBS)).il2cpp)
+
+    def test_two_apks_with_the_same_bytes_have_the_same_digest(self):
+        first = inspect_apk(self.apk("one.apk", DEVICE_LIBS))
+        second = inspect_apk(self.apk("two.apk", DEVICE_LIBS))
+        self.assertEqual(first.digest, second.digest)
+
+
+class ProblemTests(ApkFixture):
+    def test_the_two_profiles_built_as_specified_pass(self):
+        self.assertEqual(problems(*self.good_pair()), [])
+
+    def test_byte_identical_assets_are_the_bug_itself(self):
+        """v0.1.0: two names, one file. The headline failure."""
+        device = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
+        emulator = inspect_apk(self.apk("emulator.apk", DEVICE_LIBS))
+
+        found = problems(device, emulator)
+
+        self.assertTrue(found)
+        self.assertTrue(any("identical" in problem for problem in found),
+                        f"expected the duplication to be named; got {found}")
+
+    def test_an_emulator_apk_built_for_the_tablet_is_caught(self):
+        device = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
+        emulator = inspect_apk(self.apk("emulator.apk", DEVICE_LIBS, filler="y"))
+
+        found = problems(device, emulator)
+
+        self.assertTrue(any("x86_64" in problem for problem in found),
+                        f"expected the missing ABI to be named; got {found}")
+
+    def test_a_device_apk_built_for_the_emulator_is_caught(self):
+        device = inspect_apk(self.apk("device.apk", EMULATOR_LIBS))
+        emulator = inspect_apk(self.apk("emulator.apk", EMULATOR_LIBS, filler="y"))
+
+        found = problems(device, emulator)
+
+        self.assertTrue(any("arm64-v8a" in problem for problem in found),
+                        f"expected the missing ABI to be named; got {found}")
+
+    def test_an_emulator_apk_carrying_the_tablet_abi_too_is_caught(self):
+        """Not just "has x86_64" — the profile says x86_64 and nothing else."""
+        device = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
+        emulator = inspect_apk(
+            self.apk("emulator.apk", DEVICE_LIBS + EMULATOR_LIBS, filler="y"))
+
+        self.assertTrue(problems(device, emulator))
+
+    def test_a_device_apk_without_il2cpp_is_caught(self):
+        """The profile is an architecture *and* a scripting backend."""
+        device = inspect_apk(
+            self.apk("device.apk", ["lib/arm64-v8a/libunity.so"]))
+        emulator = inspect_apk(self.apk("emulator.apk", EMULATOR_LIBS, filler="y"))
+
+        found = problems(device, emulator)
+
+        self.assertTrue(any("IL2CPP" in problem for problem in found),
+                        f"expected the backend to be named; got {found}")
+
+    def test_an_emulator_apk_built_with_il2cpp_is_caught(self):
+        device = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
+        emulator = inspect_apk(
+            self.apk("emulator.apk",
+                     ["lib/x86_64/libunity.so", "lib/x86_64/libil2cpp.so"],
+                     filler="y"))
+
+        found = problems(device, emulator)
+
+        self.assertTrue(any("IL2CPP" in problem for problem in found),
+                        f"expected the backend to be named; got {found}")
+
+    def test_an_apk_with_no_native_libraries_at_all_is_caught(self):
+        """A build that produced no player is not a build that passed."""
+        device = inspect_apk(self.apk("device.apk", []))
+        emulator = inspect_apk(self.apk("emulator.apk", EMULATOR_LIBS, filler="y"))
+
+        self.assertTrue(problems(device, emulator))
+
+    def test_every_problem_names_the_file_it_is_about(self):
+        """Two APKs in one message, so the report has to say which."""
+        device = inspect_apk(self.apk("device.apk", EMULATOR_LIBS))
+        emulator = inspect_apk(self.apk("emulator.apk", DEVICE_LIBS, filler="y"))
+
+        for problem in problems(device, emulator):
+            self.assertTrue("device.apk" in problem or "emulator.apk" in problem,
+                            f"{problem!r} does not say which APK it is about")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -91,8 +91,12 @@ jobs:
           restore-keys: Library-android-
 
       # The version name, versionCode, and .debug suffix are applied by
-      # BuildStampPreprocessor from these variables — a build pre-processor, so
-      # no build can be produced without them. See docs/engineering/versioning.md.
+      # BuildStampPreprocessor from these values — a build pre-processor, so no
+      # build can be produced without them. See docs/engineering/versioning.md.
+      #
+      # They go in `customParameters`, which unity-builder appends to the
+      # `unity-editor` command line, and not in `env:`, which stops at the
+      # container the editor runs inside (#218).
       - name: Build the debug APK
         if: steps.licence.outputs.present == 'true'
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
@@ -100,9 +104,6 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
-          FROGS_BUILD_SHA: ${{ steps.stamp.outputs.build_sha }}
-          FROGS_APPLICATION_ID_SUFFIX: .debug
         with:
           unityVersion: 6000.0.81f1
           targetPlatform: Android
@@ -112,6 +113,7 @@ jobs:
           # not be able to reach from a PR branch.
           buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-${{ steps.stamp.outputs.build_sha }}
           allowDirtyBuild: true
+          customParameters: -frogsVersionCode ${{ steps.stamp.outputs.version_code }} -frogsBuildSha ${{ steps.stamp.outputs.build_sha }} -frogsApplicationIdSuffix .debug
 
       - name: Upload the APK
         if: steps.licence.outputs.present == 'true'

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -107,6 +107,9 @@ jobs:
       # Same debug signing and .debug suffix as a PR build. An RC is for trying
       # the game, and release signing needs a secret this workflow should not be
       # able to reach.
+      #
+      # `customParameters` rather than `env:`, for the reason in #218: the
+      # editor runs in a container that sees only unity-builder's own variables.
       - name: Build the release candidate
         if: steps.licence.outputs.present == 'true'
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
@@ -114,15 +117,13 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
-          FROGS_RC_NUMBER: ${{ steps.stamp.outputs.rc }}
-          FROGS_APPLICATION_ID_SUFFIX: .debug
         with:
           unityVersion: 6000.0.81f1
           targetPlatform: Android
           androidExportType: androidPackage
           buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-rc${{ steps.stamp.outputs.rc }}
           allowDirtyBuild: true
+          customParameters: -frogsVersionCode ${{ steps.stamp.outputs.version_code }} -frogsRcNumber ${{ steps.stamp.outputs.rc }} -frogsApplicationIdSuffix .debug
 
       # Artifacts only. An RC is not a release: no tag, no GitHub release.
       - name: Upload the release candidate

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -109,8 +109,16 @@ jobs:
           key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: Library-android-
 
-      # No FROGS_BUILD_SHA and no FROGS_RC_NUMBER: this is the release, so the
-      # version name is bare. No applicationId suffix either — this is the app.
+      # No build sha and no rc number: this is the release, so the version name
+      # is bare. No applicationId suffix either — this is the app.
+      #
+      # `customParameters`, not `env:`. unity-builder runs the editor inside a
+      # container and forwards only its own allow-list of variables into it, so
+      # a FROGS_* variable set here would never reach Unity — which is exactly
+      # how v0.1.0 shipped two identical APKs (#218). customParameters is
+      # appended verbatim to the `unity-editor` command line, which does
+      # arrive. Guarded by
+      # .github/scripts/tests/test_build_inputs_reach_unity.py.
       - name: Build the device APK
         if: steps.licence.outputs.present == 'true'
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
@@ -118,8 +126,6 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
-          FROGS_ANDROID_PROFILE: device
         with:
           unityVersion: 6000.0.81f1
           targetPlatform: Android
@@ -127,6 +133,7 @@ jobs:
           buildsPath: build/device
           buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}
           allowDirtyBuild: true
+          customParameters: -frogsVersionCode ${{ steps.stamp.outputs.version_code }} -frogsAndroidProfile device
 
       # Its own build path, so the two APKs cannot be confused with each other —
       # they have the same version and differ only in architecture, which is not
@@ -138,8 +145,6 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          FROGS_VERSION_CODE: ${{ steps.stamp.outputs.version_code }}
-          FROGS_ANDROID_PROFILE: emulator
         with:
           unityVersion: 6000.0.81f1
           targetPlatform: Android
@@ -147,6 +152,19 @@ jobs:
           buildsPath: build/emulator
           buildName: multiplying-frogs-${{ steps.stamp.outputs.version }}-emulator
           allowDirtyBuild: true
+          customParameters: -frogsVersionCode ${{ steps.stamp.outputs.version_code }} -frogsAndroidProfile emulator
+
+      # Before attaching, not after. Two profiles that produced one build is a
+      # release that should not go out: an ARM64-only APK labelled "emulator"
+      # fails at install time on someone else's machine, with no build log
+      # anywhere near it. That is what v0.1.0 did (#218).
+      - name: Check the two APKs are the two builds
+        if: steps.licence.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/check_release_apks.py \
+            --device build/device/Android/multiplying-frogs-${{ steps.stamp.outputs.version }}.apk \
+            --emulator build/emulator/Android/multiplying-frogs-${{ steps.stamp.outputs.version }}-emulator.apk
 
       - name: Attach the APKs to the release
         if: steps.licence.outputs.present == 'true'

--- a/Assets/Editor/BuildInputs.cs
+++ b/Assets/Editor/BuildInputs.cs
@@ -1,0 +1,85 @@
+using System;
+using Frogs.Core;
+
+namespace Frogs.EditorTools
+{
+    /// <summary>
+    /// The values CI passes into a build, and where they come from.
+    ///
+    /// **Unity's command line first, the environment second**, and the order
+    /// is the whole point of this file.
+    ///
+    /// CI used to pass these as environment variables on the workflow step.
+    /// They never reached Unity. `game-ci/unity-builder` runs the editor inside
+    /// a container and forwards only its own allow-list of variables into it —
+    /// `UNITY_*`, `BUILD_*`, `ANDROID_*`, `CUSTOM_PARAMETERS`, a few
+    /// `GITHUB_*`. A `FROGS_*` variable sat on the runner, outside the
+    /// container, unread. Every caller here treats an absent value as "this
+    /// build did not ask for that", so nothing failed: `v0.1.0` shipped a
+    /// device APK and an emulator APK that were the same file, byte for byte
+    /// (issue #218).
+    ///
+    /// What does arrive is the command line. The action appends its
+    /// `customParameters` input to the `unity-editor` invocation verbatim, so
+    /// the workflows pass `-frogsAndroidProfile emulator` and it lands in
+    /// <c>Environment.GetCommandLineArgs()</c>.
+    ///
+    /// The environment is kept as a fallback because it still works everywhere
+    /// the container is not involved — a local headless
+    /// `-executeMethod BuildStampApplier.ApplyRelease`, and the EditMode tests,
+    /// which set the variables directly.
+    ///
+    /// See docs/engineering/ci-cd.md and docs/engineering/versioning.md.
+    /// </summary>
+    public static class BuildInputs
+    {
+        public const string VersionCodeFlag = "-frogsVersionCode";
+        public const string BuildShaFlag = "-frogsBuildSha";
+        public const string RcNumberFlag = "-frogsRcNumber";
+        public const string ApplicationIdSuffixFlag = "-frogsApplicationIdSuffix";
+        public const string AndroidProfileFlag = "-frogsAndroidProfile";
+
+        public const string VersionCodeVariable = "FROGS_VERSION_CODE";
+        public const string BuildShaVariable = "FROGS_BUILD_SHA";
+        public const string RcNumberVariable = "FROGS_RC_NUMBER";
+        public const string ApplicationIdSuffixVariable = "FROGS_APPLICATION_ID_SUFFIX";
+        public const string AndroidProfileVariable = "FROGS_ANDROID_PROFILE";
+
+        /// <summary>Android's versionCode: the commit count.</summary>
+        public static string VersionCode => Read(VersionCodeFlag, VersionCodeVariable);
+
+        /// <summary>The short commit sha, set for a PR build.</summary>
+        public static string BuildSha => Read(BuildShaFlag, BuildShaVariable);
+
+        /// <summary>The release-candidate number, set for an RC build.</summary>
+        public static string RcNumber => Read(RcNumberFlag, RcNumberVariable);
+
+        /// <summary>".debug" for a PR or RC build, absent for a release.</summary>
+        public static string ApplicationIdSuffix =>
+            Read(ApplicationIdSuffixFlag, ApplicationIdSuffixVariable);
+
+        /// <summary>"device" or "emulator", absent for an editor build.</summary>
+        public static string AndroidProfile =>
+            Read(AndroidProfileFlag, AndroidProfileVariable);
+
+        /// <summary>
+        /// How to say, in an error, that a value the build needed is missing.
+        ///
+        /// Both names, because "set FROGS_ANDROID_PROFILE" is advice that has
+        /// already been followed once, in a place where it does nothing.
+        /// </summary>
+        public static string Describe(string flag, string variable) =>
+            $"`{flag}` on the Unity command line (or {variable} in the environment, "
+            + "which only works outside the build container)";
+
+        static string Read(string flag, string variable)
+        {
+            var fromCommandLine =
+                BuildArguments.From(Environment.GetCommandLineArgs()).Value(flag);
+
+            return string.IsNullOrWhiteSpace(fromCommandLine)
+                ? Environment.GetEnvironmentVariable(variable)
+                : fromCommandLine;
+        }
+    }
+}

--- a/Assets/Editor/BuildStampApplier.cs
+++ b/Assets/Editor/BuildStampApplier.cs
@@ -22,16 +22,14 @@ namespace Frogs.EditorTools
     ///     Unity -batchmode -quit -projectPath . \
     ///           -executeMethod Frogs.EditorTools.BuildStampApplier.ApplyRelease
     ///
-    /// CI sets FROGS_VERSION_CODE and FROGS_BUILD_SHA rather than making this
-    /// shell out — a checkout with `fetch-depth: 1` has no history to count.
-    /// Locally, both fall back to git.
+    /// CI passes the version code and the sha in rather than making this shell
+    /// out — a checkout with `fetch-depth: 1` has no history to count. See
+    /// <see cref="BuildInputs"/> for how they travel. Locally, both fall back
+    /// to git.
     /// </summary>
     public static class BuildStampApplier
     {
         const string VersionFileName = "VERSION";
-        const string VersionCodeVariable = "FROGS_VERSION_CODE";
-        const string BuildShaVariable = "FROGS_BUILD_SHA";
-        const string RcNumberVariable = "FROGS_RC_NUMBER";
 
         /// <summary>A release build: PlayerSettings shows the bare version.</summary>
         public static void ApplyRelease() => Apply(BuildStamp.Release(ReadVersion(), ReadCommitCount()));
@@ -72,14 +70,18 @@ namespace Frogs.EditorTools
 
         static int ReadCommitCount()
         {
-            var fromEnvironment = Environment.GetEnvironmentVariable(VersionCodeVariable);
+            var given = BuildInputs.VersionCode;
 
-            if (!string.IsNullOrWhiteSpace(fromEnvironment))
+            if (!string.IsNullOrWhiteSpace(given))
             {
-                if (!int.TryParse(fromEnvironment, out var parsed))
+                if (!int.TryParse(given, out var parsed))
                 {
+                    var source = BuildInputs.Describe(
+                        BuildInputs.VersionCodeFlag, BuildInputs.VersionCodeVariable);
+
                     throw new FormatException(
-                        $"{VersionCodeVariable} is '{fromEnvironment}', which is not a number.");
+                        $"The version code is '{given}', which is not a number. It comes "
+                        + $"from {source}.");
                 }
 
                 return parsed;
@@ -90,13 +92,17 @@ namespace Frogs.EditorTools
 
         static int ReadRcNumber()
         {
-            var value = Environment.GetEnvironmentVariable(RcNumberVariable);
+            var given = BuildInputs.RcNumber;
 
-            if (string.IsNullOrWhiteSpace(value) || !int.TryParse(value, out var parsed))
+            if (string.IsNullOrWhiteSpace(given) || !int.TryParse(given, out var parsed))
             {
+                var source = BuildInputs.Describe(
+                    BuildInputs.RcNumberFlag, BuildInputs.RcNumberVariable);
+
                 throw new FormatException(
-                    $"{RcNumberVariable} is '{value}', which is not a release-candidate "
-                    + "number. It is derived by .github/scripts/next_rc_number.py.");
+                    $"The release-candidate number is '{given}', which is not a number. "
+                    + $"It comes from {source}, and is derived by "
+                    + ".github/scripts/next_rc_number.py.");
             }
 
             return parsed;
@@ -104,11 +110,9 @@ namespace Frogs.EditorTools
 
         static string ReadCommitSha()
         {
-            var fromEnvironment = Environment.GetEnvironmentVariable(BuildShaVariable);
+            var given = BuildInputs.BuildSha;
 
-            return string.IsNullOrWhiteSpace(fromEnvironment)
-                ? Git("rev-parse --short=7 HEAD")
-                : fromEnvironment;
+            return string.IsNullOrWhiteSpace(given) ? Git("rev-parse --short=7 HEAD") : given;
         }
 
         static string Git(string arguments)
@@ -132,8 +136,10 @@ namespace Frogs.EditorTools
                 {
                     throw new InvalidOperationException(
                         $"`git {arguments}` failed with exit code {process.ExitCode}: {error}. "
-                        + $"In CI, set {VersionCodeVariable} and {BuildShaVariable} instead — a "
-                        + "shallow checkout has no history to count.");
+                        + $"In CI, pass {BuildInputs.VersionCodeFlag} and "
+                        + $"{BuildInputs.BuildShaFlag} on the Unity command line instead — a "
+                        + "shallow checkout has no history to count, and the build container "
+                        + "may have no git at all.");
                 }
 
                 return output;

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -16,24 +16,22 @@ namespace Frogs.EditorTools
     /// builds, CI builds, and builds started from the editor all go through
     /// here.
     ///
-    /// CI sets the environment; nothing here reads git, because a shallow
-    /// checkout has no history to count:
+    /// CI passes these on the Unity command line; nothing here reads git,
+    /// because a shallow checkout has no history to count:
     ///
-    ///     FROGS_VERSION_CODE            the Android versionCode
-    ///     FROGS_BUILD_SHA               set for a PR build, absent otherwise
-    ///     FROGS_RC_NUMBER               set for a release candidate
-    ///     FROGS_APPLICATION_ID_SUFFIX   ".debug" for a PR or RC build
-    ///     FROGS_ANDROID_PROFILE         "device" or "emulator"
+    ///     -frogsVersionCode           the Android versionCode
+    ///     -frogsBuildSha              set for a PR build, absent otherwise
+    ///     -frogsRcNumber              set for a release candidate
+    ///     -frogsApplicationIdSuffix   ".debug" for a PR or RC build
+    ///     -frogsAndroidProfile        "device" or "emulator"
+    ///
+    /// They used to be environment variables, which never reached the editor
+    /// inside CI's build container — see <see cref="BuildInputs"/> and #218.
     ///
     /// See docs/engineering/versioning.md.
     /// </summary>
     public sealed class BuildStampPreprocessor : IPreprocessBuildWithReport
     {
-        const string ApplicationIdSuffixVariable = "FROGS_APPLICATION_ID_SUFFIX";
-        const string BuildShaVariable = "FROGS_BUILD_SHA";
-        const string RcNumberVariable = "FROGS_RC_NUMBER";
-        const string AndroidProfileVariable = "FROGS_ANDROID_PROFILE";
-
         /// <summary>Early, so later pre-processors see the stamped values.</summary>
         public int callbackOrder => -100;
 
@@ -45,12 +43,12 @@ namespace Frogs.EditorTools
             // without this the app is called after the working directory.
             ProjectBootstrap.ApplyToBuild();
 
-            // Which kind of build this is, decided by which variable CI set.
+            // Which kind of build this is, decided by which value CI passed.
             // An rc number wins over a sha: a release candidate is identified
             // by its position in the queue, because "is this newer than the one
             // I tried yesterday" is not a question a sha answers by eye.
-            var rcNumber = Environment.GetEnvironmentVariable(RcNumberVariable);
-            var sha = Environment.GetEnvironmentVariable(BuildShaVariable);
+            var rcNumber = BuildInputs.RcNumber;
+            var sha = BuildInputs.BuildSha;
 
             if (!string.IsNullOrWhiteSpace(rcNumber))
             {
@@ -78,7 +76,7 @@ namespace Frogs.EditorTools
         /// </summary>
         static void ApplyAndroidProfile()
         {
-            var profile = Environment.GetEnvironmentVariable(AndroidProfileVariable);
+            var profile = BuildInputs.AndroidProfile;
 
             if (string.IsNullOrWhiteSpace(profile))
             {
@@ -104,17 +102,27 @@ namespace Frogs.EditorTools
                     break;
 
                 default:
+                    var source = BuildInputs.Describe(
+                        BuildInputs.AndroidProfileFlag, BuildInputs.AndroidProfileVariable);
+
                     throw new ArgumentException(
-                        $"{AndroidProfileVariable} is '{profile}'. It must be 'device' or "
-                        + "'emulator'; guessing would silently ship the wrong architecture.");
+                        $"The Android build profile is '{profile}'. It must be 'device' or "
+                        + "'emulator'; guessing would silently ship the wrong architecture. "
+                        + $"It comes from {source}.");
             }
 
-            Debug.Log($"Android build profile: {profile}.");
+            // Read back rather than echoing the request: this line is how a
+            // build log answers "did the profile actually take", which is the
+            // question #218 left open.
+            Debug.Log(
+                $"Android build profile: {profile} — "
+                + $"{PlayerSettings.Android.targetArchitectures}, "
+                + $"{PlayerSettings.GetScriptingBackend(NamedBuildTarget.Android)}.");
         }
 
         static void ApplyApplicationIdSuffix()
         {
-            var suffix = Environment.GetEnvironmentVariable(ApplicationIdSuffixVariable);
+            var suffix = BuildInputs.ApplicationIdSuffix;
 
             if (string.IsNullOrWhiteSpace(suffix))
             {

--- a/Assets/Scripts/Core/BuildArguments.cs
+++ b/Assets/Scripts/Core/BuildArguments.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// What CI asked this build to be, read off Unity's command line.
+    ///
+    /// These values used to travel in environment variables. They never
+    /// arrived: `game-ci/unity-builder` runs Unity inside a container and
+    /// forwards only its own allow-list of variables into it, so an
+    /// `env: FROGS_ANDROID_PROFILE` on the workflow step sat in the runner's
+    /// environment where the Unity process never looked. Every reader treated
+    /// the absence as "this build did not ask for a profile", and `v0.1.0`
+    /// shipped its device and emulator APKs as one byte-identical file
+    /// (issue #218).
+    ///
+    /// Unity's own command line does arrive — the action appends whatever is
+    /// in its `customParameters` input to the `unity-editor` invocation
+    /// verbatim. So that is the road these values take now.
+    ///
+    /// Lives in Core so the reading rules are covered by the fast NUnit suite.
+    /// The editor shell asks Unity for the command line and hands it here; it
+    /// does not pick arguments apart itself.
+    ///
+    /// See docs/engineering/ci-cd.md.
+    /// </summary>
+    public readonly struct BuildArguments
+    {
+        readonly string[] words;
+
+        BuildArguments(string[] words)
+        {
+            this.words = words;
+        }
+
+        /// <summary>
+        /// Wraps a command line — typically <c>Environment.GetCommandLineArgs()</c>.
+        ///
+        /// A null command line is no arguments rather than an error: it is what
+        /// a caller with nothing to pass looks like, and there is nothing wrong
+        /// with a build that asks for none of this.
+        /// </summary>
+        public static BuildArguments From(IEnumerable<string> commandLine)
+        {
+            if (commandLine == null)
+            {
+                return new BuildArguments(new string[0]);
+            }
+
+            var collected = new List<string>();
+
+            foreach (var word in commandLine)
+            {
+                collected.Add(word ?? string.Empty);
+            }
+
+            return new BuildArguments(collected.ToArray());
+        }
+
+        /// <summary>
+        /// The value passed after <paramref name="flag"/>, or empty if the flag
+        /// was not passed at all.
+        ///
+        /// Empty means "not asked for", which is a real and normal answer — the
+        /// editor's own Build button passes none of these. But a flag that *is*
+        /// present and has no usable value throws, because that is the exact
+        /// shape of the bug this type exists to prevent: something went wrong
+        /// upstream, and reading it as "not asked for" hides it until the APK
+        /// is on somebody's tablet.
+        /// </summary>
+        public string Value(string flag)
+        {
+            RequireFlag(flag);
+
+            var arguments = words ?? new string[0];
+
+            for (var index = 0; index < arguments.Length; index++)
+            {
+                if (!string.Equals(arguments[index], flag, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var next = index + 1;
+
+                if (next >= arguments.Length || IsFlag(arguments[next]))
+                {
+                    throw new ArgumentException(
+                        $"'{flag}' was passed to the build with no value after it. It "
+                        + "carries something the build cannot invent — the profile, the "
+                        + "versionCode, the applicationId suffix — so a build that "
+                        + "continued would quietly be the wrong build.",
+                        nameof(flag));
+                }
+
+                return arguments[next];
+            }
+
+            return string.Empty;
+        }
+
+        static bool IsFlag(string word) => word.Length > 0 && word[0] == '-';
+
+        static void RequireFlag(string flag)
+        {
+            if (string.IsNullOrWhiteSpace(flag) || !IsFlag(flag))
+            {
+                throw new ArgumentException(
+                    $"'{flag}' is not a command-line flag. Without its leading dash it "
+                    + "would never match, and a value that is always absent looks "
+                    + "exactly like a value nobody passed.",
+                    nameof(flag));
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ProjectIdentityTests.cs
+++ b/Assets/Tests/EditMode/ProjectIdentityTests.cs
@@ -21,8 +21,8 @@ namespace Frogs.Unity.EditModeTests
     /// </summary>
     public sealed class ProjectIdentityTests
     {
-        const string BuildShaVariable = "FROGS_BUILD_SHA";
-        const string VersionCodeVariable = "FROGS_VERSION_CODE";
+        const string BuildShaVariable = BuildInputs.BuildShaVariable;
+        const string VersionCodeVariable = BuildInputs.VersionCodeVariable;
 
         string previousSha;
         string previousVersionCode;
@@ -31,9 +31,15 @@ namespace Frogs.Unity.EditModeTests
         public void StampADebugBuildWithoutTouchingGit()
         {
             // The pre-processor stamps a version before anything else, and the
-            // debug path reads both of these from the environment. Set, so the
-            // stamp cannot shell out to git — a shallow CI checkout has no
-            // history to count, and this test is not about the version anyway.
+            // debug path needs both of these. Set, so the stamp cannot shell
+            // out to git — a shallow CI checkout has no history to count, and
+            // this test is not about the version anyway.
+            //
+            // The environment, not the command line, because a test cannot
+            // change the process's arguments. That fallback is exactly why
+            // `BuildInputs` keeps reading the variables: in CI the values ride
+            // the Unity command line instead, which nothing in-process can
+            // fake. See docs/engineering/ci-cd.md#build-inputs.
             previousSha = Environment.GetEnvironmentVariable(BuildShaVariable);
             previousVersionCode = Environment.GetEnvironmentVariable(VersionCodeVariable);
 

--- a/Tests/Core/BuildArgumentsTests.cs
+++ b/Tests/Core/BuildArgumentsTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// Reading what CI asked this build to be, off Unity's command line.
+    ///
+    /// This used to be read from environment variables, and CI used to set
+    /// them — on the runner. `game-ci/unity-builder` runs Unity in a container
+    /// and forwards only its own allow-list of variables into it, so none of
+    /// them ever arrived, and every reader treated "absent" as "not asked for".
+    /// Two release profiles silently produced one APK (issue #218).
+    ///
+    /// The values now travel on Unity's own command line, so these are the
+    /// rules for reading them — in Core, where the fast suite covers them.
+    /// </summary>
+    public sealed class BuildArgumentsTests
+    {
+        static BuildArguments Of(params string[] commandLine) =>
+            BuildArguments.From(commandLine);
+
+        [Test]
+        public void Value_ReadsTheWordAfterTheFlag()
+        {
+            var arguments = Of("-frogsAndroidProfile", "emulator");
+
+            Assert.That(arguments.Value("-frogsAndroidProfile"), Is.EqualTo("emulator"));
+        }
+
+        [Test]
+        public void Value_FindsAFlagAmongUnityAndTheBuildersOwnArguments()
+        {
+            // What the command line actually looks like: unity-builder puts a
+            // dozen of its own arguments in front of ours.
+            var arguments = Of(
+                "unity-editor", "-batchmode", "-quit",
+                "-projectPath", "/github/workspace",
+                "-executeMethod", "UnityBuilderAction.Builder.BuildProject",
+                "-frogsVersionCode", "412",
+                "-frogsAndroidProfile", "device");
+
+            Assert.That(arguments.Value("-frogsVersionCode"), Is.EqualTo("412"));
+            Assert.That(arguments.Value("-frogsAndroidProfile"), Is.EqualTo("device"));
+        }
+
+        [Test]
+        public void Value_IsEmptyWhenTheFlagWasNotPassed()
+        {
+            // Not an error: a build started from the editor's own Build button
+            // passes none of these, and must keep working.
+            Assert.That(Of("-batchmode").Value("-frogsAndroidProfile"), Is.Empty);
+        }
+
+        [Test]
+        public void Value_IsEmptyForAnEmptyCommandLine()
+        {
+            Assert.That(Of().Value("-frogsAndroidProfile"), Is.Empty);
+        }
+
+        [Test]
+        public void Value_MatchesTheWholeFlagRatherThanAPrefix()
+        {
+            // `-frogsVersionCode` must not answer for `-frogsVersion`, or a
+            // renamed flag reads the wrong value instead of reading none.
+            var arguments = Of("-frogsVersionCodeExtra", "nonsense");
+
+            Assert.That(arguments.Value("-frogsVersionCode"), Is.Empty);
+        }
+
+        [Test]
+        public void Value_TakesTheFirstOfARepeatedFlag()
+        {
+            var arguments = Of("-frogsAndroidProfile", "device",
+                               "-frogsAndroidProfile", "emulator");
+
+            Assert.That(arguments.Value("-frogsAndroidProfile"), Is.EqualTo("device"));
+        }
+
+        // A flag with nothing usable after it is the failure this whole change
+        // is about: silently reading it as "absent" is what shipped one APK
+        // twice. Fail loudly instead, while the build log is still open.
+        [Test]
+        public void Value_RejectsAFlagAtTheEndOfTheCommandLine()
+        {
+            Assert.That(
+                () => Of("-batchmode", "-frogsAndroidProfile").Value("-frogsAndroidProfile"),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void Value_RejectsAFlagWhoseValueIsAnotherFlag()
+        {
+            Assert.That(
+                () => Of("-frogsAndroidProfile", "-frogsVersionCode", "412")
+                    .Value("-frogsAndroidProfile"),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void From_TreatsANullCommandLineAsNoArguments()
+        {
+            Assert.That(BuildArguments.From(null).Value("-frogsAndroidProfile"), Is.Empty);
+        }
+
+        [Test]
+        public void Value_RejectsAFlagThatIsNotAFlag()
+        {
+            // Asking for "frogsAndroidProfile" without the dash would never
+            // match, and would look like the value simply was not passed.
+            Assert.That(
+                () => Of("-frogsAndroidProfile", "device").Value("frogsAndroidProfile"),
+                Throws.TypeOf<ArgumentException>());
+        }
+    }
+}

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -222,6 +222,51 @@ wrong version cannot be identified afterwards.
 Red here almost always means a compile error the Core suite couldn't catch,
 because it lives in the Unity layer. Read the build log, not the test log.
 
+#### How a value reaches the Unity process {#build-inputs}
+
+**On Unity's command line, via the action's `customParameters` input.** Never in
+the step's `env:`.
+
+`game-ci/unity-builder` does not run Unity on the runner. It runs it inside a
+container, and it forwards a **fixed allow-list** of environment variables into
+that container — `UNITY_*`, `BUILD_*`, `ANDROID_*`, `CUSTOM_PARAMETERS`, a
+handful of `GITHUB_*`. Nothing else. A `FROGS_ANDROID_PROFILE` set in a step's
+`env:` sits on the runner, outside the container, where the editor never looks.
+
+That failure is silent by construction. Every reader of these values treats
+"absent" as "this build did not ask for that" — which is the right answer for
+the editor's own Build button, and the wrong one here. So a build that received
+none of its inputs looks exactly like a build that wanted none of them. `v0.1.0`
+shipped a device APK and an emulator APK that were the same file, byte for byte,
+and every check upstream of the APK was green (#218).
+
+`customParameters` is appended verbatim to the container's `unity-editor`
+invocation, so it does arrive:
+
+| Value | Flag |
+| --- | --- |
+| Android `versionCode` | `-frogsVersionCode` |
+| Short commit sha, for a PR build | `-frogsBuildSha` |
+| Release-candidate number | `-frogsRcNumber` |
+| `applicationId` suffix | `-frogsApplicationIdSuffix` |
+| Android build profile | `-frogsAndroidProfile` |
+
+`BuildInputs` reads the command line first and the matching `FROGS_*` variable
+second. The variables still work everywhere the container is not involved — a
+local headless `-executeMethod`, and the EditMode tests — and mean nothing in
+CI.
+
+Two things hold this in place, and both are why the rule is written down rather
+than remembered:
+
+- **`.github/scripts/tests/test_build_inputs_reach_unity.py`** fails if any
+  Unity build step sets a `FROGS_*` variable in its `env:`, if a build is not
+  told its `versionCode`, if a flag is passed with no value after it, or if two
+  builds in one workflow ask for the same profile.
+- **`BuildArguments`** throws when a flag is present with no usable value,
+  rather than reading it as absent. A build that received a broken command line
+  stops while the log is still open.
+
 ### `rc-build` — release candidates
 
 An RC is a build of what is *about* to be released, produced so someone can play
@@ -378,9 +423,37 @@ Two things now stop it recurring:
   because "the build produced nothing" and "nothing matched the glob" have
   completely different fixes and used to be the same message.
 
-The profile is applied by `BuildStampPreprocessor` from `FROGS_ANDROID_PROFILE`,
-and an unrecognised value fails the build rather than defaulting: guessing here
-ships the wrong architecture, which looks fine until someone installs it.
+The profile is applied by `BuildStampPreprocessor` from `-frogsAndroidProfile`
+on the Unity command line ([how a value gets there](#build-inputs)), and an
+unrecognised value fails the build rather than defaulting: guessing here ships
+the wrong architecture, which looks fine until someone installs it.
+
+#### The two APKs are checked against each other before either is attached
+
+Running Unity twice is not the same as getting two builds. For `v0.1.0` it was
+not: the profile never reached the editor, both invocations built the same
+thing, and the release went out with two byte-identical assets under different
+names (#218). Nothing upstream of the APK could have seen it — both builds went
+green, both files existed, both were a plausible size.
+
+So `.github/scripts/check_release_apks.py` opens them. An APK's native
+libraries live under `lib/<abi>/`, and those ABI names are Android's, so they
+mean the same thing in every APK ever built; IL2CPP additionally ships
+`libil2cpp.so` and Mono does not. That is enough to assert the whole profile
+table:
+
+| Check | Why |
+| --- | --- |
+| the two files are not byte-identical | two profiles cannot produce one file |
+| device has `arm64-v8a` and nothing else | the tablet's architecture, alone |
+| emulator has `x86_64` and nothing else | an ARM64 APK will not install on an x86_64 emulator |
+| device ships `libil2cpp.so`, emulator does not | the profile is a backend as well as an architecture |
+
+It runs **before** the attach step, so a release that failed it gets no assets
+rather than the wrong ones. That is the right way round: a bad APK attached to
+a tag is a failure that surfaces on someone else's machine, days later, with no
+build log anywhere near it, while a release missing its APKs is a backfill this
+workflow already knows how to do.
 
 Both are **attached to the GitHub release** rather than left as workflow
 artifacts, so the tag and the thing you install are one object. A release whose

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -372,6 +372,13 @@ not by a tool. They are overwritten at build time from the values above. A
 number typed into that file is a number that disagrees with `/VERSION` on the
 first release after someone forgets it.
 
-CI passes `FROGS_VERSION_CODE` and `FROGS_BUILD_SHA` rather than letting the
-editor shell out to git, because a checkout with `fetch-depth: 1` has no history
-to count. Locally both fall back to git, and a failure says so.
+CI passes the version code and the sha in rather than letting the editor shell
+out to git, because a checkout with `fetch-depth: 1` has no history to count.
+Locally both fall back to git, and a failure says so.
+
+They travel as `-frogsVersionCode` and `-frogsBuildSha` **on Unity's command
+line**, not as environment variables: the editor runs inside a container that
+receives only `game-ci/unity-builder`'s own allow-list, so a variable set on the
+workflow step never reaches it. See
+[how a value reaches the Unity process](ci-cd.md#build-inputs) — getting this
+wrong is silent, and did ship a wrong build (#218).


### PR DESCRIPTION
Closes #218

When CI builds the game it has to tell Unity a few things — which version this is, and whether it is building for the tablet or for a desktop emulator. It was telling them to the wrong place, so Unity never heard any of it and just built whatever it felt like. That is why the two APKs on `v0.1.0` are the same file: both are the tablet build, and the one labelled "emulator" will not install on an emulator. CI now tells Unity properly, and refuses to publish a release where the two builds came out the same.

**Docs:** `docs/engineering/ci-cd.md` — new "How a value reaches the Unity process" section (the command line, never the step's `env:`, with the flag table), and the release-build section now describes the APK check that runs before anything is attached. `docs/engineering/versioning.md` — the version code and sha travel as `-frogsVersionCode` / `-frogsBuildSha`, not as environment variables.

## What was actually wrong

The issue offered two hypotheses and asked that one be established before anything changed. **Hypothesis 2 holds**, and it is provable without a Unity build:

`game-ci/unity-builder` does not run Unity on the runner. It runs it in a container, and [`ImageEnvironmentFactory.getEnvironmentVariables`](https://github.com/game-ci/unity-builder/blob/d829bfc901f2347c8fe18898f06712b66916ef42/src/model/image-environment-factory.ts#L30) builds the `--env` list from a **fixed allow-list** — `UNITY_*`, `BUILD_*`, `ANDROID_*`, `CUSTOM_PARAMETERS`, some `GITHUB_*`. The only way to add to it is the `additionalVariables` argument, and the GitHub Actions path calls `Docker.run(image, parameters)` with two arguments, so it is always empty. **No `FROGS_*` variable has ever reached the Unity process.**

The shipped artifacts agree. Both `v0.1.0` APKs are sha256 `becef021…` — not merely the same size, the same file — and both contain `lib/arm64-v8a/libil2cpp.so` and no `lib/x86_64/`.

So it was never only the profile. `-frogsApplicationIdSuffix` and `-frogsBuildSha` were going nowhere too, which means PR and RC builds have been getting a bare release version name and the **release applicationId**, installing over the real game instead of alongside it as `.debug`.

Hypothesis 1 — that `OnPreprocessBuild` may be too late to change the scripting backend — is **untested, and was untestable**: it was masked by hypothesis 2, since the callback never had a profile to apply. See below.

## Spec invariants

| Rule kept true | Test that asserts it |
| --- | --- |
| The two release assets are ARM64/IL2CPP and x86_64/Mono (`tech-stack.md`) | `test_check_release_apks.py`, and the gate itself on every release |
| An unrecognised profile fails the build rather than defaulting | unchanged in `BuildStampPreprocessor`; the error now names both places the value could come from |
| A build never invents its own versionCode | `test_build_inputs_reach_unity.py::test_every_build_is_told_its_version_code` |
| A missing value is never silently read as "not asked for" | `BuildArgumentsTests.Value_RejectsAFlagAtTheEndOfTheCommandLine` and `…WhoseValueIsAnotherFlag` |
| The editor's own Build button still works with none of this passed | `BuildArgumentsTests.Value_IsEmptyWhenTheFlagWasNotPassed` |

## How the spec is changing

**Old rule:** CI passes the build's inputs as `FROGS_*` environment variables on the workflow step.
**New rule:** CI passes them as `-frogs…` flags in the action's `customParameters`, which the container entrypoint appends verbatim to `unity-editor`. `BuildInputs` reads the command line first and the environment second; the variables still work outside the container (a local `-executeMethod`, the EditMode tests) and mean nothing in CI.

**Why better:** the old rule described a channel that does not exist. It is not that it was fragile — nothing ever came through it, and because absent means "not asked for" everywhere downstream, nothing could tell the difference between a build with no inputs and a build with no requests.

## Showing it red

- `test_build_inputs_reach_unity.py` failed 9 assertions against the workflows as they were, across all three.
- `check_release_apks.py`, run against the two real `v0.1.0` assets, reports the shipped bug:
  ```
  multiplying-frogs-0.1.0.apk: arm64-v8a, IL2CPP, sha256 becef02141ee3e83…
  multiplying-frogs-0.1.0-emulator.apk: arm64-v8a, IL2CPP, sha256 becef02141ee3e83…
  ::error::… are byte-for-byte identical …
  ::error::multiplying-frogs-0.1.0-emulator.apk is the 'emulator' profile, so it must contain x86_64 and nothing else. It has arm64-v8a.
  ::error::… which is Mono, but it ships libil2cpp.so — it was built with IL2CPP.
  ```
- `BuildArgumentsTests` failed to compile before `BuildArguments` existed.

## Deviations and Decisions

- **Hypothesis 1 is left open on purpose, not settled by guessing.** Whether `IPreprocessBuildWithReport` runs early enough for `SetScriptingBackend` to take is a Unity-behaviour question, and CLAUDE.md rule 6 says look it up or ask rather than reason it out. I could not find an authoritative statement, and I cannot run a build here. Rather than restructure the profile mechanism on a hunch, the APK gate turns the question into a loud failure: `v0.2.0`'s release build either produces two correct APKs, or refuses to attach anything and says exactly what it found. `ApplyAndroidProfile` now also logs the architecture and backend *read back* from `PlayerSettings`, so the build log distinguishes "the profile was applied" from "the profile stuck". If the gate does fire, the likely next step is Unity 6 Build Profile assets, which need an Editor session.
- **The checklist's EditMode test is not in here, and I do not think it should be.** The thing it asks to pin — that the profile changes settings *at the point the build reads them* — is precisely what an in-process test cannot observe. A test that only proved `ApplyAndroidProfile` calls the setters would have passed on `main`, before the fix, for a bug it could not catch, and it would leave the project on x86_64/Mono for the rest of the run. The reading rules are covered in the fast Core suite instead, and the outcome by the gate.
- **The fix reaches past the profile.** The issue is about the emulator APK, but the same broken channel carried the `.debug` suffix and the build sha, so PR and RC builds were shipping with the release applicationId. Fixing only the profile would have left that in place, silently, with a test asserting the mechanism was sound.
- **The gate runs before the attach step**, so a release that fails it gets no assets at all rather than one good APK and one bad one. That is what the issue asked for ("should fail the build, not ship"); the cost is that a failed release needs the backfill, which this workflow already exists to do.
- **`build.sh` word-splits `$CUSTOM_PARAMETERS` unquoted**, so none of these values may contain a space. All of them are tokens — a number, a 7-character sha, `.debug`, `device`/`emulator` — and `test_every_flag_passed_has_a_value` catches the shape that would break first.
- **Opened #252** (`Direct Involvement Needed`): the wrong emulator APK is already published on `v0.1.0` and only a person can decide to remove it. It cannot be backfilled — `release-build` checks out the tag, so a re-run would rebuild the unfixed code.
- **EditMode tests were written-adjacent but not run** (no editor here). `ProjectIdentityTests` was touched only to reference the variable names from `BuildInputs`; its env-var setup still works through the fallback, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_