### PR TITLE
docs(ui): draw the growable addition section in the working-out grid

### DIFF
--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -18,18 +18,28 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
 | Working-out grid, `331 × 41` | [`working-out-grid-331x41.html`](working-out-grid-331x41.html) | [Working-out grid](../working-out-grid.md) |
 | Working-out grid, `68 × 5` | [`working-out-grid-68x5.html`](working-out-grid-68x5.html) | [Working-out grid](../working-out-grid.md) |
+| Working-out grid, `331 × 41` grown to the cap | [`working-out-grid-331x41-grown.html`](working-out-grid-331x41-grown.html) | [Working-out grid](../working-out-grid.md) |
 | Answer result — right | [`answer-result-right.html`](answer-result-right.html) | [Answer result](../answer-result.md) |
 | Answer result — wrong | [`answer-result-wrong.html`](answer-result-wrong.html) | [Answer result](../answer-result.md) |
 | Settings dialog | [`settings-dialog.html`](settings-dialog.html) | [Settings dialog](../settings-dialog.md) |
 | End-game confirm | [`end-game-confirm.html`](end-game-confirm.html) | [End-game confirm](../end-game-confirm.md) |
 | Game over | [`game-over.html`](game-over.html) | [Game over](../game-over.md) |
 
-Three screens have two mockups each, for two different reasons.
+Three screens have more than one mockup, for two different reasons.
 
 Two of them are drawing **a state that only exists in contrast** — a state you
 have to see next to its opposite. The grid is drawn at the biggest and the
 smallest problem the game can deal, and the result dialog is drawn right and
 wrong. Both files in each pair are agreed pictures of the same screen.
+
+The grid's **third** file is neither: it is the widest card with its addition
+section grown to the cap, drawn to find out what the cap costs at today's
+constants. The answer is that it does not fit — the answer row ends up below the
+bottom of the tablet. That is
+[an open question on the spec page](../working-out-grid.md#open-questions), and
+the mockup is its input rather than an agreed picture. A mockup that overflows
+is doing its job here; it is cheaper to find this in a picture than in a built
+screen.
 
 The title screen's pair is **a question, not two states**. Which of `RESUME` and
 `NEW` is the primary button is

--- a/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
+++ b/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-  Multiplying Frogs — Working-out grid — 331 × 41
+  Multiplying Frogs — Working-out grid — 331 × 41, addition section grown to the cap
   Device: kids' Android tablet, held landscape.
   Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
 
@@ -8,14 +8,20 @@
   can be told apart in a picture; the palette is an area:art decision.
   Numbers here are the numbers in the spec page's constants table.
 
-  This is the grid as the card deals it — the addition section at the two rows
-  every card starts with. The player can grow that section to six.
-  working-out-grid-331x41-grown.html draws the same screen at that cap.
+  THIS MOCKUP IS A QUESTION, NOT AN AGREED PICTURE.
+
+  It is the same screen as working-out-grid-331x41.html with the addition
+  section drawn at its cap of six rows instead of the two it starts with,
+  at today's constants and nothing else changed. At those constants it does
+  not fit: the answer row ends up below the bottom of the tablet.
+
+  That overrun is the point of the drawing. What to do about it is an open
+  question on the spec page, and this picture is its input, not its answer.
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Multiplying Frogs — Working-out grid — 331 × 41</title>
+<title>Multiplying Frogs — Working-out grid — 331 × 41 grown to the cap</title>
 <style>
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
@@ -67,12 +73,21 @@
         display:flex;align-items:center;justify-content:center}
   .gear{width:96px;height:96px;border-radius:50%;border:4px solid var(--line);display:flex;align-items:center;
         justify-content:center;font-size:44px}
+  /* Measurement annotations. Not part of the screen — they are the drawing
+     talking about itself, and none of them is an element to be built. */
+  .limit{position:absolute;left:0;right:0;height:0;border-top:4px dashed var(--warn)}
+  .limit span{position:absolute;right:0;top:-38px;font-size:24px;font-weight:700;color:var(--warn)}
+  .overrun{position:absolute;left:0;right:0;background:rgba(176,58,46,.10);
+           border-top:4px dashed var(--warn)}
+  .tag{font-size:24px;color:var(--warn);font-weight:700}
+  .brace{position:absolute;border:4px solid var(--accent);border-right:none;border-radius:20px 0 0 20px}
 </style>
 </head>
 <body>
 <div class="frame">
     <div class="abs" style="inset:0;background:#E2E8E5"></div>
     <div class="scrim"></div>
+
     <div class="abs panel" style="left:48px;top:48px;width:1824px;height:1104px">
       <div class="abs row" style="left:56px;top:44px;gap:32px">
         <div class="chip act"><span class="sw" style="background:var(--green)"></span><span>Green</span></div>
