### PR TITLE
feat(core): grade the answer and resolve the frog's move

### DIFF
--- a/Assets/Scripts/Core/Lane.cs
+++ b/Assets/Scripts/Core/Lane.cs
@@ -1,10 +1,13 @@
+using System;
+
 namespace Frogs.Core
 {
     /// <summary>
     /// One player's private column: the Start log, seven lily pads, and the
-    /// End log. A <see cref="Lane"/> owns where its frog is and the two moves
-    /// a frog can make — nothing else. Lanes never talk to each other; a
-    /// player's entire state is this one number.
+    /// End log. A <see cref="Lane"/> owns where its frog is, the two moves a
+    /// frog can make, and grading an answer into one of those moves —
+    /// nothing else. Lanes never talk to each other; a player's entire state
+    /// is this one number.
     /// </summary>
     public sealed class Lane
     {
@@ -67,6 +70,44 @@ namespace Frogs.Core
             {
                 _position--;
             }
+        }
+
+        /// <summary>
+        /// Grades <paramref name="submittedAnswer"/> against
+        /// <paramref name="card"/> and applies exactly one of the three
+        /// outcomes docs/specs/rules.md § Moving lists, via
+        /// <see cref="MoveForward"/> or <see cref="MoveBack"/> — no position
+        /// arithmetic of its own. Takes only the submitted answer and the
+        /// card: nothing about how the working-out grid was filled in can
+        /// reach this call (ADR-0002 — nothing in the grid is marked).
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="card"/> is null.</exception>
+        public TurnResolution Resolve(int submittedAnswer, Card card)
+        {
+            if (card == null)
+            {
+                throw new ArgumentNullException(nameof(card));
+            }
+
+            var positionBefore = _position;
+            var isCorrect = submittedAnswer == card.Product;
+
+            if (isCorrect)
+            {
+                MoveForward();
+                return new TurnResolution(TurnOutcome.Correct, positionBefore, _position, card.Product);
+            }
+
+            MoveBack();
+
+            // Which of the two wrong outcomes this was is read off whether
+            // MoveBack actually moved the frog, not by re-checking the Start
+            // log's position here — that clamp already lives in MoveBack.
+            var outcome = _position < positionBefore
+                ? TurnOutcome.WrongAboveStartLog
+                : TurnOutcome.WrongOnStartLog;
+
+            return new TurnResolution(outcome, positionBefore, _position, card.Product);
         }
     }
 }

--- a/Assets/Scripts/Core/TurnOutcome.cs
+++ b/Assets/Scripts/Core/TurnOutcome.cs
@@ -1,0 +1,29 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// Which of the three things happened when a submitted answer was graded
+    /// against a <see cref="Card"/>'s answer — docs/specs/rules.md § Moving:
+    ///
+    /// | Outcome | Effect |
+    /// | --- | --- |
+    /// | Correct | Forward one lily pad |
+    /// | Wrong, anywhere above the Start log | Back one lily pad |
+    /// | Wrong, on the Start log | Stay |
+    ///
+    /// Three outcomes, not two: the Start log is a floor, not a special case,
+    /// so a wrong answer there is its own named outcome rather than a "back"
+    /// that silently does nothing. See <see cref="Lane.Resolve"/>, which maps
+    /// each of these onto the moves <see cref="Lane"/> already provides.
+    /// </summary>
+    public enum TurnOutcome
+    {
+        /// <summary>The submitted answer matched the card. The frog hops forward one lily pad.</summary>
+        Correct,
+
+        /// <summary>The submitted answer was wrong, and the frog was above the Start log. It hops back one lily pad.</summary>
+        WrongAboveStartLog,
+
+        /// <summary>The submitted answer was wrong, and the frog was already on the Start log — the floor. It stays.</summary>
+        WrongOnStartLog
+    }
+}

