### PR TITLE
feat(core): add the roll and its fixed mapping to the three piles

### DIFF
--- a/Assets/Scripts/Core/Pile.cs
+++ b/Assets/Scripts/Core/Pile.cs
@@ -1,0 +1,25 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// Which of the three sources a card is drawn from. A pile is decided by
+    /// the roll (see <see cref="Roll"/>) and never chosen by the player.
+    ///
+    /// Named to match CONTEXT.md's glossary exactly — the roll-and-card dialog
+    /// prints "Easy pile · 1 or 2", "Medium pile · 3 or 4" and
+    /// "Hard pile · 5 or 6" — and deliberately not "Tier" or "Difficulty",
+    /// which CONTEXT.md's avoid-list rules out even though ADR-0002's prose
+    /// calls the piles "difficulty tiers".
+    /// docs/specs/rules.md — "the roll's mapping to piles is fixed".
+    /// </summary>
+    public enum Pile
+    {
+        /// <summary>2-digit × 1-digit. Reached by a roll of 1 or 2.</summary>
+        Easy,
+
+        /// <summary>2-digit × 2-digit. Reached by a roll of 3 or 4.</summary>
+        Medium,
+
+        /// <summary>3-digit × 2-digit. Reached by a roll of 5 or 6.</summary>
+        Hard
+    }
+}

