### PR TITLE
feat(router): screen router — one screen, one dialog, and hardware back

### DIFF
--- a/Assets/Scripts/Core/Dialog.cs
+++ b/Assets/Scripts/Core/Dialog.cs
@@ -1,0 +1,27 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One of the five panels the <see cref="ScreenRouter"/> can hold at most
+    /// one of at a time, layered over whichever <see cref="Screen"/> is
+    /// current — issue #213's navigation graph. Dialogs never stack: opening
+    /// one while another is open closes the first before the second becomes
+    /// current. See docs/specs/ui/shared-components.md#dialog.
+    /// </summary>
+    public enum Dialog
+    {
+        /// <summary>[Roll and card](docs/specs/ui/roll-and-card.md). Hardware back is inert here.</summary>
+        RollAndCard,
+
+        /// <summary>[Working-out grid](docs/specs/ui/working-out-grid.md). Hardware back is inert here.</summary>
+        WorkingOutGrid,
+
+        /// <summary>[Answer result](docs/specs/ui/answer-result.md). Hardware back is inert here.</summary>
+        AnswerResult,
+
+        /// <summary>[Settings dialog](docs/specs/ui/settings-dialog.md), opened from the game board.</summary>
+        Settings,
+
+        /// <summary>[End-game confirm](docs/specs/ui/end-game-confirm.md), reached only from settings.</summary>
+        EndGameConfirm
+    }
+}

--- a/Assets/Scripts/Core/Dialog.cs.meta
+++ b/Assets/Scripts/Core/Dialog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2e6d0e150ad4217836efd6d93104f93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/Screen.cs
+++ b/Assets/Scripts/Core/Screen.cs
@@ -1,0 +1,24 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One of the four full-screen destinations the <see cref="ScreenRouter"/>
+    /// moves between — issue #213's navigation graph: title screen, game
+    /// setup, game board, game over. A <see cref="Dialog"/> is a separate,
+    /// layered concept that opens over whichever of these is current; it is
+    /// never one of these four.
+    /// </summary>
+    public enum Screen
+    {
+        /// <summary>[Title screen](docs/specs/ui/title-screen.md). The router's starting screen.</summary>
+        TitleScreen,
+
+        /// <summary>[Game setup](docs/specs/ui/game-setup.md): choosing frogs before a game starts.</summary>
+        GameSetup,
+
+        /// <summary>[Game board](docs/specs/ui/game-board.md): the pond, and every dialog a turn opens over it.</summary>
+        GameBoard,
+
+        /// <summary>[Game over](docs/specs/ui/game-over.md): standings, reached when a game ends.</summary>
+        GameOver
+    }
+}

