### PR TITLE
feat(core): report the working-out grid's shape for a card and row count

### DIFF
--- a/Assets/Scripts/Core/WorkingOutGrid.cs
+++ b/Assets/Scripts/Core/WorkingOutGrid.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The kind of row in a <see cref="WorkingOutGrid"/>, top to bottom.
+    /// docs/specs/ui/working-out-grid.md#how-many-columns-and-rows: every
+    /// card is dealt the same row *kinds* — a carry strip, the multiplicand,
+    /// the multiplier, the addition section, another carry strip, then the
+    /// answer row. There is no <c>Rule</c> entry: a rule line is a drawn
+    /// separator between two adjacent rows, not a row of its own
+    /// (docs/adr/0002-structured-working-out-grid.md's amendment note). There
+    /// is no <c>SumRow</c> entry either — the answer row *is* the sum.
+    /// </summary>
+    public enum GridRowKind
+    {
+        /// <summary>
+        /// A strip of dashed carry boxes, one per digit column. Two of these
+        /// exist on every grid — see <see cref="WorkingOutGrid.CarryStripCount"/> —
+        /// and neither is graded.
+        /// </summary>
+        CarryStrip,
+
+        /// <summary>The card's first operand, printed and not editable.</summary>
+        Multiplicand,
+
+        /// <summary>The card's second operand, printed and not editable.</summary>
+        Multiplier,
+
+        /// <summary>
+        /// One row of the growable addition section — CONTEXT.md and Derek
+        /// call it the <c>"+ "</c> section. Ordinary editable cells; nothing
+        /// here is graded. How many of these a grid has is the one row count
+        /// this type does not fix — see <see cref="WorkingOutGrid.For"/>.
+        /// </summary>
+        AdditionRow,
+
+        /// <summary>
+        /// The only row that is graded. Editable, and always exactly one.
+        /// </summary>
+        AnswerRow
+    }
+
+    /// <summary>
+    /// The kind of a single cell within a <see cref="GridRow"/>.
+    /// docs/specs/ui/working-out-grid.md#elements and #204's cell-kind list.
+    /// </summary>
+    public enum GridCellKind
+    {
+        /// <summary>
+        /// A digit column with nothing in it and nothing fillable — the
+        /// leading positions of a printed row — or the operator column, which
+        /// is never fillable and never carries a printed digit. Which glyph
+        /// (if any) the shell draws over an operator-column cell is derived
+        /// from the row kind and is not this type's concern
+        /// (#204 "The operator column").
+        /// </summary>
+        Blank,
+
+        /// <summary>A digit off the card, right-aligned. Never fillable.</summary>
+        Printed,
+
+        /// <summary>An empty cell the player may fill.</summary>
+        Editable,
+
+        /// <summary>The dashed carry box on a carry strip. Optional, never graded.</summary>
+        CarryBox
+    }
+
+    /// <summary>
+    /// One cell of a <see cref="GridRow"/>. <see cref="Digit"/> is only
+    /// meaningful when <see cref="Kind"/> is <see cref="GridCellKind.Printed"/>
+    /// — every other kind carries no content, because this type reports the
+    /// grid's *shape*, not anything a player has typed into it.
+    /// </summary>
+    public readonly struct GridCell
+    {
+        internal GridCell(GridCellKind kind, int? digit = null)
+        {
+            Kind = kind;
+            Digit = digit;
+        }
+
+        public GridCellKind Kind { get; }
+
+        public int? Digit { get; }
+    }
+
+    /// <summary>
+    /// One row of a <see cref="WorkingOutGrid"/>: a <see cref="GridRowKind"/>
+    /// and one <see cref="GridCell"/> per column, left to right, column zero
+    /// being the operator column.
+    /// </summary>
+    public sealed class GridRow
+    {
+        internal GridRow(GridRowKind kind, IReadOnlyList<GridCell> cells)
+        {
+            Kind = kind;
+            Cells = cells;
+        }
+
+        public GridRowKind Kind { get; }
+
+        public IReadOnlyList<GridCell> Cells { get; }
+    }
+
+    /// <summary>
+    /// The working-out grid's shape for a card, before any of it is drawn —
+    /// ADR-0002: "Which cells exist for a given problem is game logic and
+    /// belongs in `Core`; only drawing them belongs in the Unity shell."
+    ///
+    /// Since the addition section became growable
+    /// (<see href="https://github.com/derekwinters/connor-multiplying-frogs/issues/234">#234</see>),
+    /// the grid's shape is no longer a pure function of the card alone —
+    /// docs/specs/ui/working-out-grid.md#what-core-decides-and-what-the-player-decides.
+    /// <see cref="For"/> takes the card **and** the addition row count as of
+    /// this moment, and reports the grid for that snapshot. It has no opinion
+    /// on when the count should grow or shrink — that policy belongs to
+    /// whichever issue owns turn interaction (#210 and the UI issues); this
+    /// type only ever answers "given these inputs, what does the grid look
+    /// like right now."
+    ///
+    /// This type knows nothing about a roll, a pile, a turn, or a correct
+    /// answer, and nothing in the grid it reports is marked
+    /// (docs/specs/ui/working-out-grid.md#invariants).
+    /// </summary>
+    public sealed class WorkingOutGrid
+    {
+        /// <summary>
+        /// Addition rows a card is dealt. docs/specs/ui/working-out-grid.md's
+        /// named-constants table — same name, same value, so a change to one
+        /// cannot drift from the other.
+        /// </summary>
+        public const int GridAdditionRowsAtStart = 2;
+
+        /// <summary>
+        /// Most addition rows the section can hold.
+        /// docs/specs/ui/working-out-grid.md's named-constants table.
+        /// </summary>
+        public const int GridAdditionRowsMax = 6;
+
+        /// <summary>
+        /// Carry strips on every grid — one above the multiplication and one
+        /// above the addition section, reused rather than one per addition
+        /// row. Settled by Derek on #255: "shared strip — matches today's
+        /// mockups." Fixed at two regardless of the addition row count, which
+        /// is exactly what makes it safe to hard-code here rather than derive
+        /// it from <see cref="GridAdditionRowsAtStart"/> or
+        /// <see cref="GridAdditionRowsMax"/>.
+        /// </summary>
+        public const int CarryStripCount = 2;
+
+        // The operator column: column zero, present in every row, never
+        // fillable, never carrying a digit. One of these and only one, on
+        // every row — see #204 "The operator column".
+        const int OperatorColumnCount = 1;
+
+        WorkingOutGrid(int columnCount, IReadOnlyList<GridRow> rows)
+        {
+            ColumnCount = columnCount;
+            Rows = rows;
+        }
+
+        /// <summary>
+        /// The operator column plus one column per digit of the largest
+        /// possible product for the card's *shape* — never the card's actual
+        /// product. Purely a function of the card; unaffected by the addition
+        /// row count.
+        /// </summary>
+        public int ColumnCount { get; }
+
+        /// <summary>Every row of the grid, top to bottom.</summary>
+        public IReadOnlyList<GridRow> Rows { get; }
+
+        /// <summary>
+        /// The grid for <paramref name="card"/> with its addition section
+        /// currently holding <paramref name="additionRowCount"/> rows.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="card"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="additionRowCount"/> is outside
+        /// <see cref="GridAdditionRowsAtStart"/> to <see cref="GridAdditionRowsMax"/> —
+        /// every card is dealt with at least the starting count and the
+        /// section never holds more than the cap
+        /// (docs/specs/ui/working-out-grid.md#invariants).
+        /// </exception>
+        public static WorkingOutGrid For(Card card, int additionRowCount)
+        {
+            if (card == null)
+            {
+                throw new ArgumentNullException(nameof(card));
+            }
+
+            if (additionRowCount < GridAdditionRowsAtStart || additionRowCount > GridAdditionRowsMax)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(additionRowCount),
+                    additionRowCount,
+                    $"the addition section holds {GridAdditionRowsAtStart} to "
+                    + $"{GridAdditionRowsMax} rows; {additionRowCount} is neither.");
+            }
+
+            var columnCount = ColumnCountFor(card);
+
+            var rows = new List<GridRow>
+            {
+                CarryStripRow(columnCount),
+                PrintedRow(GridRowKind.Multiplicand, card.Multiplicand, columnCount),
+                PrintedRow(GridRowKind.Multiplier, card.Multiplier, columnCount),
+            };
+
+            for (var i = 0; i < additionRowCount; i++)
+            {
+                rows.Add(EditableRow(GridRowKind.AdditionRow, columnCount));
+            }
+
+            rows.Add(CarryStripRow(columnCount));
+            rows.Add(EditableRow(GridRowKind.AnswerRow, columnCount));
+
+            return new WorkingOutGrid(columnCount, rows);
+        }
+
+        // The card decides the columns — docs/specs/ui/working-out-grid.md:
+        // "the number of digits in the largest possible product for that
+        // card's shape, plus one operator column." The shape is read off the
+        // card's own operands' digit counts, not off the pile it came from —
+        // this type has no notion of a pile — and the *largest possible*
+        // product for that shape, never the card's actual product, which is
+        // what keeps the grid sized to the shape and not to the answer.
+        static int ColumnCountFor(Card card)
+        {
+            var largestPossibleProduct =
+                LargestValueOfSameDigitCount(card.Multiplicand)
+                * LargestValueOfSameDigitCount(card.Multiplier);
+
+            return DigitCount(largestPossibleProduct) + OperatorColumnCount;
+        }
+
+        // The largest operand sharing `operand`'s digit count — e.g. 68 and
+        // 11 both have two digits, so both map to 99. The three digit-count
+        // bands are Card's own named bounds, not new literals standing in for
+        // "one digit" or "two digits".
+        static int LargestValueOfSameDigitCount(int operand)
+        {
+            if (operand <= Card.OneDigitMaximum)
+            {
+                return Card.OneDigitMaximum;
+            }
+
+            if (operand <= Card.TwoDigitMaximum)
+            {
+                return Card.TwoDigitMaximum;
+            }
+
+            return Card.ThreeDigitMaximum;
+        }
+
+        static int DigitCount(int value)
+        {
+            return value.ToString().Length;
+        }
+
+        static GridRow CarryStripRow(int columnCount)
+        {
+            var cells = new GridCell[columnCount];
+            cells[0] = new GridCell(GridCellKind.Blank);
+
+            for (var column = OperatorColumnCount; column < columnCount; column++)
+            {
+                cells[column] = new GridCell(GridCellKind.CarryBox);
+            }
+
+            return new GridRow(GridRowKind.CarryStrip, cells);
+        }
+
+        // A printed row: the operand's digits, right-aligned, with blank
+        // digit cells filling whatever leading columns the operand doesn't
+        // reach — e.g. `331 × 41`'s multiplier row is one blank operator
+        // cell, three blank digit cells, then printed `4`, `1`.
+        static GridRow PrintedRow(GridRowKind kind, int operand, int columnCount)
+        {
+            var digits = DigitsOf(operand);
+            var digitColumnCount = columnCount - OperatorColumnCount;
+            var leadingBlankCount = digitColumnCount - digits.Length;
+
+            var cells = new GridCell[columnCount];
+            cells[0] = new GridCell(GridCellKind.Blank);
+
+            for (var i = 0; i < leadingBlankCount; i++)
+            {
+                cells[OperatorColumnCount + i] = new GridCell(GridCellKind.Blank);
+            }
+
+            for (var i = 0; i < digits.Length; i++)
+            {
+                cells[OperatorColumnCount + leadingBlankCount + i] =
+                    new GridCell(GridCellKind.Printed, digits[i]);
+            }
+
+            return new GridRow(kind, cells);
+        }
+
+        static GridRow EditableRow(GridRowKind kind, int columnCount)
+        {
+            var cells = new GridCell[columnCount];
+            cells[0] = new GridCell(GridCellKind.Blank);
+
+            for (var column = OperatorColumnCount; column < columnCount; column++)
+            {
+                cells[column] = new GridCell(GridCellKind.Editable);
+            }
+
+            return new GridRow(kind, cells);
+        }
+
+        // Most-significant digit first, so `DigitsOf(68)` is `[6, 8]`.
+        static int[] DigitsOf(int value)
+        {
+            var text = value.ToString();
+            var digits = new int[text.Length];
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                digits[i] = text[i] - '0';
+            }
+
+            return digits;
+        }
+    }
+}

