### PR TITLE
feat(build): create the Game scene, the scene the app actually boots into

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -90,25 +90,6 @@ jobs:
           key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: Library-android-
 
-      # TEMPORARY — remove before merge. Runs Unity once with -executeMethod to
-      # create Assets/Scenes/Game.unity and register it in build settings, so
-      # the files it writes can be read back out of the log below and
-      # committed. See issue #209 and PR #179, which did the same for
-      # HelloWorldScene.
-      - name: Create the Game scene
-        if: steps.licence.outputs.present == 'true'
-        continue-on-error: true
-        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        with:
-          unityVersion: 6000.0.81f1
-          targetPlatform: Android
-          buildMethod: Frogs.EditorTools.GameScene.EnsureReadyToBuild
-          allowDirtyBuild: true
-
       # The version name, versionCode, and .debug suffix are applied by
       # BuildStampPreprocessor from these values — a build pre-processor, so no
       # build can be produced without them. See docs/engineering/versioning.md.
@@ -153,19 +134,3 @@ jobs:
                  "(versionCode ${{ steps.stamp.outputs.version_code }}), installs alongside the" \
                  "release build as \`.debug\`." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      # TEMPORARY — remove before merge. Last, so it lands at the end of the
-      # log where it can be read back. See issue #209 and PR #179.
-      - name: Show what Unity wrote
-        if: always()
-        run: |
-          ls -la Assets/Scenes ProjectSettings || true
-          for file in \
-            Assets/Scenes/Game.unity \
-            Assets/Scenes/Game.unity.meta \
-            ProjectSettings/EditorBuildSettings.asset
-          do
-            echo "vvvvv $file vvvvv"
-            cat "$file" 2>&1 || true
-            echo "^^^^^ $file ^^^^^"
-          done

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -90,6 +90,25 @@ jobs:
           key: Library-android-${{ hashFiles('Packages/manifest.json', 'ProjectSettings/ProjectVersion.txt') }}
           restore-keys: Library-android-
 
+      # TEMPORARY — remove before merge. Runs Unity once with -executeMethod to
+      # create Assets/Scenes/Game.unity and register it in build settings, so
+      # the files it writes can be read back out of the log below and
+      # committed. See issue #209 and PR #179, which did the same for
+      # HelloWorldScene.
+      - name: Create the Game scene
+        if: steps.licence.outputs.present == 'true'
+        continue-on-error: true
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: 6000.0.81f1
+          targetPlatform: Android
+          buildMethod: Frogs.EditorTools.GameScene.EnsureReadyToBuild
+          allowDirtyBuild: true
+
       # The version name, versionCode, and .debug suffix are applied by
       # BuildStampPreprocessor from these values — a build pre-processor, so no
       # build can be produced without them. See docs/engineering/versioning.md.
@@ -134,3 +153,19 @@ jobs:
                  "(versionCode ${{ steps.stamp.outputs.version_code }}), installs alongside the" \
                  "release build as \`.debug\`." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      # TEMPORARY — remove before merge. Last, so it lands at the end of the
+      # log where it can be read back. See issue #209 and PR #179.
+      - name: Show what Unity wrote
+        if: always()
+        run: |
+          ls -la Assets/Scenes ProjectSettings || true
+          for file in \
+            Assets/Scenes/Game.unity \
+            Assets/Scenes/Game.unity.meta \
+            ProjectSettings/EditorBuildSettings.asset
+          do
+            echo "vvvvv $file vvvvv"
+            cat "$file" 2>&1 || true
+            echo "^^^^^ $file ^^^^^"
+          done