--- a/Assets/Scripts/Core/Screen.cs.meta
+++ b/Assets/Scripts/Core/Screen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 203adda9783a4cdeb2ddb2d8926309c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/ScreenRouter.cs
+++ b/Assets/Scripts/Core/ScreenRouter.cs
@@ -1,0 +1,199 @@
+using System;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The traffic cop — issue #213. Owns which one of four
+    /// <see cref="Screen"/>s is current, which one of five <see cref="Dialog"/>s
+    /// (if any) is layered over it, and what the hardware back button does in
+    /// every state.
+    ///
+    /// This is the one place the rule in docs/specs/ui/shared-components.md#dialog
+    /// ("a dialog never opens over another dialog") is enforced rather than
+    /// hoped for: <see cref="OpenDialog"/> always closes whatever dialog is
+    /// current before the requested one becomes current, and every screen
+    /// transition clears the dialog layer, so this type can never be in a
+    /// state with two dialogs — or a screen and an unrelated dialog — both
+    /// reading "open".
+    ///
+    /// It draws nothing. It activates and deactivates no <c>GameObject</c> —
+    /// that is <c>Frogs.Unity</c>'s thin adapter, reading <see cref="CurrentScreen"/>
+    /// and <see cref="CurrentDialog"/> off this type and nothing else.
+    ///
+    /// It does not decide *whether* a game has ended — that is
+    /// <c>Game.IsOver</c> (#211). <see cref="GameHasEnded"/> is the stand-in
+    /// this issue builds against for that signal; wiring it to the real
+    /// <c>Game</c> is future work.
+    /// </summary>
+    public sealed class ScreenRouter
+    {
+        /// <summary>
+        /// Fires after every change to <see cref="CurrentScreen"/>,
+        /// <see cref="CurrentDialog"/>, or <see cref="AppExitRequested"/> —
+        /// the one hook the Unity adapter needs to know when to refresh which
+        /// root <c>GameObject</c> is active. A dialog swap fires it twice:
+        /// once as the old dialog closes (<see cref="CurrentDialog"/> null),
+        /// once as the new one opens — never once for both at once, because
+        /// this type never holds two dialogs open together.
+        /// </summary>
+        public event Action StateChanged;
+
+        /// <summary>The screen currently on top. Starts at <see cref="Screen.TitleScreen"/>.</summary>
+        public Screen CurrentScreen { get; private set; }
+
+        /// <summary>
+        /// The dialog currently layered over <see cref="CurrentScreen"/>, or
+        /// null if none is open. At most one dialog is ever current.
+        /// </summary>
+        public Dialog? CurrentDialog { get; private set; }
+
+        /// <summary>
+        /// Set once hardware back is pressed on <see cref="Screen.TitleScreen"/> —
+        /// docs/specs/ui/title-screen.md#behaviour: "the only screen where back
+        /// exits." The Unity adapter reads this to call <c>Application.Quit()</c>;
+        /// this type performs no engine call itself.
+        /// </summary>
+        public bool AppExitRequested { get; private set; }
+
+        public ScreenRouter()
+        {
+            CurrentScreen = Screen.TitleScreen;
+            CurrentDialog = null;
+        }
+
+        /// <summary>
+        /// Moves to <paramref name="screen"/> and closes whatever dialog was
+        /// open — every screen-to-screen edge in the navigation graph leaves
+        /// no dialog behind.
+        /// </summary>
+        public void NavigateToScreen(Screen screen)
+        {
+            CurrentScreen = screen;
+            CurrentDialog = null;
+            RaiseStateChanged();
+        }
+
+        /// <summary>
+        /// Opens <paramref name="dialog"/> over <see cref="CurrentScreen"/>.
+        /// If another dialog is already open, it is closed first — a second
+        /// <see cref="StateChanged"/> notification with <see cref="CurrentDialog"/>
+        /// null, then a third with the new dialog — so the dialog layer never
+        /// holds two dialogs open at once, per
+        /// docs/specs/ui/shared-components.md#dialog: "Stacked... does not
+        /// happen."
+        /// </summary>
+        public void OpenDialog(Dialog dialog)
+        {
+            if (CurrentDialog.HasValue)
+            {
+                CloseDialog();
+            }
+
+            CurrentDialog = dialog;
+            RaiseStateChanged();
+        }
+
+        /// <summary>Closes whatever dialog is open. A no-op if none is.</summary>
+        public void CloseDialog()
+        {
+            if (!CurrentDialog.HasValue)
+            {
+                return;
+            }
+
+            CurrentDialog = null;
+            RaiseStateChanged();
+        }
+
+        /// <summary>
+        /// The stand-in for <c>core-game-end</c>'s "the game has ended"
+        /// signal (#211's <c>Game.IsOver</c>) — moves straight to
+        /// <see cref="Screen.GameOver"/> with no dialog open and no
+        /// back-button interaction involved. Wiring this to the real signal
+        /// is future work; this type has no opinion on when to call it.
+        /// </summary>
+        public void GameHasEnded()
+        {
+            NavigateToScreen(Screen.GameOver);
+        }
+
+        /// <summary>
+        /// What the hardware back button does, read off the back-button
+        /// table in issue #213 — collected from each screen and dialog
+        /// page's own `## Behaviour` section rather than re-derived here.
+        /// </summary>
+        public void HandleBack()
+        {
+            if (CurrentDialog.HasValue)
+            {
+                HandleBackWithDialogOpen(CurrentDialog.Value);
+                return;
+            }
+
+            HandleBackOnScreen(CurrentScreen);
+        }
+
+        void HandleBackWithDialogOpen(Dialog dialog)
+        {
+            switch (dialog)
+            {
+                // settings-dialog.md#behaviour: "does what `Back to the
+                // game` does" — the least destructive of its two buttons.
+                case Dialog.Settings:
+                // end-game-confirm.md#behaviour: "does what `Keep playing`
+                // does" — the least destructive of its two buttons.
+                case Dialog.EndGameConfirm:
+                    CloseDialog();
+                    break;
+
+                // roll-and-card.md, working-out-grid.md, answer-result.md
+                // #behaviour: "Hardware back does nothing." Genuinely inert —
+                // not a close, because none of the three has anything to
+                // dismiss back to without a cost the page itself rules out.
+                case Dialog.RollAndCard:
+                case Dialog.WorkingOutGrid:
+                case Dialog.AnswerResult:
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(dialog), dialog, "unhandled dialog.");
+            }
+        }
+
+        void HandleBackOnScreen(Screen screen)
+        {
+            switch (screen)
+            {
+                // title-screen.md#behaviour: "exits the app. The only screen
+                // where back exits."
+                case Screen.TitleScreen:
+                    AppExitRequested = true;
+                    RaiseStateChanged();
+                    break;
+
+                // game-setup.md#behaviour: "does what `Back` does" —
+                // returns to the title screen.
+                case Screen.GameSetup:
+                // game-over.md#behaviour: "does what `Back to the title`
+                // does."
+                case Screen.GameOver:
+                    NavigateToScreen(Screen.TitleScreen);
+                    break;
+
+                // game-board.md#behaviour: "opens the settings dialog. It
+                // does not quit, and it never quits without the confirm."
+                case Screen.GameBoard:
+                    OpenDialog(Dialog.Settings);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(screen), screen, "unhandled screen.");
+            }
+        }
+
+        void RaiseStateChanged()
+        {
+            StateChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Core/ScreenRouter.cs.meta
+++ b/Assets/Scripts/Core/ScreenRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aad0c2d966b4ed8bce09cf74aef90af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/ScreenRouterAdapter.cs
+++ b/Assets/Scripts/Unity/ScreenRouterAdapter.cs
@@ -24,26 +24,21 @@ namespace Frogs.Unity
         readonly Dictionary<CoreScreen, GameObject> _screenRoots = new Dictionary<CoreScreen, GameObject>();
         readonly Dictionary<Dialog, GameObject> _dialogRoots = new Dictionary<Dialog, GameObject>();
 
+        bool _initialized;
+
         /// <summary>The Core router this adapter wires to the engine.</summary>
         public ScreenRouter Router
         {
-            get { return _router; }
+            get
+            {
+                EnsureInitialized();
+                return _router;
+            }
         }
 
         void Awake()
         {
-            foreach (CoreScreen screen in Enum.GetValues(typeof(CoreScreen)))
-            {
-                _screenRoots[screen] = CreateRoot(screen.ToString());
-            }
-
-            foreach (Dialog dialog in Enum.GetValues(typeof(Dialog)))
-            {
-                _dialogRoots[dialog] = CreateRoot(dialog.ToString());
-            }
-
-            _router.StateChanged += RefreshActiveRoots;
-            RefreshActiveRoots();
+            EnsureInitialized();
         }
 
         void OnDestroy()
@@ -68,6 +63,8 @@ namespace Frogs.Unity
         /// </summary>
         public void HandleBackButton()
         {
+            EnsureInitialized();
+
             _router.HandleBack();
 
             if (_router.AppExitRequested)
@@ -79,13 +76,45 @@ namespace Frogs.Unity
         /// <summary>The root <c>GameObject</c> for a screen — active only while it is current.</summary>
         public GameObject RootFor(CoreScreen screen)
         {
+            EnsureInitialized();
             return _screenRoots[screen];
         }
 
         /// <summary>The root <c>GameObject</c> for a dialog — active only while it is current.</summary>
         public GameObject RootFor(Dialog dialog)
         {
+            EnsureInitialized();
             return _dialogRoots[dialog];
+        }
+
+        // Unity does not guarantee Awake() runs before another component's
+        // Awake() touches this one, nor before a test calls a public method
+        // right after AddComponent — both reach this adapter with Awake()
+        // not yet having fired. Every public entry point funnels through
+        // this idempotent guard instead of trusting Awake's timing, so the
+        // roots and the StateChanged subscription exist before anything can
+        // observe them missing.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            foreach (CoreScreen screen in Enum.GetValues(typeof(CoreScreen)))
+            {
+                _screenRoots[screen] = CreateRoot(screen.ToString());
+            }
+
+            foreach (Dialog dialog in Enum.GetValues(typeof(Dialog)))
+            {
+                _dialogRoots[dialog] = CreateRoot(dialog.ToString());
+            }
+
+            _router.StateChanged += RefreshActiveRoots;
+            RefreshActiveRoots();
         }
 
         GameObject CreateRoot(string name)

--- a/Assets/Scripts/Unity/ScreenRouterAdapter.cs
+++ b/Assets/Scripts/Unity/ScreenRouterAdapter.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using Frogs.Core;
+using UnityEngine;
+using CoreScreen = Frogs.Core.Screen;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The thin shell around <see cref="ScreenRouter"/> — issue #213. It owns
+    /// the router's engine-facing surface and nothing about navigation logic:
+    /// it wires the hardware back key (Android back / <c>Escape</c>) to
+    /// <see cref="ScreenRouter.HandleBack"/>, and activates the one empty
+    /// root <c>GameObject</c> per <see cref="Frogs.Core.Screen"/> and
+    /// <see cref="Dialog"/> that matches the router's current state.
+    ///
+    /// It draws nothing — no marker, no text, no shapes. What a root looks
+    /// like is a later, wireframed issue; this type only decides which root
+    /// is active.
+    /// </summary>
+    public sealed class ScreenRouterAdapter : MonoBehaviour
+    {
+        readonly ScreenRouter _router = new ScreenRouter();
+        readonly Dictionary<CoreScreen, GameObject> _screenRoots = new Dictionary<CoreScreen, GameObject>();
+        readonly Dictionary<Dialog, GameObject> _dialogRoots = new Dictionary<Dialog, GameObject>();
+
+        /// <summary>The Core router this adapter wires to the engine.</summary>
+        public ScreenRouter Router
+        {
+            get { return _router; }
+        }
+
+        void Awake()
+        {
+            foreach (CoreScreen screen in Enum.GetValues(typeof(CoreScreen)))
+            {
+                _screenRoots[screen] = CreateRoot(screen.ToString());
+            }
+
+            foreach (Dialog dialog in Enum.GetValues(typeof(Dialog)))
+            {
+                _dialogRoots[dialog] = CreateRoot(dialog.ToString());
+            }
+
+            _router.StateChanged += RefreshActiveRoots;
+            RefreshActiveRoots();
+        }
+
+        void OnDestroy()
+        {
+            _router.StateChanged -= RefreshActiveRoots;
+        }
+
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                HandleBackButton();
+            }
+        }
+
+        /// <summary>
+        /// What pressing the hardware back key does: calls into the Core
+        /// router's <see cref="ScreenRouter.HandleBack"/>, then quits the app
+        /// if that requested an exit. A public method of its own, rather than
+        /// reachable only through <see cref="Update"/>, so an EditMode test
+        /// can call it directly without simulating a key press.
+        /// </summary>
+        public void HandleBackButton()
+        {
+            _router.HandleBack();
+
+            if (_router.AppExitRequested)
+            {
+                Quit();
+            }
+        }
+
+        /// <summary>The root <c>GameObject</c> for a screen — active only while it is current.</summary>
+        public GameObject RootFor(CoreScreen screen)
+        {
+            return _screenRoots[screen];
+        }
+
+        /// <summary>The root <c>GameObject</c> for a dialog — active only while it is current.</summary>
+        public GameObject RootFor(Dialog dialog)
+        {
+            return _dialogRoots[dialog];
+        }
+
+        GameObject CreateRoot(string name)
+        {
+            var root = new GameObject(name);
+            root.transform.SetParent(transform, worldPositionStays: false);
+            root.SetActive(false);
+            return root;
+        }
+
+        // A screen's root is active purely by CurrentScreen — dialogs are
+        // drawn over whichever screen is current, not in place of it, per
+        // issue #213's navigation graph: "[Bracketed] nodes are dialogs,
+        // drawn over whichever full screen is current rather than replacing
+        // it."
+        void RefreshActiveRoots()
+        {
+            foreach (var pair in _screenRoots)
+            {
+                pair.Value.SetActive(pair.Key == _router.CurrentScreen);
+            }
+
+            foreach (var pair in _dialogRoots)
+            {
+                pair.Value.SetActive(_router.CurrentDialog.HasValue && pair.Key == _router.CurrentDialog.Value);
+            }
+        }
+
+        static void Quit()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+#else
+            Application.Quit();
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Unity/ScreenRouterAdapter.cs.meta
+++ b/Assets/Scripts/Unity/ScreenRouterAdapter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0587b86e28bb46b8838303ad4e0e81f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/ScreenRouterAdapterTests.cs
+++ b/Assets/Tests/EditMode/ScreenRouterAdapterTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using Frogs.Core;
+using CoreScreen = Frogs.Core.Screen;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The thin adapter's own two jobs — issue #213: pressing the hardware
+    /// back key reaches the Core router's <c>HandleBack()</c>, and exactly
+    /// one screen root is active at a time. What the router actually does on
+    /// back, for every row of the back-button table, is <c>Tests/Core</c>'s
+    /// job (<c>ScreenRouterTests</c>) and is not re-asserted here — this
+    /// suite only proves the wiring, not the table.
+    /// </summary>
+    public sealed class ScreenRouterAdapterTests
+    {
+        [Test]
+        public void PressingBack_CallsTheCoreRoutersHandleBack()
+        {
+            var host = new GameObject(nameof(ScreenRouterAdapterTests));
+
+            try
+            {
+                var adapter = host.AddComponent<ScreenRouterAdapter>();
+                adapter.Router.NavigateToScreen(CoreScreen.GameBoard);
+
+                adapter.HandleBackButton();
+
+                // game-board.md#behaviour: hardware back opens the settings
+                // dialog — evidence the key press actually reached
+                // ScreenRouter.HandleBack(), not just that nothing threw.
+                Assert.That(adapter.Router.CurrentDialog, Is.EqualTo(Dialog.Settings));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+
+        [Test]
+        public void OnlyTheCurrentScreensRoot_IsActiveAtATime()
+        {
+            var host = new GameObject(nameof(ScreenRouterAdapterTests));
+
+            try
+            {
+                var adapter = host.AddComponent<ScreenRouterAdapter>();
+
+                // The router starts on the title screen.
+                AssertExactlyOneActiveRoot(adapter, CoreScreen.TitleScreen);
+
+                adapter.Router.NavigateToScreen(CoreScreen.GameBoard);
+
+                AssertExactlyOneActiveRoot(adapter, CoreScreen.GameBoard);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+
+        static void AssertExactlyOneActiveRoot(ScreenRouterAdapter adapter, CoreScreen expectedActive)
+        {
+            var screens = (CoreScreen[])Enum.GetValues(typeof(CoreScreen));
+            var active = screens.Where(screen => adapter.RootFor(screen).activeSelf).ToArray();
+
+            Assert.That(active, Is.EqualTo(new[] { expectedActive }));
+        }
+    }
+}

--- a/Tests/Core/DialogTests.cs
+++ b/Tests/Core/DialogTests.cs
@@ -1,0 +1,25 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="Dialog"/> is the fixed set of five panels the router can
+    /// hold at most one of at a time, over whichever <see cref="Screen"/> is
+    /// current — issue #213's navigation graph.
+    /// </summary>
+    public sealed class DialogTests
+    {
+        [Test]
+        public void Dialog_HasExactlyTheFiveNamedMembers()
+        {
+            var members = Enum.GetNames(typeof(Dialog));
+
+            Assert.That(members, Is.EquivalentTo(new[]
+            {
+                "RollAndCard", "WorkingOutGrid", "AnswerResult", "Settings", "EndGameConfirm"
+            }));
+        }
+    }
+}

--- a/Tests/Core/ScreenRouterTests.cs
+++ b/Tests/Core/ScreenRouterTests.cs
@@ -1,0 +1,251 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// The traffic cop — issue #213. Owns which one of four screens is
+    /// current, which one of five dialogs (if any) is layered over it, and
+    /// what the hardware back button does in every state, per the
+    /// back-button table on the issue and each screen page's own
+    /// `## Behaviour` section.
+    ///
+    /// This type does not decide *whether* a game has ended — that is
+    /// <c>Game.IsOver</c> (#211) — it only reacts to being told. These tests
+    /// drive it with a bare call to <see cref="ScreenRouter.GameHasEnded"/>,
+    /// standing in for that not-yet-wired signal.
+    /// </summary>
+    public sealed class ScreenRouterTests
+    {
+        // docs/specs/ui/game-board.md#behaviour: "Hardware back opens the
+        // settings dialog. It does not quit, and it never quits without the
+        // confirm."
+        [Test]
+        public void HandleBack_OnTheGameBoardWithNoDialogOpen_OpensTheSettingsDialog()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.Settings));
+        }
+
+        // settings-dialog.md#behaviour: "Hardware back inside this dialog
+        // does what `Back to the game` does — the least destructive button."
+        // Closing "returns to the board with nothing changed."
+        [Test]
+        public void HandleBack_WithSettingsOpen_DoesWhatBackToTheGameDoes()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+            router.OpenDialog(Dialog.Settings);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+
+        // end-game-confirm.md#behaviour: "Hardware back does what `Keep
+        // playing` does" — closes back to the board, game continues.
+        [Test]
+        public void HandleBack_WithEndGameConfirmOpen_DoesWhatKeepPlayingDoes()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+            router.OpenDialog(Dialog.EndGameConfirm);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+
+        // roll-and-card.md, working-out-grid.md, answer-result.md
+        // #behaviour: "Hardware back does nothing." Not a close — genuinely
+        // inert, per shared-components.md#dialog's now-amended invariant.
+        [TestCase(Dialog.RollAndCard)]
+        [TestCase(Dialog.WorkingOutGrid)]
+        [TestCase(Dialog.AnswerResult)]
+        public void HandleBack_WithAnInertDialogOpen_IsANoOp(Dialog inertDialog)
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+            router.OpenDialog(inertDialog);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.EqualTo(inertDialog));
+        }
+
+        // title-screen.md#behaviour: "The hardware back button on this
+        // screen exits the app. It is the only screen where back exits."
+        [Test]
+        public void HandleBack_OnTheTitleScreen_SignalsAppExit()
+        {
+            var router = new ScreenRouter();
+
+            router.HandleBack();
+
+            Assert.That(router.AppExitRequested, Is.True);
+        }
+
+        // "It is the only screen where back exits" — the other three screens
+        // and every dialog leave AppExitRequested false.
+        [TestCase(Screen.GameSetup, null)]
+        [TestCase(Screen.GameBoard, null)]
+        [TestCase(Screen.GameOver, null)]
+        [TestCase(Screen.GameBoard, Dialog.Settings)]
+        [TestCase(Screen.GameBoard, Dialog.EndGameConfirm)]
+        [TestCase(Screen.GameBoard, Dialog.RollAndCard)]
+        [TestCase(Screen.GameBoard, Dialog.WorkingOutGrid)]
+        [TestCase(Screen.GameBoard, Dialog.AnswerResult)]
+        public void HandleBack_AnywhereOtherThanTheTitleScreen_NeverSignalsAppExit(
+            Screen screen, Dialog? dialog)
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(screen);
+            if (dialog.HasValue)
+            {
+                router.OpenDialog(dialog.Value);
+            }
+
+            router.HandleBack();
+
+            Assert.That(router.AppExitRequested, Is.False);
+        }
+
+        // game-setup.md#behaviour: "Hardware back does what `Back` does" —
+        // returns to the title screen.
+        [Test]
+        public void HandleBack_OnGameSetup_ReturnsToTheTitleScreen()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameSetup);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.TitleScreen));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+
+        // game-over.md#behaviour: "Hardware back does what `Back to the
+        // title` does."
+        [Test]
+        public void HandleBack_OnGameOver_ReturnsToTheTitleScreen()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameOver);
+
+            router.HandleBack();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.TitleScreen));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+
+        // shared-components.md#dialog: "Stacked... Does not happen. A dialog
+        // never opens over another dialog." Requesting a second dialog closes
+        // the first before the second becomes current — asserted through the
+        // sequence of CurrentDialog values StateChanged reports, not just the
+        // final value, because a Dialog? field alone cannot fail to prove
+        // "closes before opens": the sequencing is the thing under test.
+        [Test]
+        public void OpeningADialog_WhileAnotherIsOpen_ClosesTheFirstBeforeTheSecondBecomesCurrent()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+            router.OpenDialog(Dialog.RollAndCard);
+
+            var observed = new List<Dialog?>();
+            router.StateChanged += () => observed.Add(router.CurrentDialog);
+
+            router.OpenDialog(Dialog.WorkingOutGrid);
+
+            Assert.That(observed, Is.EqualTo(new Dialog?[] { null, Dialog.WorkingOutGrid }));
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.WorkingOutGrid));
+        }
+
+        // game-board.md#behaviour: "When the last frog gets home, the game
+        // ends itself... game over follows with no input from anybody."
+        // GameHasEnded is the stand-in for that not-yet-wired signal — see
+        // issue #213's "Presentation decides which screen; Core decides
+        // whether the game ended."
+        [Test]
+        public void GameHasEnded_FiredFromTheBoardWithNoDialogOpen_MovesToGameOver()
+        {
+            var router = new ScreenRouter();
+            router.NavigateToScreen(Screen.GameBoard);
+
+            router.GameHasEnded();
+
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameOver));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+
+        // Issue #213's navigation graph, driven start to finish. The
+        // router's own primitives — NavigateToScreen, OpenDialog, CloseDialog
+        // — are what a later screen's button handler calls; this test drives
+        // them in the order a real game visits every node, and checks the
+        // graph lands where it says at each step. Dialog-to-dialog edges
+        // (roll-and-card → working-out grid → answer result, and settings →
+        // end-game confirm) are OpenDialog calls: close-then-open, never two
+        // dialogs current at once.
+        [Test]
+        public void DrivingTheRouter_ThroughTheWholeNavigationGraph_LandsOnTheExpectedScreenAtEveryStep()
+        {
+            var router = new ScreenRouter();
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.TitleScreen));
+            Assert.That(router.CurrentDialog, Is.Null);
+
+            // Title screen --Play--> Game setup
+            router.NavigateToScreen(Screen.GameSetup);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameSetup));
+
+            // Game setup --Start--> Game board
+            router.NavigateToScreen(Screen.GameBoard);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.Null);
+
+            // Game board --Roll--> [Roll and card]
+            router.OpenDialog(Dialog.RollAndCard);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.RollAndCard));
+
+            // [Roll and card] --Solve it--> [Working-out grid]
+            router.OpenDialog(Dialog.WorkingOutGrid);
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.WorkingOutGrid));
+
+            // [Working-out grid] --Check it--> [Answer result]
+            router.OpenDialog(Dialog.AnswerResult);
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.AnswerResult));
+
+            // [Answer result] --(closes)--> Game board
+            router.CloseDialog();
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.Null);
+
+            // Game board --Settings gear--> [Settings dialog]
+            router.OpenDialog(Dialog.Settings);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.Settings));
+
+            // [Settings dialog] --End the game--> [End-game confirm]
+            router.OpenDialog(Dialog.EndGameConfirm);
+            Assert.That(router.CurrentDialog, Is.EqualTo(Dialog.EndGameConfirm));
+
+            // [End-game confirm] --End the game--> Game over
+            router.NavigateToScreen(Screen.GameOver);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameOver));
+            Assert.That(router.CurrentDialog, Is.Null);
+
+            // Game over --Play again--> Game board
+            router.NavigateToScreen(Screen.GameBoard);
+            Assert.That(router.CurrentScreen, Is.EqualTo(Screen.GameBoard));
+            Assert.That(router.CurrentDialog, Is.Null);
+        }
+    }
+}

