### PR TITLE
feat(core): the two ways a game ends, and the standings it produces

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -6,17 +6,24 @@ namespace Frogs.Core
 {
     /// <summary>
     /// A whole game: the roster and its turn order, a <see cref="Lane"/> per
-    /// frog, and which of the five <see cref="TurnPhase"/> moments the
-    /// current turn is in. A screen asks this type "whose turn is it, and
-    /// what should I be showing right now?" — nothing else holds that answer.
+    /// frog, which of the five <see cref="TurnPhase"/> moments the current
+    /// turn is in, and whether the game is over. A screen asks this type
+    /// "whose turn is it, and what should I be showing right now?" and,
+    /// eventually, "is it over, and who won?" — nothing else holds those
+    /// answers.
     ///
     /// A <see cref="Game"/> owns advancing to the next player and the rule
     /// that a turn's phase only ever moves forward one step at a time. It
     /// does **not** own whether an answer is right or how far a frog moves as
     /// a result — that is grading, <c>core-turn-resolution</c> (#210). It
-    /// does **not** own how a game ends — that is <c>core-game-end</c> (#211).
-    /// This type only guarantees that advancing to the next player never
-    /// hangs, even when every frog is home, so #211 has a seam to build on.
+    /// does own the two ways a game ends (<see cref="IsOver"/>) and the
+    /// standings that come out of one (<see cref="Winner"/>,
+    /// <see cref="FinishingOrder"/>, <see cref="Standings"/>) —
+    /// <c>core-game-end</c> (#211). "Every frog home" is computed fresh from
+    /// lane position on every call; a deliberate end and finishing order are
+    /// the two facts nothing about lane position can reconstruct, so they are
+    /// the ones this type remembers, via <see cref="EndGame"/> and
+    /// <see cref="RecordFinish"/>.
     /// </summary>
     public sealed class Game
     {
@@ -44,6 +51,8 @@ namespace Frogs.Core
         TurnPhase _phase;
         Roll _drawnRoll;
         Card _drawnCard;
+        bool _endedDeliberately;
+        readonly List<FrogColour> _finishingOrder = new List<FrogColour>();
 
         /// <summary>
         /// A game for <paramref name="turnOrder"/> — already-ordered, first
@@ -158,6 +167,130 @@ namespace Frogs.Core
         public FrogColour NextActiveFrog
         {
             get { return _turnOrder[NextActiveIndex()]; }
+        }
+
+        /// <summary>
+        /// Whether the game is over — the OR of the two ways it can be:
+        /// every frog is home, or it was ended deliberately.
+        /// docs/specs/reference/index.md#where-v1-fills-a-gap-the-board-leaves-open
+        /// names both. The first fact is computed fresh from every frog's
+        /// lane position each time this is asked — nothing is cached, and
+        /// nothing needs to be told to "notice" a frog landing on the End
+        /// log. The second cannot be computed the same way — a deliberate end
+        /// can happen with frogs still short of home, so it is the one fact
+        /// this type has to remember, set by <see cref="EndGame"/>.
+        /// </summary>
+        public bool IsOver
+        {
+            get { return _endedDeliberately || _turnOrder.All(colour => _lanes[colour].IsHome); }
+        }
+
+        /// <summary>
+        /// Ends the game deliberately, right now, regardless of whether any
+        /// frog is home. docs/specs/reference/index.md#where-v1-fills-a-gap-the-board-leaves-open:
+        /// "A game can be ended deliberately" — purely a v1 gap-fill, not a
+        /// rule the classroom board specifies. Every frog's <see cref="Lane"/>
+        /// is left exactly as it was: ending a game is not losing it — see
+        /// docs/specs/ui/end-game-confirm.md ("stops the game and shows the
+        /// results" rather than resetting anyone).
+        /// </summary>
+        public void EndGame()
+        {
+            _endedDeliberately = true;
+        }
+
+        /// <summary>
+        /// The frog that reached the End log first, or null if the game was
+        /// ended before anyone finished — a well-defined Core answer to "did
+        /// anyone finish, and if so who was first", not a display string.
+        /// docs/specs/ui/game-over.md#invariants: "the winner is the frog
+        /// that reached the End log first."
+        /// </summary>
+        public FrogColour? Winner
+        {
+            get { return _finishingOrder.Count > 0 ? _finishingOrder[0] : (FrogColour?)null; }
+        }
+
+        /// <summary>
+        /// The order frogs got home, first to last. Not roster order, and
+        /// not recomputed from position — every finisher sits on the same
+        /// <see cref="Lane.LaneWinningPosition"/>, so position cannot tell
+        /// them apart; this is only ever the order <see cref="RecordFinish"/>
+        /// was told about arrivals. docs/specs/ui/game-over.md#invariants:
+        /// "finishing order is the order frogs got home."
+        /// </summary>
+        public IReadOnlyList<FrogColour> FinishingOrder
+        {
+            get { return _finishingOrder; }
+        }
+
+        /// <summary>
+        /// Records that <paramref name="colour"/>'s frog has reached the End
+        /// log, if it has — the moment its place in <see cref="FinishingOrder"/>
+        /// has to be captured, since nothing about a frog's position can tell
+        /// arrival order apart afterward. A no-op if the frog is not home, and
+        /// a no-op if it was already recorded — safe to call more than once.
+        /// </summary>
+        /// <exception cref="ArgumentException"><paramref name="colour"/> is not in this game's roster.</exception>
+        public void RecordFinish(FrogColour colour)
+        {
+            var lane = LaneFor(colour);
+
+            if (lane.IsHome && !_finishingOrder.Contains(colour))
+            {
+                _finishingOrder.Add(colour);
+            }
+        }
+
+        /// <summary>
+        /// One row per frog: place, colour, lane position, and whether it is
+        /// home — the fact docs/specs/ui/game-over.md's standings screen
+        /// reads directly. Finishers come first, in <see cref="FinishingOrder"/>;
+        /// everyone else follows, most lily pads made first. Frogs tied on
+        /// lane position share the same place number —
+        /// docs/specs/ui/game-over.md#open-questions: "Two frogs on the same
+        /// pad currently share a place number." No turn-order tiebreak: that
+        /// question is still open, and this does not answer it.
+        /// </summary>
+        public IReadOnlyList<StandingsRow> Standings
+        {
+            get
+            {
+                var unfinished = _turnOrder
+                    .Where(colour => !_finishingOrder.Contains(colour))
+                    .OrderByDescending(colour => _lanes[colour].Position);
+
+                var ranked = _finishingOrder.Concat(unfinished).ToArray();
+                var rows = new List<StandingsRow>(ranked.Length);
+
+                for (var index = 0; index < ranked.Length; index++)
+                {
+                    var colour = ranked[index];
+                    var lane = _lanes[colour];
+
+                    var tiedWithPrevious = index > 0
+                        && !_finishingOrder.Contains(colour)
+                        && !_finishingOrder.Contains(ranked[index - 1])
+                        && lane.Position == _lanes[ranked[index - 1]].Position;
+
+                    var place = tiedWithPrevious ? rows[index - 1].Place : index + 1;
+
+                    rows.Add(new StandingsRow(colour, place, lane.Position, lane.IsHome));
+                }
+
+                return rows;
+            }
+        }
+
+        /// <summary>
+        /// How many frogs have not yet reached their End log — readable at
+        /// any point during play, not only once the game is over. This is
+        /// the count docs/specs/ui/end-game-confirm.md's cost sentence
+        /// builds its wording around ("Three frogs are still swimming...").
+        /// </summary>
+        public int FrogsStillSwimming
+        {
+            get { return _turnOrder.Count(colour => !_lanes[colour].IsHome); }
         }
 
         /// <summary>This frog's lane — where it is, and whether it is home.</summary>

--- a/Assets/Scripts/Core/StandingsRow.cs
+++ b/Assets/Scripts/Core/StandingsRow.cs
@@ -1,0 +1,39 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One frog's row in <see cref="Game.Standings"/> —
+    /// docs/specs/ui/game-over.md's "Standings row × 2–4": a place number, the
+    /// frog, and how far it got. Nothing else; the row's rendering — the
+    /// colour swatch, the name, and formatting <see cref="Position"/> as
+    /// "Home — 8 of 8" or "6 of 8" — is the screen's job, not this type's.
+    /// </summary>
+    public sealed class StandingsRow
+    {
+        public StandingsRow(FrogColour colour, int place, int position, bool isHome)
+        {
+            Colour = colour;
+            Place = place;
+            Position = position;
+            IsHome = isHome;
+        }
+
+        /// <summary>Which frog this row is about.</summary>
+        public FrogColour Colour { get; }
+
+        /// <summary>
+        /// This frog's rank, 1-based. Frogs tied on <see cref="Position"/>
+        /// share the same place number — docs/specs/ui/game-over.md#open-questions:
+        /// "Two frogs on the same pad currently share a place number."
+        /// </summary>
+        public int Place { get; }
+
+        /// <summary>
+        /// This frog's lane position — how many lily pads it made, 0 to
+        /// <see cref="Lane.LaneWinningPosition"/>.
+        /// </summary>
+        public int Position { get; }
+
+        /// <summary>Whether this frog reached the End log.</summary>
+        public bool IsHome { get; }
+    }
+}

--- a/Assets/Scripts/Core/StandingsRow.cs.meta
+++ b/Assets/Scripts/Core/StandingsRow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48493ec3dd42462b9ee125b8e7c53b63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/GameTests.cs
+++ b/Tests/Core/GameTests.cs
@@ -321,6 +321,151 @@ namespace Frogs.Core.Tests
             Assert.That(game.Seed, Is.EqualTo(Seed));
         }
 
