### PR TITLE
feat(ui): choose uGUI, then build the shared Button and the frog colours

### DIFF
--- a/Assets/Scripts/Unity/UI/Button.cs
+++ b/Assets/Scripts/Unity/UI/Button.cs
@@ -55,10 +55,20 @@ namespace Frogs.Unity.UI
 
         // No imported texture, sprite, or font — docs/specs/ui/shared-components.md
         // "no external assets". A uGUI Image needs *some* sprite to draw a
-        // rounded rect rather than a plain rectangle, so this uses the sprite
-        // Unity ships with every editor and player build for exactly this
-        // purpose (ADR-0005), not a project asset.
-        const string BuiltinButtonSpriteName = "UI/Skin/UISprite.psd";
+        // rounded rect rather than a plain rectangle.
+        //
+        // This used to ask Resources.GetBuiltinResource<Sprite> for Unity's own
+        // "UI/Skin/UISprite.psd" — the built-in resource ADR-0005 names as one
+        // of the two sanctioned options. CI on 6000.0.81f1 logged
+        // "Failed to find UI/Skin/UISprite.psd" and GetBuiltinResource returned
+        // null: that resource name is either wrong or unavailable at runtime on
+        // this Unity version, and GetBuiltinResource fails silently (a null
+        // return plus a log) rather than with a catchable exception, so every
+        // Button in every test kept re-attempting and re-logging the failure.
+        // Rather than guess at a different string with no editor to check it
+        // against, this generates the rounded rect procedurally — the issue's
+        // other sanctioned option, and the one that doesn't depend on a Unity
+        // version's internal resource catalogue at all.
         const string BuiltinLabelFontName = "LegacyRuntime.ttf";
 
         static Sprite s_buttonSprite;
@@ -69,11 +79,69 @@ namespace Frogs.Unity.UI
             {
                 if (s_buttonSprite == null)
                 {
-                    s_buttonSprite = Resources.GetBuiltinResource<Sprite>(BuiltinButtonSpriteName);
+                    s_buttonSprite = CreateRoundedRectSprite(Mathf.RoundToInt(ButtonRadius));
                 }
 
                 return s_buttonSprite;
             }
+        }
+
+        const float FullyOpaqueByte = 255f;
+
+        // A square alpha-mask texture just big enough to hold one rounded
+        // corner (radius*2+1, so there is exactly one solid centre pixel),
+        // sliced with a border of `radius` on every side. uGUI's Sliced Image
+        // stretches only the 1-pixel middle band, so the corner stays exactly
+        // `radius` texture pixels regardless of how large the button's
+        // RectTransform is — the same guarantee a hand-drawn 9-slice asset
+        // would give, without importing one.
+        static Sprite CreateRoundedRectSprite(int radius)
+        {
+            radius = Mathf.Max(radius, 1);
+            var size = radius * 2 + 1;
+            var half = size / 2f;
+            var pixels = new Color32[size * size];
+
+            for (var y = 0; y < size; y++)
+            {
+                for (var x = 0; x < size; x++)
+                {
+                    // Signed distance from a box of half-size `half` rounded
+                    // by `radius`, sampled at the pixel centre — the standard
+                    // rounded-box SDF. <= 0 is inside the shape.
+                    var px = x + 0.5f - half;
+                    var py = y + 0.5f - half;
+                    var dx = Mathf.Max(Mathf.Abs(px) - (half - radius), 0f);
+                    var dy = Mathf.Max(Mathf.Abs(py) - (half - radius), 0f);
+                    var distance = Mathf.Sqrt(dx * dx + dy * dy) - radius;
+
+                    // A soft one-pixel edge instead of a hard cutoff, so the
+                    // curve doesn't alias at the sizes this renders at.
+                    var alpha = Mathf.Clamp01(0.5f - distance);
+                    pixels[(y * size) + x] = new Color32(255, 255, 255, (byte)(alpha * FullyOpaqueByte));
+                }
+            }
+
+            var texture = new Texture2D(size, size, TextureFormat.RGBA32, mipChain: false)
+            {
+                name = "Frogs Button Rounded Rect (procedural)",
+                wrapMode = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Bilinear
+            };
+            texture.SetPixels32(pixels);
+            texture.Apply(updateMipmaps: false, makeNoLongerReadable: false);
+
+            var rect = new Rect(0f, 0f, size, size);
+            var pivot = new Vector2(0.5f, 0.5f);
+            var border = new Vector4(radius, radius, radius, radius);
+
+            // Matches CanvasScaler's default referencePixelsPerUnit (100), so
+            // the sliced border renders as exactly `radius` UI pixels — the
+            // same 1:1 pixel-to-unit mapping every other Button constant
+            // already assumes.
+            const float pixelsPerUnit = 100f;
+            const uint extrude = 0;
+            return Sprite.Create(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.FullRect, border);
         }
 
         [SerializeField] ButtonKind _kind = ButtonKind.Primary;