@@ -80,14 +95,27 @@
         <div class="row" style="height:96px;padding:0 32px;border-radius:20px;border:3px solid var(--faint);font-size:40px;font-weight:700">331 × 41 · hard pile</div>
       </div>
 
-      <!-- grid -->
+      <!-- grid: the committed origin, left 370 / top 216, unchanged.
+           Only the addition section's row count differs from
+           working-out-grid-331x41.html. -->
       <div class="abs col" style="left:370px;top:216px;gap:8px">
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">3</div><div class="cell fix">3</div><div class="cell fix">1</div></div>
         <div class="row" style="gap:8px"><div class="cell fix">×</div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">4</div><div class="cell fix">1</div></div>
         <div style="height:6px;background:var(--ink);width:664px"></div>
+
+        <!-- addition section: the two rows every card starts with … -->
+        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <!-- … and the four a player can grow it by, to the cap of six. A grown
+             row is an ordinary row: same cells, same size, no marking. The `+`
+             stays on the bottom row of the section, where the committed
+             two-row drawing puts it. -->
+        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
         <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
         <div class="row" style="gap:8px"><div class="cell fix">+</div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+
         <div style="height:6px;background:var(--ink);width:664px"></div>
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px">
@@ -98,28 +126,51 @@
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
         </div>
-        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:664px;text-align:center">the answer row — the only row that counts</div>
       </div>
 
-      <!-- Annotation, not an element. -->
+      <!-- Left margin: which rows are the addition section, and where it
+           starts and stops. Annotation, not an element. -->
+      <div class="abs brace" style="left:300px;top:518px;width:44px;height:664px"></div>
       <div class="abs col" style="left:64px;top:530px;width:224px;gap:10px">
-        <div style="font-size:26px;font-weight:700;color:#6C7873">addition section</div>
-        <div style="font-size:24px;color:#6C7873;line-height:1.3">
-          two rows to start, on every card. A player who writes carries out as
-          whole lines instead of superscripts can grow it to six.
-        </div>
+        <div style="font-size:26px;font-weight:700;color:var(--accent)">addition section</div>
+        <div style="font-size:24px;color:#6C7873;line-height:1.3">rows 1–2 are what<br>every card starts with</div>
+      </div>
+      <div class="abs" style="left:64px;top:748px;width:224px;font-size:24px;color:#6C7873;line-height:1.3">
+        rows 3–6 are grown by the player, one at a time, and stop here
       </div>
 
-      <!-- keypad -->
-      <div class="abs col" style="right:56px;top:216px;gap:24px">
-        <div style="display:grid;grid-template-columns:repeat(3,140px);gap:16px">
-          <div class="key">1</div><div class="key">2</div><div class="key">3</div>
-          <div class="key">4</div><div class="key">5</div><div class="key">6</div>
-          <div class="key">7</div><div class="key">8</div><div class="key">9</div>
-          <div class="key" style="font-size:40px">⌫</div><div class="key">0</div><div class="key" style="font-size:32px">clear</div>
+      <!-- Right of the grid: what the drawing measures. -->
+      <div class="abs col" style="left:1060px;top:216px;width:240px;gap:18px">
+        <div style="font-size:28px;font-weight:700;color:var(--warn)">This does not fit.</div>
+        <div style="font-size:24px;color:#6C7873;line-height:1.35">
+          Two rows: the grid is 732 px tall and ends 948 px into the panel,
+          with about 100 px to spare.
         </div>
-        <div class="btn p" style="width:452px;min-width:0;height:128px">Check it</div>
+        <div style="font-size:24px;color:#6C7873;line-height:1.35">
+          Six rows: 1180 px tall, ending 1396 px into the panel. There are
+          908 px between the header and <code>DialogPadding</code>, so it is
+          272 px too tall even pushed right up under the header.
+        </div>
+        <div style="font-size:24px;color:var(--warn);line-height:1.35;font-weight:700">
+          The second rule line, the second carry strip and the answer row are
+          all below the bottom of the tablet.
+        </div>
+        <div style="font-size:24px;color:#6C7873;line-height:1.35">
+          What gives — scroll, smaller cells, something else — is an open
+          question on the spec page. This picture is the question, not the
+          answer.
+        </div>
       </div>
+    </div>
+
+    <!-- Everything from the DialogPadding limit down to the bottom of the
+         tablet: outside the dialog, and past the panel edge, off the screen. -->
+    <div class="abs overrun" style="left:0;right:0;top:1096px;height:104px"></div>
+
+    <!-- The last usable pixel inside the dialog: DialogMaxHeight less
+         DialogPadding, 1096 px down the canvas. -->
+    <div class="abs limit" style="left:48px;right:48px;top:1096px">
+      <span>DialogPadding — the last usable pixel inside the dialog</span>
     </div>
 </div>
 </body>