+        // docs/specs/reference/index.md#where-v1-fills-a-gap-the-board-leaves-open:
+        // "The game also ends on its own once every frog is home." Computed
+        // fresh from lane position every time it's asked — no flag, and
+        // nothing is called to "notice" it.
+        [Test]
+        public void AGameWhereEveryFrogIsOnItsEndLog_ReportsItselfOver_WithNoSeparateCallNeeded()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var game = new Game(roster, Seed);
+
+            SendHome(game, FrogColour.Green);
+            SendHome(game, FrogColour.Blue);
+
+            Assert.That(game.IsOver, Is.True);
+        }
+
+        // The exact state docs/specs/ui/game-over.md's own mockup is drawn
+        // in — four frogs, one home, three still short of LaneWinningPosition
+        // — described there as "the state where the game was ended before
+        // the others finished."
+        [Test]
+        public void EndingTheGameDeliberately_WithFrogsShortOfHome_ReportsTheGameAsOver()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Green);
+            AdvanceTo(game, FrogColour.Blue, 6);
+            AdvanceTo(game, FrogColour.Orange, 4);
+            AdvanceTo(game, FrogColour.Pink, 1);
+
+            game.EndGame();
+
+            Assert.That(game.IsOver, Is.True);
+        }
+
+        // docs/specs/ui/end-game-confirm.md: ending "stops the game and shows
+        // the results" rather than resetting anyone — every frog keeps the
+        // pads it has.
+        [Test]
+        public void EndingTheGameDeliberately_ChangesNoFrogsPosition()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Green);
+            AdvanceTo(game, FrogColour.Blue, 6);
+            AdvanceTo(game, FrogColour.Orange, 4);
+            AdvanceTo(game, FrogColour.Pink, 1);
+            var positionsBefore = roster.ToDictionary(colour => colour, colour => game.LaneFor(colour).Position);
+
+            game.EndGame();
+
+            foreach (var colour in roster)
+            {
+                Assert.That(game.LaneFor(colour).Position, Is.EqualTo(positionsBefore[colour]), colour.ToString());
+            }
+        }
+
+        // docs/specs/ui/game-over.md#invariants: "the winner is the frog
+        // that reached the End log first, and finishing order is the order
+        // frogs got home." Every finisher sits on the same
+        // Lane.LaneWinningPosition, so position alone cannot tell them apart
+        // afterward — Orange finishes before Blue here even though Blue
+        // comes first in the roster, proving finishing order tracks arrival,
+        // not the roster array.
+        [Test]
+        public void Winner_IsWhicheverFrogFinishedFirst_AndFinishingOrderIsArrivalOrderNotRosterOrder()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Orange);
+
+            game.RecordFinish(FrogColour.Orange);
+
+            Assert.That(game.Winner, Is.EqualTo(FrogColour.Orange));
+            Assert.That(game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Orange }));
+
+            SendHome(game, FrogColour.Blue);
+            game.RecordFinish(FrogColour.Blue);
+
+            Assert.That(game.Winner, Is.EqualTo(FrogColour.Orange), "a later finisher must not change who won");
+            Assert.That(game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Orange, FrogColour.Blue }));
+        }
+
+        // docs/specs/ui/game-over.md: "Frogs that did not finish are ranked
+        // by how many lily pads they made", and the open question's own
+        // wording is the current, still-open-to-change behaviour to build:
+        // "Two frogs on the same pad currently share a place number."
+        [Test]
+        public void Standings_RanksUnfinishedFrogsBelowFinishedOnes_ByLilyPadsMade_WithTiesSharingAPlaceNumber()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink };
+            var game = new Game(roster, Seed);
+            SendHome(game, FrogColour.Green);
+            game.RecordFinish(FrogColour.Green);
+            AdvanceTo(game, FrogColour.Blue, 4);
+            AdvanceTo(game, FrogColour.Orange, 4); // ties with Blue
+            AdvanceTo(game, FrogColour.Pink, 1);
+
+            var standings = game.Standings;
+            var green = standings.Single(row => row.Colour == FrogColour.Green);
+            var blue = standings.Single(row => row.Colour == FrogColour.Blue);
+            var orange = standings.Single(row => row.Colour == FrogColour.Orange);
+            var pink = standings.Single(row => row.Colour == FrogColour.Pink);
+
+            Assert.That(blue.Place, Is.EqualTo(orange.Place), "same lily pad, same place number");
+            Assert.That(blue.Place, Is.GreaterThan(green.Place), "unfinished ranked below every finished frog");
+            Assert.That(pink.Place, Is.GreaterThan(blue.Place), "fewer pads, a lower place");
+        }
+
+        // docs/specs/ui/game-over.md: the headline reads "Game over" rather
+        // than naming a winner when the game was ended before anybody got
+        // home. Core's job is the unambiguous fact, not the wording — a null
+        // Winner is that fact.
+        [Test]
+        public void AGameEndedBeforeAnyoneFinished_HasNoWinner()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var game = new Game(roster, Seed);
+            AdvanceTo(game, FrogColour.Green, 3);
+
+            game.EndGame();
+
+            Assert.That(game.IsOver, Is.True);
+            Assert.That(game.Winner, Is.Null);
+            Assert.That(game.FinishingOrder, Is.Empty);
+        }
+
+        // docs/specs/ui/end-game-confirm.md builds its cost sentence from
+        // this count — "Three frogs are still swimming..." — and needs it
+        // mid-game, not only once the game is already over.
+        [Test]
+        public void FrogsStillSwimming_IsReadableAtAnyPointDuringPlay_NotOnlyAfterTheGameEnds()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue, FrogColour.Orange };
+            var game = new Game(roster, Seed);
+
+            Assert.That(game.FrogsStillSwimming, Is.EqualTo(3));
+
+            SendHome(game, FrogColour.Green);
+            game.RecordFinish(FrogColour.Green);
+
+            Assert.That(game.IsOver, Is.False, "the game keeps going once one frog is home");
+            Assert.That(game.FrogsStillSwimming, Is.EqualTo(2));
+        }
+
         const int TurnsToPlay = 12;
 
         static FrogColour[] FourFrogRoster()