--- a/Assets/Scripts/Core/TurnOutcome.cs.meta
+++ b/Assets/Scripts/Core/TurnOutcome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65d84f19ea8e429ea3f99b5cee30c78c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/TurnResolution.cs
+++ b/Assets/Scripts/Core/TurnResolution.cs
@@ -1,0 +1,42 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The fact produced by grading one submitted answer — which of the three
+    /// <see cref="TurnOutcome"/>s occurred, the frog's <see cref="Lane"/>
+    /// position immediately before and after, and the card's correct answer.
+    /// See <see cref="Lane.Resolve"/>, the only place this is constructed.
+    ///
+    /// Nothing else. docs/specs/ui/answer-result.md's regions read backwards
+    /// pin exactly these four facts and no more — no formatted strings, no
+    /// colour, no next player, no button label. Those are the dialog's job to
+    /// render (#224) and #208's turn-advancement job to compute, not this
+    /// type's to carry.
+    /// </summary>
+    public sealed class TurnResolution
+    {
+        public TurnResolution(TurnOutcome outcome, int positionBefore, int positionAfter, int correctAnswer)
+        {
+            Outcome = outcome;
+            PositionBefore = positionBefore;
+            PositionAfter = positionAfter;
+            CorrectAnswer = correctAnswer;
+        }
+
+        /// <summary>Which of the three things happened.</summary>
+        public TurnOutcome Outcome { get; }
+
+        /// <summary>The frog's lane position immediately before this answer was graded.</summary>
+        public int PositionBefore { get; }
+
+        /// <summary>The frog's lane position immediately after this answer was graded.</summary>
+        public int PositionAfter { get; }
+
+        /// <summary>
+        /// The card's true answer — revealed on a wrong answer per
+        /// docs/adr/0002-structured-working-out-grid.md ("the correct answer
+        /// is revealed; the working is not"), and equally present on a
+        /// correct one since <c>verdict</c> shows the full equation either way.
+        /// </summary>
+        public int CorrectAnswer { get; }
+    }
+}

--- a/Assets/Scripts/Core/TurnResolution.cs.meta
+++ b/Assets/Scripts/Core/TurnResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdcb7214239c417e914a1eeb3adfcc93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/LaneTests.cs
+++ b/Tests/Core/LaneTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using NUnit.Framework;
 using Frogs.Core;
 
@@ -116,6 +118,93 @@ namespace Frogs.Core.Tests
 
             Assert.That(lane.Position, Is.EqualTo(Lane.LaneWinningPosition));
             Assert.That(lane.IsHome, Is.True);