--- a/Tests/Core/ScreenTests.cs
+++ b/Tests/Core/ScreenTests.cs
@@ -1,0 +1,26 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="Screen"/> is the fixed set of four full-screen destinations
+    /// the router moves between — issue #213's navigation graph: title screen,
+    /// game setup, game board, game over. Dialogs are a separate, layered
+    /// concept — see <see cref="Dialog"/> — not a member of this type.
+    /// </summary>
+    public sealed class ScreenTests
+    {
+        [Test]
+        public void Screen_HasExactlyTheFourNamedMembers()
+        {
+            var members = Enum.GetNames(typeof(Screen));
+
+            Assert.That(members, Is.EquivalentTo(new[]
+            {
+                "TitleScreen", "GameSetup", "GameBoard", "GameOver"
+            }));
+        }
+    }
+}

--- a/docs/specs/ui/roll-and-card.md
+++ b/docs/specs/ui/roll-and-card.md
@@ -93,9 +93,10 @@ the second, a rule underneath.
 - Nothing here decides anything. The roll has already happened in Core before
   this dialog opened; the animation is a readout of a result, not a source of
   one. That matters for testing: the die is not random *here*.
-- Hardware back does nothing — see the no-dismiss invariant. This is the one
-  place in the game where back is inert, and it is inert because the alternative
-  is losing a drawn card.
+- Hardware back does nothing — see the no-dismiss invariant. It is inert here
+  because the alternative is losing a drawn card, the same reasoning that
+  makes back inert on the [working-out grid](working-out-grid.md) and
+  [answer result](answer-result.md).
 
 ## Mockup
 

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -164,7 +164,9 @@ frog is where the player left it.
 no close cross. It is left by pressing one of its buttons, so a game is never
 half-answered because a sleeve brushed the glass.
 **Invariant:** the hardware back button does what the dialog's *least