--- a/Assets/Scripts/Core/WorkingOutGrid.cs.meta
+++ b/Assets/Scripts/Core/WorkingOutGrid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c77ae8c4d9247a69d835ffbc16696a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/WorkingOutGridTests.cs
+++ b/Tests/Core/WorkingOutGridTests.cs
@@ -1,0 +1,315 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="WorkingOutGrid"/> reports the working-out grid's shape for a
+    /// card and a current addition-row count — see
+    /// docs/specs/ui/working-out-grid.md#how-many-columns-and-rows. Since
+    /// #234 the addition section is growable on every card, so the row *kind*
+    /// list is identical for every shape; only the column count and the
+    /// number of addition rows vary.
+    ///
+    /// <see cref="Card"/> only builds through <see cref="Card.Draw"/>, so
+    /// these tests draw cards from a fixed-seed <see cref="Rng"/> (matching
+    /// <c>CardTests</c>' own pattern) rather than asserting against literal
+    /// operand values. Every assertion about printed digits is checked
+    /// against the drawn card's own <see cref="Card.Multiplicand"/> and
+    /// <see cref="Card.Multiplier"/>, not a hard-coded `68`/`5` pair.
+    /// </summary>
+    public sealed class WorkingOutGridTests
+    {
+        const ulong Seed = 13579UL;
+
+        // Enough draws that a test relying on seeing two different answer
+        // digit counts (see the "grid never looks at the product" test below)
+        // could not pass by a single lucky draw.
+        const int DrawCount = 200;
+
+        [Test]
+        public void For_ACardAtTheStartingRowCount_ReportsCarryMultiplicandMultiplierAdditionCarryAnswer()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Easy, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+
+            Assert.That(RowKindsOf(grid), Is.EqualTo(new[]
+            {
+                GridRowKind.CarryStrip,
+                GridRowKind.Multiplicand,
+                GridRowKind.Multiplier,
+                GridRowKind.AdditionRow,
+                GridRowKind.AdditionRow,
+                GridRowKind.CarryStrip,
+                GridRowKind.AnswerRow,
+            }));
+        }
+
+        // The row *kind* list no longer depends on the multiplier's digit
+        // count (#234) — every shape gets the same list, at whatever addition
+        // row count it currently holds. Only the column count is
+        // shape-specific.
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void For_EveryShapeAtTheStartingRowCount_ReportsTheSameRowKindList(Pile pile)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(pile, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+
+            Assert.That(RowKindsOf(grid), Is.EqualTo(new[]
+            {
+                GridRowKind.CarryStrip,
+                GridRowKind.Multiplicand,
+                GridRowKind.Multiplier,
+                GridRowKind.AdditionRow,
+                GridRowKind.AdditionRow,
+                GridRowKind.CarryStrip,
+                GridRowKind.AnswerRow,
+            }), $"pile {pile}");
+        }
+
+        [TestCase(Pile.Easy, 4)]
+        [TestCase(Pile.Medium, 5)]
+        [TestCase(Pile.Hard, 6)]
+        public void For_EachShape_ReportsTheColumnCountTheSpecPageStates(Pile pile, int expectedColumnCount)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(pile, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+
+            Assert.That(grid.ColumnCount, Is.EqualTo(expectedColumnCount));
+        }
+
+        // The test the issue calls out explicitly: two Easy-shaped cards
+        // whose actual products have different digit counts must still
+        // report an identical grid, because the grid is sized to the shape's
+        // largest possible product, never the card's actual answer. Rather
+        // than hard-code an operand pair (Card has no constructor that
+        // accepts one), this draws until the fixed seed has produced two
+        // Easy cards with differing answer digit counts, which it does well
+        // within DrawCount — and asserts the diversity actually happened, so
+        // the test cannot pass vacuously.
+        [Test]
+        public void For_TwoCardsOfTheSameShapeWithDifferentAnswerDigitCounts_ReportIdenticalGrids()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var columnCounts = new HashSet<int>();
+            var answerDigitCounts = new HashSet<int>();
+            var rowKindLists = new HashSet<string>();
+
+            for (var draw = 0; draw < DrawCount; draw++)
+            {
+                var card = Card.Draw(Pile.Easy, rng);
+                var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+
+                columnCounts.Add(grid.ColumnCount);
+                answerDigitCounts.Add(card.Product.ToString().Length);
+                rowKindLists.Add(string.Join(",", RowKindsOf(grid)));
+            }
+
+            Assert.That(answerDigitCounts.Count, Is.GreaterThan(1),
+                "the draws never produced two different answer digit counts — this test would pass vacuously.");
+            Assert.That(columnCounts, Has.Count.EqualTo(1),
+                "the column count must be identical across every draw of the same shape.");
+            Assert.That(rowKindLists, Has.Count.EqualTo(1),
+                "the row kind list must be identical across every draw of the same shape.");
+        }
+
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void For_ThePrintedMultiplicandRow_IsBlankOperatorThenBlankLeadingCellsThenTheOperandsDigits(Pile pile)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(pile, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+            var row = grid.Rows.Single(r => r.Kind == GridRowKind.Multiplicand);
+
+            AssertIsAPrintedRow(row, card.Multiplicand, grid.ColumnCount);
+        }
+
+        [TestCase(Pile.Easy)]
+        [TestCase(Pile.Medium)]
+        [TestCase(Pile.Hard)]
+        public void For_ThePrintedMultiplierRow_IsBlankOperatorThenBlankLeadingCellsThenTheOperandsDigits(Pile pile)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(pile, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+            var row = grid.Rows.Single(r => r.Kind == GridRowKind.Multiplier);
+
+            AssertIsAPrintedRow(row, card.Multiplier, grid.ColumnCount);
+        }
+
+        [Test]
+        public void For_EveryCarryStrip_HasACarryBoxOverEveryDigitColumnAndNoneOverTheOperatorColumn()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+            var strips = grid.Rows.Where(r => r.Kind == GridRowKind.CarryStrip).ToList();
+
+            Assert.That(strips, Has.Count.EqualTo(WorkingOutGrid.CarryStripCount));
+
+            foreach (var strip in strips)
+            {
+                Assert.That(strip.Cells[0].Kind, Is.EqualTo(GridCellKind.Blank));
+
+                for (var column = 1; column < grid.ColumnCount; column++)
+                {
+                    Assert.That(strip.Cells[column].Kind, Is.EqualTo(GridCellKind.CarryBox), $"column {column}");
+                }
+            }
+        }
+
+        // Settled by Derek on #255: a shared strip, not one per addition row.
+        // The carry strip count must stay fixed at two no matter how many
+        // addition rows the section currently holds.
+        [TestCase(WorkingOutGrid.GridAdditionRowsAtStart)]
+        [TestCase(WorkingOutGrid.GridAdditionRowsMax)]
+        public void For_AnyAdditionRowCount_TheCarryStripCountStaysFixedAtTwo(int additionRowCount)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            var grid = WorkingOutGrid.For(card, additionRowCount);
+
+            Assert.That(grid.Rows.Count(r => r.Kind == GridRowKind.CarryStrip),
+                Is.EqualTo(WorkingOutGrid.CarryStripCount));
+        }
+
+        [Test]
+        public void For_EveryAdditionRow_ReportsEveryDigitColumnAsEditableIncludingTheUnitsColumn()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+            var additionRows = grid.Rows.Where(r => r.Kind == GridRowKind.AdditionRow).ToList();
+
+            Assert.That(additionRows, Has.Count.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart));
+
+            foreach (var row in additionRows)
+            {
+                Assert.That(row.Cells[0].Kind, Is.EqualTo(GridCellKind.Blank));
+
+                for (var column = 1; column < grid.ColumnCount; column++)
+                {
+                    Assert.That(row.Cells[column].Kind, Is.EqualTo(GridCellKind.Editable), $"column {column}");
+                    Assert.That(row.Cells[column].Digit, Is.Null, "no placeholder digit is pre-printed");
+                }
+            }
+        }
+
+        [Test]
+        public void For_TheAnswerRow_IsEditableInEveryDigitColumn()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            var grid = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+            var answerRow = grid.Rows.Single(r => r.Kind == GridRowKind.AnswerRow);
+
+            Assert.That(answerRow.Cells[0].Kind, Is.EqualTo(GridCellKind.Blank));
+
+            for (var column = 1; column < grid.ColumnCount; column++)
+            {
+                Assert.That(answerRow.Cells[column].Kind, Is.EqualTo(GridCellKind.Editable), $"column {column}");
+            }
+        }
+
+        // The addition section starts at GridAdditionRowsAtStart and can grow
+        // to GridAdditionRowsMax — docs/specs/ui/working-out-grid.md's row
+        // table — and a snapshot at every count in between must report
+        // exactly that many AdditionRow rows.
+        [TestCase(WorkingOutGrid.GridAdditionRowsAtStart)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(5)]
+        [TestCase(WorkingOutGrid.GridAdditionRowsMax)]
+        public void For_AnAdditionRowCountWithinBounds_ReportsExactlyThatManyAdditionRows(int additionRowCount)
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            var grid = WorkingOutGrid.For(card, additionRowCount);
+
+            Assert.That(grid.Rows.Count(r => r.Kind == GridRowKind.AdditionRow), Is.EqualTo(additionRowCount));
+        }
+
+        // Open question 5, settled by Derek on #204: a grown row can be
+        // removed again — backspacing the last digit out of it takes it away.
+        // That is exactly a lower addition-row-count snapshot, which this
+        // type already reports correctly; there is no separate "remove a
+        // row" operation for Core to own, only the count going down instead
+        // of up. GridAdditionRowsAtStart is the floor: every card is dealt at
+        // least that many, so a snapshot can never legitimately ask for
+        // fewer.
+        [Test]
+        public void For_ARowCountBelowTheStartingCount_IsRejected()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            Assert.That(
+                () => WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart - 1),
+                Throws.TypeOf<System.ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void For_ARowCountAboveTheCap_IsRejected()
+        {
+            var rng = Rng.FromSeed(Seed);
+            var card = Card.Draw(Pile.Hard, rng);
+
+            Assert.That(
+                () => WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsMax + 1),
+                Throws.TypeOf<System.ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void For_ANullCard_IsRejected()
+        {
+            Assert.That(
+                () => WorkingOutGrid.For(null, WorkingOutGrid.GridAdditionRowsAtStart),
+                Throws.TypeOf<System.ArgumentNullException>());
+        }
+
+        static void AssertIsAPrintedRow(GridRow row, int operand, int columnCount)
+        {
+            var digits = operand.ToString();
+            var digitColumnCount = columnCount - 1;
+            var leadingBlankCount = digitColumnCount - digits.Length;
+
+            Assert.That(row.Cells[0].Kind, Is.EqualTo(GridCellKind.Blank), "operator column");
+
+            for (var i = 0; i < leadingBlankCount; i++)
+            {
+                Assert.That(row.Cells[1 + i].Kind, Is.EqualTo(GridCellKind.Blank), $"leading column {i}");
+            }
+
+            for (var i = 0; i < digits.Length; i++)
+            {
+                var cell = row.Cells[1 + leadingBlankCount + i];
+                Assert.That(cell.Kind, Is.EqualTo(GridCellKind.Printed), $"digit column {i}");
+                Assert.That(cell.Digit, Is.EqualTo(digits[i] - '0'), $"digit column {i}");
+            }
+        }
+
+        static IEnumerable<GridRowKind> RowKindsOf(WorkingOutGrid grid)
+        {
+            return grid.Rows.Select(r => r.Kind);
+        }
+    }
+}

