### PR TITLE
feat(core): add a seeded, deterministic random number generator

### DIFF
--- a/Assets/Scripts/Core/Rng.cs
+++ b/Assets/Scripts/Core/Rng.cs
@@ -1,0 +1,172 @@
+using System;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The game's source of chance: the roll that opens a turn, and the card
+    /// the pile hands over. Nothing in the game rolls anything of its own.
+    ///
+    /// It is **seeded**, and it can only be built from a seed or from a state
+    /// it reported earlier — never from the clock, and never from nothing. Two
+    /// things depend on that:
+    ///
+    /// - A save that is restored has to carry on, not re-randomise everything
+    ///   that has not happened yet (<c>docs/adr/0004-core-owns-the-save-format.md</c>).
+    ///   Restoring from the seed alone would replay rolls the players already
+    ///   played, so <see cref="State"/> is what a save writes down and
+    ///   <see cref="FromState"/> is what reads it back.
+    /// - A generator with no seed is not testable, and a whole game has to be
+    ///   replayable move for move in the two-second suite.
+    ///
+    /// **The sequence is the same everywhere the game runs** — an ARM64 device
+    /// build, an x86_64 emulator build, and <c>dotnet test</c>. That is why the
+    /// algorithm is written here rather than borrowed, why every step of it is
+    /// fixed-width unsigned integer arithmetic in an <c>unchecked</c> context,
+    /// and why no part of it — including the bounded draw — touches floating
+    /// point. A sequence that drifts between backends is a game that does not
+    /// restore the way it was saved.
+    /// </summary>
+    public sealed class Rng
+    {
+        // PCG-XSH-RR 64/32: a 64-bit state stepped by a multiply-add, and a
+        // 32-bit output folded out of it. All of these are the algorithm's
+        // published constants; none of them is a number to tune.
+        const ulong Multiplier = 6364136223846793005UL;
+        const ulong Increment = 1442695040888963407UL;
+        const int XorShiftAmount = 18;
+        const int OutputShiftAmount = 27;
+        const int RotationSelectShift = 59;
+        const int RotationMask = 31;
+
+        // Where seeding starts from, before the seed is stirred in.
+        const ulong SeedingInitialState = 0UL;
+
+        // How many values a 32-bit draw can take. What a bounded draw has to
+        // fold into its range without leaning on the low end of it.
+        const ulong DistinctOutputs = 1UL << OutputBits;
+        const int OutputBits = 32;
+
+        ulong _state;
+
+        Rng(ulong state)
+        {
+            _state = state;
+        }
+
+        /// <summary>
+        /// A generator at the start of the sequence a seed names.
+        ///
+        /// The seed is stirred in and the state stepped either side of it, so
+        /// that seeds one apart — two games started a moment apart — begin far
+        /// apart in the sequence rather than side by side.
+        /// </summary>
+        public static Rng FromSeed(ulong seed)
+        {
+            unchecked
+            {
+                var generator = new Rng(SeedingInitialState);
+                generator.Advance();
+                generator._state += seed;
+                generator.Advance();
+                return generator;
+            }
+        }
+
+        /// <summary>
+        /// Where the generator has got to: everything needed to carry the
+        /// sequence on from here, and the number a save writes down.
+        /// </summary>
+        public ulong State
+        {
+            get { return _state; }
+        }
+
+        /// <summary>
+        /// A generator that carries on from a state a generator reported
+        /// earlier — deliberately not the same call as starting from a seed,
+        /// because a seed and a state are both a `ulong` and confusing the two
+        /// silently restarts the sequence.
+        /// </summary>
+        public static Rng FromState(ulong state)
+        {
+            return new Rng(state);
+        }
+
+        /// <summary>The next 32 bits of the sequence.</summary>
+        public uint NextUInt()
+        {
+            var drawn = Output(_state);
+            Advance();
+            return drawn;
+        }
+
+        /// <summary>
+        /// A draw from <paramref name="minimumInclusive"/> to
+        /// <paramref name="maximumInclusive"/>, both ends reachable.
+        /// </summary>
+        public int NextInt(int minimumInclusive, int maximumInclusive)
+        {
+            if (maximumInclusive < minimumInclusive)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(maximumInclusive),
+                    maximumInclusive,
+                    $"A range runs upwards: {minimumInclusive} to {maximumInclusive} is a range "
+                    + "with nothing in it, and drawing from one would never return.");
+            }
+
+            unchecked
+            {
+                var span = (ulong)((long)maximumInclusive - minimumInclusive) + 1UL;
+
+                return (int)(minimumInclusive + (long)DrawBelow(span));
+            }
+        }
+
+        /// <summary>
+        /// A draw in [0, span), with no lean toward the low end.
+        ///
+        /// Folding 2^32 outputs into a span that does not divide it leaves a
+        /// remainder, and the values that remainder reaches would otherwise be
+        /// drawn one time more often than the rest. So the outputs above the
+        /// last whole multiple of the span are thrown away and redrawn rather
+        /// than shared out unevenly.
+        /// </summary>
+        ulong DrawBelow(ulong span)
+        {
+            unchecked
+            {
+                var limit = DistinctOutputs - (DistinctOutputs % span);
+
+                while (true)
+                {
+                    var drawn = (ulong)NextUInt();
+
+                    if (drawn < limit)
+                    {
+                        return drawn % span;
+                    }
+                }
+            }
+        }
+
+        void Advance()
+        {
+            unchecked
+            {
+                _state = (_state * Multiplier) + Increment;
+            }
+        }
+
+        static uint Output(ulong state)
+        {
+            unchecked
+            {
+                var xorshifted = (uint)(((state >> XorShiftAmount) ^ state) >> OutputShiftAmount);
+                var rotation = (int)(state >> RotationSelectShift);
+
+                return (xorshifted >> rotation) | (xorshifted << ((-rotation) & RotationMask));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Rng.cs.meta
+++ b/Assets/Scripts/Core/Rng.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9686c79233844f08b0612af9e2e6c6c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/RngTests.cs
+++ b/Tests/Core/RngTests.cs
@@ -1,0 +1,187 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// Every number here is a named constant, and every one of them comes from
+    /// issue #200. The generator is deterministic given a seed, so no test on
+    /// this page has any business varying between runs or between machines:
+    /// nothing here reads a clock, a Guid, or any other entropy.
+    /// </summary>
+    public sealed class RngTests
+    {
+        const ulong Seed = 12345UL;
+        const int DrawCount = 50;
+        const ulong SeedA = 12345UL;
+        const ulong SeedB = 12346UL;
+        const int MinDifferingDraws = 40;
+        const int DrawsBeforeSnapshot = 10;
+        const int DrawsAfterSnapshot = 20;
+        const int RangeMin = 5;
+        const int RangeMax = 17;
+        const int BoundedDrawCount = 10000;
+        const int BackwardsRangeTimeoutMilliseconds = 5000;
+        const ulong UniformitySeed = 12345UL;
+        const int SampleSize = 120000;
+        const int BucketCount = 12;
+        const int TolerancePercent = 5;
+
+        // The uniformity range is enormous on purpose, and it is the only
+        // number on this page that is not the one issue #200 named.
+        //
+        // What can skew a bounded draw is the leftover when the generator's
+        // 2^32 outputs are folded into a range that does not divide it: the
+        // first few values of the range get one more output than the rest. Over
+        // a die-sized range that leftover is 12 values in 4.3 billion, and no
+        // sample size distinguishes it from noise — the test came out green
+        // against the biased implementation, which by the issue's own rule
+        // means it was testing nothing.
+        //
+        // Spanning three quarters of the generator's output makes the same flaw
+        // enormous instead: the leftover is a third of the range, so the bottom
+        // four buckets get drawn twice as often as the other eight. Same defect,
+        // same fix, in a size a 120,000-draw sample can see.
+        const int BiasRangeMin = -1073741824;
+        const int BiasRangeMax = 2147483647;
+        const long BucketWidth = 268435456L;
+
+        [Test]
+        public void TwoGeneratorsWithTheSameSeed_ProduceTheSameSequence()
+        {
+            var first = Rng.FromSeed(Seed);
+            var second = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                Assert.That(
+                    second.NextUInt(),
+                    Is.EqualTo(first.NextUInt()),
+                    $"the sequences parted company at draw {draw}");
+            }
+        }
+
+        // Two games started a moment apart get adjacent seeds, so seeds one
+        // apart are the ones that have to diverge — not seeds picked far apart
+        // to flatter the generator.
+        [Test]
+        public void TwoGeneratorsWithDifferentSeeds_ProduceDivergingSequences()
+        {
+            var first = Rng.FromSeed(SeedA);
+            var second = Rng.FromSeed(SeedB);
+
+            var differing = 0;
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                if (first.NextUInt() != second.NextUInt())
+                {
+                    differing++;
+                }
+            }
+
+            Assert.That(differing, Is.GreaterThanOrEqualTo(MinDifferingDraws));
+        }
+
+        // A game restored from a save has to carry on, not start the sequence
+        // over: rebuilding from the seed alone replays rolls the players
+        // already played, which is re-randomising while holding a seed.
+        [Test]
+        public void AGeneratorRebuiltFromAReportedState_ResumesTheSequence()
+        {
+            var original = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawsBeforeSnapshot; draw++)
+            {
+                original.NextUInt();
+            }
+
+            var resumed = Rng.FromState(original.State);
+
+            for (var draw = 0; draw < DrawsAfterSnapshot; draw++)
+            {
+                Assert.That(
+                    resumed.NextUInt(),
+                    Is.EqualTo(original.NextUInt()),
+                    $"the resumed sequence parted company at draw {draw}");
+            }
+        }
+
+        // Both ends of the range have to come up, which is what says the upper
+        // bound is inclusive — so the next issue to draw a die face or a
+        // multiplicand does not have to guess whether 17 is reachable.
+        [Test]
+        public void ABoundedDraw_StaysInRangeAndReachesBothEnds()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            var sawMin = false;
+            var sawMax = false;
+
+            for (var draw = 0; draw < BoundedDrawCount; draw++)
+            {
+                var value = rng.NextInt(RangeMin, RangeMax);
+
+                Assert.That(value, Is.InRange(RangeMin, RangeMax));
+
+                sawMin |= value == RangeMin;
+                sawMax |= value == RangeMax;
+            }
+
+            Assert.That(sawMin, Is.True, $"{RangeMin} never came up");
+            Assert.That(sawMax, Is.True, $"{RangeMax} never came up");
+        }
+
+        // A range handed over backwards is a caller's bug, and without this it
+        // is a spectacular one: the span underflows to something larger than
+        // the generator can draw, every draw is rejected, and the game hangs
+        // inside the roll instead of throwing.
+        [Test]
+        [Timeout(BackwardsRangeTimeoutMilliseconds)]
+        public void ABoundedDraw_RejectsABackwardsRange()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            Assert.That(
+                () => rng.NextInt(RangeMax, RangeMin),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        // Nothing in the game may be likelier than anything else it is drawn
+        // beside: a die whose low faces come up half again as often is a game
+        // that is quietly unfair, and nobody would see it happening.
+        [Test]
+        public void ABoundedDraw_IsUniformAcrossTheRange()
+        {
+            // The buckets only mean anything while they tile the range exactly.
+            Assert.That(
+                (long)BiasRangeMax - BiasRangeMin + 1,
+                Is.EqualTo((long)BucketCount * BucketWidth),
+                "the buckets no longer tile the range");
+
+            var rng = Rng.FromSeed(UniformitySeed);
+            var counts = new int[BucketCount];
+
+            for (var draw = 0; draw < SampleSize; draw++)
+            {
+                var value = rng.NextInt(BiasRangeMin, BiasRangeMax);
+
+                Assert.That(value, Is.InRange(BiasRangeMin, BiasRangeMax));
+
+                counts[(int)(((long)value - BiasRangeMin) / BucketWidth)]++;
+            }
+
+            var expected = SampleSize / BucketCount;
+            var tolerance = (expected * TolerancePercent) / 100;
+
+            for (var bucket = 0; bucket < BucketCount; bucket++)
+            {
+                Assert.That(
+                    counts[bucket],
+                    Is.EqualTo(expected).Within(tolerance),
+                    $"bucket {bucket} of {BucketCount}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #200

The game now has one source of chance, and it is one you can start again from
the same place. Given a number to start from, it produces the same run of
numbers every time, on a tablet or on a laptop, so a game that is saved and
picked up later carries on exactly where it stopped instead of quietly
re-rolling everything that had not happened yet. It also hands out a number
between two limits — a die face, a times-table number — without any of them
being likelier than the others. Nothing uses it yet; the roll and the cards are
later issues built on top of it.

**Docs:** None — no behaviour the docs describe was changed. Issue #200 states
that no page under `docs/specs/` describes how randomness is generated, and
ADR-0004 already records the decision this implements. The one line ADR-0004
will need — the save stores the RNG **state**, not only the seed — is reconciled
by the PR that builds the save round-trip, in a later milestone, because nothing
here writes a save.

## Spec invariants

Nothing in `docs/specs/rules.md` describes how randomness is produced, so this
change had no rule of play to keep true. The two contracts it does have to keep
are ADR-0004's, and each has a test:

| Contract | Test |
| --- | --- |
| A restore is not a re-randomisation (ADR-0004, *Consequences*) | `AGeneratorRebuiltFromAReportedState_ResumesTheSequence` |
| A generator without a seed is not testable (ADR-0004, *Consequences*) | `TwoGeneratorsWithTheSameSeed_ProduceTheSameSequence`, and there is no way to build one without a seed or a state |

Rule 2 holds — `check_core_isolation.py` passes and the type has no engine
types in it. Determinism across the ARM64, x86_64 and `dotnet test` backends is
structural rather than asserted: every step is fixed-width unsigned integer
arithmetic in an `unchecked` context, and neither the generator nor the bounded
draw contains a floating-point value.

## What it is

PCG-XSH-RR 64/32 — a 64-bit state stepped by a multiply-add, with 32 bits folded
out of it. Written here rather than borrowed, because the sequence has to be one
this project controls the stability of, and because it is thirty lines.

- `Rng.FromSeed(seed)` and `Rng.FromState(state)` are the only ways to make one.
  They are deliberately separate calls: a seed and a state are both a `ulong`,
  and one silently restarting the sequence is precisely the bug this exists to
  prevent.
- `State` is what a save will write down.
- `NextUInt()` is the raw draw; `NextInt(min, max)` is bounded, **inclusive at
  both ends**, which the in-range test pins down so #202 and #203 do not have to
  guess.

## How the red phase went

Every implementation step was the smallest thing that passed, and each test was
run and seen red first. The one worth reading is the second: with the seed not
yet folded in, `TwoGeneratorsWithDifferentSeeds_ProduceDivergingSequences` said
`Expected: greater than or equal to 40 / But was: 0` — two different seeds
producing the same 50 draws, which is exactly the hole the first test cannot
see.

## Deviations and Decisions

- **The uniformity test does not use a die-sized range, and the issue's numbers
  did not go red as written.** Over a 12-value range, `% span` gave buckets of
  9933–10169 against 10000 ± 500 — a comfortable pass, because the bias there is
  12 values in 4.3 billion and no sample size separates it from noise. Following
  the issue's own instruction to pick a range that exposes the skew, the test now
  draws across three quarters of the generator's output (`-1073741824` to
  `2147483647`, tiled by 12 buckets of 2^28). Seed, sample size, bucket count and
  tolerance are all unchanged. Against `% span` that reported
  `bucket 0 of 12 / Expected: 10000 +/- 500 / But was: 14962`, and rejection
  sampling turned it green.
- **`NextInt` throws on a backwards range, which the issue did not ask for.**
  Without it, `NextInt(17, 5)` underflowed the span to something wider than the
  generator can draw, every draw was rejected, and the call never returned — the
  test hit its five-second timeout rather than throwing. A hang inside a roll is
  worse than a failed build, so it is a guard with a test rather than a hole.
- **`skip-docs` is applied.** Rule 9's escape hatch, used because there is no
  page for this to reconcile with: the issue says as much, and inventing a docs
  page describing randomness would be writing a contract nobody agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_