### PR TITLE
feat(core): add the Game type — roster, turn order, and turn phases

### DIFF
--- a/Assets/Scripts/Core/FrogColour.cs
+++ b/Assets/Scripts/Core/FrogColour.cs
@@ -1,0 +1,28 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// Which of the four frogs a player is playing. Exactly four are ever
+    /// offered — docs/specs/ui/shared-components.md#frog-colours: "exactly
+    /// four are offered" — and a <see cref="Game"/> never accepts two roster
+    /// entries of the same colour.
+    ///
+    /// Turn order is not this type's concern: a colour says who a frog *is*,
+    /// not where it sits or when it goes. The order a <see cref="Game"/> is
+    /// constructed with is the turn order, first to last — see
+    /// docs/specs/ui/game-setup.md#invariants.
+    /// </summary>
+    public enum FrogColour
+    {
+        /// <summary>docs/specs/ui/shared-components.md § Named constants — `FrogGreen`.</summary>
+        Green,
+
+        /// <summary>docs/specs/ui/shared-components.md § Named constants — `FrogBlue`.</summary>
+        Blue,
+
+        /// <summary>docs/specs/ui/shared-components.md § Named constants — `FrogOrange`.</summary>
+        Orange,
+
+        /// <summary>docs/specs/ui/shared-components.md § Named constants — `FrogPink`.</summary>
+        Pink
+    }
+}