--- a/Assets/Scripts/Unity/UI/Button.cs
+++ b/Assets/Scripts/Unity/UI/Button.cs
@@ -1,0 +1,435 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The one button in the game — docs/specs/ui/shared-components.md#button.
+    /// Built entirely through the typed Unity API when it first needs itself,
+    /// the way <c>HelloWorldScene.cs</c> builds the committed scene: no
+    /// committed <c>.prefab</c>, because there is no editor here to author one
+    /// honestly (issue #214). Three <see cref="ButtonKind"/>s share every
+    /// geometry constant below and differ only in colour and weight; three
+    /// more states — <see cref="SetDisabled"/>, hidden via
+    /// <see cref="SetHidden"/>, and pressed, tracked internally — round out
+    /// the six the spec's States table lists.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    [RequireComponent(typeof(CanvasGroup))]
+    public sealed class Button : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerExitHandler
+    {
+        // docs/specs/ui/shared-components.md#button — Named constants.
+        public const float MinTouchTarget = 96f;
+        public const float ButtonHeight = 112f;
+        public const float ButtonMinWidth = 320f;
+        public const float ButtonPaddingX = 48f;
+        public const float ButtonRadius = 24f;
+        public const float ButtonLabelSize = 44f;
+        public const float ButtonGap = 32f;
+        public const float ButtonDestructiveGap = 96f;
+        public const float ButtonPressOffset = 4f;
+        public const float ButtonBorderWidth = 4f;
+        public const float ButtonDisabledOpacity = 0.40f;
+
+        // How much darker the fill/border go while pressed. The spec states
+        // "fill darkens" without a number — this is a rendering detail the
+        // spec leaves to presentation (ADR-0001), not a geometry or tuning
+        // value with a named row of its own.
+        const float PressedDarkenFactor = 0.85f;
+
+        // Chrome colours. Not on shared-components.md's Named constants table
+        // — that table is geometry and opacity, not colour — so these are not
+        // declared as named spec constants; they are copied verbatim from the
+        // committed mockups' CSS custom properties (every mockup under
+        // docs/specs/ui/mockups/ defines the same four), which is the agreed
+        // picture this component is built to match. See this issue's PR for
+        // where that line is drawn.
+        static readonly Color AccentColor = new Color32(0x2E, 0x7D, 0x4F, 0xFF); // mockups' --accent
+        static readonly Color WarningColor = new Color32(0xB0, 0x3A, 0x2E, 0xFF); // mockups' --warn
+        static readonly Color OutlineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' --line
+        static readonly Color DarkLabelColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
+        static readonly Color LightLabelColor = Color.white; // mockups' --paper / #fff labels
+        static readonly Color NoFillColor = new Color(1f, 1f, 1f, 0f); // "no fill" — fully transparent
+
+        // No imported texture, sprite, or font — docs/specs/ui/shared-components.md
+        // "no external assets". A uGUI Image needs *some* sprite to draw a
+        // rounded rect rather than a plain rectangle, so this uses the sprite
+        // Unity ships with every editor and player build for exactly this
+        // purpose (ADR-0005), not a project asset.
+        const string BuiltinButtonSpriteName = "UI/Skin/UISprite.psd";
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        static Sprite s_buttonSprite;
+
+        static Sprite ButtonSprite
+        {
+            get
+            {
+                if (s_buttonSprite == null)
+                {
+                    s_buttonSprite = Resources.GetBuiltinResource<Sprite>(BuiltinButtonSpriteName);
+                }
+
+                return s_buttonSprite;
+            }
+        }
+
+        [SerializeField] ButtonKind _kind = ButtonKind.Primary;
+
+        RectTransform _rect;
+        RectTransform _visualRoot;
+        Image _border;
+        Image _fill;
+        Text _label;
+        CanvasGroup _canvasGroup;
+
+        bool _initialized;
+        bool _isPressed;
+        bool _isDisabled;
+
+        Color _defaultBorderColor;
+        Color _defaultFillColor;
+        Color _defaultLabelColor;
+
+        /// <summary>Fires on release, only when the release lands over the button and it was the one pressed.</summary>
+        public event Action Clicked;
+
+        /// <summary>The button's own <see cref="RectTransform"/> — its layout and hit-test bounds.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The child that moves by <see cref="ButtonPressOffset"/> while pressed, so the outer bounds never do.</summary>
+        public RectTransform VisualRoot
+        {
+            get
+            {
+                EnsureInitialized();
+                return _visualRoot;
+            }
+        }
+
+        /// <summary>The button's label.</summary>
+        public Text Label
+        {
+            get
+            {
+                EnsureInitialized();
+                return _label;
+            }
+        }
+
+        /// <summary>The <see cref="CanvasGroup"/> that carries <see cref="ButtonDisabledOpacity"/>.</summary>
+        public CanvasGroup CanvasGroup
+        {
+            get
+            {
+                EnsureInitialized();
+                return _canvasGroup;
+            }
+        }
+
+        public ButtonKind Kind
+        {
+            get
+            {
+                EnsureInitialized();
+                return _kind;
+            }
+        }
+
+        public bool IsDisabled
+        {
+            get
+            {
+                EnsureInitialized();
+                return _isDisabled;
+            }
+        }
+
+        public bool IsPressed
+        {
+            get
+            {
+                EnsureInitialized();
+                return _isPressed;
+            }
+        }
+
+        /// <summary>Not laid out at all — the shared component's Hidden state.</summary>
+        public bool IsHidden => !gameObject.activeSelf;
+
+        public Color FillColor
+        {
+            get
+            {
+                EnsureInitialized();
+                return _fill.color;
+            }
+        }
+
+        public Color BorderColor
+        {
+            get
+            {
+                EnsureInitialized();
+                return _border.color;
+            }
+        }
+
+        public Color LabelColor
+        {
+            get
+            {
+                EnsureInitialized();
+                return _label.color;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>Sets the kind. Touches colour and weight only, never geometry.</summary>
+        public void SetKind(ButtonKind kind)
+        {
+            EnsureInitialized();
+            _kind = kind;
+            ApplyKindColours();
+            RefreshVisual();
+        }
+
+        public void SetLabelText(string text)
+        {
+            EnsureInitialized();
+            _label.text = text;
+        }
+
+        /// <summary>
+        /// Overrides the button's default size. Never smaller than
+        /// <see cref="MinTouchTarget"/> in either direction, at any
+        /// caller-supplied size — docs/specs/ui/shared-components.md#button's
+        /// first invariant.
+        /// </summary>
+        public void SetSize(float width, float height)
+        {
+            EnsureInitialized();
+            _rect.sizeDelta = new Vector2(Mathf.Max(width, MinTouchTarget), Mathf.Max(height, MinTouchTarget));
+        }
+
+        /// <summary>Disabled does nothing at all and does not explain itself.</summary>
+        public void SetDisabled(bool disabled)
+        {
+            EnsureInitialized();
+            _isDisabled = disabled;
+
+            if (disabled)
+            {
+                _isPressed = false;
+            }
+
+            RefreshVisual();
+        }
+
+        /// <summary>Hidden is not laid out at all — buttons do not leave gaps behind.</summary>
+        public void SetHidden(bool hidden)
+        {
+            EnsureInitialized();
+            gameObject.SetActive(!hidden);
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            EnsureInitialized();
+
+            if (_isDisabled)
+            {
+                return;
+            }
+
+            _isPressed = true;
+            RefreshVisual();
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            EnsureInitialized();
+
+            if (_isDisabled)
+            {
+                return;
+            }
+
+            var wasPressed = _isPressed;
+            _isPressed = false;
+            RefreshVisual();
+
+            if (!wasPressed)
+            {
+                return;
+            }
+
+            // Acts on release, and only when the release lands over the
+            // button — docs/specs/ui/shared-components.md#button's Behaviour:
+            // "a finger that lands wrong can slide off and cancel."
+            if (RectTransformUtility.RectangleContainsScreenPoint(_rect, eventData.position, eventData.pressEventCamera))
+            {
+                Clicked?.Invoke();
+            }
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            EnsureInitialized();
+
+            if (!_isPressed)
+            {
+                return;
+            }
+
+            _isPressed = false;
+            RefreshVisual();
+        }
+
+        // Unity does not guarantee Awake() has run before another component's
+        // Awake() or a test reaches this one right after AddComponent — the
+        // same reasoning as ScreenRouterAdapter.EnsureInitialized. Every
+        // public entry point funnels through this idempotent guard instead of
+        // trusting Awake's timing.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+            ApplyKindColours();
+            RefreshVisual();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.sizeDelta = new Vector2(ButtonMinWidth, ButtonHeight);
+
+            _canvasGroup = GetComponent<CanvasGroup>();
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+            }
+
+            // Always blocks — a disabled button swallows the tap rather than
+            // letting it pass through to whatever is behind it.
+            _canvasGroup.blocksRaycasts = true;
+
+            var visualGO = new GameObject("Visual", typeof(RectTransform));
+            _visualRoot = visualGO.GetComponent<RectTransform>();
+            _visualRoot.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(_visualRoot);
+
+            var borderGO = new GameObject("Border", typeof(RectTransform), typeof(Image));
+            _border = borderGO.GetComponent<Image>();
+            _border.sprite = ButtonSprite;
+            _border.type = Image.Type.Sliced;
+            _border.raycastTarget = true;
+            var borderRect = _border.rectTransform;
+            borderRect.SetParent(_visualRoot, worldPositionStays: false);
+            StretchToFill(borderRect);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            _fill = fillGO.GetComponent<Image>();
+            _fill.sprite = ButtonSprite;
+            _fill.type = Image.Type.Sliced;
+            _fill.raycastTarget = false;
+            var fillRect = _fill.rectTransform;
+            fillRect.SetParent(_visualRoot, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(ButtonBorderWidth, ButtonBorderWidth);
+            fillRect.offsetMax = new Vector2(-ButtonBorderWidth, -ButtonBorderWidth);
+
+            var labelGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            _label = labelGO.GetComponent<Text>();
+            _label.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _label.fontSize = (int)ButtonLabelSize;
+            _label.alignment = TextAnchor.MiddleCenter;
+            _label.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _label.verticalOverflow = VerticalWrapMode.Overflow;
+            _label.raycastTarget = false;
+            var labelRect = _label.rectTransform;
+            labelRect.SetParent(_visualRoot, worldPositionStays: false);
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = new Vector2(ButtonPaddingX, 0f);
+            labelRect.offsetMax = new Vector2(-ButtonPaddingX, 0f);
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        void ApplyKindColours()
+        {
+            switch (_kind)
+            {
+                case ButtonKind.Primary:
+                    _defaultBorderColor = AccentColor;
+                    _defaultFillColor = AccentColor;
+                    _defaultLabelColor = LightLabelColor;
+                    break;
+
+                case ButtonKind.Secondary:
+                    _defaultBorderColor = OutlineColor;
+                    _defaultFillColor = NoFillColor;
+                    _defaultLabelColor = DarkLabelColor;
+                    break;
+
+                case ButtonKind.Destructive:
+                    _defaultBorderColor = WarningColor;
+                    _defaultFillColor = NoFillColor;
+                    _defaultLabelColor = WarningColor;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(_kind), _kind, null);
+            }
+        }
+
+        void RefreshVisual()
+        {
+            _border.color = _isPressed ? Darken(_defaultBorderColor) : _defaultBorderColor;
+            _fill.color = _isPressed ? Darken(_defaultFillColor) : _defaultFillColor;
+            _label.color = _defaultLabelColor;
+
+            _visualRoot.anchoredPosition = _isPressed ? new Vector2(0f, -ButtonPressOffset) : Vector2.zero;
+
+            _canvasGroup.alpha = _isDisabled ? ButtonDisabledOpacity : 1f;
+            _canvasGroup.interactable = !_isDisabled;
+        }
+
+        static Color Darken(Color colour)
+        {
+            return new Color(colour.r * PressedDarkenFactor, colour.g * PressedDarkenFactor, colour.b * PressedDarkenFactor, colour.a);
+        }
+    }
+}