@@ -357,6 +502,18 @@ namespace Frogs.Core.Tests
             var lane = game.LaneFor(colour);
 
             while (!lane.IsHome)
+            {
+                lane.MoveForward();
+            }
+        }
+
+        // Advances a frog's Lane directly to a given lily pad — for setting
+        // up standings scenarios without going through a real turn.
+        static void AdvanceTo(Game game, FrogColour colour, int position)
+        {
+            var lane = game.LaneFor(colour);
+
+            for (var move = 0; move < position; move++)
             {
                 lane.MoveForward();
             }

--- a/Tests/Core/StandingsRowTests.cs
+++ b/Tests/Core/StandingsRowTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="StandingsRow"/> is the fact <see cref="Game.Standings"/>
+    /// hands back for one frog — docs/specs/ui/game-over.md's standings row
+    /// reads directly off it: place number, frog colour, and how far it got
+    /// (`Position` out of <see cref="Lane.LaneWinningPosition"/>, and whether
+    /// it is home). Nothing else — no formatted "6 of 8" string, no colour
+    /// swatch; those are the screen's job to render.
+    /// </summary>
+    public sealed class StandingsRowTests
+    {
+        [Test]
+        public void ANewStandingsRow_CarriesExactlyTheColourPlacePositionAndIsHome()
+        {
+            var row = new StandingsRow(FrogColour.Blue, 1, 8, true);
+
+            Assert.That(row.Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(row.Place, Is.EqualTo(1));
+            Assert.That(row.Position, Is.EqualTo(8));
+            Assert.That(row.IsHome, Is.True);
+        }
+
+        // Structural, not behavioural: game-over.md's standings row needs
+        // exactly these four facts and nothing more.
+        [Test]
+        public void StandingsRow_ExposesNoPublicMembersBeyondTheFourFacts()
+        {
+            var propertyNames = typeof(StandingsRow)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name)
+                .OrderBy(name => name)
+                .ToArray();
+
+            Assert.That(propertyNames, Is.EqualTo(new[]
+            {
+                "Colour",
+                "IsHome",
+                "Place",
+                "Position"
+            }));
+        }
+    }
+}