--- a/Assets/Scripts/Core/FrogColour.cs.meta
+++ b/Assets/Scripts/Core/FrogColour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a971c8906f2144cd89538c6032a2da44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// A whole game: the roster and its turn order, a <see cref="Lane"/> per
+    /// frog, and which of the five <see cref="TurnPhase"/> moments the
+    /// current turn is in. A screen asks this type "whose turn is it, and
+    /// what should I be showing right now?" — nothing else holds that answer.
+    ///
+    /// A <see cref="Game"/> owns advancing to the next player and the rule
+    /// that a turn's phase only ever moves forward one step at a time. It
+    /// does **not** own whether an answer is right or how far a frog moves as
+    /// a result — that is grading, <c>core-turn-resolution</c> (#210). It
+    /// does **not** own how a game ends — that is <c>core-game-end</c> (#211).
+    /// This type only guarantees that advancing to the next player never
+    /// hangs, even when every frog is home, so #211 has a seam to build on.
+    /// </summary>
+    public sealed class Game
+    {
+        /// <summary>
+        /// The fewest frogs a game can be played with.
+        /// docs/specs/ui/game-setup.md#invariants: "a game cannot start with
+        /// fewer than two frogs."
+        /// </summary>
+        public const int MinFrogsPerGame = 2;
+
+        /// <summary>
+        /// The most frogs a game can be played with — a recorded rule change
+        /// from the classroom game's 2–8 players; see ADR-0001 and
+        /// docs/specs/future-ideas.md#five-to-eight-players.
+        /// docs/specs/ui/game-setup.md#invariants: "or more than four."
+        /// </summary>
+        public const int MaxFrogsPerGame = 4;
+
+        readonly FrogColour[] _turnOrder;
+        readonly IReadOnlyDictionary<FrogColour, Lane> _lanes;
+        readonly Rng _rng;
+        readonly ulong _seed;
+
+        int _activeIndex;
+        TurnPhase _phase;
+        Roll _drawnRoll;
+        Card _drawnCard;
+
+        /// <summary>
+        /// A game for <paramref name="turnOrder"/> — already-ordered, first
+        /// frog to last — running on <paramref name="seed"/>.
+        /// docs/specs/ui/game-setup.md#behaviour: "`Start` begins the game
+        /// with the chosen frogs in badge order" — the order the caller hands
+        /// in *is* the turn order; this type does not reorder it.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="turnOrder"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="turnOrder"/> has fewer than <see cref="MinFrogsPerGame"/>
+        /// or more than <see cref="MaxFrogsPerGame"/> frogs.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="turnOrder"/> lists the same colour twice — two
+        /// frogs in the same game are never the same colour.
+        /// </exception>
+        public Game(IReadOnlyList<FrogColour> turnOrder, ulong seed)
+        {
+            if (turnOrder == null)
+            {
+                throw new ArgumentNullException(nameof(turnOrder));
+            }
+
+            if (turnOrder.Count < MinFrogsPerGame || turnOrder.Count > MaxFrogsPerGame)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(turnOrder),
+                    turnOrder.Count,
+                    $"a game is {MinFrogsPerGame} to {MaxFrogsPerGame} frogs; {turnOrder.Count} is neither.");
+            }
+
+            if (turnOrder.Distinct().Count() != turnOrder.Count)
+            {
+                throw new ArgumentException(
+                    "two frogs in the same game are never the same colour.",
+                    nameof(turnOrder));
+            }
+
+            _turnOrder = turnOrder.ToArray();
+
+            var lanes = new Dictionary<FrogColour, Lane>();
+            foreach (var colour in _turnOrder)
+            {
+                lanes[colour] = new Lane();
+            }
+            _lanes = lanes;
+
+            _seed = seed;
+            _rng = Rng.FromSeed(seed);
+            _activeIndex = 0;
+            _phase = TurnPhase.WaitingToRoll;
+        }
+
+        /// <summary>The roster, first frog to last — the order turns are taken in.</summary>
+        public IReadOnlyList<FrogColour> TurnOrder
+        {
+            get { return _turnOrder; }
+        }
+
+        /// <summary>The frog whose turn it currently is.</summary>
+        public FrogColour ActiveFrog
+        {
+            get { return _turnOrder[_activeIndex]; }
+        }
+
+        /// <summary>Which of the five moments the current turn is in.</summary>
+        public TurnPhase Phase
+        {
+            get { return _phase; }
+        }
+
+        /// <summary>
+        /// The seed this game is running on — exactly the seed it was
+        /// constructed with, not the generator's current state. See
+        /// docs/adr/0004-core-owns-the-save-format.md.
+        /// </summary>
+        public ulong Seed
+        {
+            get { return _seed; }
+        }
+
+        /// <summary>
+        /// The roll the current turn drew, from <see cref="TurnPhase.RolledAndCardDrawn"/>
+        /// onward. Null before the first roll of a turn.
+        /// </summary>
+        public Roll DrawnRoll
+        {
+            get { return _drawnRoll; }
+        }
+
+        /// <summary>
+        /// The card the current turn drew, from <see cref="TurnPhase.RolledAndCardDrawn"/>
+        /// onward — the seam #203 exists for. Null before the first roll of a
+        /// turn.
+        /// </summary>
+        public Card DrawnCard
+        {
+            get { return _drawnCard; }
+        }
+
+        /// <summary>
+        /// The frog that would become active next — turn order, skipping any
+        /// frog that is home — without changing anything. This is the fact
+        /// docs/specs/ui/answer-result.md's button label needs while the
+        /// dialog is still open on the *current* player's result, before
+        /// hand-off has run.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Every frog in turn order is home — there is no next frog.
+        /// </exception>
+        public FrogColour NextActiveFrog
+        {
+            get { return _turnOrder[NextActiveIndex()]; }
+        }
+
+        /// <summary>This frog's lane — where it is, and whether it is home.</summary>
+        /// <exception cref="ArgumentException"><paramref name="colour"/> is not in this game's roster.</exception>
+        public Lane LaneFor(FrogColour colour)
+        {
+            if (!_lanes.TryGetValue(colour, out var lane))
+            {
+                throw new ArgumentException($"{colour} is not in this game's roster.", nameof(colour));
+            }
+
+            return lane;
+        }
+
+        /// <summary>
+        /// Opens the turn: draws the roll and the card it sends the turn to,
+        /// from this game's own seeded generator and nothing else. Moves the
+        /// phase from <see cref="TurnPhase.WaitingToRoll"/> to
+        /// <see cref="TurnPhase.RolledAndCardDrawn"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The turn is not waiting to roll.</exception>
+        public void RollDie()
+        {
+            RequirePhase(TurnPhase.WaitingToRoll);
+
+            _drawnRoll = Roll.Draw(_rng);
+            _drawnCard = Card.Draw(_drawnRoll.Pile, _rng);
+            _phase = TurnPhase.RolledAndCardDrawn;
+        }
+
+        /// <summary>
+        /// Moves the phase from <see cref="TurnPhase.RolledAndCardDrawn"/> to
+        /// <see cref="TurnPhase.Answering"/> — the working-out grid opens.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The turn has not drawn a card yet.</exception>
+        public void BeginAnswering()
+        {
+            RequirePhase(TurnPhase.RolledAndCardDrawn);
+            _phase = TurnPhase.Answering;
+        }
+
+        /// <summary>
+        /// Moves the phase from <see cref="TurnPhase.Answering"/> to
+        /// <see cref="TurnPhase.ResultShown"/>. Deciding whether the answer
+        /// was right belongs to <c>core-turn-resolution</c> (#210), not this
+        /// type — this only moves the phase along.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The turn is not answering.</exception>
+        public void ShowResult()
+        {
+            RequirePhase(TurnPhase.Answering);
+            _phase = TurnPhase.ResultShown;
+        }
+
+        /// <summary>
+        /// Moves the phase from <see cref="TurnPhase.ResultShown"/> to
+        /// <see cref="TurnPhase.HandOff"/> — the result dialog closes and the
+        /// board is back on screen for the frog's hop.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The turn's result is not shown.</exception>
+        public void BeginHandOff()
+        {
+            RequirePhase(TurnPhase.ResultShown);
+            _phase = TurnPhase.HandOff;
+        }
+
+        /// <summary>
+        /// Completes the hand-off: advances the active frog to the next frog
+        /// in turn order — skipping any frog that is home — and resets that
+        /// frog's turn to <see cref="TurnPhase.WaitingToRoll"/>.
+        /// docs/specs/ui/game-board.md#behaviour: "A frog that is home is
+        /// skipped in turn order."
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The turn is not mid-hand-off, or every frog in turn order is home.
+        /// </exception>
+        public void CompleteHandOff()
+        {
+            RequirePhase(TurnPhase.HandOff);
+
+            _activeIndex = NextActiveIndex();
+            _phase = TurnPhase.WaitingToRoll;
+            _drawnRoll = null;
+            _drawnCard = null;
+        }
+
+        void RequirePhase(TurnPhase required)
+        {
+            if (_phase != required)
+            {
+                throw new InvalidOperationException(
+                    $"this call needs the turn to be {required}, but it is {_phase}.");
+            }
+        }
+
+        // Turn order minus whoever is already home, starting the search one
+        // past the active frog and wrapping all the way around back to it —
+        // which is what lets the lone frog left not home be its own answer.
+        int NextActiveIndex()
+        {
+            for (var offset = 1; offset <= _turnOrder.Length; offset++)
+            {
+                var candidate = (_activeIndex + offset) % _turnOrder.Length;
+
+                if (!_lanes[_turnOrder[candidate]].IsHome)
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException(
+                "every frog in turn order is home; there is no next frog to advance to.");
+        }
+    }
+}