+        }
+
+        // Resolving a turn grades the submitted answer against the card and
+        // moves the frog exactly as the outcome table in docs/specs/rules.md
+        // says — the resolution entry point maps onto MoveForward/MoveBack,
+        // adding no position arithmetic of its own.
+        [Test]
+        public void Resolve_WithACorrectAnswer_MovesForwardOneLilyPadAndReportsCorrect()
+        {
+            var lane = new Lane();
+            lane.MoveForward();
+            lane.MoveForward();
+            var card = Card.Draw(Pile.Easy, Rng.FromSeed(1));
+
+            var resolution = lane.Resolve(card.Product, card);
+
+            Assert.That(resolution.Outcome, Is.EqualTo(TurnOutcome.Correct));
+            Assert.That(resolution.PositionBefore, Is.EqualTo(2));
+            Assert.That(resolution.PositionAfter, Is.EqualTo(3));
+            Assert.That(resolution.CorrectAnswer, Is.EqualTo(card.Product));
+            Assert.That(lane.Position, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Resolve_WithAWrongAnswerAboveTheStartLog_MovesBackOneLilyPadAndReportsWrongAboveStartLog()
+        {
+            var lane = new Lane();
+            lane.MoveForward();
+            lane.MoveForward();
+            var card = Card.Draw(Pile.Easy, Rng.FromSeed(1));
+
+            var resolution = lane.Resolve(card.Product + 1, card);
+
+            Assert.That(resolution.Outcome, Is.EqualTo(TurnOutcome.WrongAboveStartLog));
+            Assert.That(resolution.PositionBefore, Is.EqualTo(2));
+            Assert.That(resolution.PositionAfter, Is.EqualTo(1));
+            Assert.That(resolution.CorrectAnswer, Is.EqualTo(card.Product));
+            Assert.That(lane.Position, Is.EqualTo(1));
+        }
+
+        // The Start log is a floor, not a special space: a wrong answer here
+        // resolves via the same MoveBack() call as any other wrong answer —
+        // it is Lane's own floor clamp that leaves the position unchanged,
+        // not a clamp reimplemented in Resolve. docs/specs/rules.md — "the
+        // Start log is a floor, not a special space".
+        [Test]
+        public void Resolve_WithAWrongAnswerOnTheStartLog_LeavesThePositionUnchangedAndReportsWrongOnStartLog()
+        {
+            var lane = new Lane();
+            var card = Card.Draw(Pile.Easy, Rng.FromSeed(1));
+
+            var resolution = lane.Resolve(card.Product + 1, card);
+
+            Assert.That(resolution.Outcome, Is.EqualTo(TurnOutcome.WrongOnStartLog));
+            Assert.That(resolution.PositionBefore, Is.EqualTo(0));
+            Assert.That(resolution.PositionAfter, Is.EqualTo(0));
+            Assert.That(resolution.CorrectAnswer, Is.EqualTo(card.Product));
+            Assert.That(lane.Position, Is.EqualTo(0));
+        }
+
+        // Consistent with WorkingOutGrid.For's guard on the same Card
+        // parameter: a null card is a caller error, not a fourth outcome.
+        [Test]
+        public void Resolve_WithANullCard_ThrowsArgumentNullException()
+        {
+            var lane = new Lane();
+
+            Assert.That(() => lane.Resolve(42, null), Throws.ArgumentNullException);
+        }
+
+        // ADR-0002: "nothing in the grid is marked" — only the answer row is
+        // graded. Proved structurally, not just by convention: Resolve's
+        // signature is exactly (int, Card), so there is no parameter or field
+        // the working-out grid's carry boxes or partial-product rows could
+        // even be passed through.
+        [Test]
+        public void Resolve_TakesOnlyTheSubmittedAnswerAndTheCard()
+        {
+            var method = typeof(Lane).GetMethod(nameof(Lane.Resolve));
+
+            Assert.That(method, Is.Not.Null);
+
+            var parameters = method.GetParameters();
+
+            Assert.That(parameters.Length, Is.EqualTo(2));
+            Assert.That(parameters[0].ParameterType, Is.EqualTo(typeof(int)));
+            Assert.That(parameters[1].ParameterType, Is.EqualTo(typeof(Card)));
         }
 
         // Frogs are independent: each player keeps their own lane for the

--- a/Tests/Core/TurnOutcomeTests.cs
+++ b/Tests/Core/TurnOutcomeTests.cs
@@ -1,0 +1,30 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="TurnOutcome"/> is the three, and only three, things that can
+    /// happen when an answer is graded — docs/specs/rules.md § Moving: "a
+    /// frog moves at most one position per turn... [and] the Start log is a
+    /// floor, not a special space." Three outcomes, not two: a wrong answer on
+    /// the Start log is its own named outcome rather than a "back" that
+    /// happens to do nothing.
+    /// </summary>
+    public sealed class TurnOutcomeTests
+    {
+        [Test]
+        public void TurnOutcome_HasExactlyTheThreeNamedMembersInOrder()
+        {
+            var members = Enum.GetNames(typeof(TurnOutcome));
+
+            Assert.That(members, Is.EqualTo(new[]
+            {
+                "Correct",
+                "WrongAboveStartLog",
+                "WrongOnStartLog"
+            }));
+        }
+    }
+}

--- a/Tests/Core/TurnResolutionTests.cs
+++ b/Tests/Core/TurnResolutionTests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="TurnResolution"/> is the fact <see cref="Lane.Resolve"/>
+    /// hands back once an answer is graded — docs/specs/ui/answer-result.md's
+    /// regions read backwards: `mark`/`verdict` need the outcome and the
+    /// card's answer, `chip` needs the position before and after. Nothing
+    /// else — no formatted strings, no colour, no next player, no button
+    /// label; those are the dialog's job (#224) and #208's turn-advancement
+    /// job, not this type's.
+    /// </summary>
+    public sealed class TurnResolutionTests
+    {
+        [Test]
+        public void ANewTurnResolution_CarriesExactlyTheOutcomePositionsAndAnswer()
+        {
+            var resolution = new TurnResolution(TurnOutcome.Correct, 3, 4, 13571);
+
+            Assert.That(resolution.Outcome, Is.EqualTo(TurnOutcome.Correct));
+            Assert.That(resolution.PositionBefore, Is.EqualTo(3));
+            Assert.That(resolution.PositionAfter, Is.EqualTo(4));
+            Assert.That(resolution.CorrectAnswer, Is.EqualTo(13571));
+        }
+
+        // Structural, not behavioural: answer-result.md's regions need exactly
+        // these four facts and nothing more — no formatted strings, no
+        // colour, no next player, no button label. A fifth public member here
+        // would be a fact the dialog was never asked to render.
+        [Test]
+        public void TurnResolution_ExposesNoPublicMembersBeyondTheFourFacts()
+        {
+            var propertyNames = typeof(TurnResolution)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name)
+                .OrderBy(name => name)
+                .ToArray();
+
+            Assert.That(propertyNames, Is.EqualTo(new[]
+            {
+                "CorrectAnswer",
+                "Outcome",
+                "PositionAfter",
+                "PositionBefore"
+            }));
+        }
+    }
+}


