### PR TITLE
feat(ui): build the shared Dialog and the Player chip

### DIFF
--- a/Assets/Scripts/Unity/UI/DialogPanel.cs
+++ b/Assets/Scripts/Unity/UI/DialogPanel.cs
@@ -1,0 +1,485 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The one dialog panel in the game —
+    /// docs/specs/ui/shared-components.md#dialog. Built entirely through the
+    /// typed Unity API, no committed <c>.prefab</c>, the same decision #214
+    /// made for <see cref="Button"/> (issue #219).
+    ///
+    /// This type owns the panel's own contract only: what a dialog looks
+    /// like, how its title/body/button row are laid out and spaced, how it
+    /// opens and closes, and — per instance — which of its buttons is the
+    /// least destructive one. It has no concept of z-order, of a
+    /// parent-dialog, or of "the dialog already open" — <see cref="Open"/>
+    /// takes no such argument, and no member on this type names one. That
+    /// absence is deliberate: at-most-one-dialog (both that at most one is
+    /// current, and that at most one is ever instantiated) is owned entirely
+    /// by the screen router's dialog layer (#213); this component structurally
+    /// cannot compete with that guarantee, and does not try to.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    [RequireComponent(typeof(CanvasGroup))]
+    public sealed class DialogPanel : MonoBehaviour
+    {
+        // docs/specs/ui/shared-components.md#dialog — Named constants.
+        public const float DialogScrimOpacity = 0.66f;
+        public const float DialogRadius = 32f;
+        public const float DialogPadding = 56f;
+        public const float DialogTitleSize = 56f;
+        public const float DialogTitleGap = 40f;
+        public const float DialogButtonRowGap = 48f;
+        public const float DialogFadeDuration = 0.15f;
+
+        // The one canvas every component is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float CanvasWidth = 1920f;
+        const float CanvasHeight = 1200f;
+
+        // "DialogMaxWidth and DialogMaxHeight are the canvas inset by 48 px
+        // on every side" — built as that relationship, not two more
+        // independent literals, so a change to the canvas or the inset only
+        // has one place to change.
+        const float DialogMargin = 48f;
+        public const float DialogMaxWidth = CanvasWidth - (DialogMargin * 2f);
+        public const float DialogMaxHeight = CanvasHeight - (DialogMargin * 2f);
+
+        // No imported texture, sprite, or font — "no external assets".
+        // Matches Button.cs's own choice of font, and RoundedRectSprite's
+        // technique for a rounded panel with none to import — see that
+        // type's own comment for why Resources.GetBuiltinResource<Sprite>
+        // is not used here.
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockups' CSS
+        // custom properties, the same line Button.cs and TitleScreenView.cs
+        // both draw for their own colours — not a shared-components.md
+        // geometry/opacity constant, so not declared as a named spec
+        // constant.
+        static readonly Color ScrimColor = new Color(0f, 0f, 0f, DialogScrimOpacity); // mockups' scrim over --ink
+        static readonly Color PanelColor = Color.white; // mockups' --paper / #fff panel
+        static readonly Color TitleColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
+
+        static Sprite s_panelSprite;
+
+        static Sprite PanelSprite
+        {
+            get
+            {
+                if (s_panelSprite == null)
+                {
+                    s_panelSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(DialogRadius));
+                }
+
+                return s_panelSprite;
+            }
+        }
+
+        RectTransform _rect;
+        CanvasGroup _canvasGroup;
+        Image _scrim;
+        Image _panelImage;
+        RectTransform _panelRect;
+        Text _titleText;
+        RectTransform _bodyRect;
+        RectTransform _buttonRowRect;
+
+        readonly List<Button> _buttons = new List<Button>();
+
+        bool _initialized;
+        bool _isOpen;
+        float _fadeElapsed;
+        Button _leastDestructiveButton;
+
+        /// <summary>The root, full-canvas <see cref="RectTransform"/> — scrim and panel both sit under this.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>Drives the open/close cross-fade over <see cref="DialogFadeDuration"/> — never the panel's position.</summary>
+        public CanvasGroup CanvasGroup
+        {
+            get
+            {
+                EnsureInitialized();
+                return _canvasGroup;
+            }
+        }
+
+        /// <summary>The dim over the screen underneath. Always present — a Dialog never renders without one.</summary>
+        public Image Scrim
+        {
+            get
+            {
+                EnsureInitialized();
+                return _scrim;
+            }
+        }
+
+        /// <summary>The panel itself — its size is the caller-supplied one, clamped to <see cref="DialogMaxWidth"/> x <see cref="DialogMaxHeight"/>.</summary>
+        public RectTransform PanelRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _panelRect;
+            }
+        }
+
+        /// <summary>The dialog's title.</summary>
+        public Text TitleText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _titleText;
+            }
+        }
+
+        /// <summary>The body area a caller composes its own content into — a card, a working-out grid, a confirm's cost sentence.</summary>
+        public RectTransform BodyRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _bodyRect;
+            }
+        }
+
+        /// <summary>The row <see cref="Button"/>s (#214) are added to, bottom of the panel, primary rightmost.</summary>
+        public RectTransform ButtonRowRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _buttonRowRect;
+            }
+        }
+
+        /// <summary>Every button added to this dialog, in the order it was added.</summary>
+        public IReadOnlyList<Button> Buttons
+        {
+            get
+            {
+                EnsureInitialized();
+                return _buttons;
+            }
+        }
+
+        /// <summary>
+        /// Which button is least destructive, for this dialog instance — the
+        /// value the router (#213) reads and invokes on hardware back for a
+        /// dialog that decides something. This type exposes the value; it
+        /// does not itself listen for hardware back.
+        /// </summary>
+        public Button LeastDestructiveButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _leastDestructiveButton;
+            }
+        }
+
+        /// <summary>True from <see cref="Open"/> until <see cref="Close"/>.</summary>
+        public bool IsOpen
+        {
+            get
+            {
+                EnsureInitialized();
+                return _isOpen;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>Sets the title text.</summary>
+        public void SetTitle(string text)
+        {
+            EnsureInitialized();
+            _titleText.text = text;
+        }
+
+        /// <summary>
+        /// Sets the panel's size to the caller's request, clamped down to
+        /// <see cref="DialogMaxWidth"/> x <see cref="DialogMaxHeight"/> if it
+        /// exceeds either. A size at or below the cap is honoured exactly —
+        /// the cap is a ceiling on how big a dialog may be, not the size
+        /// every dialog is.
+        /// </summary>
+        public void SetSize(float width, float height)
+        {
+            EnsureInitialized();
+            _panelRect.sizeDelta = new Vector2(Mathf.Min(width, DialogMaxWidth), Mathf.Min(height, DialogMaxHeight));
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Button"/> (#214) to the button row, in the
+        /// order called — later calls sit further right, which is what puts
+        /// the primary button rightmost when it is added last.
+        /// </summary>
+        public Button AddButton(ButtonKind kind, string label, Action onClick, bool isLeastDestructive = false)
+        {
+            EnsureInitialized();
+
+            var buttonGO = new GameObject(string.IsNullOrEmpty(label) ? "Button" : label, typeof(RectTransform));
+            buttonGO.transform.SetParent(_buttonRowRect, worldPositionStays: false);
+
+            var button = buttonGO.AddComponent<Button>();
+            button.SetKind(kind);
+            button.SetLabelText(label);
+
+            if (onClick != null)
+            {
+                button.Clicked += onClick;
+            }
+
+            _buttons.Add(button);
+
+            if (isLeastDestructive)
+            {
+                _leastDestructiveButton = button;
+            }
+
+            LayoutButtonRow();
+
+            return button;
+        }
+
+        /// <summary>
+        /// Opens the dialog: the scrim and panel begin their cross-fade in
+        /// from fully transparent. Takes no ordering or parent-dialog
+        /// argument — see this type's own summary for why.
+        /// </summary>
+        public void Open()
+        {
+            EnsureInitialized();
+
+            _isOpen = true;
+            _fadeElapsed = 0f;
+            _canvasGroup.interactable = true;
+            _canvasGroup.blocksRaycasts = true;
+            RefreshFade();
+        }
+
+        /// <summary>Closes the dialog: the scrim and panel begin their cross-fade out.</summary>
+        public void Close()
+        {
+            EnsureInitialized();
+
+            _isOpen = false;
+            _fadeElapsed = 0f;
+            RefreshFade();
+        }
+
+        /// <summary>
+        /// Advances the open/close cross-fade by <paramref name="deltaSeconds"/>,
+        /// clamped to <see cref="DialogFadeDuration"/> — the same shape as
+        /// <c>TitleScreenView.AdvanceFade</c>. A public method of its own,
+        /// rather than reachable only through <c>Update</c>, so an EditMode
+        /// test can simulate elapsed time directly without advancing real
+        /// time, which it cannot do.
+        /// </summary>
+        public void AdvanceFade(float deltaSeconds)
+        {
+            EnsureInitialized();
+
+            _fadeElapsed = Mathf.Clamp(_fadeElapsed + Mathf.Max(deltaSeconds, 0f), 0f, DialogFadeDuration);
+            RefreshFade();
+        }
+
+        void RefreshFade()
+        {
+            var t = _fadeElapsed / DialogFadeDuration;
+            _canvasGroup.alpha = _isOpen ? t : 1f - t;
+
+            if (!_isOpen && _fadeElapsed >= DialogFadeDuration)
+            {
+                _canvasGroup.interactable = false;
+                _canvasGroup.blocksRaycasts = false;
+            }
+        }
+
+        // Unity does not guarantee Awake() has run before another
+        // component's Awake() or a test reaches this one right after
+        // AddComponent — the same reasoning as Button and ScreenRouterAdapter's
+        // own EnsureInitialized. Every public entry point funnels through
+        // this idempotent guard instead of trusting Awake's timing.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+            RefreshFade();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.anchorMin = new Vector2(0.5f, 0.5f);
+            _rect.anchorMax = new Vector2(0.5f, 0.5f);
+            _rect.pivot = new Vector2(0.5f, 0.5f);
+            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+
+            _canvasGroup = GetComponent<CanvasGroup>();
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+            }
+
+            _canvasGroup.alpha = 0f;
+            _canvasGroup.interactable = false;
+            _canvasGroup.blocksRaycasts = false;
+
+            BuildScrim();
+            BuildPanel();
+        }
+
+        void BuildScrim()
+        {
+            // The scrim: a dimmed copy of the screen underneath — "a dialog
+            // always dims what is behind it". It carries no click handler of
+            // any kind: "a dialog that decides something has no
+            // tap-outside-to-dismiss". It still blocks the raycast, so a tap
+            // on the board underneath cannot reach it while a dialog is open.
+            var scrimGO = new GameObject("Scrim", typeof(RectTransform), typeof(Image));
+            _scrim = scrimGO.GetComponent<Image>();
+            _scrim.color = ScrimColor;
+            _scrim.raycastTarget = true;
+
+            var scrimRect = _scrim.rectTransform;
+            scrimRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(scrimRect);
+        }
+
+        void BuildPanel()
+        {
+            var panelGO = new GameObject("Panel", typeof(RectTransform), typeof(Image));
+            _panelImage = panelGO.GetComponent<Image>();
+            _panelImage.sprite = PanelSprite;
+            _panelImage.type = Image.Type.Sliced;
+            _panelImage.color = PanelColor;
+            _panelImage.raycastTarget = true;
+
+            _panelRect = _panelImage.rectTransform;
+            _panelRect.SetParent(_rect, worldPositionStays: false);
+            _panelRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _panelRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _panelRect.pivot = new Vector2(0.5f, 0.5f);
+            _panelRect.sizeDelta = new Vector2(DialogMaxWidth, DialogMaxHeight);
+
+            BuildTitle();
+            BuildBody();
+            BuildButtonRow();
+        }
+
+        void BuildTitle()
+        {
+            var titleGO = new GameObject("Title", typeof(RectTransform), typeof(Text));
+            _titleText = titleGO.GetComponent<Text>();
+            _titleText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _titleText.fontSize = (int)DialogTitleSize;
+            _titleText.color = TitleColor;
+            _titleText.alignment = TextAnchor.UpperLeft;
+            _titleText.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _titleText.verticalOverflow = VerticalWrapMode.Overflow;
+            _titleText.raycastTarget = false;
+
+            var titleRect = _titleText.rectTransform;
+            titleRect.SetParent(_panelRect, worldPositionStays: false);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(0f, 1f);
+            titleRect.pivot = new Vector2(0f, 1f);
+            titleRect.sizeDelta = Vector2.zero;
+            titleRect.anchoredPosition = new Vector2(DialogPadding, -DialogPadding);
+        }
+
+        void BuildBody()
+        {
+            // A generic area, not a Text — the body is a card, a
+            // working-out grid, a cost sentence, depending on the screen.
+            // This issue builds the region; what a caller parents into it is
+            // that screen's own issue.
+            var bodyGO = new GameObject("Body", typeof(RectTransform));
+            _bodyRect = (RectTransform)bodyGO.transform;
+            _bodyRect.SetParent(_panelRect, worldPositionStays: false);
+            _bodyRect.anchorMin = Vector2.zero;
+            _bodyRect.anchorMax = Vector2.one;
+            _bodyRect.offsetMin = new Vector2(DialogPadding, DialogPadding + Button.ButtonHeight + DialogButtonRowGap);
+            _bodyRect.offsetMax = new Vector2(-DialogPadding, -(DialogPadding + DialogTitleSize + DialogTitleGap));
+        }
+
+        void BuildButtonRow()
+        {
+            var rowGO = new GameObject("ButtonRow", typeof(RectTransform));
+            _buttonRowRect = (RectTransform)rowGO.transform;
+            _buttonRowRect.SetParent(_panelRect, worldPositionStays: false);
+            _buttonRowRect.anchorMin = new Vector2(0f, 0f);
+            _buttonRowRect.anchorMax = new Vector2(1f, 0f);
+            _buttonRowRect.pivot = new Vector2(0.5f, 0f);
+            _buttonRowRect.offsetMin = new Vector2(DialogPadding, DialogPadding);
+            _buttonRowRect.offsetMax = new Vector2(-DialogPadding, DialogPadding + Button.ButtonHeight);
+        }
+
+        // Right-to-left, so the button added last ends up rightmost — the
+        // shared Button (#214) is composed here, not resized: adjacent
+        // buttons keep Button.ButtonGap apart, widened to
+        // Button.ButtonDestructiveGap whenever either neighbour is
+        // ButtonKind.Destructive, per that component's own invariant.
+        void LayoutButtonRow()
+        {
+            var cursor = 0f;
+
+            for (var index = _buttons.Count - 1; index >= 0; index--)
+            {
+                var button = _buttons[index];
+                var rect = button.RectTransform;
+                rect.anchorMin = new Vector2(1f, 0.5f);
+                rect.anchorMax = new Vector2(1f, 0.5f);
+                rect.pivot = new Vector2(1f, 0.5f);
+                rect.anchoredPosition = new Vector2(-cursor, 0f);
+
+                cursor += rect.sizeDelta.x;
+
+                if (index > 0)
+                {
+                    var neighbour = _buttons[index - 1];
+                    var gap = button.Kind == ButtonKind.Destructive || neighbour.Kind == ButtonKind.Destructive
+                        ? Button.ButtonDestructiveGap
+                        : Button.ButtonGap;
+                    cursor += gap;
+                }
+            }
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/UI/DialogPanel.cs.meta
+++ b/Assets/Scripts/Unity/UI/DialogPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a12a77b043a40a587a2430dbb37b9c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/PlayerChip.cs
+++ b/Assets/Scripts/Unity/UI/PlayerChip.cs
@@ -1,0 +1,309 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// A frog's identity — docs/specs/ui/shared-components.md#player-chip.
+    /// Built entirely through the typed Unity API, no committed
+    /// <c>.prefab</c>, the same decision #214 made for <see cref="Button"/>
+    /// (issue #219).
+    ///
+    /// A readout only, everywhere it appears in v0.2 — it implements no
+    /// pointer-event interface and declares no event of its own. Tapping to
+    /// add or remove a frog belongs to game setup's own **Frog seat**
+    /// element (docs/specs/ui/game-setup.md), not this component; see this
+    /// issue's PR for the reconciliation between the two pages.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class PlayerChip : MonoBehaviour
+    {
+        // docs/specs/ui/shared-components.md#player-chip — Named constants.
+        public const float PlayerChipHeight = 96f;
+        public const float PlayerChipWidth = 256f;
+        public const float PlayerSwatchDiameter = 64f;
+        public const float PlayerChipSwatchGap = 24f;
+        public const float PlayerChipLabelSize = 32f;
+        public const float PlayerChipPadCountSize = 24f;
+        public const float PlayerChipRadius = 20f;
+        public const float PlayerChipActiveRing = 6f;
+
+        const string HomeLabel = "Home!";
+
+        // No imported texture, sprite, or font — "no external assets".
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockups' CSS
+        // custom properties, the same line Button.cs, TitleScreenView.cs and
+        // DialogPanel.cs each draw for their own colours — not a
+        // shared-components.md geometry/opacity constant, so not declared as
+        // a named spec constant.
+        static readonly Color ChipBackgroundColor = Color.white; // mockups' --paper / #fff chip fill
+        static readonly Color RingColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' .chip.act border, --ink
+        static readonly Color NoRingColor = new Color(0f, 0f, 0f, 0f); // no ring — fully transparent
+        static readonly Color LabelColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
+        static readonly Color PadCountColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' .chip s, --line
+
+        static Sprite s_chipSprite;
+        static Sprite s_swatchSprite;
+
+        static Sprite ChipSprite
+        {
+            get
+            {
+                if (s_chipSprite == null)
+                {
+                    s_chipSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(PlayerChipRadius));
+                }
+
+                return s_chipSprite;
+            }
+        }
+
+        static Sprite SwatchSprite
+        {
+            get
+            {
+                if (s_swatchSprite == null)
+                {
+                    // A rounded rect whose radius is half its own size is a
+                    // circle — no separate circle-drawing code needed.
+                    s_swatchSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(PlayerSwatchDiameter / 2f));
+                }
+
+                return s_swatchSprite;
+            }
+        }
+
+        RectTransform _rect;
+        Image _border;
+        Image _fill;
+        Image _swatch;
+        Text _label;
+        Text _padCountText;
+
+        bool _initialized;
+        PlayerChipState _state = PlayerChipState.Default;
+        string _padCount = string.Empty;
+
+        /// <summary>The chip's own <see cref="RectTransform"/>, sized to <see cref="PlayerChipWidth"/> x <see cref="PlayerChipHeight"/>.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The frog's colour swatch — <see cref="PlayerSwatchDiameter"/> across.</summary>
+        public Image Swatch
+        {
+            get
+            {
+                EnsureInitialized();
+                return _swatch;
+            }
+        }
+
+        /// <summary>The colour's name, in words — always shown alongside the swatch, never colour alone.</summary>
+        public Text Label
+        {
+            get
+            {
+                EnsureInitialized();
+                return _label;
+            }
+        }
+
+        /// <summary>The pad-count line — replaced by <c>Home!</c> while <see cref="State"/> is <see cref="PlayerChipState.Home"/>.</summary>
+        public Text PadCountText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _padCountText;
+            }
+        }
+
+        /// <summary>The <see cref="PlayerChipActiveRing"/> ring's colour — transparent outside <see cref="PlayerChipState.Active"/>.</summary>
+        public Color BorderColor
+        {
+            get
+            {
+                EnsureInitialized();
+                return _border.color;
+            }
+        }
+
+        public PlayerChipState State
+        {
+            get
+            {
+                EnsureInitialized();
+                return _state;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>
+        /// Sets the frog's colour and its colour's name, in words —
+        /// docs/specs/ui/shared-components.md#player-chip's first invariant:
+        /// colour and name always together, never colour alone.
+        /// </summary>
+        public void SetFrog(Color color, string colourName)
+        {
+            EnsureInitialized();
+            _swatch.color = color;
+            _label.text = colourName;
+        }
+
+        /// <summary>
+        /// Sets the pad-count line's text while not <see cref="PlayerChipState.Home"/> —
+        /// e.g. game-board.md's <c>"3 of 8"</c>. The chip is a readout: it
+        /// does not compute this string itself, since what "8" means is a
+        /// screen's own constant (`LaneWinningPosition`), not this
+        /// component's.
+        /// </summary>
+        public void SetPadCount(string text)
+        {
+            EnsureInitialized();
+            _padCount = text;
+            RefreshVisual();
+        }
+
+        /// <summary>Sets which of the three built states the chip is in, and refreshes its appearance to match.</summary>
+        public void SetState(PlayerChipState state)
+        {
+            EnsureInitialized();
+            _state = state;
+            RefreshVisual();
+        }
+
+        // Unity does not guarantee Awake() has run before another
+        // component's Awake() or a test reaches this one right after
+        // AddComponent — the same reasoning as Button, DialogPanel and
+        // ScreenRouterAdapter's own EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+            RefreshVisual();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.sizeDelta = new Vector2(PlayerChipWidth, PlayerChipHeight);
+
+            var borderGO = new GameObject("Border", typeof(RectTransform), typeof(Image));
+            _border = borderGO.GetComponent<Image>();
+            _border.sprite = ChipSprite;
+            _border.type = Image.Type.Sliced;
+            _border.raycastTarget = false;
+            var borderRect = _border.rectTransform;
+            borderRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(borderRect);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            _fill = fillGO.GetComponent<Image>();
+            _fill.sprite = ChipSprite;
+            _fill.type = Image.Type.Sliced;
+            _fill.color = ChipBackgroundColor;
+            _fill.raycastTarget = false;
+            var fillRect = _fill.rectTransform;
+            fillRect.SetParent(_rect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(PlayerChipActiveRing, PlayerChipActiveRing);
+            fillRect.offsetMax = new Vector2(-PlayerChipActiveRing, -PlayerChipActiveRing);
+
+            var swatchGO = new GameObject("Swatch", typeof(RectTransform), typeof(Image));
+            _swatch = swatchGO.GetComponent<Image>();
+            _swatch.sprite = SwatchSprite;
+            _swatch.raycastTarget = false;
+            var swatchRect = _swatch.rectTransform;
+            swatchRect.SetParent(_fill.rectTransform, worldPositionStays: false);
+            swatchRect.anchorMin = new Vector2(0f, 0.5f);
+            swatchRect.anchorMax = new Vector2(0f, 0.5f);
+            swatchRect.pivot = new Vector2(0f, 0.5f);
+            swatchRect.sizeDelta = new Vector2(PlayerSwatchDiameter, PlayerSwatchDiameter);
+            swatchRect.anchoredPosition = Vector2.zero;
+
+            // The text stack — colour name above, pad count below — fills
+            // the chip's height to the right of the swatch, split evenly.
+            var textStackGO = new GameObject("TextStack", typeof(RectTransform));
+            var textStackRect = (RectTransform)textStackGO.transform;
+            textStackRect.SetParent(_fill.rectTransform, worldPositionStays: false);
+            textStackRect.anchorMin = Vector2.zero;
+            textStackRect.anchorMax = Vector2.one;
+            textStackRect.offsetMin = new Vector2(PlayerSwatchDiameter + PlayerChipSwatchGap, 0f);
+            textStackRect.offsetMax = Vector2.zero;
+
+            var labelGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            _label = labelGO.GetComponent<Text>();
+            _label.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _label.fontSize = (int)PlayerChipLabelSize;
+            _label.color = LabelColor;
+            _label.alignment = TextAnchor.LowerLeft;
+            _label.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _label.verticalOverflow = VerticalWrapMode.Overflow;
+            _label.raycastTarget = false;
+            var labelRect = _label.rectTransform;
+            labelRect.SetParent(textStackRect, worldPositionStays: false);
+            labelRect.anchorMin = new Vector2(0f, 0.5f);
+            labelRect.anchorMax = new Vector2(1f, 1f);
+            labelRect.offsetMin = Vector2.zero;
+            labelRect.offsetMax = Vector2.zero;
+
+            var padCountGO = new GameObject("PadCount", typeof(RectTransform), typeof(Text));
+            _padCountText = padCountGO.GetComponent<Text>();
+            _padCountText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _padCountText.fontSize = (int)PlayerChipPadCountSize;
+            _padCountText.color = PadCountColor;
+            _padCountText.alignment = TextAnchor.UpperLeft;
+            _padCountText.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _padCountText.verticalOverflow = VerticalWrapMode.Overflow;
+            _padCountText.raycastTarget = false;
+            var padCountRect = _padCountText.rectTransform;
+            padCountRect.SetParent(textStackRect, worldPositionStays: false);
+            padCountRect.anchorMin = new Vector2(0f, 0f);
+            padCountRect.anchorMax = new Vector2(1f, 0.5f);
+            padCountRect.offsetMin = Vector2.zero;
+            padCountRect.offsetMax = Vector2.zero;
+        }
+
+        void RefreshVisual()
+        {
+            var isActive = _state == PlayerChipState.Active;
+            var isHome = _state == PlayerChipState.Home;
+
+            _border.color = isActive ? RingColor : NoRingColor;
+            _label.fontStyle = isActive ? FontStyle.Bold : FontStyle.Normal;
+            _padCountText.text = isHome ? HomeLabel : _padCount;
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/UI/PlayerChip.cs.meta
+++ b/Assets/Scripts/Unity/UI/PlayerChip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 065b7c6028ba47b299a758212c4c5d98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/PlayerChipState.cs
+++ b/Assets/Scripts/Unity/UI/PlayerChipState.cs
@@ -1,0 +1,21 @@
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The three states the shared <see cref="PlayerChip"/> is built in for
+    /// v0.2 — docs/specs/ui/shared-components.md#player-chip's States table.
+    /// There is no fourth, "Empty seat", state: that reading of the page was
+    /// a stale disagreement with docs/specs/ui/game-setup.md, corrected in
+    /// the same PR that added this type — see issue #219.
+    /// </summary>
+    public enum PlayerChipState
+    {
+        /// <summary>Swatch, colour name, pad count.</summary>
+        Default,
+
+        /// <summary><see cref="PlayerChip.PlayerChipActiveRing"/> ring, label at full weight.</summary>
+        Active,
+
+        /// <summary>Pad count replaced by <c>Home!</c>.</summary>
+        Home
+    }
+}

--- a/Assets/Scripts/Unity/UI/PlayerChipState.cs.meta
+++ b/Assets/Scripts/Unity/UI/PlayerChipState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 751dffff112f4606afc8726152cba973
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/RoundedRectSprite.cs
+++ b/Assets/Scripts/Unity/UI/RoundedRectSprite.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// Procedural rounded-rect sprite generation, shared by every component
+    /// under this folder that needs a rounded panel and has no imported
+    /// texture to draw one with — docs/specs/ui/shared-components.md's "no
+    /// external assets".
+    ///
+    /// <see cref="Button"/> (#214) generates its own copy of this same shape
+    /// inline, after <c>Resources.GetBuiltinResource&lt;Sprite&gt;("UI/Skin/UISprite.psd")</c>
+    /// returned null on CI's Unity version rather than throwing — see
+    /// <c>Button.cs</c>'s own comment for the full story. This issue
+    /// (#219) needs the identical shape for the Dialog panel and the Player
+    /// chip, so it lives here once rather than as two more inline copies;
+    /// <c>Button.cs</c> is left untouched rather than refactored to call
+    /// this, since it already has a tested implementation of its own and
+    /// there is no editor here to re-verify a refactor of it against.
+    /// </summary>
+    public static class RoundedRectSprite
+    {
+        const float FullyOpaqueByte = 255f;
+
+        // Matches CanvasScaler's default referencePixelsPerUnit (100), so the
+        // sliced border renders as exactly `radius` UI pixels — the same 1:1
+        // pixel-to-unit mapping every other geometry constant in this UI
+        // folder already assumes.
+        const float PixelsPerUnit = 100f;
+
+        /// <summary>
+        /// A square alpha-mask sprite just big enough to hold one rounded
+        /// corner (radius*2+1, so there is exactly one solid centre pixel),
+        /// sliced with a border of <paramref name="radius"/> on every side.
+        /// uGUI's Sliced Image stretches only the 1-pixel middle band, so the
+        /// corner stays exactly <paramref name="radius"/> texture pixels
+        /// regardless of how large the target RectTransform is.
+        /// </summary>
+        public static Sprite CreateRoundedRect(int radius)
+        {
+            radius = Mathf.Max(radius, 1);
+            var size = radius * 2 + 1;
+            var half = size / 2f;
+            var pixels = new Color32[size * size];
+
+            for (var y = 0; y < size; y++)
+            {
+                for (var x = 0; x < size; x++)
+                {
+                    // Signed distance from a box of half-size `half` rounded
+                    // by `radius`, sampled at the pixel centre — the standard
+                    // rounded-box SDF. <= 0 is inside the shape.
+                    var px = x + 0.5f - half;
+                    var py = y + 0.5f - half;
+                    var dx = Mathf.Max(Mathf.Abs(px) - (half - radius), 0f);
+                    var dy = Mathf.Max(Mathf.Abs(py) - (half - radius), 0f);
+                    var distance = Mathf.Sqrt(dx * dx + dy * dy) - radius;
+
+                    // A soft one-pixel edge instead of a hard cutoff, so the
+                    // curve doesn't alias at the sizes this renders at.
+                    var alpha = Mathf.Clamp01(0.5f - distance);
+                    pixels[(y * size) + x] = new Color32(255, 255, 255, (byte)(alpha * FullyOpaqueByte));
+                }
+            }
+
+            var texture = new Texture2D(size, size, TextureFormat.RGBA32, mipChain: false)
+            {
+                name = "Frogs Rounded Rect (procedural)",
+                wrapMode = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Bilinear
+            };
+            texture.SetPixels32(pixels);
+            texture.Apply(updateMipmaps: false, makeNoLongerReadable: false);
+
+            var rect = new Rect(0f, 0f, size, size);
+            var pivot = new Vector2(0.5f, 0.5f);
+            var border = new Vector4(radius, radius, radius, radius);
+            const uint extrude = 0;
+
+            return Sprite.Create(texture, rect, pivot, PixelsPerUnit, extrude, SpriteMeshType.FullRect, border);
+        }
+    }
+}

--- a/Assets/Scripts/Unity/UI/RoundedRectSprite.cs.meta
+++ b/Assets/Scripts/Unity/UI/RoundedRectSprite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40fbfc83527b414381a5abf9567d86ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/DialogPanelTests.cs
+++ b/Assets/Tests/EditMode/DialogPanelTests.cs
@@ -1,0 +1,290 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Unity.UI;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The shared Dialog — issue #219. Built through the typed Unity API
+    /// with no committed prefab, the same decision #214 made for
+    /// <see cref="Button"/>. Written before <c>DialogPanel</c> exists, per
+    /// docs/engineering/testing.md's sanctioned flow: there is no editor
+    /// here to see these fail, so they were written first and pushed
+    /// unexecuted, and CI is what turns them red before it turns them green.
+    /// </summary>
+    public sealed class DialogPanelTests
+    {
+        [Test]
+        public void DialogMaxWidthAndHeight_AreTheCanvasInsetByA48PxMarginOnEverySide()
+        {
+            // docs/specs/ui/shared-components.md#dialog: "DialogMaxWidth and
+            // DialogMaxHeight are the canvas inset by 48 px on every side."
+            // The 1920 x 1200 canvas and the 48 px margin are independently
+            // known here (docs/engineering/tech-stack.md's reference
+            // resolution, and shared-components.md's own inset), so this
+            // proves the relationship rather than just the two totals.
+            const float canvasWidth = 1920f;
+            const float canvasHeight = 1200f;
+            const float margin = 48f;
+
+            Assert.That(DialogPanel.DialogMaxWidth, Is.EqualTo(canvasWidth - (margin * 2f)));
+            Assert.That(DialogPanel.DialogMaxWidth, Is.EqualTo(1824f));
+            Assert.That(DialogPanel.DialogMaxHeight, Is.EqualTo(canvasHeight - (margin * 2f)));
+            Assert.That(DialogPanel.DialogMaxHeight, Is.EqualTo(1104f));
+        }
+
+        [Test]
+        public void EveryDialogConstant_ExistsAsANamedValue()
+        {
+            // The nine named constants from shared-components.md#dialog's
+            // table, nothing free to invent.
+            Assert.That(DialogPanel.DialogScrimOpacity, Is.EqualTo(0.66f));
+            Assert.That(DialogPanel.DialogRadius, Is.EqualTo(32f));
+            Assert.That(DialogPanel.DialogPadding, Is.EqualTo(56f));
+            Assert.That(DialogPanel.DialogTitleSize, Is.EqualTo(56f));
+            Assert.That(DialogPanel.DialogTitleGap, Is.EqualTo(40f));
+            Assert.That(DialogPanel.DialogButtonRowGap, Is.EqualTo(48f));
+            Assert.That(DialogPanel.DialogMaxWidth, Is.EqualTo(1824f));
+            Assert.That(DialogPanel.DialogMaxHeight, Is.EqualTo(1104f));
+            Assert.That(DialogPanel.DialogFadeDuration, Is.EqualTo(0.15f));
+        }
+
+        [Test]
+        public void PanelSize_AtOrBelowTheCap_RendersUnchanged()
+        {
+            // end-game-confirm.md's committed 1160 x 540 — below the cap,
+            // honoured unchanged, not clamped to it.
+            var dialog = CreateDialog();
+
+            try
+            {
+                dialog.SetSize(1160f, 540f);
+
+                Assert.That(dialog.PanelRect.sizeDelta, Is.EqualTo(new Vector2(1160f, 540f)));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void PanelSize_AboveTheCapOnEitherAxis_IsClampedDownToTheCap()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                dialog.SetSize(2200f, 1500f);
+
+                Assert.That(
+                    dialog.PanelRect.sizeDelta,
+                    Is.EqualTo(new Vector2(DialogPanel.DialogMaxWidth, DialogPanel.DialogMaxHeight)),
+                    "the cap is a ceiling, not the panel's actual size — a caller-supplied size at or below it must not be touched");
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Dialog_ComposesAScrimTitleBodyAndButtonRow_FromTheSharedButton()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                dialog.SetTitle("End the game for everyone?");
+                var button = dialog.AddButton(ButtonKind.Primary, "Keep playing", onClick: null);
+
+                Assert.That(dialog.Scrim, Is.Not.Null, "a Dialog must always compose a scrim");
+                Assert.That(dialog.TitleText, Is.Not.Null);
+                Assert.That(dialog.TitleText.text, Is.EqualTo("End the game for everyone?"));
+                Assert.That(dialog.BodyRect, Is.Not.Null, "a Dialog must always compose a body area");
+                Assert.That(dialog.ButtonRowRect, Is.Not.Null);
+                Assert.That(button, Is.InstanceOf<Button>(), "the button row is built from the shared Button (#214)");
+                Assert.That(dialog.Buttons, Does.Contain(button));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Dialog_WiresItsBuiltInSpriteAndFont_RatherThanLeavingThemMissing()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                var panelImage = dialog.PanelRect.GetComponent<UnityImage>();
+
+                Assert.That(panelImage.sprite, Is.Not.Null, "built-in panel sprite missing — check the resource name");
+                Assert.That(dialog.TitleText.font, Is.Not.Null, "built-in title font missing — check the resource name");
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Scrim_RendersAtDialogScrimOpacity_WheneverTheDialogIsOpen_AndIsNeverAbsent()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                // Present as soon as the component exists — a Dialog never
+                // renders without a scrim, whether open or not.
+                Assert.That(dialog.Scrim, Is.Not.Null);
+
+                dialog.Open();
+
+                Assert.That(dialog.Scrim.color.a, Is.EqualTo(DialogPanel.DialogScrimOpacity).Within(0.0001f));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void FadeDriver_IsSeededFromDialogFadeDuration()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                dialog.Open();
+                dialog.AdvanceFade(0f);
+                Assert.That(dialog.CanvasGroup.alpha, Is.EqualTo(0f).Within(0.0001f));
+
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration / 2f);
+                Assert.That(dialog.CanvasGroup.alpha, Is.EqualTo(0.5f).Within(0.0001f));
+
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration / 2f);
+                Assert.That(dialog.CanvasGroup.alpha, Is.EqualTo(1f).Within(0.0001f));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void OpenAndClose_NeverMoveThePanel_NoSlideNoBounce()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                var startPosition = dialog.PanelRect.anchoredPosition;
+
+                dialog.Open();
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration / 3f);
+                Assert.That(dialog.PanelRect.anchoredPosition, Is.EqualTo(startPosition));
+
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration);
+                Assert.That(dialog.PanelRect.anchoredPosition, Is.EqualTo(startPosition));
+
+                dialog.Close();
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration / 2f);
+                Assert.That(dialog.PanelRect.anchoredPosition, Is.EqualTo(startPosition));
+
+                dialog.AdvanceFade(DialogPanel.DialogFadeDuration);
+                Assert.That(dialog.PanelRect.anchoredPosition, Is.EqualTo(startPosition));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Dialog_HasNoTapOutsideToDismiss_AndNoCloseCross()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                Assert.That(
+                    dialog.Scrim.GetComponent<IPointerClickHandler>(),
+                    Is.Null,
+                    "the scrim must not be a dismiss handler — a dialog that decides something is left only by its own buttons");
+
+                var childNames = dialog.RectTransform
+                    .GetComponentsInChildren<Transform>(includeInactive: true)
+                    .Select(t => t.name.ToLowerInvariant());
+
+                Assert.That(childNames, Has.None.Contains("close"), "no close-cross element anywhere in the hierarchy");
+                Assert.That(childNames, Has.None.Contains("dismiss"));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Dialog_ExposesWhichButtonIsLeastDestructive()
+        {
+            var dialog = CreateDialog();
+
+            try
+            {
+                var destructive = dialog.AddButton(ButtonKind.Destructive, "End the game", onClick: null);
+                var keepPlaying = dialog.AddButton(ButtonKind.Primary, "Keep playing", onClick: null, isLeastDestructive: true);
+
+                Assert.That(dialog.LeastDestructiveButton, Is.SameAs(keepPlaying));
+                Assert.That(dialog.LeastDestructiveButton, Is.Not.SameAs(destructive));
+            }
+            finally
+            {
+                Destroy(dialog);
+            }
+        }
+
+        [Test]
+        public void Open_TakesNoOrderingOrParentDialogArgument_AndExposesNoZOrderOrTopmostConcept()
+        {
+            // Proves this component cannot itself produce the "Stacked"
+            // state or a second live instance — the router's dialog layer
+            // (#213) is the sole place at-most-one-dialog is enforced, and
+            // this Dialog carries no field, method, or argument that would
+            // let it, or a caller, compete with that guarantee.
+            var openMethod = typeof(DialogPanel).GetMethod("Open");
+            Assert.That(openMethod, Is.Not.Null);
+            Assert.That(openMethod.GetParameters(), Is.Empty, "Open() takes no ordering or parent-dialog argument");
+
+            var forbidden = new[] { "zorder", "z-order", "topmost", "toplevel", "parentdialog", "sortorder", "stackindex", "priority" };
+            var memberNames = typeof(DialogPanel)
+                .GetMembers(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Static)
+                .Select(m => m.Name.ToLowerInvariant());
+
+            foreach (var forbiddenTerm in forbidden)
+            {
+                Assert.That(memberNames, Has.None.Contains(forbiddenTerm), $"DialogPanel must expose no '{forbiddenTerm}' concept");
+            }
+        }
+
+        static DialogPanel CreateDialog()
+        {
+            var host = new GameObject(nameof(DialogPanelTests), typeof(RectTransform));
+            return host.AddComponent<DialogPanel>();
+        }
+
+        static void Destroy(DialogPanel dialog)
+        {
+            if (dialog != null)
+            {
+                Object.DestroyImmediate(dialog.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/DialogPanelTests.cs.meta
+++ b/Assets/Tests/EditMode/DialogPanelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc6ad8c36958465097c68f1c55743082
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/PlayerChipTests.cs
+++ b/Assets/Tests/EditMode/PlayerChipTests.cs
@@ -1,0 +1,147 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Unity.UI;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The shared Player chip — issue #219. Built through the typed Unity
+    /// API with no committed prefab, the same decision #214 made for
+    /// <see cref="Button"/>. Written before <c>PlayerChip</c> exists, per
+    /// docs/engineering/testing.md's sanctioned flow: pushed unexecuted,
+    /// with CI turning these red before green — there is no editor here to
+    /// watch them fail.
+    /// </summary>
+    public sealed class PlayerChipTests
+    {
+        [Test]
+        public void Default_ShowsSwatchColourNameAndPadCount_SizedToTheNamedConstants()
+        {
+            var chip = CreateChip();
+
+            try
+            {
+                chip.SetFrog(new Color32(0x3F, 0x8E, 0x4F, 0xFF), "Green");
+                chip.SetPadCount("3 of 8");
+
+                Assert.That(chip.RectTransform.sizeDelta, Is.EqualTo(new Vector2(PlayerChip.PlayerChipWidth, PlayerChip.PlayerChipHeight)));
+                Assert.That(chip.Swatch.rectTransform.sizeDelta, Is.EqualTo(new Vector2(PlayerChip.PlayerSwatchDiameter, PlayerChip.PlayerSwatchDiameter)));
+                Assert.That(chip.Label.fontSize, Is.EqualTo((int)PlayerChip.PlayerChipLabelSize));
+                Assert.That(chip.PadCountText.fontSize, Is.EqualTo((int)PlayerChip.PlayerChipPadCountSize));
+                Assert.That(chip.Label.text, Is.EqualTo("Green"));
+                Assert.That(chip.PadCountText.text, Is.EqualTo("3 of 8"));
+                Assert.That(chip.State, Is.EqualTo(PlayerChipState.Default));
+            }
+            finally
+            {
+                Destroy(chip);
+            }
+        }
+
+        [Test]
+        public void Chip_WiresItsBuiltInSpriteAndFont_RatherThanLeavingThemMissing()
+        {
+            var chip = CreateChip();
+
+            try
+            {
+                Assert.That(chip.Swatch.sprite, Is.Not.Null, "built-in swatch sprite missing — check the resource name");
+                Assert.That(chip.Label.font, Is.Not.Null, "built-in label font missing — check the resource name");
+                Assert.That(chip.PadCountText.font, Is.Not.Null, "built-in pad-count font missing — check the resource name");
+            }
+            finally
+            {
+                Destroy(chip);
+            }
+        }
+
+        [Test]
+        public void Active_RendersThePlayerChipActiveRing_AndIsVisiblyDifferentByMoreThanColour()
+        {
+            var chip = CreateChip();
+
+            try
+            {
+                chip.SetFrog(Color.green, "Green");
+                var defaultBorderAlpha = chip.BorderColor.a;
+                var defaultFontStyle = chip.Label.fontStyle;
+
+                chip.SetState(PlayerChipState.Active);
+
+                Assert.That(chip.State, Is.EqualTo(PlayerChipState.Active));
+                Assert.That(chip.BorderColor.a, Is.GreaterThan(0f), "the ring must actually render, not just be present at zero alpha");
+                Assert.That(chip.BorderColor.a, Is.Not.EqualTo(defaultBorderAlpha));
+                Assert.That(chip.Label.fontStyle, Is.EqualTo(FontStyle.Bold), "label at full weight");
+                Assert.That(chip.Label.fontStyle, Is.Not.EqualTo(defaultFontStyle));
+
+                // Visibly different by something other than colour: the
+                // swatch and label colour are untouched by the state change.
+                Assert.That(chip.Swatch.color, Is.EqualTo(Color.green));
+            }
+            finally
+            {
+                Destroy(chip);
+            }
+        }
+
+        [Test]
+        public void Home_ReplacesThePadCountWithHomeExclamationPoint()
+        {
+            var chip = CreateChip();
+
+            try
+            {
+                chip.SetFrog(Color.blue, "Blue");
+                chip.SetPadCount("6 of 8");
+
+                chip.SetState(PlayerChipState.Home);
+
+                Assert.That(chip.PadCountText.text, Is.EqualTo("Home!"));
+            }
+            finally
+            {
+                Destroy(chip);
+            }
+        }
+
+        [Test]
+        public void Chip_ExposesNoTapHandler_AndEmitsNothingOnTap_InAnyState()
+        {
+            foreach (var state in new[] { PlayerChipState.Default, PlayerChipState.Active, PlayerChipState.Home })
+            {
+                var chip = CreateChip();
+
+                try
+                {
+                    chip.SetState(state);
+
+                    Assert.That(chip, Is.Not.InstanceOf<IPointerClickHandler>());
+                    Assert.That(chip, Is.Not.InstanceOf<IPointerDownHandler>());
+                    Assert.That(chip, Is.Not.InstanceOf<IPointerUpHandler>());
+
+                    var events = typeof(PlayerChip).GetEvents();
+                    Assert.That(events, Is.Empty, "the chip is a readout in v0.2 — it emits nothing, in any state");
+                }
+                finally
+                {
+                    Destroy(chip);
+                }
+            }
+        }
+
+        static PlayerChip CreateChip()
+        {
+            var host = new GameObject(nameof(PlayerChipTests), typeof(RectTransform));
+            return host.AddComponent<PlayerChip>();
+        }
+
+        static void Destroy(PlayerChip chip)
+        {
+            if (chip != null)
+            {
+                Object.DestroyImmediate(chip.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/PlayerChipTests.cs.meta
+++ b/Assets/Tests/EditMode/PlayerChipTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 809cc285453c45ee8a4e96d6558977af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -231,9 +231,8 @@ tap.
 A frog's identity, wherever the game has to say *which frog* — its colour, its
 name, and how far up its lane it is.
 
-Used by: [game setup](game-setup.md), [game board](game-board.md),
-[roll and card](roll-and-card.md), [answer result](answer-result.md),
-[game over](game-over.md).
+Used by: [game board](game-board.md), [roll and card](roll-and-card.md),
+[answer result](answer-result.md).
 
 #### 2. Invariants
 
@@ -253,24 +252,59 @@ from every other chip on screen, by something other than colour.
 | Chip width on the board | `PlayerChipWidth` | 256 px |
 | Frog swatch diameter | `PlayerSwatchDiameter` | 64 px |
 | Gap between swatch and label | `PlayerChipSwatchGap` | 24 px |
-| Label size | `PlayerChipLabelSize` | 40 px |
+| Label size | `PlayerChipLabelSize` | 32 px |
+| Pad-count text size | `PlayerChipPadCountSize` | 24 px |
 | Corner radius | `PlayerChipRadius` | 20 px |
 | Ring drawn around the active chip | `PlayerChipActiveRing` | 6 px |
+
+`PlayerChipLabelSize` was 40 px on this page; the committed mockups' shared
+stylesheet — repeated across all eleven files — draws the name at 32 px and the
+pad-count line separately at 24 px, and `game-board.html`'s five instantiated
+chips (covering all three states below) all render at those two sizes. The
+mockups are what Connor approved when each screen's wireframe was signed off,
+so they win: `PlayerChipLabelSize` is corrected to 32 px, and
+`PlayerChipPadCountSize` — a value this table previously had no name for at
+all — is added at 24 px.
 
 #### 4. States
 
 | State | Appearance |
 | --- | --- |
 | Default | Swatch, colour name, pad count |
-| Active (this player's turn) | `PlayerChipActiveRing` ring, filled background, label at full weight |
-| Home (frog has finished) | A small home marker after the name; pad count replaced by `Home!` |
-| Empty seat (setup only) | Dashed outline, `Tap to add` in place of the name |
+| Active (this player's turn) | `PlayerChipActiveRing` ring, label at full weight |
+| Home (frog has finished) | Pad count replaced by `Home!` |
+
+The Active row dropped "filled background": the mockups' `.chip.act` rule
+gives the ring and the bold weight but leaves the base chip background
+unchanged, and the chip invariant only requires the active chip be visibly
+different by something other than colour, which the ring and weight already
+satisfy without a fill.
+
+The Home row dropped "a small home marker after the name": no committed
+mockup has ever drawn one — the only rendered Home chip
+(`game-board.html`'s Blue) is just the swatch, the colour name, and `Home!`.
+Building a marker now would mean inventing a visual for it, which
+[rule 8](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CLAUDE.md)
+(wireframe before UI code) exists to prevent. A marker, if wanted later, needs
+its own wireframe first.
+
+There is no longer an Empty-seat state on this page.
+[Game setup](game-setup.md) does not use this chip — it specifies its own
+Frog seat element, with its own constants and states, and its mockup draws
+that element's numbers, not this one's. See that page for the setup screen.
+
+[Game over](game-over.md) does not use this chip either, for the same
+reason: it specifies its own **Standings row** element — its own constants
+(`StandingsSwatchDiameter` 88 px against this chip's `PlayerSwatchDiameter`
+64 px, `StandingsNameSize` 52 px, no `PlayerChip*` constant anywhere on that
+page) and its mockup draws `.row` markup, not `.chip`. It stays listed under
+[Frog colours](#frog-colours) below, since it legitimately reuses that
+element's four colour constants for its own swatch.
 
 #### 5. Behaviour
 
-The chip is not a button anywhere except on
-[game setup](game-setup.md), where tapping one adds or removes that frog from
-the game. On every other screen it is a readout.
+The chip is a readout on every screen that uses it. It has no button state in
+v0.2 — no tap handler, on any screen, in any state.
 
 #### Why there is no typing
 


### PR DESCRIPTION
Every dialog from here on — the card, the working-out grid, the answer result, settings, the end-game confirm — and every place the game has to say *which frog* now has one component built once, instead of nine screens each re-describing "the primary button on the right" or "the chip with a ring around it". This PR builds those two: the Dialog panel and the Player chip.

**Docs:** `docs/specs/ui/shared-components.md` — the Player chip section's disagreements with what was actually built and approved are reconciled, all in this PR:
- Game setup and game over are dropped from the chip's "Used by" list. Both specify their own distinct elements — game setup's **Frog seat** and game over's **Standings row** — with their own constants tables and their own committed mockups drawing `.seat`/`.row` markup, not `.chip`. The chip's "tap to add/remove" behaviour and its fourth "Empty seat" state are removed along with it; game setup and game over pages are untouched.
- `PlayerChipLabelSize` corrected from 40 px to 32 px, and a new `PlayerChipPadCountSize` (24 px) added — every committed mockup's shared stylesheet draws the name and pad-count lines at those two sizes, and no mockup anywhere draws 40 px.
- The Active row drops "filled background" — the mockups' `.chip.act` rule only adds a ring and bold weight, never a fill swap.
- The Home row drops "a small home marker after the name" — nothing committed has ever drawn one; adding one now would mean inventing a visual without a wireframe.

## Spec invariants

- A dialog always dims what's behind it, never floats on live board: the scrim is built unconditionally, in the same hierarchy as the panel, with no code path that shows one without the other.
- A dialog that decides something has no tap-outside-to-dismiss and no close cross: the scrim carries no click handler, and there is no "Close" element anywhere in the hierarchy — asserted directly.
- The panel never slides or bounces open/closed: its `anchoredPosition` is never touched by `Open`, `Close`, or `AdvanceFade` — only the wrapping `CanvasGroup`'s alpha animates.
- `DialogMaxWidth`/`DialogMaxHeight` are a cap, not a size: a caller-supplied size at or below the cap (tested against end-game-confirm's 1160×540) renders unchanged; only an oversized request is clamped down.
- The Dialog cannot itself produce the "Stacked" state: `Open()` takes no ordering or parent-dialog argument, and no member exposes a z-order/topmost/parent concept — the router (#213) is the sole enforcement point, and this PR includes a reflection-based test proving the absence.
- The chip is a readout only in v0.2: it implements no pointer-event interface and declares no event, in any of its three states — asserted directly, across all three.

## Deviations and Decisions

- The Dialog's component is named `DialogPanel`, not `Dialog` — `Frogs.Core.Dialog` already exists (#213's router enum for which of five panels is current). Different namespaces, so either name would have compiled, but a shared bare name for two different things in the same feature area wasn't worth it.
- Added a small `RoundedRectSprite` static helper (`Assets/Scripts/Unity/UI/`) so the Dialog panel and the Player chip could share the procedural rounded-rect technique #214 used for `Button`, rather than each reimplementing it inline. `Button.cs` itself is left untouched rather than refactored to call it — it already has a tested implementation, and there is no editor here to re-verify a refactor of it against.
- The Player chip's pad-count text (`"3 of 8"`) is caller-supplied via `SetPadCount`, not computed by the chip — what the `8` means (`LaneWinningPosition`) is game-board.md's constant, not this shared, screen-agnostic component's.
- The Dialog's button row widens the gap next to a destructive button (`ButtonDestructiveGap` instead of `ButtonGap`) since Button's own invariant already specifies it and it was cheap to honour while composing the row — no checklist item required it, and no test enforces the exact spacing.
- Per a mid-task instruction from the orchestrating session (to avoid a merge conflict with the parallel #225 session, which independently found the same stale cross-reference), also dropped `game-over.md` from the Player chip's "Used by" list — left in the Frog colours list, since game-over legitimately reuses those four colour constants for its own Standings-row swatch.
- EditMode tests (`DialogPanelTests.cs`, `PlayerChipTests.cs`) were written before either component existed, and pushed unexecuted — there is no Unity editor in this environment; CI runs them. Per `docs/engineering/testing.md`, this is the sanctioned flow, not a reportable deviation.

Closes #219


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_