--- a/Assets/Scripts/Core/Game.cs.meta
+++ b/Assets/Scripts/Core/Game.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7711fa023ac743818039503817b22dac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/TurnPhase.cs
+++ b/Assets/Scripts/Core/TurnPhase.cs
@@ -1,0 +1,46 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One of the five moments a turn is in, in the fixed order a turn moves
+    /// through them — docs/specs/ui/game-board.md#behaviour: "`Roll` → roll
+    /// and card → working-out grid → answer result → back here with the frog
+    /// moved and the turn passed to the next frog in order," and CONTEXT.md's
+    /// definition of hand-off ("the board is on screen during a hand-off and
+    /// not during the rest of a turn").
+    ///
+    /// A <see cref="Game"/> only ever moves one step forward through this
+    /// order; it never skips a phase and never goes backwards. Grading an
+    /// answer (what happens inside <see cref="Answering"/> and
+    /// <see cref="ResultShown"/>) and how a game ends are not this type's
+    /// concern — see <see cref="Game"/>.
+    /// </summary>
+    public enum TurnPhase
+    {
+        /// <summary>[Game board](docs/specs/ui/game-board.md): `Roll` enabled, nothing rolled yet.</summary>
+        WaitingToRoll,
+
+        /// <summary>
+        /// [Roll and card](docs/specs/ui/roll-and-card.md): the die has
+        /// landed, the pile is fixed, the card is on screen.
+        /// </summary>
+        RolledAndCardDrawn,
+
+        /// <summary>
+        /// [Working-out grid](docs/specs/ui/working-out-grid.md): the grid
+        /// and its keypad, filling in the answer row.
+        /// </summary>
+        Answering,
+
+        /// <summary>
+        /// [Answer result](docs/specs/ui/answer-result.md): right or wrong,
+        /// the frog's move stated in words before it happens.
+        /// </summary>
+        ResultShown,
+
+        /// <summary>
+        /// Back on the [game board](docs/specs/ui/game-board.md): the frog's
+        /// hop animates, then the device passes to the next frog.
+        /// </summary>
+        HandOff
+    }
+}

