### PR TITLE
feat(core): add the Lane type — nine positions, forward, back, home

### DIFF
--- a/Assets/Scripts/Core/Lane.cs
+++ b/Assets/Scripts/Core/Lane.cs
@@ -1,0 +1,72 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One player's private column: the Start log, seven lily pads, and the
+    /// End log. A <see cref="Lane"/> owns where its frog is and the two moves
+    /// a frog can make — nothing else. Lanes never talk to each other; a
+    /// player's entire state is this one number.
+    /// </summary>
+    public sealed class Lane
+    {
+        /// <summary>
+        /// The Start log, seven lily pads, and the End log.
+        /// docs/specs/ui/game-board.md § Named constants.
+        /// </summary>
+        public const int LanePositionCount = 9;
+
+        /// <summary>
+        /// The End log's index — the winning space. A frog wins by landing on
+        /// it, not by reaching the last lily pad.
+        /// docs/specs/ui/game-board.md § Named constants.
+        /// </summary>
+        public const int LaneWinningPosition = LanePositionCount - 1;
+
+        /// <summary>Where a new frog starts — the floor of the lane.</summary>
+        const int StartingPosition = 0;
+
+        int _position = StartingPosition;
+
+        /// <summary>How far up the lane the frog is, 0 to <see cref="LaneWinningPosition"/>.</summary>
+        public int Position
+        {
+            get { return _position; }
+        }
+
+        /// <summary>
+        /// Whether the frog has landed on the End log. Matches the
+        /// <c>Home</c> chip state in docs/specs/ui/game-board.md § Behaviour.
+        /// </summary>
+        public bool IsHome
+        {
+            get { return _position == LaneWinningPosition; }
+        }
+
+        /// <summary>
+        /// A correct answer: advance one lily pad. A frog that is already
+        /// home is never legally asked to move — it is skipped in turn order
+        /// — so this guards that call rather than encoding a rule of play:
+        /// the End log clamps, symmetric with the Start log's floor.
+        /// </summary>
+        public void MoveForward()
+        {
+            if (_position < LaneWinningPosition)
+            {
+                _position++;
+            }
+        }
+
+        /// <summary>
+        /// A wrong answer: retreat one lily pad. The Start log is a floor, not
+        /// a special space — a wrong answer there leaves the frog where it is.
+        /// Symmetrically, a frog already home stays home: see
+        /// <see cref="MoveForward"/>.
+        /// </summary>
+        public void MoveBack()
+        {
+            if (_position > StartingPosition && _position < LaneWinningPosition)
+            {
+                _position--;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Lane.cs.meta
+++ b/Assets/Scripts/Core/Lane.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5f3a20015a143588203908210ed4128
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/LaneTests.cs
+++ b/Tests/Core/LaneTests.cs
@@ -1,0 +1,140 @@
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    public sealed class LaneTests
+    {
+        [Test]
+        public void ANewLane_StartsOnTheStartLog()
+        {
+            var lane = new Lane();
+
+            Assert.That(lane.Position, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MoveForward_AdvancesTheFrogExactlyOneLilyPad()
+        {
+            var lane = new Lane();
+
+            lane.MoveForward();
+
+            Assert.That(lane.Position, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void MoveBack_MovesTheFrogExactlyOneLilyPad()
+        {
+            var lane = new Lane();
+            lane.MoveForward();
+            lane.MoveForward();
+
+            lane.MoveBack();
+
+            Assert.That(lane.Position, Is.EqualTo(1));
+        }
+
+        // The Start log is a floor, not a special space: a wrong answer there
+        // leaves the frog where it is rather than moving it off the lane.
+        // docs/specs/rules.md — "The Start log is a floor, not a special space".
+        [Test]
+        public void MoveBack_OnTheStartLog_LeavesTheFrogAtTheFloor()
+        {
+            var lane = new Lane();
+
+            lane.MoveBack();
+
+            Assert.That(lane.Position, Is.EqualTo(0));
+        }
+
+        // A lane is nine positions — the Start log, seven lily pads, and the
+        // End log — so eight correct answers from the Start log land the frog
+        // on the End log. docs/specs/rules.md: "a lane has nine positions".
+        [Test]
+        public void EightForwardMoves_FromTheStartLog_LandOnTheEndLog()
+        {
+            var lane = new Lane();
+
+            for (var move = 0; move < 8; move++)
+            {
+                lane.MoveForward();
+            }
+
+            Assert.That(lane.Position, Is.EqualTo(Lane.LaneWinningPosition));
+        }
+
+        // IsHome matches the Home chip state in game-board.md § Behaviour: a
+        // frog that reaches the End log stays there and its chip switches to
+        // Home. False until the frog lands on the End log, true after.
+        [Test]
+        public void IsHome_IsFalseUntilTheFrogReachesTheEndLog_ThenTrue()
+        {
+            var lane = new Lane();
+
+            for (var move = 0; move < 7; move++)
+            {
+                lane.MoveForward();
+                Assert.That(lane.IsHome, Is.False, $"home after only {move + 1} forward moves");
+            }
+
+            lane.MoveForward();
+
+            Assert.That(lane.IsHome, Is.True);
+        }
+
+        // The top of the lane is a clamp, symmetric with the Start log's
+        // floor: a home frog is never legally asked to move (a home frog is
+        // skipped in turn order), so a further move guards a call that should
+        // not happen rather than exercising a rule of play. Settled by Derek
+        // and recorded in docs/specs/rules.md.
+        [Test]
+        public void MoveForward_OnTheEndLog_LeavesTheFrogHomeOnTheEndLog()
+        {
+            var lane = new Lane();
+            for (var move = 0; move < 8; move++)
+            {
+                lane.MoveForward();
+            }
+
+            lane.MoveForward();
+
+            Assert.That(lane.Position, Is.EqualTo(Lane.LaneWinningPosition));
+            Assert.That(lane.IsHome, Is.True);
+        }
+
+        [Test]
+        public void MoveBack_OnTheEndLog_LeavesTheFrogHomeOnTheEndLog()
+        {
+            var lane = new Lane();
+            for (var move = 0; move < 8; move++)
+            {
+                lane.MoveForward();
+            }
+
+            lane.MoveBack();
+
+            Assert.That(lane.Position, Is.EqualTo(Lane.LaneWinningPosition));
+            Assert.That(lane.IsHome, Is.True);
+        }
+
+        // Frogs are independent: each player keeps their own lane for the
+        // whole game, and a lane never affects another. Worth an explicit
+        // test rather than an assumption — it is what lets the rest of the
+        // game treat a player's whole state as one number.
+        // docs/specs/rules.md — "frogs are independent".
+        [Test]
+        public void TwoIndependentLanes_NeverAffectOneAnother()
+        {
+            var moved = new Lane();
+            var untouched = new Lane();
+
+            moved.MoveForward();
+            moved.MoveForward();
+            moved.MoveForward();
+
+            Assert.That(untouched.Position, Is.EqualTo(0));
+            Assert.That(untouched.IsHome, Is.False);
+        }
+    }
+}

--- a/docs/specs/rules.md
+++ b/docs/specs/rules.md
@@ -215,6 +215,17 @@ changes who won.
 ([Game board](ui/game-board.md#behaviour): *"a frog that reaches the End log
 stays there"*)
 
+**Invariant:** a frog that is home does not move. A forward move or a back move
+made while the frog is on the End log leaves it on the End log, still home —
+the same clamp the Start log has at the other end. This is a guard on a call
+that should not happen, not a rule of play in its own right: a home frog is
+skipped in turn order (below), so a correctly-behaving caller never asks a
+home frog to move. Settled by Derek — *"once home, the player is skipped,
+letting other players finish until everyone is home or anyone ends the
+game"* — confirming the reading `Lane` (#201) was built against, that the
+logs are symmetric ends of the lane rather than one of them being an overflow
+into a tenth position.
+
 ## Finishing
 
 The classroom game does not say what happens after the first frog wins. The card


### PR DESCRIPTION
Closes #201

Adds `Lane`, the first piece of real game logic: one player's private column of nine positions — the Start log, seven lily pads, and the End log — with the two moves a frog can make (forward on a correct answer, back on a wrong one), the floor clamp at the Start log, and `IsHome` for landing on the End log. Also settles and records the one thing the issue left open: what a lane does if moved while already home.

**Spec invariants:**
- A lane has nine positions, Start log at 0 and End log at 8 (`docs/specs/rules.md`) — asserted by `EightForwardMoves_FromTheStartLog_LandOnTheEndLog` and the `LanePositionCount`/`LaneWinningPosition` constants.
- The Start log is a floor, not a special space; a wrong answer there leaves the frog where it is (`docs/specs/rules.md`) — `MoveBack_OnTheStartLog_LeavesTheFrogAtTheFloor`.
- Frogs are independent — a lane never affects another (`docs/specs/rules.md`) — `TwoIndependentLanes_NeverAffectOneAnother`.

**How the spec is changing:** `docs/specs/rules.md` previously said what "home" is but not what moving a home frog does — that was an open gap, not a contradiction. Derek settled it directly: *"once home, the player is skipped, letting other players finish until everyone is home or anyone ends the game."* That confirms the existing turn-order rule (a home frog is skipped, so a correctly-behaving caller never legally asks one to move) and settles `Lane`'s own behaviour if it is ever called anyway: it clamps, symmetric with the Start-log floor, rather than throwing. New rule, recorded in `docs/specs/rules.md`: a forward or back move made on the End log leaves the frog on the End log, still home.

**Docs:** docs/specs/rules.md — adds the settled top-of-lane invariant (home frog clamps, does not throw), with Derek's reasoning quoted as the settled rule.

## Deviations and Decisions

- None. The one open question the issue raised (clamp vs. throw when `Lane` is moved while home) was settled by Derek before this issue was worked, not decided here; implemented exactly as the issue's proposed invariant instructed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_