### PR TITLE
docs(specs): write the normative rules of play

### DIFF
--- a/docs/intro/how-to-play.md
+++ b/docs/intro/how-to-play.md
@@ -11,9 +11,9 @@ way you would explain it to someone who has just picked the tablet up.
 
 This is the friendly version, not the exact one. The rules spec — every rule
 stated precisely, edge case by edge case, for the code to be built against — is
-[issue #199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199)
-and this page will link to it once it exists. Until then, and whenever the two
-disagree, the classroom game wins: it is photographed and transcribed in
+[rules of play](../specs/rules.md), and where this page and that one disagree,
+that one is right and this one gets corrected. Behind both of them the classroom
+game wins: it is photographed and transcribed in
 [reference material](../specs/reference/index.md), and
 [ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) makes it the authority
 on every rule.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -81,14 +81,13 @@ worth knowing in itself.
 
 | Page | What it settles |
 | --- | --- |
+| [Rules of play](rules.md) | Every rule the code is built against, stated as invariants: how many frogs play, what a roll does, how far a frog moves, what winning is, and the two ways a game ends. |
 | [Reference material](reference/index.md) | The classroom board, photographed and transcribed: the rules card verbatim, the three card piles and the rolls that reach them, the nine positions in a lane, and the handful of things the board leaves open. |
 
-The precise rules spec — every rule stated edge case by edge case for the code
-to be built against — is
-[issue #199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199)
-and does not exist yet. Until it lands, reference material is where the rules
-are recorded, and [how to play](../intro/how-to-play.md) is the same rules in
-the friendly form.
+The two are a pair, and the order matters: reference material is the source and
+decides nothing, [rules of play](rules.md) is the contract distilled from it,
+and [how to play](../intro/how-to-play.md) is the same rules in the friendly
+form.
 
 ### The product
 

--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -5,6 +5,12 @@ Source material for the port. Nothing on this page is a decision — it is the
 about the game can be checked against the board rather than against somebody's
 summary of it.
 
+The normative statement of these rules — every one of them stated as an
+invariant for the code to be built against — is [rules of play](../rules.md).
+This page describes the board Connor's class uses; that page describes the game
+this app implements, and the two differ where the project has recorded a rule
+change.
+
 ## The classroom game
 
 Multiplying Frogs is a board game from Connor's math class. Everything in

--- a/docs/specs/rules.md
+++ b/docs/specs/rules.md
@@ -1,0 +1,363 @@
+# Rules of play
+
+**The rules of Multiplying Frogs, stated once, precisely enough to build
+against.** How many frogs play, how far one moves, what a wrong answer costs,
+what winning is, and how a game finishes.
+
+Nothing on this page was decided by this page. Every rule below is transcribed
+from the classroom game or carried over from a decision already recorded
+elsewhere, and each one says where it came from. Where a rule is the project's
+rather than the classroom game's, it is marked as such — see
+[what is ours and what is theirs](#what-is-ours-and-what-is-theirs).
+
+[Reference material](reference/index.md) is the source this page distils: the
+board photograph, the rules card, and the notes taken off them. It is
+deliberately not normative — *"nothing on this page is a decision"* — and it
+stays that way. This page is the decision.
+
+## How to read this page
+
+**Rules are stated as `**Invariant:** …` lines**, the convention the
+[UI specs](ui/index.md#2-invariants) already use, so that a rule can be quoted
+in a pull request and asserted in a test. Prose around them is framing, not
+contract.
+
+**Where this page restates a rule that is also written in a UI spec, this page
+is that rule's normative home and the UI spec is the presentation contract for
+its screen** — the screen page describes the rule, it does not own it. Neither
+is a rival authority to the other, and a disagreement between them is a bug in
+one of them.
+
+The page uses the project's words — lane, lily pad, log, frog, pile, card, roll,
+turn — as fixed in `CONTEXT.md`. That file is the glossary and is never the
+source of a rule.
+
+**A gap here is a stop, not an invitation.** Behaviour this page does not
+describe is behaviour nobody has decided; the response is a `type:question`
+issue, never a sensible-looking guess. See
+[a gap is a stop](index.md#a-gap-is-a-stop-not-an-invitation), and
+[what this page does not settle](#what-this-page-does-not-settle) for the gaps
+that are already known and already tracked.
+
+## The players and the board
+
+**Invariant:** a game is played by **two to four frogs**, one per player, each
+in its own lane — so a game has between two and four lanes.
+
+This is **ours, not the classroom game's**: the rules card says
+[2–8 players](reference/index.md#the-rules-card-verbatim) and the physical board
+has eight lanes. Capping v1 at four is a **recorded rule change**, and
+[ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) names it as the worked
+example of one. Derek made the call in
+[#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7) and
+restated it while this page was being written:
+*"the mobile game will support 4 players for now"*
+([#199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199#issuecomment-5239966336)).
+Four is **v1's limit rather than a permanent ceiling** — letting five to eight
+play is [parked, not dropped](future-ideas.md#five-to-eight-players). The
+same bound is stated for the screen that enforces it in
+[game setup](ui/game-setup.md#invariants), and the four colours a frog can be
+are fixed in [shared components](ui/shared-components.md#frog-colours).
+
+The reference page and this page are describing two different things and do not
+contradict each other: **the reference page describes the board Connor's class
+uses, and this page describes the game this app implements.**
+
+**Invariant:** a lane has **nine positions** — the Start log is position 0,
+seven lily pads are positions 1–7, and the End log is position 8.
+
+| Position | What it is |
+| --- | --- |
+| 0 | **Start log.** Every frog begins here. The floor of the lane. |
+| 1–7 | **Lily pads.** The ordinary spaces. |
+| 8 | **End log.** The goal — landing on it wins. |
+
+Confirmed by Derek in
+[#185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185) and
+recorded under
+[the End log is the winning space](reference/index.md#the-end-log-is-the-winning-space);
+the same nine positions are the `LanePositionCount` and `LaneWinningPosition`
+constants in [game board](ui/game-board.md#named-constants).
+
+**Invariant:** frogs are **independent**. Each player keeps their own lane for
+the whole game; frogs never share a lane, never pass one another, and never
+interact. A frog's entire state is the one number saying how far up its own lane
+it is, and there is no board state beyond those numbers.
+([Frogs are independent](reference/index.md#frogs-are-independent), confirmed by
+Derek in
+[#170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170);
+[game board](ui/game-board.md#invariants))
+
+**Invariant:** turn order is fixed when the game starts and does not change
+while it is played. It is the order the frogs were chosen in, and it is visible
+before the first roll.
+([Game setup](ui/game-setup.md#invariants), whose `Start` "begins the game with
+the chosen frogs in badge order")
+
+**Invariant:** the first frog in turn order takes the first turn, with every
+frog on its Start log.
+([Game board](ui/game-board.md#behaviour): *"every frog on its Start log, frog 1
+active"*)
+
+## A turn
+
+**Invariant:** a turn is **roll, draw, answer, move**, in that order, and a turn
+draws exactly one card and answers it exactly once.
+([The rules card](reference/index.md#the-rules-card-verbatim): *"On your turn
+role the Dice then draw from the pile that matches what you roled"*;
+[roll and card](ui/roll-and-card.md#invariants), which fixes that there is no
+re-roll and no discard)
+
+**Invariant:** there is **one die, of six faces**, and **three piles, of two
+faces each** — so each pile is drawn a uniform third of the time.
+([What is in the photograph](reference/index.md#what-is-in-the-photograph);
+[the pile labels](reference/index.md#the-pile-labels);
+[ADR-0002](../adr/0002-structured-working-out-grid.md#there-are-exactly-three-problem-shapes))
+
+**Invariant:** the roll's mapping to piles is **fixed**, and the player never
+chooses a pile.
+
+| Roll | Pile | Problem shape | Sample card on the board |
+| --- | --- | --- | --- |
+| **1 or 2** | Easy pile | 2-digit × 1-digit | `68 × 5` |
+| **3 or 4** | Medium pile | 2-digit × 2-digit | `22 × 41` |
+| **5 or 6** | Hard pile | 3-digit × 2-digit | `331 × 41` |
+
+The board labels each pile with the two die faces that reach it, and the game
+uses the same three names ([roll and card](ui/roll-and-card.md#elements)). The
+table is read off the pile labels in the board photograph
+([the pile labels](reference/index.md#the-pile-labels)) and confirmed by Derek
+in [#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7);
+the same table is
+[ADR-0002](../adr/0002-structured-working-out-grid.md#there-are-exactly-three-problem-shapes)'s.
+The three shapes are the only shapes: `331 × 41` is the confirmed widest problem
+in the game.
+
+**Invariant:** the roll **selects the pile and does nothing else**. It is not
+how far a frog moves, and it never moves a frog.
+([Roll and card](ui/roll-and-card.md#invariants))
+
+**Invariant:** the pile decides the problem's shape and nothing else. **Every
+pile is worth the same one lily pad** on a correct answer — there is no bonus
+for a harder card, and no points of any kind.
+([ADR-0002](../adr/0002-structured-working-out-grid.md#there-are-exactly-three-problem-shapes);
+[roll and card](ui/roll-and-card.md#invariants);
+[game over](ui/game-over.md#invariants), which rules out a score)
+
+**Invariant:** a card is one multiplication problem, and the player answers it
+by entering a **positive whole number**. The answer is correct when that number
+equals the product on the card; nothing else the player wrote is looked at.
+([Working-out grid](ui/working-out-grid.md#invariants): *"nothing in the grid is
+marked. Only the answer row decides whether the frog moves"*, and its keypad has
+"no decimal point, no minus";
+[ADR-0002](../adr/0002-structured-working-out-grid.md#two-constraints-that-keep-it-from-becoming-a-tutor))
+
+**Invariant:** an **empty answer is not a wrong answer** — a turn is not
+resolved until a number has been entered.
+([Working-out grid](ui/working-out-grid.md#invariants): `Check it` is disabled
+until at least one digit is in the answer row)
+
+The working-out grid itself is the one part of the game the classroom game has
+no equivalent of — it is the project's, under
+[ADR-0002](../adr/0002-structured-working-out-grid.md), decided by Derek in
+[#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7). It
+changes no rule of play: it is somewhere to work, and none of it is graded. Its
+shape, its carry strips and its growable addition section are the
+[working-out grid](ui/working-out-grid.md)'s to specify, not this page's.
+
+## Moving
+
+**Invariant:** a frog moves **at most one position per turn**, and only as the
+direct result of the answer just given.
+
+| Outcome | Effect |
+| --- | --- |
+| Correct | Forward one lily pad |
+| Wrong, anywhere above the Start log | Back one lily pad |
+| Wrong, on the Start log | Stay |
+
+The first two rows are the rules card —
+*"If you answer the question correctly move forward. If wrong move one space
+back."* The card gives no quantity for "forward"; that it is **one lily pad**
+was confirmed by Derek in
+[#170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170) and
+is the outcome table under
+[the Start log is a floor](reference/index.md#the-start-log-is-a-floor-not-a-special-space).
+
+**Invariant:** the **Start log is a floor, not a special space**. A wrong answer
+there leaves the frog where it is — a clamp at the bottom of the lane, not a
+rule of its own.
+([The Start log is a floor](reference/index.md#the-start-log-is-a-floor-not-a-special-space);
+[answer result](ui/answer-result.md#the-three-consequence-sentences), which
+states the three outcomes as three sentences)
+
+**Invariant:** the board never moves on its own. Nothing but an answer moves a
+frog.
+([Game board](ui/game-board.md#invariants))
+
+## Winning, and being home
+
+**Invariant:** a frog wins by **landing on the End log** — position 8 — not by
+reaching the last lily pad. From the Start log that takes **at least eight
+correct answers**, because each correct answer advances exactly one lily pad.
+([The End log is the winning space](reference/index.md#the-end-log-is-the-winning-space),
+confirmed by Derek in
+[#185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185);
+[game over](ui/game-over.md#invariants))
+
+**Invariant:** the **first frog onto its End log wins**, which is where the
+classroom rules card stops: *"First one to the end wins!"*
+([The rules card](reference/index.md#the-rules-card-verbatim))
+
+A frog that has reached its End log is **home**. Being home is a position and
+nothing more: a frog that gets there stays there, and no later frog getting home
+changes who won.
+([Game board](ui/game-board.md#behaviour): *"a frog that reaches the End log
+stays there"*)
+
+## Finishing
+
+The classroom game does not say what happens after the first frog wins. The card
+stops at *"First one to the end wins!"*, and what Connor's class does next
+[is not recorded and stays unknown](reference/index.md#still-unsettled). The
+four rules in this section are therefore **ours** — v1 filling a gap the board
+leaves open, recorded in
+[where v1 fills a gap](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open)
+so that nobody later mistakes them for what the classroom game says.
+
+**Invariant:** *(ours)* **play continues after the first frog reaches the End
+log.** The first frog home wins; the other frogs keep taking turns. Derek's
+provisional call — *"for now"*.
+([Where v1 fills a gap](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open))
+
+**Invariant:** *(ours)* **a frog that is home is skipped in turn order.** Turn
+order itself does not change; whose turn comes up next is turn order minus the
+frogs already home.
+([Game board](ui/game-board.md#behaviour))
+
+**Invariant:** *(ours)* **the game ends by itself once every frog is home.** The
+last frog to land on its End log finishes the game and the standings appear,
+with nobody choosing to stop it. Derek's call in
+[#186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
+([Where v1 fills a gap](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open);
+[game board](ui/game-board.md#behaviour);
+[game over](ui/game-over.md#behaviour))
+
+**Invariant:** *(ours)* **a game can also be ended deliberately — by anyone, on
+any turn, behind a confirm.** The device cannot tell who is holding it, so
+restricting the exit to one player was never enforceable; what protects a game
+in progress is that the confirm names the cost before it acts. Derek's call in
+[#186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186).
+([Who may end a game](ui/end-game-confirm.md#who-may-end-a-game); the route to
+it is the [settings dialog](ui/settings-dialog.md))
+
+**Invariant:** ending a game deliberately is **not** losing it. Every frog keeps
+the position it had, and the standings are produced from those positions.
+([End-game confirm](ui/end-game-confirm.md#behaviour): *"stops the game and
+shows the results"*)
+
+**Invariant:** those two are the **only** ways a game ends, and there is **no
+third state** in which a finished game sits waiting to be dismissed.
+
+| How a game ends | Who caused it |
+| --- | --- |
+| Every frog reaches its End log | Nobody — the game ends itself |
+| Somebody ends it early, with a confirm | Any player, on any turn |
+
+([There is no third way](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open))
+
+## The standings
+
+**Invariant:** the standings list **every frog that played**. Nobody is left
+off, however far they got.
+([Game over](ui/game-over.md#invariants))
+
+**Invariant:** the winner is the frog that reached its End log **first**, and
+finishers are listed in the order they got home. Frogs that did not finish are
+ranked below every finisher, by how many lily pads they made.
+([Game over](ui/game-over.md#invariants))
+
+**Invariant:** **there is no score.** The classroom game has an order, not a
+score, and inventing one would be inventing a mechanic.
+([Game over](ui/game-over.md#invariants))
+
+**Invariant:** a game ended before any frog got home produces standings with **no
+winner**. There is always a well-defined answer to "did anyone finish".
+([Game over](ui/game-over.md#elements): the headline reads `Game over` rather
+than announcing a winner who did not win)
+
+How **tied** non-finishers are ranked is
+[game over](ui/game-over.md#open-questions)'s open question — two frogs on the
+same lily pad currently share a place number, and whether they should instead be
+ordered by turn order is not settled. That question stays that page's to
+resolve, and this page does not answer it.
+
+## What is ours and what is theirs
+
+Everything above traces to the classroom game except the rules in this table.
+They are the project's own, recorded as such so the line stays visible.
+
+| Rule | What kind | Where it was decided |
+| --- | --- | --- |
+| A game seats **two to four** frogs, not two to eight | A **rule change** — the card says 2–8 | [ADR-0001](../adr/0001-rules-sacred-presentation-ours.md), [#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7), restated on [#199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199#issuecomment-5239966336) |
+| **Play continues** past the first frog home | A **gap-fill** — the card says nothing | [Where v1 fills a gap](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open) — Derek's provisional call |
+| A frog that is **home is skipped** in turn order | A **gap-fill**, following from the one above | [Game board](ui/game-board.md#behaviour) |
+| A game can be **ended deliberately**, behind a confirm | **Purely ours** — a cardboard game ends when you close the box | [#186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186), [end-game confirm](ui/end-game-confirm.md#who-may-end-a-game) |
+| A game **ends itself** once the last frog is home | A **gap-fill** | [#186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186), [where v1 fills a gap](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open) |
+
+The [working-out grid](ui/working-out-grid.md) is also ours
+([ADR-0002](../adr/0002-structured-working-out-grid.md)), but it is not in this
+table because it changes no rule of play: it is where the multiplication is
+done, and nothing in it is graded.
+
+## What this page does not settle
+
+Named here so that nothing below is read as settled by omission.
+
+- **What the classroom game does after the first frog finishes.** Genuinely
+  unknown, not chosen — the v1 answer above is a gap-fill, and the question
+  stays [open on the reference page](reference/index.md#still-unsettled).
+- **How the problems on the cards are generated.** This page fixes the three
+  shapes and nothing else. What a card may contain within a shape — the ranges,
+  whether carrying is always required, which multipliers the deck avoids — is
+  waiting on the full deck being photographed,
+  [#171](https://github.com/derekwinters/connor-multiplying-frogs/issues/171).
+- **The shape of the working-out grid.** Its columns, rows, carry strips and
+  growable addition section belong to
+  [working-out grid](ui/working-out-grid.md), which carries six open questions
+  of its own. One of them changes the grid in `Core`: whether a carry strip is
+  shared or belongs to each addition row,
+  [#255](https://github.com/derekwinters/connor-multiplying-frogs/issues/255).
+  Whether a grown addition row can be taken away again by backspacing is
+  [another](ui/working-out-grid.md#open-questions). None of them is a rule of
+  play — nothing in the grid is graded either way.
+- **How tied non-finishers are ranked** —
+  [game over](ui/game-over.md#open-questions)'s question, above.
+- **Starting, saving and resuming a session.** How a game is set up, whether a
+  half-finished game survives the app closing, and what the title screen's
+  `RESUME` and `NEW` buttons do — including which is emphasised and what
+  `RESUME` does with no save — are the
+  [title screen](ui/title-screen.md#open-questions)'s and
+  [product scope](product-scope.md)'s, not rules of the classroom game. A
+  cardboard game starts when you open the box.
+- **Anything about how the game looks.** Layout, animation and what is tapped
+  are presentation and belong to the [UI specs](ui/index.md), per
+  [ADR-0001](../adr/0001-rules-sacred-presentation-ours.md).
+
+## Where these rules come from
+
+| What | Where it was settled |
+| --- | --- |
+| The rules card, the board, the die, the three piles | [Reference material](reference/index.md) |
+| Frogs are independent; the Start log is a floor | [Reference material](reference/index.md#frogs-are-independent), from Connor via [#170](https://github.com/derekwinters/connor-multiplying-frogs/issues/170) |
+| The End log is the winning position, and a lane is nine | [#185](https://github.com/derekwinters/connor-multiplying-frogs/issues/185) |
+| Play after the first frog home; the two ways a game ends | [#186](https://github.com/derekwinters/connor-multiplying-frogs/issues/186), [reference material](reference/index.md#where-v1-fills-a-gap-the-board-leaves-open) |
+| The rules belong to the classroom game | [ADR-0001](../adr/0001-rules-sacred-presentation-ours.md) |
+| The three problem shapes, and the working-out grid | [ADR-0002](../adr/0002-structured-working-out-grid.md) |
+| Four players, and the shape of a turn | [#7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7), restated on [#199](https://github.com/derekwinters/connor-multiplying-frogs/issues/199#issuecomment-5239966336) |
+| Turn order, whose turn is first, and skipping a home frog | [Game setup](ui/game-setup.md), [game board](ui/game-board.md) |
+| The standings, and that there is no score | [Game over](ui/game-over.md) |
+
+[How to play](../intro/how-to-play.md) is the same rules told to a person
+holding the tablet. Where the two disagree, this page is the one the code
+follows and the friendly page is the one that gets corrected.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
   - Specs:
       - specs/index.md
       - Product scope: specs/product-scope.md
+      - Rules of play: specs/rules.md
       - Future ideas: specs/future-ideas.md
       - Reference material: specs/reference/index.md
       - UI:


### PR DESCRIPTION
Closes #199

The rules of Multiplying Frogs now live on one page. How many frogs play, what a roll does, how far a frog moves when you get it right, what a wrong answer costs, what winning is, and the two ways a game finishes — all in one place, each rule saying where it came from, so the game we build is the same game Connor plays. Nothing on the page is new: it is the board photograph, the two ADRs and the calls Derek has already made, written out as rules instead of as notes about a photograph.

**Docs:** `docs/specs/rules.md` (new) — the normative rules of play; `docs/specs/reference/index.md` — a pointer saying the normative statement of these rules is the new page, and that the reference page describes the classroom board while the rules page describes the game this app implements; `docs/specs/index.md` and `docs/intro/how-to-play.md` — both said the rules spec did not exist yet and pointed at #199, so both now point at the page; `mkdocs.yml` — one nav line under Specs.

## Spec invariants this had to keep true

| Rule it had to keep true | Where the page keeps it |
| --- | --- |
| The reference page decides nothing and stays that way | Its new pointer describes `rules.md`; no rule on it was edited, and the eight-lane board and the 2–8 rules card are still described exactly as before |
| Every rule traces to the reference page, an ADR, a committed UI spec, or #7/#170/#185/#186 | Every `**Invariant:**` line carries an inline citation; the page's own "Where these rules come from" table lists the sources |
| The classroom game's rules and the project's own calls stay distinguishable | Each project rule is marked *(ours)* in place, and all five are listed again in "What is ours and what is theirs" with what kind of change each is |
| `CONTEXT.md` is a glossary, never a citation | Cited once, for vocabulary only, and said so in that sentence; "tier" appears nowhere |
| v0.2 excludes save/resume, scores, choosing your pile, five-plus frogs | None of those is specified; save/resume and the title screen's `RESUME`/`NEW` questions are named under "What this page does not settle" as not rules of play |

## How the spec is changing

**Old:** the rules were spread across the reference page (source material that explicitly decides nothing), two ADRs, and `**Invariant:**` lines inside nine UI specs. There was no page a Core test could be written against, and `docs/specs/index.md` said so.

**New:** `docs/specs/rules.md` is the normative home. Where it restates a rule that also appears in a UI spec, the page says in one line that it owns the rule and the UI spec remains the presentation contract for its screen — so the two can never be read as rival authorities.

**One rule changes value rather than home:** the player count. Derek's call on #199 during this run — *"the mobile game will support 4 players for now"* — is recorded as **two to four frogs, and therefore two to four lanes**, marked as a recorded rule change against the card's 2–8, with "for now" preserved as v1's limit rather than a permanent ceiling. The reference page keeps describing the eight-lane classroom board; the rules page describes the game this app implements, and the page says which is which rather than editing the reference page to agree.

## Deviations and Decisions

- **No `type:question` issues were opened — none found.** Every rule the POC needs traced to a source. The three gaps I hit are already tracked and are named on the page rather than answered: the card generator's constraints ([#171](https://github.com/derekwinters/connor-multiplying-frogs/issues/171)), the carry-strip layout that changes the grid in Core ([#255](https://github.com/derekwinters/connor-multiplying-frogs/issues/255), plus the grid's other open questions including whether a grown addition row can be backspaced away), and how tied non-finishers are ranked (`game-over.md`'s own open question). No blocking edge was added to any POC issue.
- **I edited `docs/specs/index.md` and `docs/intro/how-to-play.md`, which #199 said not to touch.** That instruction was written while #13 and #11 were still open, to keep three concurrent PRs from conflicting; both merged earlier in this run, and both pages assert in prose that the rules spec "does not exist yet" and link to the issue instead. Leaving them would have shipped two docs pages that are false the moment this one lands. Each is a two-sentence correction, not a rewrite.
- **The nav line went in after `Product scope` rather than at the end of the `Specs` block.** Same reasoning — the "append it" instruction existed for rebase safety against PRs that have since merged, and the rules page reads better next to the other whole-game pages than after `Mockups`.
- **Two invariants are distillations rather than quotations**, both flagged here because a reviewer might want different wording: *"a turn draws exactly one card and answers it exactly once"* (from roll-and-card's no-re-roll/no-discard/no-dismiss invariants) and *"the answer is correct when the number in the answer row equals the product on the card"* (from the grid's "only the answer row decides" plus its digits-only keypad). Neither adds a mechanic; both give Core a sentence to test against instead of an inference.
- **The page states the mapping table with the pile names the game shows** — Easy, Medium, Hard — matching `roll-and-card.md`'s labels and ADR-0002's table, not the pip labels on the board photograph. "Tier" is not used anywhere, per the glossary.

Validation: `mkdocs build --strict` passes, and every internal link and anchor on the changed pages resolves. `dotnet test Tests/Core/Frogs.Core.Tests.csproj` (59 passed), `check_core_isolation.py`, `check_geometry_literals.py` and `run_python_tests.py` all pass, though this PR touches no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_