--- a/Assets/Scripts/Core/TurnPhase.cs.meta
+++ b/Assets/Scripts/Core/TurnPhase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 565fe30870a145c098f674f3508268f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/FrogColourTests.cs
+++ b/Tests/Core/FrogColourTests.cs
@@ -1,0 +1,23 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="FrogColour"/> is the fixed set of four colours a player can
+    /// be — docs/specs/ui/shared-components.md#frog-colours: "exactly four
+    /// are offered". Nothing else about a frog (turn order, its lane) is this
+    /// type's concern.
+    /// </summary>
+    public sealed class FrogColourTests
+    {
+        [Test]
+        public void FrogColour_HasExactlyTheFourNamedMembers()
+        {
+            var members = Enum.GetNames(typeof(FrogColour));
+
+            Assert.That(members, Is.EquivalentTo(new[] { "Green", "Blue", "Orange", "Pink" }));
+        }
+    }
+}

--- a/Tests/Core/GameTests.cs
+++ b/Tests/Core/GameTests.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="Game"/> owns the roster, turn order, and the five phases of
+    /// a turn. It does not decide whether an answer is right (#210) or how a
+    /// game ends (#211) — every test here stays on this side of both lines.
+    /// </summary>
+    public sealed class GameTests
+    {
+        const ulong Seed = 12345UL;
+
+        [Test]
+        public void ConstructedFromTwoFrogs_SetsTurnOrderToTheRosterOrder_WithTheFirstFrogActive()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+
+            var game = new Game(roster, Seed);
+
+            Assert.That(game.TurnOrder, Is.EqualTo(roster));
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+        }
+
+        [Test]
+        public void ConstructedFromFourFrogs_TheMaximum_MatchesTheRosterOrderForAllFour()
+        {
+            var roster = new[] { FrogColour.Pink, FrogColour.Orange, FrogColour.Blue, FrogColour.Green };
+
+            var game = new Game(roster, Seed);
+
+            Assert.That(game.TurnOrder, Is.EqualTo(roster));
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Pink));
+        }
+
+        [Test]
+        public void ConstructedFromOneFrog_BelowTheMinimum_IsRejected()
+        {
+            var roster = new[] { FrogColour.Green };
+
+            Assert.That(
+                () => new Game(roster, Seed),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void ConstructedFromFiveFrogs_AboveTheMaximum_IsRejected()
+        {
+            var roster = new[]
+            {
+                FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink, FrogColour.Green
+            };
+
+            Assert.That(
+                () => new Game(roster, Seed),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void ConstructedWithTheSameColourTwice_IsRejected()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Green };
+
+            Assert.That(
+                () => new Game(roster, Seed),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        // docs/specs/ui/game-board.md#behaviour: "Entering from game setup:
+        // every frog on its Start log, frog 1 active, `Roll` enabled."
+        [Test]
+        public void ANewGame_StartsWaitingToRoll()
+        {
+            var game = new Game(FourFrogRoster(), Seed);
+
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+        }
+
+        [Test]
+        public void ThePhase_AdvancesOneStepAtATime_AndRejectsSkippingAStep()
+        {
+            var game = new Game(FourFrogRoster(), Seed);
+
+            // Skipping straight from waiting-to-roll to answering — nothing
+            // has been rolled or drawn yet.
+            Assert.That(() => game.BeginAnswering(), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+
+            game.RollDie();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.RolledAndCardDrawn));
+
+            // Skipping straight from rolled-and-card-drawn to result-shown.
+            Assert.That(() => game.ShowResult(), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.RolledAndCardDrawn));
+
+            game.BeginAnswering();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.Answering));
+
+            game.ShowResult();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.ResultShown));
+
+            game.BeginHandOff();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.HandOff));
+        }
+
+        [Test]
+        public void TheRolledAndCardDrawnPhase_CarriesTheCardTheTurnDrew()
+        {
+            var game = new Game(FourFrogRoster(), Seed);
+
+            game.RollDie();
+
+            Assert.That(game.DrawnCard, Is.Not.Null);
+            Assert.That(game.DrawnCard.Multiplicand, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void CompletingHandOff_AdvancesTheActiveFrog_AndResetsItsPhaseToWaitingToRoll()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+
+            PlayThroughOneTurn(game);
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+        }
+
+        [Test]
+        public void CompletingHandOff_ForTheLastFrogInTurnOrder_WrapsBackAroundToTheFirst()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+
+            PlayThroughOneTurn(game); // Green -> Blue
+            PlayThroughOneTurn(game); // Blue -> Orange
+            PlayThroughOneTurn(game); // Orange -> back to Green
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+        }
+
+        // docs/specs/ui/game-board.md#behaviour: "A frog that is home is
+        // skipped in turn order." Driven by advancing the Lane directly, not
+        // by answering a question — grading and moving a frog is #210's job.
+        [Test]
+        public void CompletingHandOff_SkipsAFrogThatIsHome()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Blue);
+
+            PlayThroughOneTurn(game); // Green -> Blue is home, so -> Orange
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Orange));
+        }
+
+        [Test]
+        public void IfEveryFrogButOneIsHome_AdvancingAlwaysReturnsToThatOneFrog()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Blue);
+            SendHome(game, FrogColour.Orange);
+            SendHome(game, FrogColour.Pink);
+
+            PlayThroughOneTurn(game); // Green -> Blue, Orange, Pink all home -> back to Green
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+        }
+
+        [Test]
+        [Timeout(5000)]
+        public void AdvancingWhenEveryFrogIsHome_ThrowsInsteadOfHangingForever()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Green);
+            SendHome(game, FrogColour.Blue);
+
+            game.RollDie();
+            game.BeginAnswering();
+            game.ShowResult();
+            game.BeginHandOff();
+
+            Assert.That(() => game.CompleteHandOff(), Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void NextActiveFrog_IsTheNextFrogInTurnOrderThatIsNotHome_WithoutAdvancingAnything()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+
+            Assert.That(game.NextActiveFrog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+        }
+
+        [Test]
+        public void NextActiveFrog_SkipsOverConsecutiveHomeFrogs()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Blue);
+            SendHome(game, FrogColour.Orange);
+
+            Assert.That(game.NextActiveFrog, Is.EqualTo(FrogColour.Pink));
+        }
+
+        [Test]
+        public void NextActiveFrog_WhenOnlyTheActiveFrogIsNotHome_WalksAllTheWayAroundBackToIt()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Blue);
+            SendHome(game, FrogColour.Orange);
+
+            Assert.That(game.NextActiveFrog, Is.EqualTo(FrogColour.Green));
+        }
+
+        [Test]
+        public void NextActiveFrog_NeverMutatesTheGame_EvenCalledSeveralTimesInARow()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Blue);
+            game.RollDie();
+
+            var activeBefore = game.ActiveFrog;
+            var phaseBefore = game.Phase;
+            var positionsBefore = roster.Select(colour => game.LaneFor(colour).Position).ToArray();
+
+            _ = game.NextActiveFrog;
+            _ = game.NextActiveFrog;
+            _ = game.NextActiveFrog;
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(activeBefore));
+            Assert.That(game.Phase, Is.EqualTo(phaseBefore));
+            Assert.That(
+                roster.Select(colour => game.LaneFor(colour).Position).ToArray(),
+                Is.EqualTo(positionsBefore));
+        }
+
+        // Frogs are independent (docs/specs/rules.md), and so are games: a
+        // save, a scripted test, and a live game must never be able to leak
+        // state into one another through shared mutable objects.
+        [Test]
+        public void TwoIndependentGames_NeverAffectOneAnother()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var touched = new Game(roster, Seed);
+            var untouched = new Game(roster, Seed);
+
+            touched.LaneFor(FrogColour.Green).MoveForward();
+            PlayThroughOneTurn(touched);
+
+            Assert.That(untouched.ActiveFrog, Is.EqualTo(FrogColour.Green));
+            Assert.That(untouched.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+            Assert.That(untouched.LaneFor(FrogColour.Green).Position, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TwoGamesWithTheSameSeedAndRoster_PlayedThroughTheSameTurns_ProduceTheSameRollsAndCards()
+        {
+            var roster = FourFrogRoster();
+            var first = new Game(roster, Seed);
+            var second = new Game(roster, Seed);
+
+            for (var turn = 0; turn < TurnsToPlay; turn++)
+            {
+                first.RollDie();
+                second.RollDie();
+
+                Assert.That(second.DrawnRoll.Face, Is.EqualTo(first.DrawnRoll.Face), $"turn {turn}: face");
+                Assert.That(
+                    second.DrawnCard.Multiplicand, Is.EqualTo(first.DrawnCard.Multiplicand), $"turn {turn}: multiplicand");
+                Assert.That(
+                    second.DrawnCard.Multiplier, Is.EqualTo(first.DrawnCard.Multiplier), $"turn {turn}: multiplier");
+
+                FinishTurnFrom(first, TurnPhase.RolledAndCardDrawn);
+                FinishTurnFrom(second, TurnPhase.RolledAndCardDrawn);
+            }
+        }
+
+        [Test]
+        public void TwoGamesWithDifferentSeeds_PlayedThroughTheSameTurns_Diverge()
+        {
+            var roster = FourFrogRoster();
+            var first = new Game(roster, Seed);
+            var second = new Game(roster, Seed + 1);
+
+            var diverged = false;
+
+            for (var turn = 0; turn < TurnsToPlay && !diverged; turn++)
+            {
+                first.RollDie();
+                second.RollDie();
+
+                if (second.DrawnRoll.Face != first.DrawnRoll.Face
+                    || second.DrawnCard.Multiplicand != first.DrawnCard.Multiplicand
+                    || second.DrawnCard.Multiplier != first.DrawnCard.Multiplier)
+                {
+                    diverged = true;
+                }
+
+                FinishTurnFrom(first, TurnPhase.RolledAndCardDrawn);
+                FinishTurnFrom(second, TurnPhase.RolledAndCardDrawn);
+            }
+
+            Assert.That(diverged, Is.True, $"no roll or card differed across {TurnsToPlay} turns");
+        }
+
+        [Test]
+        public void TheSeedAGameIsRunningOn_IsReadableBack_AndMatchesTheConstructorSeed()
+        {
+            var game = new Game(FourFrogRoster(), Seed);
+
+            Assert.That(game.Seed, Is.EqualTo(Seed));
+        }
+
+        const int TurnsToPlay = 12;
+
+        static FrogColour[] FourFrogRoster()
+        {
+            return new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+        }
+
+        // Drives one whole turn from wherever the phase currently is through
+        // to hand-off completing — the game-board.md sequence, minus the
+        // roll if it has already happened this turn.
+        static void PlayThroughOneTurn(Game game)
+        {
+            FinishTurnFrom(game, TurnPhase.WaitingToRoll);
+        }
+
+        static void FinishTurnFrom(Game game, TurnPhase phase)
+        {
+            if (phase == TurnPhase.WaitingToRoll)
+            {
+                game.RollDie();
+            }
+
+            game.BeginAnswering();
+            game.ShowResult();
+            game.BeginHandOff();
+            game.CompleteHandOff();
+        }
+
+        // Sends a frog home by advancing its Lane directly to the End log —
+        // not by answering a question. Moving a frog as the result of an
+        // answer is #210's job and is not reached for here.
+        static void SendHome(Game game, FrogColour colour)
+        {
+            var lane = game.LaneFor(colour);
+
+            while (!lane.IsHome)
+            {
+                lane.MoveForward();
+            }
+        }
+    }
+}