--- a/docs/specs/reference/index.md
+++ b/docs/specs/reference/index.md
@@ -160,3 +160,10 @@ Together those two decisions describe the whole of how a game finishes:
 There is no third way, and in particular there is no state where a finished
 game sits waiting to be dismissed. That is what makes the ordinary two-player
 game work without anyone ever opening the settings.
+
+Only the first of those two routes is derivable from where the frogs are: every
+frog's lane position can be checked fresh, at any moment, to see whether all of
+them are home. The second cannot — a deliberate end can happen with frogs still
+short of home, so nothing about lane position says it happened. `Frogs.Core`
+computes the first fact every time it is asked and records the second the
+moment it occurs; the game being over is the two facts combined with OR.


### PR DESCRIPTION
A game now knows when it is over — either every frog reached home (checked fresh from lane positions every time) or somebody ended it early — and can answer who won, the order everyone finished in, and how far everyone else got, ties and all. That's the same fact the game-over screen and the end-game confirm's warning will read from directly, once they're built.

**Docs:** docs/specs/reference/index.md — added a sentence to "Where v1 fills a gap the board leaves open" stating that only the everyone-home route is derivable from lane position; a deliberate end has to be recorded, since nothing about where the frogs are sitting can tell you it happened.

Closes #211

## Spec invariants