--- a/Assets/Scripts/Unity/UI/Button.cs.meta
+++ b/Assets/Scripts/Unity/UI/Button.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 483dd2f14fdf403aa6990dfcda88e5b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/ButtonKind.cs
+++ b/Assets/Scripts/Unity/UI/ButtonKind.cs
@@ -1,0 +1,21 @@
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The three kinds the shared <see cref="Button"/> comes in. Per
+    /// docs/specs/ui/shared-components.md#button: "It comes in three kinds,
+    /// which differ in colour and weight but never in size or shape." A kind
+    /// switch touches only the colours <see cref="Button"/> applies, never its
+    /// geometry.
+    /// </summary>
+    public enum ButtonKind
+    {
+        /// <summary>Filled accent, light label. At most one visible at a time.</summary>
+        Primary,
+
+        /// <summary>Outlined, dark label, no fill.</summary>
+        Secondary,
+
+        /// <summary>Outlined in the warning colour, warning-coloured label.</summary>
+        Destructive
+    }
+}

--- a/Assets/Scripts/Unity/UI/ButtonKind.cs.meta
+++ b/Assets/Scripts/Unity/UI/ButtonKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f611b9b3eda84e14b14b236e5c0c2387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/FrogColours.cs
+++ b/Assets/Scripts/Unity/UI/FrogColours.cs
@@ -1,0 +1,51 @@
+using System;
+using UnityEngine;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The four colours a player can be in v1 — docs/specs/ui/shared-components.md
+    /// § Frog colours. These four hex values are wireframe placeholders, not the
+    /// final palette: "the real palette is an area:art decision and it lands
+    /// with the frog sprites; when it does, these four constants take the real
+    /// values and nothing else on any screen changes."
+    ///
+    /// <see cref="Frogs.Core.FrogColour"/> names *which* frog a player is; it
+    /// carries no <c>UnityEngine.Color</c> because Core never references
+    /// UnityEngine. This is the one place that maps that identity to the
+    /// colour it is painted — declared once so no screen hard-codes a hex value
+    /// a second time.
+    /// </summary>
+    public static class FrogColours
+    {
+        /// <summary>docs/specs/ui/shared-components.md § Frog colours — `FrogGreen`, `#3F8E4F`.</summary>
+        public static readonly Color FrogGreen = new Color32(0x3F, 0x8E, 0x4F, 0xFF);
+
+        /// <summary>docs/specs/ui/shared-components.md § Frog colours — `FrogBlue`, `#2C6DAF`.</summary>
+        public static readonly Color FrogBlue = new Color32(0x2C, 0x6D, 0xAF, 0xFF);
+
+        /// <summary>docs/specs/ui/shared-components.md § Frog colours — `FrogOrange`, `#D2762B`.</summary>
+        public static readonly Color FrogOrange = new Color32(0xD2, 0x76, 0x2B, 0xFF);
+
+        /// <summary>docs/specs/ui/shared-components.md § Frog colours — `FrogPink`, `#C24C86`.</summary>
+        public static readonly Color FrogPink = new Color32(0xC2, 0x4C, 0x86, 0xFF);
+
+        /// <summary>The concrete colour for a <see cref="Frogs.Core.FrogColour"/> identity.</summary>
+        public static Color For(Frogs.Core.FrogColour colour)
+        {
+            switch (colour)
+            {
+                case Frogs.Core.FrogColour.Green:
+                    return FrogGreen;
+                case Frogs.Core.FrogColour.Blue:
+                    return FrogBlue;
+                case Frogs.Core.FrogColour.Orange:
+                    return FrogOrange;
+                case Frogs.Core.FrogColour.Pink:
+                    return FrogPink;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(colour), colour, null);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/UI/FrogColours.cs.meta
+++ b/Assets/Scripts/Unity/UI/FrogColours.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c7775b09d6e4098acbe08dbffaacc9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/ButtonTests.cs
+++ b/Assets/Tests/EditMode/ButtonTests.cs
@@ -1,0 +1,282 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Unity.UI;
+// UnityEngine.UI also declares a Button type, so it is deliberately not
+// imported wholesale here — only Image is needed, qualified below, so a bare
+// `Button` in this file always means Frogs.Unity.UI.Button.
+using UnityImage = UnityEngine.UI.Image;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The shared Button — issue #214. Built through the typed Unity API with
+    /// no committed prefab (docs/engineering/unity-serialization.md's
+    /// <c>FrogPrefab_HasItsSpriteAndScriptWiredUp</c> pattern, applied to a
+    /// component that builds itself instead of one loaded from an asset), so
+    /// these tests prove the pieces the constructor wires together rather than
+    /// asserting on a `.prefab` file.
+    /// </summary>
+    public sealed class ButtonTests
+    {
+        [Test]
+        public void Button_WiresItsBuiltInSpriteAndFont_RatherThanLeavingThemMissing()
+        {
+            // docs/engineering/unity-serialization.md's
+            // FrogPrefab_HasItsSpriteAndScriptWiredUp pattern, applied to a
+            // component built at runtime instead of loaded from an asset:
+            // Resources.GetBuiltinResource fails silently (returns null, not
+            // an exception) if the built-in resource name is wrong, so assert
+            // the wiring rather than trusting the lookup succeeded.
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                var border = button.RectTransform.Find("Visual/Border").GetComponent<UnityImage>();
+                var fill = button.RectTransform.Find("Visual/Fill").GetComponent<UnityImage>();
+
+                Assert.That(border.sprite, Is.Not.Null, "built-in button sprite missing — check the resource name");
+                Assert.That(fill.sprite, Is.Not.Null, "built-in button sprite missing — check the resource name");
+                Assert.That(button.Label.font, Is.Not.Null, "built-in label font missing — check the resource name");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void ThreeKinds_ShareIdenticalGeometry_AndDifferOnlyInColour()
+        {
+            var primary = CreateButton(ButtonKind.Primary);
+            var secondary = CreateButton(ButtonKind.Secondary);
+            var destructive = CreateButton(ButtonKind.Destructive);
+
+            try
+            {
+                foreach (var button in new[] { primary, secondary, destructive })
+                {
+                    // docs/specs/ui/shared-components.md#button: "All three
+                    // share ButtonHeight, ButtonMinWidth, ButtonPaddingX,
+                    // ButtonRadius and ButtonLabelSize exactly."
+                    Assert.That(
+                        button.RectTransform.sizeDelta,
+                        Is.EqualTo(new Vector2(Button.ButtonMinWidth, Button.ButtonHeight)),
+                        $"{button.Kind} must default to the shared ButtonMinWidth x ButtonHeight");
+                    Assert.That(button.Label.fontSize, Is.EqualTo((int)Button.ButtonLabelSize));
+
+                    var labelRect = button.Label.rectTransform;
+                    Assert.That(labelRect.offsetMin.x, Is.EqualTo(Button.ButtonPaddingX));
+                    Assert.That(labelRect.offsetMax.x, Is.EqualTo(-Button.ButtonPaddingX));
+                }
+
+                var signatures = new[] { primary, secondary, destructive }
+                    .Select(button => (button.FillColor, button.BorderColor, button.LabelColor))
+                    .Distinct()
+                    .Count();
+
+                Assert.That(signatures, Is.EqualTo(3), "each of the three kinds must have its own colour signature");
+            }
+            finally
+            {
+                Destroy(primary);
+                Destroy(secondary);
+                Destroy(destructive);
+            }
+        }
+
+        [Test]
+        public void Button_IsNeverSmallerThanMinTouchTarget_AtAnyKindOrCallerSuppliedSize()
+        {
+            foreach (var kind in new[] { ButtonKind.Primary, ButtonKind.Secondary, ButtonKind.Destructive })
+            {
+                var button = CreateButton(kind);
+
+                try
+                {
+                    button.SetSize(10f, 10f);
+
+                    Assert.That(button.RectTransform.sizeDelta.x, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+                    Assert.That(button.RectTransform.sizeDelta.y, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+                }
+                finally
+                {
+                    Destroy(button);
+                }
+            }
+        }
+
+        [Test]
+        public void CallerSuppliedSize_LargerThanMinTouchTarget_IsRespected()
+        {
+            // title-screen.md gives its buttons their own 560 x 160 —
+            // "never differ in size" is a rule about the three kinds, not a
+            // ban on a screen sizing its own instance.
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                button.SetSize(560f, 160f);
+
+                Assert.That(button.RectTransform.sizeDelta, Is.EqualTo(new Vector2(560f, 160f)));
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void Pressed_MovesTheVisualDownByButtonPressOffset_AndDarkensTheFill()
+        {
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                var defaultFill = button.FillColor;
+                var defaultBorder = button.BorderColor;
+
+                button.OnPointerDown(EventDataAt(button, inside: true));
+
+                Assert.That(button.IsPressed, Is.True);
+                Assert.That(button.VisualRoot.anchoredPosition, Is.EqualTo(new Vector2(0f, -Button.ButtonPressOffset)));
+                Assert.That(button.FillColor, Is.Not.EqualTo(defaultFill), "fill must darken while pressed");
+                Assert.That(button.BorderColor, Is.Not.EqualTo(defaultBorder), "border must darken while pressed");
+
+                button.OnPointerUp(EventDataAt(button, inside: true));
+
+                Assert.That(button.IsPressed, Is.False);
+                Assert.That(button.VisualRoot.anchoredPosition, Is.EqualTo(Vector2.zero));
+                Assert.That(button.FillColor, Is.EqualTo(defaultFill), "fill must return to its default once released");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void Disabled_RendersAtButtonDisabledOpacity_AndSwallowsTheTapWithoutEmittingAnything()
+        {
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                var clicks = 0;
+                button.Clicked += () => clicks++;
+
+                button.SetDisabled(true);
+
+                Assert.That(button.CanvasGroup.alpha, Is.EqualTo(Button.ButtonDisabledOpacity).Within(0.0001f));
+
+                button.OnPointerDown(EventDataAt(button, inside: true));
+                button.OnPointerUp(EventDataAt(button, inside: true));
+
+                Assert.That(button.IsPressed, Is.False, "a disabled button has no press response");
+                Assert.That(clicks, Is.EqualTo(0), "a disabled button does nothing at all");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void Hidden_IsRemovedFromLayoutEntirely_NotMadeTransparent()
+        {
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                Assert.That(button.IsHidden, Is.False);
+
+                button.SetHidden(true);
+
+                Assert.That(button.IsHidden, Is.True);
+                Assert.That(button.gameObject.activeSelf, Is.False, "Hidden buttons do not leave gaps behind — they are removed from layout, not faded out");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void ActsOnRelease_NotOnPress()
+        {
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                var clicks = 0;
+                button.Clicked += () => clicks++;
+
+                button.OnPointerDown(EventDataAt(button, inside: true));
+                Assert.That(clicks, Is.EqualTo(0), "must not fire on press");
+
+                button.OnPointerUp(EventDataAt(button, inside: true));
+                Assert.That(clicks, Is.EqualTo(1), "must fire on release, over the button");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        [Test]
+        public void EmitsNothing_WhenReleaseLandsOutsideTheButton()
+        {
+            var button = CreateButton(ButtonKind.Primary);
+
+            try
+            {
+                var clicks = 0;
+                button.Clicked += () => clicks++;
+
+                button.OnPointerDown(EventDataAt(button, inside: true));
+                button.OnPointerUp(EventDataAt(button, inside: false));
+
+                Assert.That(clicks, Is.EqualTo(0), "a finger that lands wrong can slide off and cancel");
+            }
+            finally
+            {
+                Destroy(button);
+            }
+        }
+
+        static Button CreateButton(ButtonKind kind)
+        {
+            var host = new GameObject(nameof(ButtonTests), typeof(RectTransform));
+            var button = host.AddComponent<Button>();
+            button.SetKind(kind);
+            return button;
+        }
+
+        static void Destroy(Button button)
+        {
+            if (button != null)
+            {
+                Object.DestroyImmediate(button.gameObject);
+            }
+        }
+
+        static PointerEventData EventDataAt(Button button, bool inside)
+        {
+            var corners = new Vector3[4];
+            button.RectTransform.GetWorldCorners(corners);
+
+            var center = (Vector2)(corners[0] + corners[2]) / 2f;
+            var width = corners[2].x - corners[0].x;
+
+            // Comfortably outside the rect in every case, regardless of the
+            // caller-supplied size the test is exercising.
+            var outside = center + new Vector2(Mathf.Abs(width) + Button.MinTouchTarget * 10f, 0f);
+
+            return new PointerEventData(null)
+            {
+                position = inside ? center : outside
+            };
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ButtonTests.cs.meta
+++ b/Assets/Tests/EditMode/ButtonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32301aaf0d1c4b5ab3b1db13de82aba2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/FrogColoursTests.cs
+++ b/Assets/Tests/EditMode/FrogColoursTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using UnityEngine;
+using Frogs.Unity.UI;
+using CoreFrogColour = Frogs.Core.FrogColour;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The four frog colours — issue #214,
+    /// docs/specs/ui/shared-components.md#frog-colours. These four values are
+    /// the v0.2 deliverable, not a placeholder for a follow-up issue.
+    /// </summary>
+    public sealed class FrogColoursTests
+    {
+        [Test]
+        public void FourFrogColours_ExistAndMatchTheNamedHexValues()
+        {
+            Assert.That(FrogColours.FrogGreen, Is.EqualTo((Color)new Color32(0x3F, 0x8E, 0x4F, 0xFF)));
+            Assert.That(FrogColours.FrogBlue, Is.EqualTo((Color)new Color32(0x2C, 0x6D, 0xAF, 0xFF)));
+            Assert.That(FrogColours.FrogOrange, Is.EqualTo((Color)new Color32(0xD2, 0x76, 0x2B, 0xFF)));
+            Assert.That(FrogColours.FrogPink, Is.EqualTo((Color)new Color32(0xC2, 0x4C, 0x86, 0xFF)));
+        }
+
+        [Test]
+        public void ExactlyFourColours_AreDistinguishableFromEachOther()
+        {
+            var colours = new[] { FrogColours.FrogGreen, FrogColours.FrogBlue, FrogColours.FrogOrange, FrogColours.FrogPink };
+
+            for (var i = 0; i < colours.Length; i++)
+            {
+                for (var j = i + 1; j < colours.Length; j++)
+                {
+                    Assert.That(colours[i], Is.Not.EqualTo(colours[j]), "two frogs in a game are never the same colour");
+                }
+            }
+        }
+
+        [TestCase(CoreFrogColour.Green, 0x3F, 0x8E, 0x4F)]
+        [TestCase(CoreFrogColour.Blue, 0x2C, 0x6D, 0xAF)]
+        [TestCase(CoreFrogColour.Orange, 0xD2, 0x76, 0x2B)]
+        [TestCase(CoreFrogColour.Pink, 0xC2, 0x4C, 0x86)]
+        public void For_MapsEachCoreIdentity_ToItsOneNamedColour(CoreFrogColour colour, byte r, byte g, byte b)
+        {
+            Assert.That(FrogColours.For(colour), Is.EqualTo((Color)new Color32(r, g, b, 0xFF)));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/FrogColoursTests.cs.meta
+++ b/Assets/Tests/EditMode/FrogColoursTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 250fde309449494aa857d9311d7ba9a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/adr/0005-ugui-not-ui-toolkit.md
+++ b/docs/adr/0005-ugui-not-ui-toolkit.md
@@ -59,7 +59,15 @@ anything.
   Each issue that draws one either uses a built-in editor UI resource
   (`Resources.GetBuiltinResource<Sprite>(…)`, shipped with every Unity install —
   not a project asset) or generates the shape procedurally at runtime, and says
-  in its PR which. This issue's Button uses the built-in resource; see its PR.
+  in its PR which. **This issue's Button tried the built-in resource first**
+  (`"UI/Skin/UISprite.psd"`) and found it unreliable: CI on the pinned
+  `6000.0.81f1` logged `Failed to find UI/Skin/UISprite.psd` and the lookup
+  returned `null` silently, with no editor available locally to find the
+  right name for this version. It switched to generating the rounded rect
+  procedurally instead, which carries no per-version resource name to get
+  right. A later issue reaching for a built-in resource should expect the
+  same risk and consider procedural generation first rather than rediscovering
+  this the same way.
 - `Packages/manifest.json` keeps `com.unity.modules.uielements` for now — it is
   a default Unity 6 module, not a UI Toolkit feature this project uses, and
   removing it is a housekeeping change with no behaviour attached to it, not

--- a/docs/adr/0005-ugui-not-ui-toolkit.md
+++ b/docs/adr/0005-ugui-not-ui-toolkit.md
@@ -1,0 +1,69 @@
+# The game's UI is built in uGUI, not UI Toolkit
+
+Unity ships two UI systems, and nothing in `/docs` had said which one this game
+uses. `Packages/manifest.json` carries both `com.unity.ugui` and
+`com.unity.modules.uielements` at once — that is the set a default Unity 6
+project ships with, not a choice anybody made. The screen router
+([#213](https://github.com/derekwinters/connor-multiplying-frogs/issues/213))
+put four empty root `GameObject`s on screen and drew nothing of its own, so it
+did not have to pick either. This issue is the first one that draws a pixel,
+so it is the first one that has to decide.
+
+## The choice: **uGUI** (`Canvas`, `RectTransform`, MonoBehaviours with
+`[SerializeField]`) — not UI Toolkit (`UXML`, `USS`, `UIDocument`).
+
+## Why
+
+**`/docs` is already written in uGUI's terms.** Every screen and shared-component
+spec page states geometry as pixels at a fixed 1920 × 1200 reference
+resolution — [the canvas every component is measured
+in](../specs/ui/shared-components.md#the-canvas-every-component-is-measured-in)
+says outright: *"Unity's `CanvasScaler` is set to that same reference
+resolution."* `CanvasScaler` is a uGUI type with no UI Toolkit equivalent that
+means the same thing. Picking UI Toolkit would mean re-deriving how "1920 × 1200
+pixels" maps onto `UIDocument`'s length units before drawing a single button.
+
+**[Unity serialization](../engineering/unity-serialization.md) — the page
+[`CLAUDE.md`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CLAUDE.md)
+rule 6 sends every agent to — is written entirely
+about uGUI's shape.** Its worked examples are a `MonoBehaviour`'s serialized
+`[SerializeField]` fields and a prefab's component tree
+(`FrogPrefab_HasItsSpriteAndScriptWiredUp`). UI Toolkit's failure modes are a
+different shape — a `UXML` element name that does not match, a `USS` class that
+does not apply — that this page says nothing about. Choosing UI Toolkit would
+leave the one page that exists specifically to stop an agent guessing at Unity
+serialization silent on the serialization format the UI actually uses.
+
+**The existing EditMode tests already assert on this shape.**
+`ScreenRouterAdapterTests` asserts on `GameObject.activeSelf` and component
+wiring built through the typed `MonoBehaviour`/`GameObject` API — the same shape
+this issue's Button tests use. Nothing in the repo is written in UI Toolkit's
+vocabulary.
+
+**What UI Toolkit would have bought instead:** every visual in v0.2 is a
+rectangle or a circle, and USS `border-radius` draws both with no sprite
+asset at all — cheaper than uGUI's `Image`, which needs *some* sprite to render
+a rounded shape (see below). That is a real cost, and it is the only one; it is
+outweighed by re-expressing an already-written design contract before drawing
+anything.
+
+## Consequences
+
+- Every shared component and every screen is a `MonoBehaviour` hierarchy built
+  through the typed `GameObject`/`RectTransform`/`Image`/`Text` API — the same
+  pattern `HelloWorldScene.cs` and `ScreenRouterAdapter` already use — guarded
+  by EditMode tests in the `FrogPrefab_HasItsSpriteAndScriptWiredUp` style.
+- **A filled rounded rectangle or circle needs a sprite for uGUI's `Image` to
+  render at all**, and [no external
+  assets](../specs/ui/shared-components.md) rules out an imported texture.
+  Each issue that draws one either uses a built-in editor UI resource
+  (`Resources.GetBuiltinResource<Sprite>(…)`, shipped with every Unity install —
+  not a project asset) or generates the shape procedurally at runtime, and says
+  in its PR which. This issue's Button uses the built-in resource; see its PR.
+- `Packages/manifest.json` keeps `com.unity.modules.uielements` for now — it is
+  a default Unity 6 module, not a UI Toolkit feature this project uses, and
+  removing it is a housekeeping change with no behaviour attached to it, not
+  something this decision needs to force.
+- If a future screen turns out to need UI Toolkit's flexbox layout badly enough
+  to be worth re-opening this, that is its own ADR that supersedes this one —
+  not a screen quietly mixing both systems.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,7 +20,11 @@ the game evolves; it is superseded by a later ADR that says so.
 | [0002](0002-structured-working-out-grid.md) | The game adds a structured working-out grid the classroom game has no equivalent of |
 | [0003](0003-network-boundary.md) | The internet is permanently out; the local network is an open question |
 | [0004](0004-core-owns-the-save-format.md) | Core owns the save format and hand-rolls it |
+| [0005](0005-ugui-not-ui-toolkit.md) | The game's UI is built in uGUI, not UI Toolkit |
 
-All four were settled in
+The first four were settled in
 [issue #7](https://github.com/derekwinters/connor-multiplying-frogs/issues/7),
-the design conversation that established what Multiplying Frogs is.
+the design conversation that established what Multiplying Frogs is. ADR-0005
+was settled in
+[issue #214](https://github.com/derekwinters/connor-multiplying-frogs/issues/214),
+the first issue to draw a pixel.

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -120,6 +120,8 @@ a player is most likely to be reaching for.
 | Gap between adjacent buttons | `ButtonGap` | 32 px |
 | Gap between a destructive button and its neighbour | `ButtonDestructiveGap` | 96 px |
 | Press travel | `ButtonPressOffset` | 4 px |
+| Border width, outlined kinds | `ButtonBorderWidth` | 4 px |
+| Opacity while disabled | `ButtonDisabledOpacity` | 0.40 |
 
 #### 4. States
 
@@ -129,8 +131,22 @@ a player is most likely to be reaching for.
 | Default (secondary) | Outlined, `ButtonBorderWidth` 4 px, dark label, no fill |
 | Default (destructive) | Outlined in the warning colour, warning-coloured label |
 | Pressed | Moves down by `ButtonPressOffset`; fill darkens |
-| Disabled | 40 % opacity, no press response |
+| Disabled | `ButtonDisabledOpacity` opacity, no press response |
 | Hidden | Not laid out at all — buttons do not leave gaps behind |
+
+`ButtonBorderWidth` and `ButtonDisabledOpacity` were always on this page — both
+appeared in the States row above with a value and no name — and are named here
+so the code has a name to declare, per
+[the named constants are the origin, not an afterthought](../../engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought).
+
+**Disabled is 40 % opacity, not a grey fill.** The committed mockups' `.btn.off`
+rule draws disabled as a flat grey (`background:#C9D2CE;color:#8C9793`), which
+disagrees with this page's own States table. This page is the component's
+contract; the mockups are drawings of screens built from it — see
+[CLAUDE.md](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CLAUDE.md)
+on which document wins being a decision, not an assumption. This page wins: disabled is the kind's own default appearance at
+`ButtonDisabledOpacity`, not a distinct grey style. The mockups should be
+redrawn to match the next time they are touched.
 
 #### 5. Behaviour
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - 0002 The working-out grid: adr/0002-structured-working-out-grid.md
       - 0003 The network boundary: adr/0003-network-boundary.md
       - 0004 Core owns the save format: adr/0004-core-owns-the-save-format.md
+      - 0005 uGUI, not UI Toolkit: adr/0005-ugui-not-ui-toolkit.md
   - Engineering:
       - engineering/index.md
       - Tech stack: engineering/tech-stack.md


### PR DESCRIPTION
Nine screens all say "the primary button" — this issue builds that button exactly once, so they all mean the same thing. It also settles, as a recorded technical decision rather than a guess, which of Unity's two UI systems the game draws in, and it declares the four frog colours every screen will tint things with. No screen ships in this PR.

**Docs:** `docs/adr/0005-ugui-not-ui-toolkit.md` (new) — records that the game's UI is built in uGUI, not UI Toolkit, and why, including a note on the built-in-resource approach it tried and abandoned; `docs/adr/index.md` — adds ADR-0005's row; `docs/specs/ui/shared-components.md` — adds `ButtonBorderWidth` (4 px) and `ButtonDisabledOpacity` (0.40) to the Button Named-constants table (both were already stated on that page's States table with a value but no name), and records that the page's 40% opacity reading for Disabled wins over the committed mockups' grey-fill drawing.

## Spec invariants

- `shared-components.md#button` — "never smaller than `MinTouchTarget` in either direction": `Button.SetSize` clamps both dimensions up to `MinTouchTarget`, asserted for all three kinds and for a size smaller than the floor by `Button_IsNeverSmallerThanMinTouchTarget_AtAnyKindOrCallerSuppliedSize`.
- `shared-components.md#button` — "differ in colour and weight but never in size or shape": `ThreeKinds_ShareIdenticalGeometry_AndDifferOnlyInColour` builds all three kinds and asserts identical `sizeDelta`, label font size, and label padding, then asserts the three kinds' (fill, border, label) colour triples are pairwise distinct.
- `shared-components.md#button` — "Acts on release, not on press... a finger that lands wrong can slide off and cancel": `ActsOnRelease_NotOnPress` and `EmitsNothing_WhenReleaseLandsOutsideTheButton` call `OnPointerDown`/`OnPointerUp` directly (no live `EventSystem` in EditMode) and check `RectTransformUtility.RectangleContainsScreenPoint` at release.
- `shared-components.md#button` — Disabled "does nothing at all" and Hidden is "not laid out at all": `Disabled_...` and `Hidden_...` assert no `Clicked` invocation and `gameObject.activeSelf == false`, respectively — not a transparency or an ignored-click flag.
- `shared-components.md#frog-colours` — "two frogs... never the same colour" / "distinguishable... by lightness alone": `FourFrogColours_ExistAndMatchTheNamedHexValues` and `ExactlyFourColours_AreDistinguishableFromEachOther` pin the four hex values and their pairwise distinctness.

## How the spec is changing

- Old: `shared-components.md`'s Button Named-constants table had nine rows; `ButtonBorderWidth` and `ButtonDisabledOpacity` existed only inside the States table's prose ("Outlined, `ButtonBorderWidth` 4 px", "40% opacity"). New: eleven rows, both named, sourced from the States table's own stated values — no new number invented. Why: code needs a name to declare against, per [the named constants are the origin](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought).``
- Old: no ADR named the UI system; `/docs` only leaned uGUI via `CanvasScaler`. New: ADR-0005 records uGUI, with the reasoning written down so a later screen issue doesn't have to re-derive or silently assume it.

## What was built

- **ADR-0005** — uGUI, not UI Toolkit. The screen router (#213) put four empty markers on screen and drew nothing, so it hadn't had to choose; this is the first issue that draws a pixel. Reasoning is in the ADR: every spec page is already pixels-at-1920×1200-`CanvasScaler`, `unity-serialization.md` is written entirely in `MonoBehaviour`/`SerializeField`/prefab terms, and the existing EditMode tests already assert on `GameObject`/component wiring in that shape.
- **`Frogs.Unity.UI.Button`** (`Assets/Scripts/Unity/UI/Button.cs`) — built through the typed Unity API the first time it initializes (`EnsureInitialized`, same idempotent-guard pattern as `ScreenRouterAdapter`), not a committed `.prefab` — there's no editor here to author one honestly, and the issue decided this explicitly. All eleven Button constants, all three kinds (colour/weight only), and all six states (the three kind defaults, Pressed, Disabled, Hidden).
- **No external assets, generated procedurally.** The rounded fill/border started as Unity's built-in editor UI resource (`Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd")`), which the issue names as one of two sanctioned options — but CI on the pinned `6000.0.81f1` logged `Failed to find UI/Skin/UISprite.psd` and the lookup returned `null`. With no local editor to find the right name for this version, this switched to the issue's other sanctioned option: the corner is generated at runtime as a rounded-box signed-distance-field alpha mask, sliced so the corner renders at exactly `ButtonRadius` UI pixels regardless of the button's size. ADR-0005 records this so a later screen issue reaching for a built-in resource isn't surprised the same way. The label still uses the built-in `LegacyRuntime.ttf` font resource, which resolved fine in CI.
- **`Frogs.Unity.UI.FrogColours`** (`Assets/Scripts/Unity/UI/FrogColours.cs`) — the four named `Color` constants plus a `For(Frogs.Core.FrogColour)` mapping, so no screen hard-codes a hex value a second time. `Frogs.Core.FrogColour` already existed (names *which* frog); this is the one place that gives it a paintable colour, since Core never references `UnityEngine`.
- EditMode tests: `Assets/Tests/EditMode/ButtonTests.cs`, `Assets/Tests/EditMode/FrogColoursTests.cs` — written before the implementation (see commit history), not executed locally per [testing.md's sanctioned flow](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/testing.md#the-sanctioned-flow) — there is no Unity editor in this environment. `dotnet test Tests/Core/Frogs.Core.Tests.csproj` (190 tests) passes unchanged — nothing here touches `Assets/Scripts/Core`.

## Deviations and Decisions

- **The Button's rounded-corner sprite moved from a built-in Unity resource to a procedurally generated one, mid-PR.** CI's first run failed 6 of 8 `ButtonTests` — all via the same unhandled `Failed to find UI/Skin/UISprite.psd` error-level log from `Resources.GetBuiltinResource<Sprite>`, not a real assertion failure. That resource name is wrong or unavailable at runtime on the pinned `6000.0.81f1`; rather than guess at another string with no editor to verify it against, this generates the shape procedurally instead — the issue's own other sanctioned option, and one with no per-Unity-version resource catalogue to get wrong. See ADR-0005's Consequences section.
- **Chrome colours (fill/border/label — accent green, warning red, ink, outline grey, white) are not new named spec constants.** `shared-components.md`'s Button Named-constants table is geometry and opacity, not colour, and the issue scoped this PR's doc additions to exactly `ButtonBorderWidth` and `ButtonDisabledOpacity`. These values are copied verbatim from the committed mockups' CSS custom properties (`--accent`, `--warn`, `--ink`, `--line`, `--paper` — identical across all nine mockup files), which is the agreed picture already in `docs/specs/ui/mockups/`. Per [ui-design-process.md](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/ui-design-process.md#what-isnt-gated), "colours within the palette" is a restyle, not gated structure, so this doesn't need its own wireframe.
- **`Frogs.Unity.UI.Button` shares its name with `UnityEngine.UI.Button`.** Kept the spec's own name for the component rather than renaming to dodge the collision. Files that need both types (e.g. `ButtonTests.cs`) alias `UnityEngine.UI.Image` instead of wildcard-importing `UnityEngine.UI`; future screen issues will need the same discipline whenever they touch both.
- **The exact pressed-state darken factor (0.85×) is not a named spec value.** The spec says "fill darkens" with no number; declared as a private implementation constant with a comment rather than added to `shared-components.md`, since it's a rendering detail (ADR-0001: presentation is ours), not geometry/tuning.
- **Dialog and Player chip are out of scope**, per the issue — not built, and no follow-up issue opened (the run's tracking owns that).

Closes #214