--- a/Tests/Core/TurnPhaseTests.cs
+++ b/Tests/Core/TurnPhaseTests.cs
@@ -1,0 +1,32 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="TurnPhase"/> is the fixed sequence a turn's screens follow —
+    /// docs/specs/ui/game-board.md#behaviour: "`Roll` → roll and card →
+    /// working-out grid → answer result → back here with the frog moved and
+    /// the turn passed to the next frog in order," read together with
+    /// CONTEXT.md's definition of hand-off. The order these members are
+    /// declared in is the order <see cref="Game"/> moves through them.
+    /// </summary>
+    public sealed class TurnPhaseTests
+    {
+        [Test]
+        public void TurnPhase_HasExactlyTheFiveNamedMembersInOrder()
+        {
+            var members = Enum.GetNames(typeof(TurnPhase));
+
+            Assert.That(members, Is.EqualTo(new[]
+            {
+                "WaitingToRoll",
+                "RolledAndCardDrawn",
+                "Answering",
+                "ResultShown",
+                "HandOff"
+            }));
+        }
+    }
+}


### PR DESCRIPTION
Closes #208

Core gains a `Game` type: the piece that knows who is playing, in what order, and which of the five moments a turn is currently in — waiting to roll, rolled and a card drawn, answering, result shown, and hand-off. It tracks a lane per frog, skips a home frog when picking who goes next, and can answer "whose turn is it after this one" without actually ending the current turn — which is what the answer-result screen's next-player button needs while its dialog is still open.