- `docs/specs/ui/game-over.md#invariants`: "the winner is the frog that reached the End log first, and finishing order is the order frogs got home" — `Game.Winner`/`Game.FinishingOrder` are populated only through `RecordFinish`, never recomputed from position, and `Winner_IsWhicheverFrogFinishedFirst_AndFinishingOrderIsArrivalOrderNotRosterOrder` proves a later finisher never overwrites the first.
- `docs/specs/ui/game-over.md#invariants`: "Frogs that did not finish are ranked by how many lily pads they made" and `#open-questions`: "Two frogs on the same pad currently share a place number" — `Game.Standings` builds exactly that, and `Standings_RanksUnfinishedFrogsBelowFinishedOnes_ByLilyPadsMade_WithTiesSharingAPlaceNumber` asserts both the ordering and the tie. No turn-order tiebreak was added; that open question stays open.
- `docs/specs/ui/end-game-confirm.md`: ending "stops the game and shows the results" rather than resetting anyone — `EndingTheGameDeliberately_ChangesNoFrogsPosition` asserts every lane position is untouched by `EndGame()`.
- `docs/specs/reference/index.md#where-v1-fills-a-gap-the-board-leaves-open`: the two routes to "over" — `AGameWhereEveryFrogIsOnItsEndLog_ReportsItselfOver_WithNoSeparateCallNeeded` and `EndingTheGameDeliberately_WithFrogsShortOfHome_ReportsTheGameAsOver` cover each route independently, combined with OR in `Game.IsOver`.

## How the spec is changing

Not a rule change — `docs/specs/reference/index.md` already stated both gap-fill rules (every-frog-home ends the game; a deliberate end is possible) but never said outright that only one is derivable from frog position. The added sentence makes that explicit, matching what the Core code now does: `IsOver`'s "every frog home" arm is computed fresh from lane positions on every call, while the deliberate-end fact is the one thing `Game` has to remember (set by `EndGame()`).

## Deviations and Decisions

- `Game` gains an explicit `RecordFinish(colour)` call rather than auto-detecting arrivals from a turn-phase transition (e.g. `CompleteHandOff`). Nothing in the current design wires `Lane.Resolve()` into `Game` yet — that wiring is a future issue's job — so there is no single choke point `Game` could hook automatically without risking silently missing a frog that finishes on the very turn that ends the whole game (e.g. via `CompleteHandOff`, which already throws once every frog is home). An explicit, idempotent call — a no-op if the frog isn't home or was already recorded — is the seam future turn-resolution wiring calls at the real moment a frog finishes.
- Standings place numbers use competition ranking (ties share a number; the next distinct value's place accounts for how many frogs are tied ahead of it — e.g. 1, 2, 2, 4) rather than dense ranking (1, 2, 2, 3). `game-over.md` only specifies that tied frogs share a place number, not what the next distinct place is — this is the one place a judgment call was needed to make the type concrete, and it's easy to change later since no test pins the exact number after a tie.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_