--- a/Assets/Editor/GameScene.cs
+++ b/Assets/Editor/GameScene.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace Frogs.EditorTools
+{
+    /// <summary>
+    /// The scene the app actually runs in, created and registered through the
+    /// typed editor API rather than by hand-authoring YAML.
+    ///
+    /// This is the same decision as <see cref="HelloWorldScene"/>, for the
+    /// same reason: a `.unity` file is file IDs and GUID references that have
+    /// to be internally consistent and consistent with every `.meta` in the
+    /// project, and Unity's deserializer ignores keys it does not recognise
+    /// rather than complaining about them. Writing one by reasoning about the
+    /// format is what docs/engineering/unity-serialization.md exists to
+    /// forbid. Asking Unity to write it removes the guess entirely.
+    ///
+    /// This is what produced the committed scene, and how to produce it again:
+    ///
+    ///     Frogs → Create the Game scene
+    ///
+    ///     Unity -batchmode -quit -projectPath . \
+    ///           -executeMethod Frogs.EditorTools.GameScene.EnsureReadyToBuild
+    ///
+    /// Commit `Assets/Scenes/Game.unity`, its `.meta`, and the changed
+    /// `ProjectSettings/EditorBuildSettings.asset` together — and the `.meta`
+    /// of any script the scene refers to, because that is where the GUID it
+    /// points at lives. This scene has nothing in it but a camera, so there is
+    /// no such script yet.
+    ///
+    /// Nothing calls this automatically, and it is not part of a build. It is
+    /// a tool for making the asset; the asset is what ships.
+    ///
+    /// The scene is deliberately close to empty: a camera, so there is
+    /// something to render, and nothing else. What a screen shows comes from
+    /// an agreed wireframe first — the screen router that puts content into
+    /// this scene is its own, later issue.
+    ///
+    /// It is idempotent: it creates the scene only when there is not one, and
+    /// it registers the scene in build settings only when it is not already
+    /// the enabled entry at index 0. Running it against a checkout that
+    /// already has both does nothing.
+    /// </summary>
+    public static class GameScene
+    {
+        /// <summary>Where the build settings and the EditMode tests look.</summary>
+        public const string AssetPath = "Assets/Scenes/Game.unity";
+
+        const string CameraName = "Camera";
+
+        /// <summary>
+        /// Makes sure there is a Game scene and that a build would boot into
+        /// it. Safe to call repeatedly.
+        /// </summary>
+        [MenuItem("Frogs/Create the Game scene")]
+        public static void EnsureReadyToBuild()
+        {
+            EnsureSceneExists();
+            EnsureRegisteredAsTheStartingScene();
+        }
+
+        static void EnsureSceneExists()
+        {
+            // Unity runs with the project root as the working directory, so the
+            // asset path is also the path on disk.
+            if (File.Exists(AssetPath))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(AssetPath));
+
+            // Anything unsaved is offered to whoever is at the keyboard first,
+            // because the new scene replaces what is open. In batch mode there
+            // is nothing open and this returns immediately.
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                throw new InvalidOperationException(
+                    "The open scene has unsaved changes and they were not saved, so the "
+                    + "Game scene was not created.");
+            }
+
+            // Single, so the new scene is the active one and objects created
+            // below land in it.
+            //
+            // Not Additive. An additive scene is not the active one, so every
+            // object has to be moved across with SceneManager.MoveGameObjectToScene
+            // — and headlessly that combination produced no scene at all, twice,
+            // without raising anything (see HelloWorldScene). This version was
+            // run in CI and its output is the committed scene, so leave it
+            // alone unless you have an editor open to check the replacement in.
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+
+            // A camera, so the app renders a screen rather than nothing.
+            // Nothing else — what a screen looks like is a wireframe decision,
+            // not something this tool gets to invent.
+            new GameObject(CameraName, typeof(Camera));
+
+            if (!EditorSceneManager.SaveScene(scene, AssetPath))
+            {
+                throw new InvalidOperationException(
+                    $"Unity would not save the scene to {AssetPath}.");
+            }
+
+            Debug.Log($"Created {AssetPath}. Commit it, and its .meta file, together.");
+        }
+
+        static void EnsureRegisteredAsTheStartingScene()
+        {
+            var scenes = EditorBuildSettings.scenes;
+
+            if (scenes.Length > 0 && scenes[0].path == AssetPath && scenes[0].enabled)
+            {
+                return;
+            }
+
+            // Placed first, not appended: Unity launches whichever enabled
+            // entry is first in the list, and this scene is the one the app
+            // is supposed to boot into. Every existing entry survives behind
+            // it, so HelloWorld.unity stays registered and enabled — just no
+            // longer what the app starts in.
+            var updated = new List<EditorBuildSettingsScene>
+            {
+                new EditorBuildSettingsScene(AssetPath, enabled: true),
+            };
+            updated.AddRange(scenes.Where(scene => scene.path != AssetPath));
+
+            EditorBuildSettings.scenes = updated.ToArray();
+
+            Debug.Log($"Registered {AssetPath} as the first scene in build settings.");
+        }
+    }
+}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1,0 +1,209 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1117470437
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1117470439}
+  - component: {fileID: 1117470438}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1117470438
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1117470437}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1117470439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1117470437}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1117470439}