--- a/Assets/Scripts/Core/Pile.cs.meta
+++ b/Assets/Scripts/Core/Pile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3045a1ca68d14861bf39e27e7a25e403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/Roll.cs
+++ b/Assets/Scripts/Core/Roll.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The roll that opens a turn: one face of a six-sided die, drawn from the
+    /// game's single seeded <see cref="Rng"/> (#200) and from nothing else —
+    /// no <see cref="System.Random"/>, no static randomness — and the pile
+    /// that face sends the turn to.
+    ///
+    /// The roll selects the pile and does nothing else. It is not how far a
+    /// frog moves, and it never moves a frog — grading an answer and resolving
+    /// a move are a later issue's job, not this type's.
+    /// docs/specs/rules.md — "the roll selects the pile and does nothing else".
+    /// </summary>
+    public sealed class Roll
+    {
+        /// <summary>The lowest face a six-sided die can show.</summary>
+        public const int MinimumFace = 1;
+
+        /// <summary>The highest face a six-sided die can show.</summary>
+        public const int MaximumFace = 6;
+
+        // The face-to-pile boundaries, read off the pile labels in the board
+        // photograph (docs/specs/reference/index.md#the-pile-labels) and
+        // repeated in ADR-0002 and docs/specs/ui/roll-and-card.md: 1 or 2 is
+        // the Easy pile, 3 or 4 the Medium pile, 5 or 6 the Hard pile.
+        const int EasyPileHighestFace = 2;
+        const int MediumPileHighestFace = 4;
+
+        Roll(int face)
+        {
+            Face = face;
+            Pile = PileForFace(face);
+        }
+
+        /// <summary>The face that came up, <see cref="MinimumFace"/> to <see cref="MaximumFace"/>.</summary>
+        public int Face { get; }
+
+        /// <summary>The pile this roll's face sends the turn to.</summary>
+        public Pile Pile { get; }
+
+        /// <summary>
+        /// A roll of one die, drawn from <paramref name="rng"/> and from
+        /// nothing else.
+        /// </summary>
+        public static Roll Draw(Rng rng)
+        {
+            return new Roll(rng.NextInt(MinimumFace, MaximumFace));
+        }
+
+        /// <summary>
+        /// The pile a die face maps to. Total over every face a die can show;
+        /// a face outside <see cref="MinimumFace"/>–<see cref="MaximumFace"/>
+        /// cannot come from the die, but the mapping still has to say what it
+        /// does with one rather than silently returning a pile for it.
+        /// </summary>
+        public static Pile PileForFace(int face)
+        {
+            if (face < MinimumFace || face > MaximumFace)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(face),
+                    face,
+                    $"a die face is {MinimumFace} to {MaximumFace}; {face} is not a face.");
+            }
+
+            if (face <= EasyPileHighestFace)
+            {
+                return Pile.Easy;
+            }
+
+            if (face <= MediumPileHighestFace)
+            {
+                return Pile.Medium;
+            }
+
+            return Pile.Hard;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Roll.cs.meta
+++ b/Assets/Scripts/Core/Roll.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f4fef6f27874f49b106a91eeb222efe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/PileTests.cs
+++ b/Tests/Core/PileTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="Pile"/> is which of the three sources a card is drawn from —
+    /// decided by the roll, never chosen by the player. docs/specs/rules.md —
+    /// "the roll's mapping to piles is fixed".
+    /// </summary>
+    public sealed class PileTests
+    {
+        // CONTEXT.md's avoid-list for "pile": the words a different board game
+        // would reach for, and the reason this type is named `Pile` rather than
+        // `Tier`, `Difficulty`, `Deck` or `Stack` despite ADR-0002's prose using
+        // "difficulty tiers".
+        static readonly string[] AvoidedWords = { "Tier", "Difficulty", "Deck", "Stack" };
+
+        // The Frogs.Core types this issue adds — deliberately not "every type in
+        // the assembly", so this test does not start failing on some unrelated
+        // future type that happens to need one of these words for its own
+        // reasons.
+        static readonly Type[] TypesAddedByThisIssue = { typeof(Pile), typeof(Roll) };
+
+        [Test]
+        public void Pile_HasExactlyTheThreeNamedMembers()
+        {
+            var members = Enum.GetNames(typeof(Pile));
+
+            Assert.That(members, Is.EquivalentTo(new[] { "Easy", "Medium", "Hard" }));
+        }
+
+        // A reflection sweep over every type, member and parameter name this
+        // issue adds, against CONTEXT.md's avoid-list for "pile". ADR-0002's own
+        // prose calls the piles "difficulty tiers", which is exactly the kind of
+        // unpinned name this test exists to keep out of Core.
+        [Test]
+        public void TypesAddedByThisIssue_NameNoneOfTheAvoidedWords()
+        {
+            var offenders = TypesAddedByThisIssue
+                .SelectMany(NamesToCheck)
+                .Where(named => AvoidedWords.Any(avoided =>
+                    named.Contains(avoided, StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+
+            Assert.That(offenders, Is.Empty,
+                "found a name containing one of: " + string.Join(", ", AvoidedWords));
+        }
+
+        static string[] NamesToCheck(Type type)
+        {
+            var typeNames = new[] { type.Name };
+
+            var memberNames = type
+                .GetMembers(BindingFlags.Public | BindingFlags.NonPublic
+                    | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(member => member.Name);
+
+            var parameterNames = type
+                .GetMembers(BindingFlags.Public | BindingFlags.NonPublic
+                    | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .OfType<MethodBase>()
+                .SelectMany(method => method.GetParameters())
+                .Select(parameter => parameter.Name);
+
+            return typeNames.Concat(memberNames).Concat(parameterNames)
+                .Where(name => name != null)
+                .ToArray()!;
+        }
+    }
+}

--- a/Tests/Core/RollTests.cs
+++ b/Tests/Core/RollTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// The roll that opens a turn: one face of a six-sided die, drawn from the
+    /// game's seeded <see cref="Rng"/> (#200) and from nothing else, and the
+    /// pile that face maps to. docs/specs/rules.md — "the roll selects the
+    /// pile and does nothing else... it never moves a frog." Every number here
+    /// is a named constant, the same convention RngTests uses.
+    /// </summary>
+    public sealed class RollTests
+    {
+        const ulong Seed = 12345UL;
+        const ulong OtherSeed = 12346UL;
+        const int DrawCount = 50;
+
+        // Unlike a 32-bit NextUInt() draw, a face is one of only six values, so
+        // two independent sequences agree by chance about a sixth of the time —
+        // over 50 draws that is roughly eight agreements, not zero. The bar
+        // here is well below that expectation, so it is divergence being
+        // asserted, not the absence of every coincidental match.
+        const int MinDifferingDraws = 30;
+
+        // Rolling drives the seeded RNG from #200 rather than a fresh
+        // System.Random: two rolls built from separately-constructed
+        // generators of the same seed have to produce the identical sequence
+        // of faces, over and over, for that to be true.
+        [Test]
+        public void RollsFromRngsOfTheSameSeed_ProduceTheIdenticalSequence()
+        {
+            var first = Rng.FromSeed(Seed);
+            var second = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                Assert.That(
+                    Roll.Draw(second).Face,
+                    Is.EqualTo(Roll.Draw(first).Face),
+                    $"the sequences parted company at draw {draw}");
+            }
+        }
+
+        // The other half of the same claim: generators seeded differently have
+        // to diverge, or the roll could be drawing from something that ignores
+        // the seed altogether — a fresh System.Random would happen to pass the
+        // same-seed test above (its own state still repeats within one run)
+        // but never diverge in the way an unseeded source would either. Faces
+        // are drawn from a 6-wide range, so two independent sequences agreeing
+        // by chance on most of 50 draws is not a real risk.
+        [Test]
+        public void RollsFromRngsOfDifferentSeeds_Diverge()
+        {
+            var first = Rng.FromSeed(Seed);
+            var second = Rng.FromSeed(OtherSeed);
+
+            var differing = 0;
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                if (Roll.Draw(first).Face != Roll.Draw(second).Face)
+                {
+                    differing++;
+                }
+            }
+
+            Assert.That(differing, Is.GreaterThanOrEqualTo(MinDifferingDraws));
+        }
+
+        // The bounds a face can come up in, asserted against the named
+        // constants rather than bare literals — so the next reader of a face
+        // comparison knows 1 and 6 are the die's ends, not two arbitrary
+        // numbers.
+        [Test]
+        public void OverAFixedSeedSequence_EveryFaceIsWithinTheDiesRange()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                var face = Roll.Draw(rng).Face;
+
+                Assert.That(face, Is.InRange(Roll.MinimumFace, Roll.MaximumFace));
+            }
+        }
+
+        // The face-to-pile table, read off the pile labels in the board
+        // photograph and repeated in ADR-0002 and docs/specs/ui/roll-and-card.md:
+        // 1 or 2 -> Easy, 3 or 4 -> Medium, 5 or 6 -> Hard. Asserted face by
+        // face so a single row moving is visible in the diff.
+        [TestCase(1, Pile.Easy)]
+        [TestCase(2, Pile.Easy)]
+        [TestCase(3, Pile.Medium)]
+        [TestCase(4, Pile.Medium)]
+        [TestCase(5, Pile.Hard)]
+        [TestCase(6, Pile.Hard)]
+        public void PileForFace_MapsEachFaceToItsPile(int face, Pile expected)
+        {
+            Assert.That(Roll.PileForFace(face), Is.EqualTo(expected));
+        }
+
+        // Two faces per pile is a counting fact over all six faces, not a
+        // statistical one — so it is asserted by grouping the enumerated
+        // results, not by sampling a die roll.
+        [Test]
+        public void EveryPile_IsReachedByExactlyTwoFaces()
+        {
+            var facesByPile = Enumerable
+                .Range(Roll.MinimumFace, Roll.MaximumFace - Roll.MinimumFace + 1)
+                .GroupBy(Roll.PileForFace);
+
+            foreach (var group in facesByPile)
+            {
+                Assert.That(group.Count(), Is.EqualTo(2), $"{group.Key} pile");
+            }
+
+            Assert.That(facesByPile.Select(group => group.Key), Is.EquivalentTo(
+                new[] { Pile.Easy, Pile.Medium, Pile.Hard }));
+        }
+
+        // The mapping cannot occur with a face outside 1-6 when the face comes
+        // from the die, but the function still has to say what it does with
+        // one rather than silently returning a pile for it.
+        [TestCase(0)]
+        [TestCase(7)]
+        [TestCase(-1)]
+        public void PileForFace_RejectsAFaceOutsideTheDiesRange(int face)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => Roll.PileForFace(face));
+
+            Assert.That(exception.Message, Does.Contain(face.ToString()));
+        }
+    }
+}