--- a/docs/adr/0002-structured-working-out-grid.md
+++ b/docs/adr/0002-structured-working-out-grid.md
@@ -71,6 +71,13 @@ player in whatever state the last one left it.
     left of the screen and the keypad the right, and the worst case fits with
     room to spare. See
     [the working-out grid wireframe](../specs/ui/working-out-grid.md).
+
+    "A sum row" reads looser than what got built. The wireframe and its
+    mockups settled on two partial-product rows, a second carry strip above
+    them, and the answer row itself standing in as the sum — there is no
+    separate `SumRow`. [#204](https://github.com/derekwinters/connor-multiplying-frogs/issues/204)
+    treats the mockups as authoritative over this bullet's wording rather than
+    the other way round.
 - Revealing the *worked solution* on a wrong answer is ruled out by the same
   reasoning: showing one method's partial products would quietly make that method
   canonical. The correct answer is revealed; the working is not.

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -156,6 +156,13 @@ rows.
     `GridAdditionRowsAtStart` of them, and the player can grow the section from
     there to `GridAdditionRowsMax`.
 
+    The `rule` entries in that list are drawn separators, not rows: a straight
+    line at `GridRuleThickness`, with no cells of its own, between two row
+    kinds the shell already knows are adjacent. `Core` does not report them —
+    [#204](https://github.com/derekwinters/connor-multiplying-frogs/issues/204)
+    reports carry strip, multiplicand, multiplier, addition rows, carry strip,
+    answer row, and nothing named `Rule`.
+
 **"The addition section"** is this page's name for those rows — the block
 between the first rule line and the second, which Derek calls the `"+ "`
 section and which this page used to call the *partial-product rows*. They are
@@ -306,39 +313,34 @@ today's numbers, not to pick the fix.
 ## Open questions
 
 Questions 2 to 5 arrived with the growable addition section
-([#234](https://github.com/derekwinters/connor-multiplying-frogs/issues/234)),
-and none of them is answered by anything Derek has said. Questions 1 and 6 are
-older. Question 1 is the one that changes what `Core` builds.
+([#234](https://github.com/derekwinters/connor-multiplying-frogs/issues/234)).
+Question 6 is older. Questions 1 and 5 are settled; 2, 3, 4 and 6 are not
+answered by anything Derek has said yet.
 
-- **1. Which carry convention does Connor's class use?** The mockups put one
-  carry strip above the multiplication and one above the addition, each reused
-  across the rows it covers. The alternative is a strip attached to each
-  addition row, so a carry is never reused across two passes. Nothing is marked
-  either way, so this is about matching what he is taught — his call, not one to
-  make in code.
+- **1. Which carry convention does Connor's class use? Settled: shared
+  strip.** The mockups put one carry strip above the multiplication and one
+  above the addition, each reused across the rows it covers. The alternative
+  was a strip attached to each addition row, so a carry is never reused across
+  two passes.
 
-    This is **the one open question on this page that changes the shape of the
-    grid in `Core`**, so it is worth being exact about what depends on it.
-    Depending on it: the number of carry strips a grid has, whether that number
-    tracks the addition row count (and therefore grows during a turn), and the
-    per-row-versus-shared structure the row list above states. Not depending on
-    it: the column count, the addition section's starting count and cap, the
-    growth trigger, the fact that nothing is graded, and the overrun measured in
-    the third mockup — a per-row strip would make the overrun worse, not
-    different in kind.
+    This was **the one open question on this page that changed the shape of
+    the grid in `Core`**, which is why it is worth being exact about what
+    depended on it. Depending on it: the number of carry strips a grid has,
+    whether that number tracks the addition row count (and therefore grows
+    during a turn), and the per-row-versus-shared structure the row list above
+    states. Not depending on it: the column count, the addition section's
+    starting count and cap, the growth trigger, the fact that nothing is
+    graded, and the overrun measured in the third mockup.
 
-    `Core` and the grid screen are being built to what the mockups draw today —
-    two strips at most — which is a recorded position, not an answer. If the
-    answer is the per-row strip, this page's row list, its `Elements` section,
-    all three mockups and the grid model change together.
-    Tracked in
-    [#255](https://github.com/derekwinters/connor-multiplying-frogs/issues/255).
-    It was originally asked in
+    Derek's call on [#255](https://github.com/derekwinters/connor-multiplying-frogs/issues/255):
+    "Shared strip — matches today's mockups." `Core` and the grid screen are
+    built to what the mockups already drew — two strips at most, confirmed
+    rather than redrawn. It was originally asked in
     [#227](https://github.com/derekwinters/connor-multiplying-frogs/issues/227),
     which was carrying two questions under one title and was closed once Derek
     answered the other one — superscript carries versus written-out addition
-    rows, the change this page has just absorbed. The layout question itself was
-    never answered, so it has its own issue now.
+    rows, the change this page has already absorbed. The layout question
+    itself is what #255 answered.
 
 - **2. What happens to the second carry strip as the section grows?** Today it
   is pinned directly above the answer row. Three readings, none picked: it stays
@@ -363,11 +365,20 @@ older. Question 1 is the one that changes what `Core` builds.
   redrawn `68 × 5` mockup uses the two-digit structure because that is the only
   one this project has drawn — a default in a picture, not a decision.
 
-- **5. Can a grown row be taken away again?** Backspacing the last digit out of
-  a grown row could remove it, or leave it. Leaving it means a mis-tap costs a
-  row permanently and, near the cap, costs the ability to grow another. Removing
-  it means a row can vanish under the caret. Neither is obviously right and
-  neither is stated.
+- **5. Can a grown row be taken away again? Settled: yes.** Derek, on
+  [#204](https://github.com/derekwinters/connor-multiplying-frogs/issues/204):
+  backspacing the last digit out of a grown row removes the row. This is
+  Core-level state, not just drawing — the grid model needs a transition for
+  the addition section shrinking by one row, not only growing by one.
+  [`WorkingOutGrid`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/Assets/Scripts/Core/WorkingOutGrid.cs)
+  reports the grid for a given `(card, addition row count)` snapshot, so a
+  shrink is nothing more than the next snapshot's count being one lower — it
+  does not need an operation of its own. `GridAdditionRowsAtStart` is the
+  floor: no snapshot may ask for fewer, because no card is ever dealt fewer.
+  What is not settled, and is not this page's or `Core`'s to settle: whether
+  removing a row the player isn't currently at (not the section's bottom row)
+  is reachable at all — that is the caret-and-keypad interaction policy, owned
+  by whichever issue builds turn interaction.
 
 - **6. Should the keypad have an `=`?** No, currently: `Check it` is the commit,
   and two ways to submit is one too many.


### PR DESCRIPTION
This is the piece of logic that decides what the working-out grid looks like before any of it is drawn: how many columns, which rows, and what kind of cell sits in each position. Columns are still purely a function of the card's shape. Rows are now a function of the card *and* how many addition rows are currently grown in, because #234 made the addition section growable on every card — a single-digit card gets it too, starting at 2 rows and capable of growing to 6.

**Docs:** `docs/adr/0002-structured-working-out-grid.md` — a short amendment reconciling "a sum row" to the settled layout (two partial-product rows, a shared second carry strip, the answer row as the sum), in the style of the existing amendment note on the next bullet. `docs/specs/ui/working-out-grid.md` — a line stating the row table's `rule` entries are drawn separators, not rows `Core` reports; open question 1 marked settled ("shared strip," confirming today's mockups, per Derek on #255); and open question 5 marked settled (a grown row can be removed, which this model handles as the next `(card, count)` snapshot simply reporting a lower count).

## Spec invariants

- **The grid is sized to the card in its columns, and never to the card's actual answer.** Tested by drawing many Easy-shaped cards from a fixed seed and asserting they never disagree on column count even though their answers' digit counts differ (`For_TwoCardsOfTheSameShapeWithDifferentAnswerDigitCounts_ReportIdenticalGrids`).
- **Every card is dealt the same row kinds, top to bottom, regardless of multiplier width.** Tested across all three piles (`For_EveryShapeAtTheStartingRowCount_ReportsTheSameRowKindList`).
- **The addition section never holds fewer than `GridAdditionRowsAtStart` or more than `GridAdditionRowsMax` rows**, and every count in between is reportable (`For_AnAdditionRowCountWithinBounds_...`, plus the two out-of-range rejection tests).
- **Two carry strips, always, regardless of how many addition rows exist** — the shared-strip convention Derek confirmed on #255 (`For_AnyAdditionRowCount_TheCarryStripCountStaysFixedAtTwo`).
- **Nothing in the grid is marked, and this type has no notion of correct.** No cell carries player-entered content or a right/wrong flag; the only content a cell ever carries is a card's own printed digit.
- **No px value from the spec page's constants table appears in `Core`.** Only counts (`GridAdditionRowsAtStart`, `GridAdditionRowsMax`, `CarryStripCount`) are named constants here, matching the spec page's own constant names.

## How the spec is changing

Old rule (what #204 was written against, before #234 landed): row *kinds* depended on the multiplier's digit count — four rows for a 1-digit multiplier, seven for a 2-digit one, with a fixed pair of partial-product rows.

New rule (what `docs/specs/ui/working-out-grid.md` states today): every card gets the identical row-kind list — carry strip, multiplicand, multiplier, addition rows, carry strip, answer row — and the only thing that varies is how many addition rows are currently grown in (2 to 6), which is player state, not something the card decides. `WorkingOutGrid.For` reflects that split directly: it takes the card and the current addition-row count and reports the grid for that one snapshot.

Why the new one is better: it's what's actually built and mocked up (`working-out-grid-68x5.html` now gets the addition section too), and it keeps "what the card decides" and "what the player decides" as two separate inputs rather than baking player state into a card-derived model.

## Deviations and Decisions

- **Built against the current docs, not #204's literal checklist — deliberately, and worth being explicit about.** #204's checklist was written before #234 merged and describes a model that's now false: fixed four-row / seven-row lists keyed off multiplier width, a `2-digit × 1-digit` card getting no addition section, and column-count examples that don't discriminate the row-count question at all. Per `CLAUDE.md`, code that disagrees with `/docs` is a bug in one of them, and `docs/specs/ui/working-out-grid.md`'s own "invariants this page used to carry" section already names #234 as the thing that made that model false and instructs building against the growable-section model instead. I did that: the row-kind list is identical for every shape, and the addition-row count is a second input rather than something the multiplier's width determines. The tests in this PR assert the current model, not #204's stale fixed counts.
- **`WorkingOutGrid.For` takes `(card, additionRowCount)` rather than `card` alone.** Since the addition section can grow and shrink during a turn, the grid's shape is no longer a pure function of the card. This type reports the grid for one snapshot and has no opinion on when the count should change — that's turn-interaction policy, left to #210 and the UI issues. This is the design split the issue asked me to judge carefully, and it's what `working-out-grid.md`'s own "What `Core` decides, and what the player decides" table already states, so I read it as confirming the split rather than inventing one.
- **Open question 5 (can a grown row be removed) needed no new operation on this type.** Removing a row is exactly the next snapshot's `additionRowCount` being one lower than the last; `WorkingOutGrid.For` already reports that correctly, so nothing beyond the existing `[GridAdditionRowsAtStart, GridAdditionRowsMax]` bound was needed. I did not invent a growth/shrink *policy* beyond that bound — e.g., whether removing a non-bottom row is reachable at all is explicitly left open in the docs as an interaction-layer question, not a `Core` one.
- **Cell-kind and printed-digit tests are derived from drawn cards, not hard-coded operand pairs.** `Card` only constructs through `Card.Draw(Pile, Rng)`; there's no way to build a literal `68 × 5` card directly. Tests draw from a fixed seed (matching `CardTests`' own pattern) and assert against the drawn card's own `Multiplicand`/`Multiplier`, rather than against a hand-picked pair — this is a test-construction detail, not a change in what's being asserted.
- Everything else in #204 — the ADR-0002 "sum row" reconciliation, the ban on any px value or a `Rule`/`SumRow` kind, the ban on this type knowing about a roll/pile/turn/correct-answer, named constants for row/column counts — is unaffected by #234 and is built exactly as #204 asked.

Closes #204
Closes #255


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_