--- a/Assets/Scenes/Game.unity.meta
+++ b/Assets/Scenes/Game.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 401a92339a3b3ea0a950570079fb8a2f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/GameSceneTests.cs
+++ b/Assets/Tests/EditMode/GameSceneTests.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The Game scene — the scene the app actually boots into — asserted at
+    /// the level it fails at: a scene asset that exists, is registered ahead
+    /// of Hello World, and still has its camera attached after a round trip
+    /// through Unity's serializer.
+    ///
+    /// These are the guards docs/engineering/unity-serialization.md asks for
+    /// around any asset that is not authored by hand — the failure being
+    /// watched for is *detachment*, which produces no error anywhere, so the
+    /// messages name the likely cause rather than the expected value.
+    /// </summary>
+    public sealed class GameSceneTests
+    {
+        // Named here rather than read from the editor tooling on purpose. This
+        // is the path the build settings and the APK depend on, so the test
+        // pins it independently — a rename that moves the asset has to fail
+        // here rather than quietly agree with itself.
+        const string ScenePath = "Assets/Scenes/Game.unity";
+
+        [Test]
+        public void TheSceneAssetIsWhereTheBuildLooksForIt()
+        {
+            Assert.That(
+                AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath),
+                Is.Not.Null,
+                $"There is no scene at {ScenePath}. An Android build with no scenes fails "
+                + "with exit code 103 and an empty output directory. Recreate it with "
+                + "Frogs → Create the Game scene, and commit the scene and its .meta "
+                + "together.");
+        }
+
+        [Test]
+        public void TheSceneIsRegisteredInBuildSettings()
+        {
+            var registered = EditorBuildSettings.scenes.Any(
+                scene => scene.path == ScenePath && scene.enabled);
+
+            Assert.That(
+                registered,
+                Is.True,
+                $"{ScenePath} exists but is not an enabled scene in build settings, so it "
+                + "would not be in the APK. ProjectSettings/EditorBuildSettings.asset is "
+                + "where that lives, and it has to be committed alongside the scene.");
+        }
+
+        [Test]
+        public void TheGameSceneIsTheOneTheAppStartsIn()
+        {
+            var scenes = EditorBuildSettings.scenes;
+
+            Assert.That(
+                scenes.Length,
+                Is.GreaterThan(0),
+                "There are no scenes in build settings at all, so the app has nothing "
+                + "to boot into.");
+
+            Assert.That(
+                scenes[0].path,
+                Is.EqualTo(ScenePath),
+                $"{ScenePath} is not first in EditorBuildSettings.scenes, so the app "
+                + "would not boot into it. Unity launches whichever enabled entry is "
+                + "first, and this is the scene that entry is supposed to be.");
+
+            Assert.That(
+                scenes[0].enabled,
+                Is.True,
+                $"{ScenePath} is first in build settings but not enabled, so a build "
+                + "would skip straight past it to whatever is enabled after it.");
+        }
+
+        [Test]
+        public void TheSceneOpensWithACameraStillAttached()
+        {
+            var scene = EditorSceneManager.OpenScene(ScenePath, OpenSceneMode.Additive);
+
+            try
+            {
+                var camera = scene.GetRootGameObjects()
+                    .Select(root => root.GetComponent<Camera>())
+                    .FirstOrDefault(found => found != null);
+
+                Assert.That(
+                    camera,
+                    Is.Not.Null,
+                    "The scene has no camera, so the app renders nothing at all and there "
+                    + "is no way to tell a working build from a broken one by looking at "
+                    + "it.");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, removeScene: true);
+            }
+        }
+
+        [Test]
+        public void RunningTheToolTwiceChangesNothing()
+        {
+            var before = EditorBuildSettings.scenes;
+
+            Frogs.EditorTools.GameScene.EnsureReadyToBuild();
+
+            var after = EditorBuildSettings.scenes;
+
+            Assert.That(
+                after.Length,
+                Is.EqualTo(before.Length),
+                "Running Frogs.EditorTools.GameScene.EnsureReadyToBuild a second time "
+                + "changed the number of registered scenes, so it is not idempotent.");
+
+            Assert.That(
+                after[0].path,
+                Is.EqualTo(before[0].path),
+                "Running Frogs.EditorTools.GameScene.EnsureReadyToBuild a second time "
+                + "changed which scene is first in build settings, so it is not "
+                + "idempotent.");
+        }
+    }
+}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/Game.unity
+    guid: 401a92339a3b3ea0a950570079fb8a2f
+  - enabled: 1
     path: Assets/Scenes/HelloWorld.unity
     guid: e0a75351cb5a86492bb0baf5a54613fd
   m_configObjects: {}

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -335,6 +335,22 @@ writes the version to the log, and nothing else: what a build-proof screen
 [the wireframe loop](ui-design-process.md) rather than being invented in an
 implementation PR.
 