--- a/docs/specs/ui/mockups/working-out-grid-68x5.html
+++ b/docs/specs/ui/mockups/working-out-grid-68x5.html
@@ -7,6 +7,13 @@
   Shapes, sizes and positions only. The colours are placeholders so the frogs
   can be told apart in a picture; the palette is an area:art decision.
   Numbers here are the numbers in the spec page's constants table.
+
+  The easy pile now gets the addition section too — two rows, the same starting
+  count as every other card. Whether it also needs the second rule line and the
+  second carry strip that wrap the section on the two-digit card, or whether the
+  rows belong there on their own, is an open question on the spec page. This
+  drawing uses the two-digit card's structure because it is the only one this
+  project has drawn; it is not an answer to that question.
 -->
 <html lang="en">
 <head>
@@ -75,18 +82,44 @@
         <div style="font-size:44px;color:#6C7873">Work it out</div>
         <div class="row" style="height:96px;padding:0 32px;border-radius:20px;border:3px solid var(--faint);font-size:40px;font-weight:700">68 × 5 · easy pile</div>
       </div>
-      <div class="abs col" style="left:480px;top:400px;gap:8px">
+      <!-- grid: same origin height as the hard card's, because every card now
+           starts with the same rows. Only the column count is smaller. -->
+      <div class="abs col" style="left:480px;top:216px;gap:8px">
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">6</div><div class="cell fix">8</div></div>
         <div class="row" style="gap:8px"><div class="cell fix">×</div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">5</div></div>
         <div style="height:6px;background:var(--ink);width:440px"></div>
+        <!-- the addition section: two rows here too, growable to six -->
+        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix">+</div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <div style="height:6px;background:var(--ink);width:440px"></div>
+        <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px">
           <div class="cell fix" style="font-size:28px;color:#6C7873">=</div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5;border-color:var(--accent)"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
         </div>
-        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:440px;text-align:center">the answer row</div>
+        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:440px;text-align:center">the answer row — the only row that counts</div>
+      </div>
+
+      <!-- Annotation, not an element. -->
+      <div class="abs col" style="left:1060px;top:216px;width:240px;gap:18px">
+        <div style="font-size:26px;color:#6C7873;line-height:1.35">
+          The easy card is narrower than the hard one — three digit columns
+          instead of five — but no shorter. Every card starts with the same
+          rows now, including the two addition rows.
+        </div>
+        <div style="font-size:26px;color:var(--warn);line-height:1.35">
+          Open on the spec page: whether the easy card really needs the second
+          rule line and the second carry strip drawn here, or just the two
+          addition rows on their own.
+        </div>
+        <div style="font-size:26px;color:#6C7873;line-height:1.35">
+          Nothing here has to be filled in. A player who knows
+          <b>68&nbsp;×&nbsp;5</b> fills the answer row and presses
+          <b>Check it</b>.
+        </div>
       </div>
       <div class="abs col" style="right:56px;top:216px;gap:24px">
         <div style="display:grid;grid-template-columns:repeat(3,140px);gap:16px">

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -12,19 +12,62 @@ there is nowhere to work.
 ## Invariants
 
 **Invariant:** nothing in the grid is marked. Only the answer row decides