**Docs:** None — the roster cap, turn order, and the turn's screen sequence were already stated in `docs/specs/ui/game-setup.md`, `game-board.md`, `roll-and-card.md`, `working-out-grid.md`, `answer-result.md`, `shared-components.md`, and `CONTEXT.md`; this PR implements them in Core without changing what any of those pages say.

## Spec invariants

- **Turn order is roster order, unchanged.** `Game.TurnOrder` is exactly the order the constructor was handed — asserted for both a 2-frog and a 4-frog roster.
- **A turn's phase only ever moves forward one step, never skips.** Each phase-transition method (`RollDie`, `BeginAnswering`, `ShowResult`, `BeginHandOff`, `CompleteHandOff`) checks its own precondition and throws `InvalidOperationException` on an out-of-order call — asserted directly by attempting to skip a step mid-sequence.
- **A home frog is skipped in turn order, and advancing never hangs even when every frog is home.** `NextActiveIndex` walks the roster starting one past the active frog and wrapping all the way back around to it; if no frog is found not-home, it throws rather than looping. Verified two ways: by watching the dedicated tests fail once this logic is temporarily reverted to a naive unconditional advance, then restoring it.
- **The read-only "who's next" query never mutates anything.** `NextActiveFrog` reads `NextActiveIndex()` without assigning it. Verified the same way — temporarily made the getter mutate `_activeIndex`, watched the never-mutates test fail, then restored the read-only version.
- **A game is deterministic from its seed.** Two games built from the same roster and seed, played through the same sequence of turns, draw identical roll faces and cards every turn; two games with different seeds diverge somewhere across 12 turns.

## Deviations and Decisions

- Exposed `Game.DrawnRoll` alongside `Game.DrawnCard`. The checklist only names the card as retrievable, but the seeded-determinism tests it also asks for ("the same rolls and the same cards") can't be written honestly without a way to observe the actual die face — two faces can map to the same pile, so the card alone can't distinguish them. `DrawnRoll` is the minimum needed to test what the issue already asks for, not new surface invented beyond it.
- Five phase-transition methods (`RollDie`, `BeginAnswering`, `ShowResult`, `BeginHandOff`, `CompleteHandOff`), each named for the UI action that triggers it and each validating its own precondition, rather than one generic "advance" method taking a target phase. Both satisfy the checklist's "reject a skipped step" test equally well; the named methods read closer to the screens in `docs/specs/ui` and avoid a stringly-typed call site.
- Applying `skip-docs`: this issue's own "Spec pages touched: None" held all the way through — nothing here changed what any spec page says, only added the Core type those pages already described.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_