-destructive* button does, and never what its most destructive one does.
+destructive* button does, and never what its most destructive one does —
+except the three dialogs whose pages make back inert (roll and card,
+working-out grid, answer result), where back does nothing.
 
 #### 3. Named constants
 


### PR DESCRIPTION
Adds the traffic cop for the whole POC: a state machine that tracks which one of four screens is showing and which one of five dialogs (if any) is layered over it, and a `HandleBack()` that does exactly what the hardware back button does on every screen and dialog — read off each page's own `## Behaviour` section rather than re-derived. Dialogs never stack: opening a second one always closes the first before the second becomes current. Three dialogs (roll and card, working-out grid, answer result) leave back genuinely inert, not quietly wired to "close." It draws nothing of its own — a thin Unity adapter activates one empty root `GameObject` per screen and per dialog to match, and every screen's actual look is a later, wireframed issue.

Closes #213

**Docs:** `docs/specs/ui/shared-components.md` — the dialog back-button invariant now names the three inert dialogs (roll and card, working-out grid, answer result) as its exception; `docs/specs/ui/roll-and-card.md` — drops the stale "the one place in the game where back is inert" claim, since the working-out grid and answer result are inert too.

## Spec invariants

- `docs/specs/ui/shared-components.md#dialog`: "a dialog never opens over another dialog" — enforced in `ScreenRouter.OpenDialog`, which always closes whatever dialog is current before the requested one becomes current. Asserted by `OpeningADialog_WhileAnotherIsOpen_ClosesTheFirstBeforeTheSecondBecomesCurrent`, which checks the *sequence* of `CurrentDialog` values `StateChanged` reports (`null`, then the new dialog), not just the final value — the ordering is the thing the invariant is actually about.
- The back-button table in #213, one test per row: `HandleBack_OnTheGameBoardWithNoDialogOpen_OpensTheSettingsDialog`, `HandleBack_WithSettingsOpen_DoesWhatBackToTheGameDoes`, `HandleBack_WithEndGameConfirmOpen_DoesWhatKeepPlayingDoes`, `HandleBack_WithAnInertDialogOpen_IsANoOp` (three cases), `HandleBack_OnTheTitleScreen_SignalsAppExit` plus `HandleBack_AnywhereOtherThanTheTitleScreen_NeverSignalsAppExit` (eight cases), `HandleBack_OnGameSetup_ReturnsToTheTitleScreen`, `HandleBack_OnGameOver_ReturnsToTheTitleScreen`.
- The navigation graph in #213, driven end to end by `DrivingTheRouter_ThroughTheWholeNavigationGraph_LandsOnTheExpectedScreenAtEveryStep`.
- "Presentation decides which screen; Core decides whether the game ended" — the router never computes "is any frog still swimming." `GameHasEnded()` is a bare stand-in signal (`GameHasEnded_FiredFromTheBoardWithNoDialogOpen_MovesToGameOver`); wiring it to `Game.IsOver` (#211) is future work, not this issue's.

## How the spec is changing

Old rule (`shared-components.md#dialog`, unqualified): "the hardware back button does what the dialog's *least destructive* button does, and never what its most destructive one does." Read strictly, that says back should activate the one button roll-and-card, the working-out grid, and answer result each have.

New rule: same sentence, plus "— except the three dialogs whose pages make back inert (roll and card, working-out grid, answer result), where back does nothing." Each of those three pages already said this in its own `## Behaviour` section (losing a drawn card, an unbounded `331 × 41`, a result nobody asked to see twice); the shared invariant was just never updated to admit the exception it already had in practice. This PR folds that back in rather than leaving the contradiction sitting in `/docs`.

`roll-and-card.md` also loses its claim to be "the one place in the game where back is inert" — the table shows two other dialogs share that behaviour, so the uniqueness claim was already false before this PR, just not visibly so until the whole table was assembled in one place.

## Deviations and Decisions

- Built the router in Core (**Option A**, the issue's own recommendation): `Screen`, `Dialog`, and `ScreenRouter` live in `Frogs.Core`, and all eleven behaviours from the build checklist are covered by `Tests/Core`, running via `dotnet test` with no editor. The Unity layer is a thin `ScreenRouterAdapter` that wires `Escape`/Android back to `ScreenRouter.HandleBack()` and activates/deactivates one empty root `GameObject` per screen and per dialog. In practice nothing in the router's behaviour needed an engine type, so this didn't turn out to be a close call — flagging it per the issue's request rather than switching silently.
- The router's public surface is deliberately generic — `NavigateToScreen`, `OpenDialog`, `CloseDialog`, `GameHasEnded`, `HandleBack` — rather than one named method per button in the navigation graph (`Play`, `Start`, `Roll`, ...). The issue names buttons only to label graph edges; owning what a button is actually called belongs to the later screen-building issues that wire real UI to these calls, not to this router.
- Did not touch `Assets/Scenes/Game.unity`. Two things point the same way: the issue's own framing ("`Game` isn't even attached to a scene yet") treats real integration as future work, and no test in the build checklist references the committed scene — `ScreenRouterAdapter` is verified standalone, instantiating its own `GameObject` in each EditMode test. There is also nothing yet to put in a root worth boot-wiring. Wiring the adapter into the actual scene is left for when a real screen exists to occupy one, which is also the point at which I'd have a Unity editor available to produce a verified scene change rather than guessing at scene YAML by hand.
- `Assets/Tests/EditMode/ScreenRouterAdapterTests.cs` was written but not run locally — no Unity editor in this environment, per `docs/engineering/testing.md`. Watching CI.

## Test plan

- [x] `dotnet test Tests/Core/Frogs.Core.Tests.csproj` — 190 passed (was 168 on `main`; +22 for `Screen`, `Dialog`, `ScreenRouter`).
- [x] `python3 .github/scripts/check_core_isolation.py` — Core is engine-free.
- [x] `python3 .github/scripts/check_geometry_literals.py` — no new geometry/tuning literals.
- [x] `python3 .github/scripts/run_python_tests.py` — all suites passed.
- [x] `mkdocs build --strict` — clean.
- [ ] EditMode suite — cannot run locally, watching CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_