+### The `Game` scene is what the app actually boots into
+
+`Assets/Editor/GameScene.cs` creates `Assets/Scenes/Game.unity` the same way —
+`EditorSceneManager`, not hand-authored YAML — with a camera and nothing else.
+No probe, no layout: what a screen shows still goes through the wireframe loop
+first, and the screen router that puts content into this scene is its own,
+later issue.
+
+`Game.unity` is **first** in `ProjectSettings/EditorBuildSettings.asset` —
+index 0, which is the entry Unity boots into. `HelloWorld.unity` stays in the
+list, enabled, one slot behind it; nothing removes it, and its own EditMode
+tests still pass unchanged, because they assert presence and `enabled`, never
+position. Registering `Game.unity` by appending it, the way a first pass at
+this might do it, would leave the built APK opening into the blank Hello World
+scene forever — the ordering is the whole point, not an incidental detail.
+
 ### Naming
 
 Use the `scaffold-core` skill to create a Core type; it applies all of this and


### PR DESCRIPTION
Multiplying Frogs now has a second scene, `Game.unity`, made and committed exactly the way `HelloWorld.unity` was: a camera, nothing else, and Unity itself wrote every byte through `EditorSceneManager`. It's now what the app actually boots into — first in the build's scene list — with `HelloWorld.unity` staying registered and enabled one slot behind it.

Closes #209

**Docs:** `docs/engineering/tech-stack.md` — a new section next to the existing Hello World one, stating that `Game.unity` is first in build settings and is what the app boots into.

## Spec invariants

| Rule | How this keeps it |
| --- | --- |
| Never guess at Unity serialization | Not one byte of `Game.unity`, its `.meta`, or the updated `EditorBuildSettings.asset` was hand-authored. Unity wrote all of it through `EditorSceneManager`/`EditorBuildSettings`, via `-executeMethod Frogs.EditorTools.GameScene.EnsureReadyToBuild` run in CI ([run 31407653797](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31407653797)). |
| `NewSceneMode.Single`, not `Additive` | Copied from `HelloWorldScene.cs` for the documented reason — `Additive` produced no scene at all headlessly. |
| Hello World stays registered | `HelloWorldSceneTests` asserts presence and `enabled`, never position, so demoting it to index 1 doesn't touch it — confirmed by CI staying green with all 15 EditMode tests passing. |
| Wireframe before UI code | The scene has a camera and nothing else. No layout, no probe, no screen content — that's the screen router's issue (slate 11), blocked on this one, and it goes through the wireframe loop first. |
| Core/Unity split | No Core changes in this issue; `Frogs.Core.Tests.csproj` still passes (168/168) and `check_core_isolation.py` / `check_assembly_references.py` both pass. |

## How the spec is changing

`docs/engineering/tech-stack.md` previously described only the Hello World scene as an example of "scenes are never hand-authored." It now documents `Game.unity` as the second instance of the same pattern, and states explicitly: `Game.unity` is index 0 in `EditorBuildSettings.scenes`, `HelloWorld.unity` stays enabled at index 1, and that ordering — not just presence — is what makes this issue's title true. A naive "append Game.unity to the list" would have left the APK booting into the blank Hello World scene forever; the docs and the registration code both call that out.

## Establishing red without an editor

Pushed `GameSceneTests.cs` + `GameScene.cs` first ([run 31407028996](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31407028996)): 14 of 15 EditMode tests passed and `RunningTheToolTwiceChangesNothing` failed, for the right reason — `Game.unity` didn't exist yet in the committed repo, so the first-ever call to `EnsureReadyToBuild()` inside that test registered a *new* scene rather than being a no-op (`before.Length != after.Length`). As a side effect within that same ephemeral run, the tool's real behavior was exercised live, which is why the other four tests passed in that run without the files being committed yet.

The scene's actual bytes were then produced the same way PR #179 produced Hello World's: a temporary step on `pr-build.yml` invoking `-executeMethod Frogs.EditorTools.GameScene.EnsureReadyToBuild` through `game-ci/unity-builder`, then `cat`-ing the three files to the log ([run 31407653797](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31407653797)). Those bytes were copied out of the log verbatim, the temporary workflow step was reverted to `pr-build.yml`'s committed shape (no diff vs. `main`), and a final dispatch of `ci-tests.yml` confirms all 15 EditMode tests pass ([run 31408406148](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31408406148)).

## Deviations and Decisions

- **No script `.meta` to commit.** The four-files table in the issue names a script `.meta` as the fourth file when the scene references one by GUID. This scene has nothing but a camera, so there's no such file today — noted explicitly rather than silently checking that box.
- **`Frogs.EditorTools.GameScene` doesn't reference `Frogs.Unity`**, unlike `HelloWorldScene` (which attaches `HelloWorldProbe`). This scene has no probe or any other component to attach, so the extra reference isn't needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_