### PR TITLE
feat(core): generate a card, shaped to the pile it was drawn from

### DIFF
--- a/Assets/Scripts/Core/Card.cs
+++ b/Assets/Scripts/Core/Card.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// A multiplication problem shaped to a pile, together with its true
+    /// product — CONTEXT.md's glossary: "a single multiplication problem
+    /// together with its answer". Drawn from the game's seeded
+    /// <see cref="Rng"/> (#200) and from nothing else, so a given seed
+    /// replays the same sequence of cards.
+    ///
+    /// docs/adr/0002-structured-working-out-grid.md pins exactly three
+    /// shapes, read off the pile labels in the board photograph:
+    ///
+    /// | Pile | Shape | Example |
+    /// | --- | --- | --- |
+    /// | Easy | 2-digit × 1-digit | `68 × 5` |
+    /// | Medium | 2-digit × 2-digit | `22 × 41` |
+    /// | Hard | 3-digit × 2-digit | `331 × 41` |
+    ///
+    /// That table pins digit counts and nothing else. Which values inside a
+    /// shape's bounds come up, and how often, is not decided by this type —
+    /// see <see cref="OneDigitMinimum"/> — and per docs/specs/reference/index.md
+    /// #still-unsettled, the rest of what the classroom deck actually
+    /// constrains (repeated digits, forced carries, trivial problems) waits on
+    /// the real deck being photographed (#171).
+    /// </summary>
+    public sealed class Card
+    {
+        /// <summary>
+        /// The lowest value a single-digit operand may draw.
+        ///
+        /// Whether the classroom deck ever deals a multiplier of `0` is not
+        /// settled by any sample card, ADR, or spec page (#203) — "1-digit"
+        /// could mean 0–9 or 1–9. `0` is the arithmetically neutral reading of
+        /// "single digit" and adds no constraint beyond the digit count, so it
+        /// is what this provisional generator draws from; it is not a claim
+        /// that `0` belongs in the real deck, and nothing here asserts it one
+        /// way or the other.
+        /// </summary>
+        public const int OneDigitMinimum = 0;
+
+        /// <summary>The highest value a single-digit operand may draw.</summary>
+        public const int OneDigitMaximum = 9;
+
+        /// <summary>The lowest value a 2-digit operand may draw.</summary>
+        public const int TwoDigitMinimum = 10;
+
+        /// <summary>The highest value a 2-digit operand may draw.</summary>
+        public const int TwoDigitMaximum = 99;
+
+        /// <summary>The lowest value a 3-digit operand may draw.</summary>
+        public const int ThreeDigitMinimum = 100;
+
+        /// <summary>The highest value a 3-digit operand may draw.</summary>
+        public const int ThreeDigitMaximum = 999;
+
+        Card(int multiplicand, int multiplier)
+        {
+            Multiplicand = multiplicand;
+            Multiplier = multiplier;
+        }
+
+        /// <summary>The first operand — printed first on the card, e.g. the `68` in `68 × 5`.</summary>
+        public int Multiplicand { get; }
+
+        /// <summary>The second operand — printed second on the card, e.g. the `5` in `68 × 5`.</summary>
+        public int Multiplier { get; }
+
+        /// <summary>
+        /// The true product of <see cref="Multiplicand"/> and
+        /// <see cref="Multiplier"/> — the only thing ADR-0002 says is graded.
+        /// </summary>
+        public int Product
+        {
+            get { return Multiplicand * Multiplier; }
+        }
+
+        /// <summary>
+        /// A card shaped for <paramref name="pile"/>, drawn from
+        /// <paramref name="rng"/> and from nothing else.
+        /// </summary>
+        public static Card Draw(Pile pile, Rng rng)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    return new Card(
+                        rng.NextInt(TwoDigitMinimum, TwoDigitMaximum),
+                        rng.NextInt(OneDigitMinimum, OneDigitMaximum));
+
+                case Pile.Medium:
+                    return new Card(
+                        rng.NextInt(TwoDigitMinimum, TwoDigitMaximum),
+                        rng.NextInt(TwoDigitMinimum, TwoDigitMaximum));
+
+                case Pile.Hard:
+                    return new Card(
+                        rng.NextInt(ThreeDigitMinimum, ThreeDigitMaximum),
+                        rng.NextInt(TwoDigitMinimum, TwoDigitMaximum));
+
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(pile),
+                        pile,
+                        $"no card shape is defined for {pile}.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Card.cs.meta
+++ b/Assets/Scripts/Core/Card.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8faa0d1e0b1f4e5ba43206ec3c884309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/CardTests.cs
+++ b/Tests/Core/CardTests.cs
@@ -1,0 +1,148 @@
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="Card"/> is a multiplication problem shaped to a pile, plus
+    /// its true product — generated from the game's seeded <see cref="Rng"/>
+    /// (#200) and from nothing else. docs/adr/0002-structured-working-out-grid.md
+    /// pins the three shapes; docs/specs/rules.md — "a card is one
+    /// multiplication problem, and the player answers it... equals the
+    /// product on the card". Only the digit-count bounds are asserted here —
+    /// per #203, nothing about which values within those bounds come up, and
+    /// nothing about whether a single-digit multiplier may be zero.
+    /// </summary>
+    public sealed class CardTests
+    {
+        const ulong Seed = 24680UL;
+
+        // Enough draws that a single lucky (or unlucky) call could not have
+        // produced the shape tests' pass by chance — this is the test that
+        // would catch an off-by-one at one end of a range that a single draw
+        // missed.
+        const int DrawCount = 200;
+
+        [Test]
+        public void Draw_ForTheEasyPile_ProducesA2DigitBy1DigitShape()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            var card = Card.Draw(Pile.Easy, rng);
+
+            Assert.That(card.Multiplicand, Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum));
+
+            // "Below 10" only — deliberately not a lower-bound check. Whether
+            // a single-digit multiplier can be 0 is an open question #203
+            // does not settle; see Card.OneDigitMaximum.
+            Assert.That(card.Multiplier, Is.LessThanOrEqualTo(Card.OneDigitMaximum));
+        }
+
+        [Test]
+        public void Draw_ForTheMediumPile_ProducesA2DigitBy2DigitShape()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            var card = Card.Draw(Pile.Medium, rng);
+
+            Assert.That(card.Multiplicand, Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum));
+            Assert.That(card.Multiplier, Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum));
+        }
+
+        [Test]
+        public void Draw_ForTheHardPile_ProducesA3DigitBy2DigitShape()
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            var card = Card.Draw(Pile.Hard, rng);
+
+            Assert.That(card.Multiplicand, Is.InRange(Card.ThreeDigitMinimum, Card.ThreeDigitMaximum));
+            Assert.That(card.Multiplier, Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum));
+        }
+
+        // Nothing beyond the digit bounds is asserted here — no claim about
+        // which values within a bound appear, or how often (#203: "do not
+        // write a test that asserts a distribution").
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void Draw_AcrossRepeatedGeneration_EveryOperandStaysWithinThePilesDigitBounds(Pile pile)
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                var card = Card.Draw(pile, rng);
+
+                AssertOperandsAreWithinDigitBounds(pile, card, draw);
+            }
+        }
+
+        static void AssertOperandsAreWithinDigitBounds(Pile pile, Card card, int draw)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    Assert.That(card.Multiplicand,
+                        Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum), $"draw {draw}");
+                    Assert.That(card.Multiplier,
+                        Is.LessThanOrEqualTo(Card.OneDigitMaximum), $"draw {draw}");
+                    break;
+
+                case Pile.Medium:
+                    Assert.That(card.Multiplicand,
+                        Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum), $"draw {draw}");
+                    Assert.That(card.Multiplier,
+                        Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum), $"draw {draw}");
+                    break;
+
+                case Pile.Hard:
+                    Assert.That(card.Multiplicand,
+                        Is.InRange(Card.ThreeDigitMinimum, Card.ThreeDigitMaximum), $"draw {draw}");
+                    Assert.That(card.Multiplier,
+                        Is.InRange(Card.TwoDigitMinimum, Card.TwoDigitMaximum), $"draw {draw}");
+                    break;
+            }
+        }
+
+        // ADR-0002: only the answer is graded — nothing about how a player
+        // works the problem out. docs/specs/rules.md — "the answer... equals
+        // the product on the card". So the card's Product has to be exactly
+        // its operands' true product, not a value drawn independently of them.
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void Draw_TheAnswerIsTheTrueProductOfItsOperands(Pile pile)
+        {
+            var rng = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                var card = Card.Draw(pile, rng);
+
+                Assert.That(card.Product, Is.EqualTo(card.Multiplicand * card.Multiplier), $"draw {draw}");
+            }
+        }
+
+        // Determinism is what makes a whole game replayable move for move in
+        // the two-second suite (#203), and what a save has to preserve —
+        // docs/adr/0004-core-owns-the-save-format.md.
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void Draw_FromRngsOfTheSameSeed_ProducesTheIdenticalSequenceOfCards(Pile pile)
+        {
+            var first = Rng.FromSeed(Seed);
+            var second = Rng.FromSeed(Seed);
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                var expected = Card.Draw(pile, first);
+                var actual = Card.Draw(pile, second);
+
+                Assert.That(actual.Multiplicand, Is.EqualTo(expected.Multiplicand), $"draw {draw}");
+                Assert.That(actual.Multiplier, Is.EqualTo(expected.Multiplier), $"draw {draw}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The game now knows how to hand out a card once a roll has picked a pile. `Card.Draw(pile, rng)` builds a multiplication problem sized to the pile — 2-digit × 1-digit for Easy, 2-digit × 2-digit for Medium, 3-digit × 2-digit for Hard — together with its true product, drawn from the same seeded RNG everything else uses, so a seed replays the same cards every time.

**Docs:** None — this implements exactly the three-shape table already pinned in `docs/adr/0002-structured-working-out-grid.md` and `docs/specs/reference/index.md`, and asserts nothing beyond it.

Closes #203

## Spec invariants

- Digit-count bounds per pile, from ADR-0002's table: Easy multiplicand 10–99 / multiplier below 10; Medium both operands 10–99; Hard multiplicand 100–999 / multiplier 10–99. Asserted in `CardTests` for a single draw per pile and again across 200 repeated draws per pile.
- The card's answer is the true product of its two operands (ADR-0002: only the answer is graded). Asserted across 200 draws for all three piles.
- A seed replays the same sequence of cards. Asserted by drawing 200 cards each from two `Rng`s built from the same seed and comparing operand-for-operand.

## Deviations and Decisions

- The issue leaves open whether a single-digit multiplier may be `0` and says not to decide it. The generator draws the multiplier from `Card.OneDigitMinimum` (`0`) to `Card.OneDigitMaximum` (`9`) — the arithmetically neutral reading of "single digit," which adds no constraint beyond the digit count itself (excluding `0` would itself be an opinionated constraint the issue rules out). No test asserts either bound of this on the low end, per the issue.
- `Card.Product` is a computed property (`Multiplicand * Multiplier`) rather than a value drawn or stored independently — the simplest way to guarantee it's always the true product, which is the only thing the issue and ADR-0002 ask of it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_