-whether the frog moves. Carry boxes and partial-product rows are scratch paper —
-they exist so you don't lose the 3, not to be checked.
+whether the frog moves. Carry boxes and addition rows are scratch paper — they
+exist so you don't lose the 3, not to be checked.
+**Invariant:** a row the player grows is exactly as ungraded as every other cell
+in the grid. Growing the addition section is asking for more scratch paper, and
+scratch paper is never checked
+([ADR-0002](../../adr/0002-structured-working-out-grid.md#two-constraints-that-keep-it-from-becoming-a-tutor)).
+**Invariant:** both superscript carry strips are always on screen, on every
+card, whether or not the player uses the addition section. The two ways of
+carrying are not alternatives the game chooses between — both are drawn, and the
+player uses whichever one they were taught.
 **Invariant:** there is no mode and no toggle. The answer box *is* the grid's
 bottom row. A player who can do `68 × 5` in their head fills one row and
 presses `Check it`.
-**Invariant:** the grid is sized to the card, not to the largest possible
-problem. `68 × 5` does not get `331 × 41`'s rows.
-**Invariant:** the grid never has to render a shape outside the three the piles
-produce — `2×1`, `2×2`, `3×2` digits. `331 × 41` is the confirmed worst case.
+**Invariant:** the grid is sized to the card in its **columns**. `68 × 5` gets
+three digit columns and `331 × 41` gets five, so an easy card still does not
+look like homework.
+**Invariant:** the grid's **rows** are not sized to the card. Every card is
+dealt the same rows, and from there the player — not the card — decides whether
+there are more.
+**Invariant:** the addition section never holds more than
+`GridAdditionRowsMax` rows. The player decides when it grows; the cap decides
+when it stops.
+**Invariant:** the game never deals a *problem* outside the three shapes the
+piles produce — `2×1`, `2×2`, `3×2` digits. `331 × 41` is still the confirmed
+widest.
 **Invariant:** `Check it` is disabled until at least one digit is in the answer
 row. An empty answer is not a wrong answer.
 **Invariant:** this dialog cannot be dismissed. The card is drawn and the turn
 is under way.
+
+### The invariants this page used to carry
+
+Until this wireframe, two of the invariants above read differently. Both were
+made false by the addition section becoming growable
+([#234](https://github.com/derekwinters/connor-multiplying-frogs/issues/234)),
+and the old wording is quoted here so the change is visible. Neither sentence is
+true anywhere else on this page.
+
+> **Invariant:** the grid is sized to the card, not to the largest possible
+> problem. `68 × 5` does not get `331 × 41`'s rows.
+
+This is now true of **columns only**, and it is no longer true of rows at all:
+`68 × 5` gets exactly `331 × 41`'s rows, because every card starts with the same
+ones. What survives is the intent — the easy card is visibly a smaller job,
+because it is narrower.
+
+> **Invariant:** the grid never has to render a shape outside the three the
+> piles produce — `2×1`, `2×2`, `3×2` digits. `331 × 41` is the confirmed worst
+> case.
+
+Still true of the three **problem** shapes; ADR-0002's bound on the problems is
+untouched, and nothing here lets the game deal a fourth shape. It is no longer
+true of the **rendered row count**, which the player extends. `331 × 41` is the
+widest grid but not the tallest one — the tallest is any card whose addition
+section has been grown to `GridAdditionRowsMax`, and that grid is the same
+height whichever card it came from.
 
 ## Regions
 
@@ -53,7 +96,16 @@ Inside it, two columns:
 This split is what landscape buys. In portrait the grid and the keypad have to
 share a single column, and `331 × 41` was
 [the project's biggest layout unknown](../../adr/0002-structured-working-out-grid.md#consequences)
-because of it. Side by side, the worst case fits with room to spare.
+because of it. Side by side, the widest card as dealt fits.
+
+It does **not** fit with room to spare — the phrase this paragraph used to end
+with, and the one ADR-0002 still ends with, both written before the addition
+section could grow. As dealt, the grid ends 948 px
+into a panel whose last usable pixel is 1048 px — about 100 px of slack against
+112 px per extra row, so the section stops fitting on the *third* of its six
+allowed rows. What to do about that is
+[open question 3](#open-questions); the numbers are worked through under
+[Mockup](#mockup), and the third mockup is the picture of them.
 
 ## Named constants
 
@@ -67,42 +119,121 @@ because of it. Side by side, the worst case fits with room to spare.
 | Answer row height | `GridAnswerRowHeight` | 128 px |
 | Answer cell border | `GridAnswerBorderWidth` | 6 px |
 | Digit size in a cell | `GridDigitSize` | 56 px |
+| Addition rows a card is dealt | `GridAdditionRowsAtStart` | 2 rows |
+| Most addition rows the section can hold | `GridAdditionRowsMax` | 6 rows |
 | Keypad key, square | `KeypadKeySize` | 140 px |
 | Gap between keys | `KeypadKeyGap` | 16 px |
 | Keypad width (3 keys + 2 gaps) | `KeypadWidth` | 452 px |
 | Gap between keypad and `Check it` | `KeypadSubmitGap` | 24 px |
 | `Check it` height | `CheckButtonHeight` | 128 px |
 
+`GridAdditionRowsAtStart` and `GridAdditionRowsMax` are counts, not pixels. They
+are in this table anyway, because the number of rows the addition section starts
+and stops at is exactly the kind of number that otherwise ends up as an unnamed
+`2` in `Core` and an unnamed `6` in the Unity shell, and then only one of them
+gets changed.
+
+**A grown row has no size constant of its own.** It is an ordinary row of
+ordinary cells: `GridCellSize` tall, `GridCellGap` below the row above it, the
+same cells the section already has. Growing the section costs
+`GridCellSize` + `GridCellGap` = 112 px of height per row and nothing else.
+
 ### How many columns and rows
 
-Both are decided by the card, in `Core`, and drawn by the Unity shell:
+The card decides the columns. The card and the player between them decide the
+rows.
 
 - **Columns** = the number of digits in the largest possible product for that
   card's shape, plus one operator column on the left. `331 × 41` needs five
   digit columns (`13571`); `68 × 5` needs three (`340`).
-- **Rows** depend on the multiplier:
+- **Rows** are the same for every card, top to bottom:
 
-    | Multiplier | Rows |
-    | --- | --- |
-    | 1 digit (`68 × 5`) | carry strip · multiplicand · multiplier · rule · answer |
-    | 2 digits (`22 × 41`, `331 × 41`) | carry strip · multiplicand · multiplier · rule · partial product · partial product · rule · carry strip · answer |
+        carry strip · multiplicand · multiplier · rule ·
+        addition rows · rule · carry strip · answer
 
-A one-digit multiplier has no partial products and nothing to add up, so those
-rows do not exist. That is the "sized to the card" rule doing its job: an easy
-card should not look like homework.
+    The addition rows are the only part of that list whose count is not fixed,
+    and what varies it is not the card: every card is dealt
+    `GridAdditionRowsAtStart` of them, and the player can grow the section from
+    there to `GridAdditionRowsMax`.
+
+**"The addition section"** is this page's name for those rows — the block
+between the first rule line and the second, which Derek calls the `"+ "`
+section and which this page used to call the *partial-product rows*. They are
+the same rows.
+[#204](https://github.com/derekwinters/connor-multiplying-frogs/issues/204)
+is written against the older name and means these. The section is renamed
+because a one-digit card now gets it too, and on `68 × 5` its rows are not
+partial products of anything — they are somewhere to add up.
+
+#### What Derek settled, in his words
+
+> Let's support both. […] The top superscript boxes can always exist. But if
+> someone instead wants to add full numbers below the numbers, they can. If they
+> enter numbers below the answer box, another row appears underneath it. Each
+> time they add a row below, it would keep expanding. […] This is the `"+ "`
+> section below the problem and above the answer.
+
+> I meant below the problem above the answer
+>
+> Single digit
+>
+> Cap the rows of addition to 6, start with 2
+
+> Single digit gets 2 rows too
+>
+> Add to bottom of addition rows, above answer row
+
+Read together: the section is the one between the problem and the answer; a
+**single digit** typed into it is what adds the next row; the new row is
+appended to the **bottom of the section**, which stays above the answer row;
+every card starts with **2** rows; and the section stops at **6**.
+
+#### What `Core` decides, and what the player decides
+
+The split matters because it is the thing
+[#204](https://github.com/derekwinters/connor-multiplying-frogs/issues/204)
+models and [#223](https://github.com/derekwinters/connor-multiplying-frogs/issues/223)
+draws, and it is not the split either issue was written against.
+
+| | Derived from the card | Player state |
+| --- | --- | --- |
+| Column count | ✓ | |
+| Which cells are printed (the multiplicand and multiplier digits) | ✓ | |
+| Every row except the addition rows | ✓ — the same for every card | |
+| How many addition rows exist | starts at `GridAdditionRowsAtStart` | grows from there, to `GridAdditionRowsMax` |
+| Cell contents | | ✓ |
+
+So the grid's shape is **no longer a pure function of the card**. It is a
+function of the card and of how many rows the player has grown, and the second
+of those changes during a turn. It is still bounded at both ends, and by the
+same two numbers for every card the piles can deal:
+`GridAdditionRowsAtStart` rows when the card is dealt, `GridAdditionRowsMax` at
+the most. There is no card that can be dealt more, and no player who can grow
+past it.
 
 ## Elements
 
 - **Multiplicand and multiplier rows** — printed, not editable. These two rows
   *are* the card.
-- **Carry strip** — dashed boxes, one per column. Two strips at most: one above
-  the multiplication and one above the final addition, which is the "twice over"
-  ADR-0002 describes. Optional to use, never checked.
-- **Partial-product rows** — ordinary empty cells, including the units column
-  of the second row. **The placeholder zero is not pre-printed.** Some
-  classrooms teach writing the `0`, some teach shifting left; leaving the cell
-  ordinary lets both work, and pre-printing it would pick one — which is the
-  thing ADR-0002 says not to do.
+- **Carry strip** — dashed boxes, one per column. Two strips, on every card: one
+  above the multiplication and one above the final addition, which is the "twice
+  over" ADR-0002 describes. Optional to use, never checked. `68 × 5` used to
+  have only the first, because it had nothing to add up; it has both now that it
+  has an addition section, subject to
+  [open question 4](#open-questions). Where the second strip goes once the
+  section grows is [open question 2](#open-questions).
+- **Addition rows** — ordinary empty cells, including the units column of every
+  row below the first. **The placeholder zero is not pre-printed.** Some classrooms teach
+  writing the `0`, some teach shifting left; leaving the cell ordinary lets both
+  work, and pre-printing it would pick one — which is the thing ADR-0002 says
+  not to do.
+  - **A grown row is indistinguishable from a dealt one.** Same cells, same
+    size, same border, no tint, no badge, nothing that says "you added this".
+    The section is scratch paper and scratch paper does not annotate itself.
+  - The `+` glyph sits in the operator column of the **bottom row of the
+    section**, wherever the bottom currently is, which is where the committed
+    two-row drawing already puts it. Growing the section moves the glyph down
+    with it rather than stamping a `+` on every row.
 - **Answer row** — taller, heavier border, tinted. The only row that counts.
 - **Keypad** — `1`–`9`, `0`, backspace, `clear`. No decimal point, no minus:
   every answer in this game is a positive whole number.
@@ -115,8 +246,21 @@ card should not look like homework.
   is the focused one; typing fills the answer row **right to left**, which is
   the direction the digits are worked out in.
 - Tapping any cell moves the caret there, so the grid can be filled in any
-  order — a player who does the partial products first, then the answer, is not
+  order — a player who fills the addition rows first, then the answer, is not
   fighting the caret.
+- **Growing the addition section.** Typing a single digit into the section's
+  current bottom row appends another row beneath it, still above the answer row.
+  That repeats each time the new bottom row is written in, until the section
+  holds `GridAdditionRowsMax` rows, after which nothing more is appended. A
+  single digit is enough; the row does not have to be finished first.
+- Nothing prompts the player to grow the section and nothing rewards it. A
+  player who carries with the superscript boxes never sees a third addition row,
+  and a player who has never been shown the superscript boxes never has to use
+  them.
+- **Whether a grown row can be taken away again is not specified here.** Neither
+  `backspace` nor `clear` is described as removing a row, and neither is
+  described as leaving one behind. It is a question, not an omission — see
+  [open question 5](#open-questions).
 - No timer, ever. `331 × 41` on paper takes as long as it takes.
 - There is no `undo`, only backspace and `clear` — and `clear` empties only the
   cell block you are in, not the whole grid.
@@ -124,18 +268,106 @@ card should not look like homework.
 
 ## Mockup
 
-- **The worst case:** [`mockups/working-out-grid-331x41.html`](mockups/working-out-grid-331x41.html)
-- **The easy pile:** [`mockups/working-out-grid-68x5.html`](mockups/working-out-grid-68x5.html)
+Three, all at 1920 × 1200.
 
-Two mockups, because "the grid shrinks to fit the card" is a claim best checked
-by looking at the biggest and the smallest one next to each other.
+- **The widest card, as dealt:** [`mockups/working-out-grid-331x41.html`](mockups/working-out-grid-331x41.html)
+- **The easy pile, as dealt:** [`mockups/working-out-grid-68x5.html`](mockups/working-out-grid-68x5.html)
+- **The widest card, grown to the cap:** [`mockups/working-out-grid-331x41-grown.html`](mockups/working-out-grid-331x41-grown.html)
+
+The first two are the agreed pictures of the screen a card deals, and they are a
+pair for the reason they always were: "the grid shrinks to fit the card" is a
+claim best checked by looking at the biggest and the smallest next to each
+other. The easy one is now the same height as the hard one and narrower, which
+is what that claim has been reduced to.
+
+**The third is a question, not an agreed picture.** It is the same screen as the
+first with the addition section at `GridAdditionRowsMax` instead of
+`GridAdditionRowsAtStart`, everything else identical, at today's constants — and
+at today's constants it does not fit:
+
+| | Grid height | Ends, measured into the panel |
+| --- | --- | --- |
+| `GridAdditionRowsAtStart` (2 rows) | 732 px | 948 px, about 100 px of slack |
+| `GridAdditionRowsMax` (6 rows) | 1180 px | 1396 px |
+
+The dialog is `DialogMaxHeight` (1104 px) tall and `DialogPadding` (56 px) of
+that is not usable, so the last usable pixel is 1048 px into the panel. The
+header takes the first 140 px. That leaves **908 px for a grid that wants
+1180 px** — 272 px too tall even shoved right up under the header, with the grid
+free to re-centre upward under the [Anchors](#anchors) rule. The second rule
+line, the second carry strip and **the answer row itself** all end up below the
+bottom edge of the tablet.
+
+That overrun is drawn rather than described because it is the input to
+[open question 3](#open-questions). A mockup that visibly overflows is the
+correct result here: the wireframe's job was to find out what the cap costs at
+today's numbers, not to pick the fix.
 
 ## Open questions
 
-- **Which carry convention does Connor's class use?** The mockups put one carry
-  strip above the multiplication and one above the addition. The alternative is
-  a strip attached to each partial-product row, which avoids reusing one strip
-  across two passes. Nothing is marked either way, so this is about matching
-  what he is taught — worth asking him rather than deciding here.
-- **Should the keypad have an `=`?** No, currently: `Check it` is the commit,
+Questions 2 to 5 arrived with the growable addition section
+([#234](https://github.com/derekwinters/connor-multiplying-frogs/issues/234)),
+and none of them is answered by anything Derek has said. Questions 1 and 6 are
+older. Question 1 is the one that changes what `Core` builds.
+
+- **1. Which carry convention does Connor's class use?** The mockups put one
+  carry strip above the multiplication and one above the addition, each reused
+  across the rows it covers. The alternative is a strip attached to each
+  addition row, so a carry is never reused across two passes. Nothing is marked
+  either way, so this is about matching what he is taught — his call, not one to
+  make in code.
+
+    This is **the one open question on this page that changes the shape of the
+    grid in `Core`**, so it is worth being exact about what depends on it.
+    Depending on it: the number of carry strips a grid has, whether that number
+    tracks the addition row count (and therefore grows during a turn), and the
+    per-row-versus-shared structure the row list above states. Not depending on
+    it: the column count, the addition section's starting count and cap, the
+    growth trigger, the fact that nothing is graded, and the overrun measured in
+    the third mockup — a per-row strip would make the overrun worse, not
+    different in kind.
+
+    `Core` and the grid screen are being built to what the mockups draw today —
+    two strips at most — which is a recorded position, not an answer. If the
+    answer is the per-row strip, this page's row list, its `Elements` section,
+    all three mockups and the grid model change together.
+    Tracked in
+    [#255](https://github.com/derekwinters/connor-multiplying-frogs/issues/255).
+    It was originally asked in
+    [#227](https://github.com/derekwinters/connor-multiplying-frogs/issues/227),
+    which was carrying two questions under one title and was closed once Derek
+    answered the other one — superscript carries versus written-out addition
+    rows, the change this page has just absorbed. The layout question itself was
+    never answered, so it has its own issue now.
+
+- **2. What happens to the second carry strip as the section grows?** Today it
+  is pinned directly above the answer row. Three readings, none picked: it stays
+  pinned above the answer; it follows the bottom of the growing section; or
+  every addition row gets its own — which is question 1 answered the other way,
+  arriving through the back door. The third mockup draws it pinned above the
+  answer, because that is where the committed drawing has it.
+
+- **3. What happens when the section outgrows the dialog?** Not decided, and by
+  the measurements above this is not a distant edge case: the section stops
+  fitting on its **third** row, and at the cap the answer row is off the bottom
+  of the tablet entirely. Options include scrolling the `grid` region, shrinking
+  `GridCellSize` once the section passes some count, shrinking it for the whole
+  grid up front, giving the addition section its own smaller row height, or
+  lowering `GridAdditionRowsMax` to what fits — which is 2 today. Each one costs
+  something different, and picking one is a layout decision.
+
+- **4. Does the one-digit card's addition section get the second rule line and
+  the second carry strip?** `68 × 5` now gets the addition rows. It is not
+  settled whether it also gets the structure that wraps them on a two-digit
+  card, or whether the rows sit under the first rule line on their own. The
+  redrawn `68 × 5` mockup uses the two-digit structure because that is the only
+  one this project has drawn — a default in a picture, not a decision.
+
+- **5. Can a grown row be taken away again?** Backspacing the last digit out of
+  a grown row could remove it, or leave it. Leaving it means a mis-tap costs a
+  row permanently and, near the cap, costs the ability to grow another. Removing
+  it means a row can vanish under the caret. Neither is obviously right and
+  neither is stated.
+
+- **6. Should the keypad have an `=`?** No, currently: `Check it` is the commit,
   and two ways to submit is one too many.


### PR DESCRIPTION
Closes #234

The block of rows between the problem and the answer — where you add the partial
products up — used to be fixed: two rows on a two-digit card, none at all on an
easy one. Now every card starts with two of them and a player who would rather
write a carry out as a whole extra line than as a tiny digit above a column can
keep adding rows, up to six. The easy card gets the section too, so `68 × 5` and
`331 × 41` are now the same height and differ only in width.

There is a catch, and it is drawn rather than described: at today's cell sizes
six rows do not fit in the dialog. The third mockup shows the hard card at the
cap with the answer row pushed off the bottom of the tablet. That picture is the
question, not a proposal — what gives is left open for Derek.

**Docs:** `docs/specs/ui/working-out-grid.md` — the addition section starts at
`GridAdditionRowsAtStart` (2) rows on every card and grows to
`GridAdditionRowsMax` (6); two invariants rewritten, three added; five open
questions. `docs/specs/ui/mockups/working-out-grid-68x5.html` — redrawn with the
section. `docs/specs/ui/mockups/working-out-grid-331x41-grown.html` — new, the
cap at today's constants. `docs/specs/ui/mockups/working-out-grid-331x41.html`
and `docs/specs/ui/mockups/index.md` — annotated for the third mockup.

## Spec invariants

No code changed, so the rules this had to keep true are kept by the spec page
rather than by a test. The ones that were load-bearing here:

- **ADR-0002: nothing in the grid is marked.** A grown row is more scratch
  paper, so it is ungraded like everything else. Now stated as its own
  invariant instead of being left to inference from the general one.
- **ADR-0002: exactly three problem shapes.** Untouched — the piles still deal
  `2×1`, `2×2`, `3×2` and nothing here lets a fourth shape exist. What changed is
  the *rendered row count*, which is a different claim, and the page now
  separates them.
- **The grid is sized to the card.** This one could not be kept and is rewritten
  rather than deleted; see below.
- **Rule 8, wireframe before UI code.** The deliverable is the wireframe. No
  UI code is in this PR.

## How the spec is changing

Two committed invariants were falsified. Both are quoted in full on the page
under *The invariants this page used to carry*, following the pattern #235 set.

- **Was:** "the grid is sized to the card, not to the largest possible problem.
  `68 × 5` does not get `331 × 41`'s rows."
  **Is:** true of **columns** only. `68 × 5` now gets exactly `331 × 41`'s rows.
  **Why:** Derek's *"Single digit gets 2 rows too"* gives the easy card the
  section. The intent survives in the columns — three digit columns against
  five is still visibly a smaller job.

- **Was:** "the grid never has to render a shape outside the three the piles
  produce … `331 × 41` is the confirmed worst case."
  **Is:** still true of the three **problem** shapes; no longer true of the row
  count, which the player extends. `331 × 41` is the widest grid, not the
  tallest.
  **Why:** the row count is no longer a pure function of the card, which is the
  single most important thing for #204 to know and the reason it was blocked on
  this.

Also new: `GridAdditionRowsAtStart` (2) and `GridAdditionRowsMax` (6) in the
constants table, and a *What `Core` decides, and what the player decides* table
written for #204 and #223 to build against.

## Deviations and Decisions

- **The `331 × 41` mockup was added to, not replaced.** The checklist said
  redraw it at the cap. Its two-row drawing is still the correct picture of what
  a hard card deals — that shape did not change — and #223 needs it, so the cap
  went into a new `working-out-grid-331x41-grown.html` and the committed file
  kept its picture and gained an annotation. The mockups index already documents
  a screen having more than one file for exactly this reason.
- **The section is renamed from "partial-product rows" to "the addition
  section".** #204 is written against the old name, so the page says in as many
  words that they are the same rows and that #204 means these. The rename is
  because a one-digit card now gets the section and on `68 × 5` its rows are not
  partial products of anything.
- **The `+` glyph stays on the bottom row of the section** as it grows, rather
  than appearing on every added row. That extends where the committed drawing
  already puts it rather than choosing something new, so it is stated on the
  page rather than made an open question.
- **Opened #255**, a `type:question` in `Direct Involvement Needed`, for the
  carry-strip layout — one shared strip or one per row. #227 was carrying that
  question and a second one, and was closed when Derek answered the second, so
  nothing tracked it any more. It is now open question 1 on the page, and the
  page says plainly that it is the only open question that changes the grid's
  shape in `Core`, and which parts depend on it. Not settled here.
- **A sixth open question was added that no round of triage asked for** — can a
  grown row be taken away again, if you backspace the last digit out of it.
  #204 cannot be built without answering it, and neither `backspace` nor `clear`
  currently says. Named as a question rather than decided.
- **`docs/adr/0002` was left alone** although its "the worst case fits with room
  to spare" is now wrong. It is a decision record, so the correction lives on
  the spec page it points at, which says the phrase is stale and gives the real
  numbers.
- **No failing test preceded this.** There is no behaviour change and nothing in
  `Core` or the Unity shell moved; `mkdocs build --strict`, the geometry-literal
  check, the Core suite and the Python suites all pass.
- **The mockups were verified by arithmetic, not by eye.** No browser is
  available in this environment, so the 1180 px / 908 px / 272 px figures were
  computed from the constants and the row list rather than measured off a
  render. Worth a glance on the tablet before the numbers are trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_