### PR TITLE
docs: draw the title screen with RESUME and NEW

### DIFF
--- a/docs/specs/ui/game-setup.md
+++ b/docs/specs/ui/game-setup.md
@@ -98,12 +98,14 @@ and the renumbering at once.
 
 ## Open questions
 
-- **Does a saved game change this screen?**
-  [ADR-0004](../../adr/0004-core-owns-the-save-format.md) puts a save format in
-  Core. If a game in progress can be resumed, the resume entry point is most
-  likely here or on the [title screen](title-screen.md), and either way it is a
-  new element that needs adding to a wireframe. Not decided; nothing on this
-  screen assumes it.
+- **Does a saved game change this screen?** **Answered: no.**
+  [#228](https://github.com/derekwinters/connor-multiplying-frogs/issues/228)
+  settled that a game in progress is re-entered from the
+  [title screen](title-screen.md), which gained a `RESUME` button beside `NEW`.
+  Nothing on this screen changes: a resumed game does not pass through setup,
+  because its roster was chosen here when that game was started.
+  [ADR-0004](../../adr/0004-core-owns-the-save-format.md)'s save format is still
+  the thing that has to exist behind that button, and it does not exist yet.
 - **Should the four colours be reorderable?** Proposed: no. Turn order is
   tap order, which is one gesture rather than two, and re-ordering is a drag
   interaction on a screen four children are all reaching at.

--- a/docs/specs/ui/index.md
+++ b/docs/specs/ui/index.md
@@ -15,7 +15,7 @@ Every screen and every dialog in v1, in the order a game meets them.
 
 | Page | What it is |
 | --- | --- |
-| [Title screen](title-screen.md) | The way in. One button. |
+| [Title screen](title-screen.md) | The way in. Carry on, or start a new game. |
 | [Game setup](game-setup.md) | Which frogs are playing, and in what order |
 | [Game board](game-board.md) | The pond, the lanes, and `Roll` |
 | [Roll and card](roll-and-card.md) | The die, the pile it maps to, the card you drew |

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -11,7 +11,8 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 
 | Screen | Mockup | Spec page |
 | --- | --- | --- |
-| Title screen | [`title-screen.html`](title-screen.html) | [Title screen](../title-screen.md) |
+| Title screen — `NEW` primary | [`title-screen.html`](title-screen.html) | [Title screen](../title-screen.md) |
+| Title screen — `RESUME` primary | [`title-screen-resume-primary.html`](title-screen-resume-primary.html) | [Title screen](../title-screen.md) |
 | Game setup | [`game-setup.html`](game-setup.html) | [Game setup](../game-setup.md) |
 | Game board | [`game-board.html`](game-board.html) | [Game board](../game-board.md) |
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
@@ -23,10 +24,21 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | End-game confirm | [`end-game-confirm.html`](end-game-confirm.html) | [End-game confirm](../end-game-confirm.md) |
 | Game over | [`game-over.html`](game-over.html) | [Game over](../game-over.md) |
 
-Two screens have two mockups each, and for the same reason both times: a state
-that only exists in contrast is a state you have to see next to its opposite.
-The grid is drawn at the biggest and the smallest problem the game can deal, and
-the result dialog is drawn right and wrong.
+Three screens have two mockups each, for two different reasons.
+
+Two of them are drawing **a state that only exists in contrast** — a state you
+have to see next to its opposite. The grid is drawn at the biggest and the
+smallest problem the game can deal, and the result dialog is drawn right and
+wrong. Both files in each pair are agreed pictures of the same screen.
+
+The title screen's pair is **a question, not two states**. Which of `RESUME` and
+`NEW` is the primary button is
+[open on its spec page](../title-screen.md#open-questions), and the wireframe
+loop's own advice is that where there is a real choice you
+[propose two mockups](../../../engineering/ui-design-process.md#the-loop),
+because comparing two pictures is a much easier conversation than critiquing
+one. Neither file is agreed yet; when review picks one it becomes
+`title-screen.html` and the other is deleted.
 
 Each row arrives with its screen's `Wireframe:` issue. See
 [UI design process](../../../engineering/ui-design-process.md).

--- a/docs/specs/ui/mockups/title-screen-resume-primary.html
+++ b/docs/specs/ui/mockups/title-screen-resume-primary.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <!--
-  Multiplying Frogs — Title screen — OPTION A: NEW is primary
+  Multiplying Frogs — Title screen — OPTION B: RESUME is primary
   Device: kids' Android tablet, held landscape.
   Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
 
-  One of a PAIR. The other is title-screen-resume-primary.html, which is this
+  One of a PAIR. The other is title-screen.html, which is this
   same layout with the primary and secondary styles swapped between the two
   buttons. Nothing else differs. Neither is agreed yet — the pair is how the
   spec page's open question 1 ("which of RESUME and NEW is primary?") gets
-  answered, and the winner becomes this file.
+  answered, and the winner becomes title-screen.html.
 
   Drawn in the state where A SAVE EXISTS, so both buttons are live. What the
   screen looks like when there is nothing to resume is open question 2 on
@@ -21,7 +21,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Multiplying Frogs — Title screen — Option A: NEW primary</title>
+<title>Multiplying Frogs — Title screen — Option B: RESUME primary</title>
 <style>
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
@@ -54,8 +54,8 @@
     <div class="abs mid" style="inset:0;font-size:34px;color:#8F9C97">SPLASH ART — issue #168 — fills the canvas</div>
     <div class="abs" style="left:0;right:0;top:180px;text-align:center;font-size:160px;font-weight:800;letter-spacing:-2px">Multiplying Frogs</div>
     <div class="action">
-      <div class="tbtn s">RESUME</div>
-      <div class="tbtn p">NEW</div>
+      <div class="tbtn p">RESUME</div>
+      <div class="tbtn s">NEW</div>
     </div>
     <div class="abs" style="left:48px;bottom:48px;font-size:28px;color:#6C7873">v0.1.0</div>
 </div>

--- a/docs/specs/ui/title-screen.md
+++ b/docs/specs/ui/title-screen.md
@@ -1,16 +1,37 @@
 # Title screen
 
-The first thing you see. It says what the game is and gives you one thing to
-press.
+The first thing you see. It says what the game is and gives you the way into a
+game: carry on with the one you left, or start a new one.
 
 ## Invariants
 
-**Invariant:** there is exactly one interactive element on this screen — `Play`.
+**Invariant:** the only interactive elements on this screen are `RESUME` and
+`NEW`. There is never a third. How many of the two are on screen when there is
+no saved game is [open question 2](#open-questions); nothing is ever *added*
+beyond these two.
 **Invariant:** nothing on this screen can start a game with the wrong number of
 players. Choosing who is playing happens on [game setup](game-setup.md), always,
-including when you have played five games in a row.
+including when you have played five games in a row. **`RESUME` is not an
+exception to this.** It does not choose a roster — it restores the one a saved
+game already carries, and that roster was chosen on game setup when that game
+was started. The one path that leaves this screen without passing through game
+setup does so because the choice has already been made, not because it can be
+made somewhere else.
 **Invariant:** the version string is present and is read from `/VERSION`, never
 typed into a layout.
+
+### The invariant this page used to carry
+
+Until this wireframe, the first invariant on this page read:
+
+> **Invariant:** there is exactly one interactive element on this screen —
+> `Play`.
+
+That stopped being true when [#228](https://github.com/derekwinters/connor-multiplying-frogs/issues/228)
+settled that a saved game is re-entered from the title screen. `Play` does not
+exist on this screen any more: it is `NEW`, and it has a neighbour. The old
+wording is quoted here so the change is visible, and it is not true anywhere
+else on this page.
 
 ## Regions
 
@@ -18,7 +39,7 @@ typed into a layout.
 | --- | --- |
 | `art` | The splash illustration — the whole canvas, behind everything |
 | `title` | The game's name |
-| `action` | The `Play` button |
+| `action` | The button row: `RESUME` and `NEW`, side by side |
 | `footprint` | Version string, bottom-left; small and quiet |
 
 ## Anchors
@@ -29,8 +50,15 @@ typed into a layout.
 - `title` is centred horizontally, its baseline at `TitleBaselineY` from the
   top. It is not vertically centred — the art has a subject in the middle of it
   and the title sits above that.
-- `action` is centred horizontally, `PlayButtonBottomOffset` up from the bottom
-  safe area, so it is under the thumb of a tablet held two-handed.
+- `action` is a **single horizontal row, centred horizontally as a row**, its
+  bottom edge `TitleButtonBottomOffset` up from the bottom safe area, so both
+  buttons are under the thumbs of a tablet held two-handed. Within the row,
+  `RESUME` is on the left and `NEW` on the right, separated by
+  `TitleButtonGap`.
+- The row is centred **as a whole**, not per button. That is what makes the
+  no-save case fall out for free: if [open question 2](#open-questions) is
+  answered `Hidden`, the row contains one button and centres it, which is
+  exactly where `Play` used to sit.
 - `footprint` is pinned to the bottom-left safe area corner.
 - On a screen that is not 16:10, the art crops and everything else keeps its
   distance from the **safe area**, not the screen edge.
@@ -42,20 +70,79 @@ typed into a layout.
 | Safe margin, every screen edge | `SafeMargin` | 48 px |
 | Title baseline from the top | `TitleBaselineY` | 300 px |
 | Title size | `TitleSize` | 160 px |
-| `Play` button width | `PlayButtonWidth` | 560 px |
-| `Play` button height | `PlayButtonHeight` | 160 px |
-| `Play` button up from the safe area | `PlayButtonBottomOffset` | 120 px |
+| Width of each button in the `action` row | `TitleButtonWidth` | 560 px |
+| Height of each button in the `action` row | `TitleButtonHeight` | 160 px |
+| Gap between `RESUME` and `NEW` | `TitleButtonGap` | 48 px |
+| Button row up from the safe area | `TitleButtonBottomOffset` | 120 px |
+| Label size on both buttons | `TitleButtonLabelSize` | 64 px |
 | Version string size | `VersionLabelSize` | 28 px |
 | Scrim behind the title, over the art | `TitleScrimOpacity` | 0.35 |
 
-`PlayButtonHeight` is larger than the shared `ButtonHeight` of 112 px. This is
-the one button on the screen and the first one a child touches; it is allowed to
-be the biggest button in the game.
+`TitleButtonHeight` is larger than the shared `ButtonHeight` of 112 px, and
+`TitleButtonWidth` larger than the shared `ButtonMinWidth` of 320 px. These are
+the first buttons a child touches and there is nothing else on the screen
+competing with them for space; they are allowed to be the biggest buttons in the
+game. Both buttons take the same width and the same height, deliberately: they
+are two peer choices, and a size difference would be a second, accidental way of
+saying which one matters — which is what
+[open question 1](#open-questions) is for the review to answer on purpose.
+
+`TitleButtonGap` is **not** the shared `ButtonGap` of 32 px. That value is sized
+for the shared 112 px button; scaled to a 160 px one the same proportion lands
+just under 48 px, and 48 px is already this page's `SafeMargin` and game
+setup's `SeatGap` at a comparable scale. At 32 px two 560 px buttons read as one
+split control rather than two choices.
+
+The row is `TitleButtonWidth` × 2 + `TitleButtonGap` = 1168 px wide, centred in
+the 1824 px between the safe margins, leaving 328 px either side. The row is
+deliberately not full-bleed, for the same reason game setup's seat row is not.
+
+`TitleButtonLabelSize` is 64 px rather than the shared `ButtonLabelSize` of
+44 px, in the same proportion as the buttons themselves are oversized
+(44 × 160 ÷ 112 ≈ 63). This is not a new decision — 64 px is what the committed
+mockup has drawn since this screen was first agreed. It is given a name here
+because there are now two labels of very different lengths (`RESUME` and `NEW`)
+sharing one button size, and a label size that only exists inside a mockup is a
+label size the next redraw gets wrong.
+
+### What became of the `Play*` constants
+
+[#216](https://github.com/derekwinters/connor-multiplying-frogs/issues/216)
+builds this screen from named constants and names three of them that no longer
+exist. They are **renamed, not removed, and their values do not change**:
+
+| Was | Is now | Value | Note |
+| --- | --- | --- | --- |
+| `PlayButtonWidth` | `TitleButtonWidth` | 560 px | Unchanged; now applies to both buttons |
+| `PlayButtonHeight` | `TitleButtonHeight` | 160 px | Unchanged; now applies to both buttons |
+| `PlayButtonBottomOffset` | `TitleButtonBottomOffset` | 120 px | Unchanged; now measured to the bottom of the row |
+
+The names lose their `Play` prefix because `Play` is not a thing on this screen
+any more, and a constant named after a button that does not exist is a constant
+somebody will eventually apply to the wrong one. `TitleButtonGap` is the one
+genuinely new number.
 
 ## Elements
 
-- **`Play`** — primary [button](shared-components.md#button). Goes to
-  [game setup](game-setup.md). Never disabled.
+- **`RESUME`** — goes back into the saved game, on the
+  [game board](game-board.md). It restores a roster; it never chooses one. What
+  state within a turn a resumed game re-enters is the save format's business
+  ([ADR-0004](../../adr/0004-core-owns-the-save-format.md)) and is not settled
+  here.
+  - **Its button kind is not assigned yet.** Whether it is the primary or the
+    secondary of the pair is [open question 1](#open-questions).
+  - **What it does when there is no game to resume is not settled either.** It
+    is [open question 2](#open-questions), and this page does not assume an
+    answer. The mockups draw the state where a save exists.
+  - Nothing on this screen writes, reads, or deletes a save. The save
+    round-trip does not exist yet — it is out of the shape-only proof of
+    concept ([#198](https://github.com/derekwinters/connor-multiplying-frogs/issues/198))
+    — and this wireframe draws the button without implying the mechanism behind
+    it.
+- **`NEW`** — renamed from `Play`, and it goes exactly where `Play` went:
+  [game setup](game-setup.md). Never disabled; there is no state of this screen
+  that would justify greying it out. Its button kind is the other half of
+  [open question 1](#open-questions).
 - **Title** — text, not a logo image, until an `area:art` issue supplies one.
   The wireframe reserves the space a wordmark would occupy.
 - **Version** — `v0.1.0`, from `/VERSION`. It exists so that a screenshot from a
@@ -64,30 +151,68 @@ be the biggest button in the game.
 
 ## Behaviour
 
-- Entering: art and title fade in over `TitleFadeDuration` (0.3 s). No
-  animation on `Play` — a button that moves is a button that gets missed.
+- Entering: art and title fade in over `TitleFadeDuration` (0.3 s). Neither
+  button animates — a button that moves is a button that gets missed.
 - The hardware back button on this screen exits the app. It is the only screen
   where back exits.
 - Nothing auto-advances. The title screen waits indefinitely.
 
 ## Mockup
 
-[`mockups/title-screen.html`](mockups/title-screen.html)
+Two mockups, drawn as a pair, differing in **exactly one thing**: which of the
+two buttons is the primary. Everything else — position, size, gap, wording — is
+identical between them, so the review is answering
+[open question 1](#open-questions) and nothing else.
+
+- **`NEW` primary:** [`mockups/title-screen.html`](mockups/title-screen.html)
+- **`RESUME` primary:** [`mockups/title-screen-resume-primary.html`](mockups/title-screen-resume-primary.html)
+
+**Neither is the agreed picture yet.** The pair is the question. Once review
+picks one, it becomes `title-screen.html` and the other file goes.
+
+Both draw the state where **a save exists**, so both buttons are live. That is
+the state the layout question is about; the no-save layout falls out of
+whichever answer [open question 2](#open-questions) gets, and is drawn when that
+is answered.
 
 The splash illustration attached to
 [issue #168](https://github.com/derekwinters/connor-multiplying-frogs/issues/168)
-is the art this screen is built around. The mockup draws its region as a
+is the art this screen is built around. The mockups draw its region as a
 placeholder block rather than embedding the image, because a mockup that needs
 a network fetch is a mockup that does not open on the sofa — and because the
 wireframe is deciding *where the art goes*, not what it is.
 
 ## Open questions
 
+- **1. Which of `RESUME` and `NEW` is the primary button?** Not decided. The
+  shared [Button](shared-components.md#button) invariant is *"exactly one
+  primary button is visible at a time"*, so one of the two is primary and the
+  other is secondary — this is not a question the page can leave unanswered
+  forever, only one it must not answer by accident. It reads either way: `NEW`
+  inherits `Play`'s emphasis and is the button that is always there, while a
+  game sitting half-finished is arguably the likelier reason somebody opened the
+  app at all. The two mockups above are the two answers, side by side.
+- **2. What does `RESUME` do when there is no game to resume?** Not decided —
+  a fresh install, or after a game has finished and no save remains. Three
+  options, all buildable from the existing
+  [Button](shared-components.md#button) states:
+  1. **Hidden** — not laid out at all. The component's `Hidden` state is
+     already *"not laid out at all — buttons do not leave gaps behind"*, and
+     because the `action` row is centred as a row, the screen then shows a
+     single centred `NEW` exactly where `Play` used to be.
+  2. **Disabled** — always laid out, at 40 % opacity and unpressable. The
+     component already has this state; it needs only a condition saying when it
+     applies.
+  3. **Absent** — `RESUME` is not built yet and the screen ships with `NEW`
+     alone until save/resume exists. This one differs from the other two in kind:
+     it makes the two-button mockup a forward record rather than a build target.
 - **Is there a `How to play` button here?** Proposed: no. The rules are one
   sentence long, Connor already knows them, and
   [an in-app tutorial is parked](../future-ideas.md). If one is wanted it goes
-  here, beneath `Play`, as a secondary button — and it needs its own wireframe
-  for the screen it opens.
+  beneath the `RESUME`/`NEW` row as a secondary button — and it needs its own
+  wireframe for the screen it opens. Note that it would make three interactive
+  elements, so it is a change to this page's first invariant as well as to its
+  layout.
 - **Does the title screen come back after a game, or does `Play again` restart
   directly?** Both exist on [game over](game-over.md); this screen does not care
   which is used.


### PR DESCRIPTION
Closes #235

The title screen used to have one button, `Play`. Derek decided on #228 that a
half-finished game comes back from the title screen, so now it has two: `RESUME`
to carry on with the game you left, and `NEW` to start a fresh one — `NEW` goes
exactly where `Play` went. They sit side by side at the bottom of the screen,
same size as each other, in the same place `Play` was. Two things are
deliberately **not** decided here and are drawn as questions for you and Connor:
which of the two buttons is the bright one, and what `RESUME` does when there is
no saved game to go back to. There are two mockups instead of one so you can put
them next to each other and pick.

**Docs:** `docs/specs/ui/title-screen.md` — the "exactly one interactive element
— `Play`" invariant is retired and replaced; the roster invariant gains an
explicit clause saying `RESUME` restores a roster rather than choosing one;
`RESUME` and `NEW` replace `Play` in Elements; the three `Play*` constants are
renamed and a gap and a label size added; both open questions are recorded
unanswered. `docs/specs/ui/mockups/title-screen.html` — redrawn with both
buttons. `docs/specs/ui/mockups/title-screen-resume-primary.html` — new, the
same picture with the emphasis swapped. `docs/specs/ui/mockups/index.md` and
`docs/specs/ui/index.md` — the new row and the "one button" description.
`docs/specs/ui/game-setup.md` — its "does a saved game change this screen?" open
question is now answered (no).

## Spec invariants

| Invariant it had to keep true | How |
| --- | --- |
| Exactly one primary button is visible at a time ([Button](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/shared-components.md#button)) | Each mockup draws exactly one filled button and one outlined one. The pair differs only in which is which — that is the open question, not a second primary. |
| A button is never smaller than `MinTouchTarget` (96 px) | Both are `TitleButtonWidth` × `TitleButtonHeight` = 560 × 160. |
| Nothing on the title screen can start a game with the wrong number of players | `RESUME` restores the roster a saved game already carries, chosen on game setup when that game was started. The invariant now says this in words rather than leaving a reader to infer it from a button that skips setup. |
| The version string is read from `/VERSION`, never typed into a layout | Untouched — `footprint` is unchanged. |
| A mockup's numbers are the spec table's numbers | Every value in both mockups has a row in the constants table, including the 64 px label size, which previously only existed in the mockup. |

## How the spec is changing

- **Old rule:** "there is exactly one interactive element on this screen —
  `Play`." **New rule:** "the only interactive elements on this screen are
  `RESUME` and `NEW`. There is never a third." **Why:** #228 put a second
  entry point on this screen, so the old wording is simply false. The new one is
  phrased as a ceiling rather than a count, so it stays true under all three
  answers to what `RESUME` does with no save — `Hidden` and `Absent` both only
  remove. The old wording is quoted on the page, marked as retired, so the change
  is visible rather than silently overwritten.
- **Old rule:** the roster invariant said choosing players happens on game setup,
  "always". **New rule:** same, plus an explicit clause that `RESUME` is not an
  exception because it restores a roster rather than choosing one. **Why:**
  `RESUME` is the first way to reach play without passing through game setup, and
  an invariant with an unmentioned exception is an invariant somebody will
  correctly conclude is broken.
- **Old rule:** `PlayButtonWidth` / `PlayButtonHeight` / `PlayButtonBottomOffset`.
  **New rule:** `TitleButtonWidth` / `TitleButtonHeight` /
  `TitleButtonBottomOffset`, **same values**, applying to both buttons, plus a new
  `TitleButtonGap` (48 px) and `TitleButtonLabelSize` (64 px). **Why:** `Play` no
  longer exists, and a constant named after a button that does not exist gets
  applied to the wrong one. #216 builds from these exact names, so the page now
  carries a was/is table rather than leaving that issue to guess.
- **Old rule:** game setup's "does a saved game change this screen?" was open.
  **New rule:** answered, no. **Why:** #228 chose the title screen, and leaving
  the question open on a second page would have it contradicting this one.

## Deviations and Decisions

- **`TitleButtonGap` is 48 px, not the shared `ButtonGap` of 32 px.** The issue
  flagged reuse as a candidate but not a foregone conclusion. 32 px is sized for
  the shared 112 px button; scaled to these 160 px ones the same proportion is
  just under 48, and at 32 px two 560 px buttons read as one split control rather
  than two choices. 48 px is also this page's `SafeMargin` and game setup's
  `SeatGap` at a comparable scale.
- **Side by side, not stacked, with `RESUME` on the left.** Drawn rather than
  argued, per the issue. Side by side keeps both buttons in the thumb zone of a
  two-handed grip, keeps every existing vertical number unchanged, and makes the
  `Hidden` answer to open question 2 fall out for free — the row is centred as a
  row, so a row of one centres itself exactly where `Play` used to be. The
  left/right order is fixed independently of which button is primary, on purpose,
  so the two comparison mockups differ in exactly one variable.
- **Added `TitleButtonLabelSize` (64 px) to the constants table.** Not asked for.
  64 px is what the committed mockup has drawn since this screen was agreed, but
  it had no row in the table, and I could not redraw two buttons with labels of
  very different lengths against a number that only existed inside an HTML file.
  This records an existing value; it does not choose a new one.
- **Edited `docs/specs/ui/game-setup.md`, which the issue did not list.** Its
  open question asked where the resume entry point goes and said "not decided".
  Leaving that standing while this page answers it would put two spec pages in
  contradiction on the day this merges.
- **Did not add the missing `TitleFadeDuration` row**, even though I was editing
  the same table. It is on #216's own build checklist and its value is already
  stated in this page's prose, so an implementer is not guessing; taking it here
  would tick a box on another issue.
- **Both open questions are left open**, so this wireframe is not agreed by
  merging it. Per [the wireframe loop](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/ui-design-process.md#the-loop),
  closing the issue is the approval, and #216 stays blocked until you close it.
  The `title-screen-resume-primary.html` comparison file is temporary by design —
  whichever option wins becomes `title-screen.html` and the other is deleted.
- **No test.** This PR changes no code. `mkdocs build --strict`,
  `check_geometry_literals.py`, `check_core_isolation.py`, `run_python_tests.py`
  and the Core suite all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_