### PR DESCRIPTION
A turn opens with a roll of one die, and the die decides which of the three piles the card comes from — nothing else. This adds that roll and that mapping to `Frogs.Core`: a `Roll` drawn from the game's seeded RNG (#200), and the `Pile` enum (`Easy`, `Medium`, `Hard`) each face maps to. Two faces reach each pile, the mapping is total (an out-of-range face throws rather than guessing), and the roll does exactly one thing — pick a pile. It never moves a frog; that is graded from an answer in a later issue.

Closes #202

**Docs:** None — `docs/specs/rules.md` already carries the face→pile table and the "the roll selects the pile and does nothing else... it never moves a frog" invariant, written by #199 before this issue was picked up. This PR implements exactly that existing contract; no rule described in the docs changed.

## Spec invariants

- **The roll's mapping to piles is fixed**, read off the pile labels in the board photograph and repeated in ADR-0002 and `docs/specs/ui/roll-and-card.md`: 1/2 → Easy, 3/4 → Medium, 5/6 → Hard. Asserted face by face in `RollTests.PileForFace_MapsEachFaceToItsPile`, and as a counting fact (exactly two faces per pile, enumerated not sampled) in `EveryPile_IsReachedByExactlyTwoFaces`.
- **The roll selects the pile and does nothing else — it never moves a frog.** `Roll` has no reference to `Lane`, frog position, or card content; nothing in it can move anything.
- **Rolling drives the seeded, deterministic RNG from #200**, not a fresh `System.Random`. `RollsFromRngsOfTheSameSeed_ProduceTheIdenticalSequence` and `RollsFromRngsOfDifferentSeeds_Diverge` assert it the same way `RngTests` does for the underlying generator.
- **None of `Tier`, `Difficulty`, `Deck` or `Stack` appears** in any type, member or parameter name this issue adds — `TypesAddedByThisIssue_NameNoneOfTheAvoidedWords` sweeps `Pile` and `Roll` by reflection. I verified the test actually catches a violation (temporarily added a `DifficultyLevel` member, watched it go red, reverted) before trusting a test that would otherwise pass vacuously.

## Deviations and Decisions

- `skip-docs` applied: the behaviour this issue adds was already fully specified in `docs/specs/rules.md` (the roll/pile table and the no-movement rule), so there is no docs edit for this PR to make. The issue's own blocked-by note assumed #199 would leave the explicit face rows out for this issue to add; #199 turned out to include them itself, so that assumption no longer held by the time this issue started.
- `Roll.Draw(Rng)` and `Roll.PileForFace(int)` are two separate static entry points rather than one — `PileForFace` is total and is exercised directly against the four out-of-range faces the checklist asks for, without needing a live `Rng` to reach it.



---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_