### PR DESCRIPTION
Closes #210

This is what happens the instant a player submits an answer: Core compares it to the card, moves the frog exactly one lily pad forward if right, one back if wrong, and — if that back move would fall off the bottom of the lane — leaves the frog exactly where it was on the Start log. Nothing about how the working-out grid was filled in is looked at, only the number in the answer row.

**Docs:** None — this implements a rule already stated fully and precisely in `docs/specs/rules.md`, corroborated by `docs/specs/reference/index.md` and `docs/adr/0002-structured-working-out-grid.md`. No behaviour described in the docs changes.

## Spec invariants

- **A frog moves at most one position per turn, only as the result of the answer just given** (`docs/specs/rules.md` § Moving) — `Lane.Resolve` calls exactly one of `MoveForward`/`MoveBack`, once, and never touches position itself. `LaneTests.Resolve_WithACorrectAnswer_…` / `Resolve_WithAWrongAnswerAboveTheStartLog_…` assert the one-step move.
- **The Start log is a floor, not a special space** (`docs/specs/rules.md`; `reference/index.md#the-start-log-is-a-floor-not-a-special-space`) — the wrong-on-Start-log outcome is read off whether `Lane`'s own clamp in `MoveBack` actually changed the position, not from a position check reimplemented in `Resolve`. `LaneTests.Resolve_WithAWrongAnswerOnTheStartLog_…` asserts the position is unchanged and the outcome is named for it.
- **Only the answer is graded, nothing in the grid is marked** (ADR-0002) — `Resolve`'s signature is exactly `(int submittedAnswer, Card card)`, proved structurally by `LaneTests.Resolve_TakesOnlyTheSubmittedAnswerAndTheCard` via reflection on the method's parameters, so there is no parameter the grid's rows could be passed through.
- **The result carries only the outcome, position before, position after, and the card's correct answer** (`docs/specs/ui/answer-result.md`'s regions read backwards) — `TurnResolutionTests.TurnResolution_ExposesNoPublicMembersBeyondTheFourFacts` asserts the type's public property set is exactly those four, via reflection.

## Deviations and Decisions

- **`Lane.Resolve` is the entry point, not a new resolver type.** The issue's checklist scaffolds only the result type; the grading itself is added as a third method on `Lane` (alongside `MoveForward`/`MoveBack`), since it composes those two moves and needs no state beyond the position `Lane` already owns. A separate `TurnResolver`-style type would have needed to either duplicate `Lane`'s position or take a `Lane` parameter, both less direct than putting it on `Lane` itself.
- **`Lane.Resolve(card: null)` throws `ArgumentNullException`.** Not asked for by the issue, but consistent with `WorkingOutGrid.For`'s existing guard on the same `Card` parameter elsewhere in Core.
- **`skip-docs`** — this issue's checklist calls for it explicitly: the three outcomes and the Start log's floor behaviour are already fully specified in `docs/specs/rules.md`; nothing here changes what any doc page describes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_