### PR TITLE
feat(ui): build the game board — lanes, frogs, turn banner, and `Roll`

### DIFF
--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
+using SharedButton = Frogs.Unity.UI.Button;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// One frog's lane on the board — docs/specs/ui/game-board.md's `chip`,
+    /// `track` and `piece`, built to that page's per-lane constants table.
+    /// The track is the Start log, seven lily pads and the End log, drawn
+    /// left to right (Derek's settled call — see the page's "why the lanes
+    /// run across"); the chip is the shared
+    /// <see cref="PlayerChip"/> (#219) in this lane's gutter.
+    ///
+    /// It reads, and never computes. Where the frog sits and whether it is
+    /// home come straight off the <see cref="Lane"/> it is handed on every
+    /// <see cref="Render"/>: this type places the piece **onto the track
+    /// element it already drew** for that index rather than deriving a pixel
+    /// offset of its own, and it never counts answers to arrive at either
+    /// number in the chip's `3 of 8`.
+    ///
+    /// Nothing here moves. The frog is drawn at rest at whatever position
+    /// Core reports; animating the change between one position and the next
+    /// belongs to <c>answer-result</c> (#224), which is what closes and
+    /// starts the hop.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class GameBoardLaneView : MonoBehaviour
+    {
+        // docs/specs/ui/game-board.md#named-constants — the lane's table.
+        public const float LaneHeight = 184f;
+        public const float LilyPadDiameter = 112f;
+        public const float FrogPieceDiameter = 88f;
+        public const float LogWidth = 176f;
+        public const float LogHeight = 120f;
+        public const float LanePositionGap = 48f;
+        public const float LaneGutterWidth = 256f;
+        public const float LaneGutterGap = 48f;
+
+        // `LanePositionCount` (9) and `LaneWinningPosition` (8) are the other
+        // two rows of that same table, and they are not this screen's to
+        // define: they are Frogs.Core.Lane's own constants, reused here under
+        // the identical name so the board's nine-position track and Core's
+        // nine-position lane can never disagree. Referenced, never
+        // redeclared — see Lane.LanePositionCount / Lane.LaneWinningPosition
+        // throughout this file.
+
+        // The chip's progress line — docs/specs/ui/game-board.md's Elements
+        // section: "Pad count — on the chip: `3 of 8`". The numerator is
+        // whatever Lane reports; the denominator is Lane.LaneWinningPosition.
+        const string PadCountFormat = "{0} of {1}";
+
+        // A log is "a flat rounded rectangle" (game-board.md's Shape-only
+        // note). The committed mockup draws it with the same 24 px corner the
+        // shared Button uses, so this names shared-components.md's own
+        // `ButtonRadius` rather than introducing a nineteenth number that
+        // game-board.md's tables do not have — see this issue's PR.
+        static readonly int LogCornerRadius = Mathf.RoundToInt(SharedButton.ButtonRadius);
+
+        // Chrome colours copied verbatim from the committed mockup
+        // (docs/specs/ui/mockups/game-board.html) — the same line Button.cs,
+        // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
+        // colours: not a geometry constant on any spec page's table, so not
+        // declared as a named spec constant.
+        static readonly Color LilyPadColor = new Color32(0xCF, 0xE0, 0xD2, 0xFF); // mockup's .pad fill
+        static readonly Color LogColor = new Color32(0xE0, 0xD4, 0xC3, 0xFF); // mockup's .log fill
+
+        static Sprite s_logSprite;
+        static Sprite s_lilyPadSprite;
+        static Sprite s_pieceSprite;
+
+        static Sprite LogSprite
+        {
+            get
+            {
+                if (s_logSprite == null)
+                {
+                    s_logSprite = RoundedRectSprite.CreateRoundedRect(LogCornerRadius);
+                }
+
+                return s_logSprite;
+            }
+        }
+
+        static Sprite LilyPadSprite
+        {
+            get
+            {
+                if (s_lilyPadSprite == null)
+                {
+                    // A rounded rect whose radius is half its own size is a
+                    // circle — the same shape the Player chip's swatch uses,
+                    // rather than a second way of drawing one.
+                    s_lilyPadSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LilyPadDiameter / 2f));
+                }
+
+                return s_lilyPadSprite;
+            }
+        }
+
+        static Sprite PieceSprite
+        {
+            get
+            {
+                if (s_pieceSprite == null)
+                {
+                    s_pieceSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(FrogPieceDiameter / 2f));
+                }
+
+                return s_pieceSprite;
+            }
+        }
+
+        /// <summary>
+        /// The track's width, fixed by its nine positions rather than by the
+        /// space available — game-board.md's Anchors section. Two logs, seven
+        /// lily pads and eight gaps: the page's own arithmetic, written out
+        /// rather than trusted as the literal 1520.
+        /// </summary>
+        public static float TrackWidth
+        {
+            get
+            {
+                return (2f * LogWidth)
+                    + ((Lane.LanePositionCount - 2) * LilyPadDiameter)
+                    + ((Lane.LanePositionCount - 1) * LanePositionGap);
+            }
+        }
+
+        /// <summary>
+        /// The centre of one track position, measured from the track's left
+        /// edge. The Start log at index 0, seven lily pads, the End log at
+        /// <see cref="Lane.LaneWinningPosition"/>.
+        /// </summary>
+        public static float PositionCenterX(int position)
+        {
+            if (position <= 0)
+            {
+                return LogWidth / 2f;
+            }
+
+            if (position >= Lane.LaneWinningPosition)
+            {
+                return TrackWidth - (LogWidth / 2f);
+            }
+
+            return LogWidth
+                + LanePositionGap
+                + ((position - 1) * (LilyPadDiameter + LanePositionGap))
+                + (LilyPadDiameter / 2f);
+        }
+
+        RectTransform _rect;
+        PlayerChip _chip;
+        RectTransform _trackRect;
+        readonly List<RectTransform> _positionRects = new List<RectTransform>();
+        readonly List<Image> _positionImages = new List<Image>();
+        Image _piece;
+
+        bool _initialized;
+        FrogColour _colour;
+        int _renderedPosition;
+
+        /// <summary>Which frog's lane this is.</summary>
+        public FrogColour Colour
+        {
+            get
+            {
+                EnsureInitialized();
+                return _colour;
+            }
+        }
+
+        /// <summary>The lane's own band — <see cref="LaneHeight"/> tall.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>`chip` — the shared Player chip, pinned to the left of the lane's gutter.</summary>
+        public PlayerChip Chip
+        {
+            get
+            {
+                EnsureInitialized();
+                return _chip;
+            }
+        }
+
+        /// <summary>`track` — pinned to the right, <see cref="TrackWidth"/> wide.</summary>
+        public RectTransform TrackRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _trackRect;
+            }
+        }
+
+        /// <summary>The nine track positions, Start log first, End log last.</summary>
+        public IReadOnlyList<RectTransform> PositionRects
+        {
+            get
+            {
+                EnsureInitialized();
+                return _positionRects;
+            }
+        }
+
+        /// <summary>
+        /// The nine positions' fills. Every lily pad is drawn identically —
+        /// "the pad a frog is on is drawn no differently from the others; the
+        /// frog on it is the marker."
+        /// </summary>
+        public IReadOnlyList<Image> PositionImages
+        {
+            get
+            {
+                EnsureInitialized();
+                return _positionImages;
+            }
+        }
+
+        /// <summary>`piece` — a flat circle in the frog's colour, sitting on its current position.</summary>
+        public Image Piece
+        {
+            get
+            {
+                EnsureInitialized();
+                return _piece;
+            }
+        }
+
+        /// <summary>The position index the piece was last drawn on — whatever <see cref="Lane"/> reported.</summary>
+        public int RenderedPosition
+        {
+            get
+            {
+                EnsureInitialized();
+                return _renderedPosition;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>Sets which frog this lane belongs to, and paints it.</summary>
+        public void Initialize(FrogColour colour)
+        {
+            EnsureInitialized();
+
+            _colour = colour;
+            _chip.SetFrog(FrogColours.For(colour), colour.ToString());
+            _piece.color = FrogColours.For(colour);
+        }
+
+        /// <summary>
+        /// Draws this lane from <paramref name="lane"/> and nothing else: the
+        /// piece onto the track element Core's position names, the chip's pad
+        /// count from that same position over
+        /// <see cref="Lane.LaneWinningPosition"/>, and the chip's state from
+        /// whether Core says the frog is home.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="lane"/> is null.</exception>
+        public void Render(Lane lane, bool isActive)
+        {
+            if (lane == null)
+            {
+                throw new ArgumentNullException(nameof(lane));
+            }
+
+            EnsureInitialized();
+
+            var position = lane.Position;
+            _renderedPosition = position;
+
+            // Placed onto the element the track already holds for that index
+            // — never at an offset this type worked out for itself.
+            var pieceRect = _piece.rectTransform;
+            pieceRect.SetParent(_positionRects[position], worldPositionStays: false);
+            pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
+            pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
+            pieceRect.pivot = new Vector2(0.5f, 0.5f);
+            pieceRect.anchoredPosition = Vector2.zero;
+
+            _chip.SetPadCount(string.Format(PadCountFormat, position, Lane.LaneWinningPosition));
+
+            if (lane.IsHome)
+            {
+                _chip.SetState(PlayerChipState.Home);
+                return;
+            }
+
+            _chip.SetState(isActive ? PlayerChipState.Active : PlayerChipState.Default);
+        }
+
+        // Unity does not guarantee Awake() has run before another
+        // component's Awake() or a caller reaches this one right after
+        // AddComponent — the same reasoning as Button, PlayerChip and
+        // GameSetupScreenView's own EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            BuildChip();
+            BuildTrack();
+            BuildPiece();
+        }
+
+        void BuildChip()
+        {
+            // chip — pinned to the left of the lane, filling the gutter.
+            var chipGO = new GameObject("Chip", typeof(RectTransform));
+            var chipRect = (RectTransform)chipGO.transform;
+            chipRect.SetParent(_rect, worldPositionStays: false);
+            chipRect.anchorMin = new Vector2(0f, 0.5f);
+            chipRect.anchorMax = new Vector2(0f, 0.5f);
+            chipRect.pivot = new Vector2(0f, 0.5f);
+            chipRect.anchoredPosition = Vector2.zero;
+
+            _chip = chipGO.AddComponent<PlayerChip>();
+
+            // The Player chip is exactly LaneGutterWidth wide — the gutter is
+            // sized for it — but say so rather than assume it.
+            chipRect.sizeDelta = new Vector2(LaneGutterWidth, PlayerChip.PlayerChipHeight);
+        }
+
+        void BuildTrack()
+        {
+            // track — pinned to the right, its width fixed by its nine
+            // positions rather than by the space available.
+            var trackGO = new GameObject("Track", typeof(RectTransform));
+            _trackRect = (RectTransform)trackGO.transform;
+            _trackRect.SetParent(_rect, worldPositionStays: false);
+            _trackRect.anchorMin = new Vector2(1f, 0.5f);
+            _trackRect.anchorMax = new Vector2(1f, 0.5f);
+            _trackRect.pivot = new Vector2(1f, 0.5f);
+            _trackRect.sizeDelta = new Vector2(TrackWidth, LogHeight);
+            _trackRect.anchoredPosition = Vector2.zero;
+
+            for (var position = 0; position < Lane.LanePositionCount; position++)
+            {
+                var isLog = position == 0 || position == Lane.LaneWinningPosition;
+                var size = isLog
+                    ? new Vector2(LogWidth, LogHeight)
+                    : new Vector2(LilyPadDiameter, LilyPadDiameter);
+
+                var positionName = position == 0
+                    ? "StartLog"
+                    : position == Lane.LaneWinningPosition ? "EndLog" : "LilyPad" + position;
+
+                var positionGO = new GameObject(positionName, typeof(RectTransform), typeof(Image));
+                var image = positionGO.GetComponent<Image>();
+                image.sprite = isLog ? LogSprite : LilyPadSprite;
+                image.type = Image.Type.Sliced;
+                image.color = isLog ? LogColor : LilyPadColor;
+                image.raycastTarget = false;
+
+                var positionRect = image.rectTransform;
+                positionRect.SetParent(_trackRect, worldPositionStays: false);
+                positionRect.anchorMin = new Vector2(0f, 0.5f);
+                positionRect.anchorMax = new Vector2(0f, 0.5f);
+                positionRect.pivot = new Vector2(0.5f, 0.5f);
+                positionRect.sizeDelta = size;
+                positionRect.anchoredPosition = new Vector2(PositionCenterX(position), 0f);
+
+                _positionRects.Add(positionRect);
+                _positionImages.Add(image);
+            }
+        }
+
+        void BuildPiece()
+        {
+            // piece — a flat circle in the frog's colour, per game-board.md's
+            // Shape-only note. It starts on the Start log and is moved onto
+            // whichever position Core reports on the first Render.
+            var pieceGO = new GameObject("Piece", typeof(RectTransform), typeof(Image));
+            _piece = pieceGO.GetComponent<Image>();
+            _piece.sprite = PieceSprite;
+            _piece.type = Image.Type.Sliced;
+            _piece.raycastTarget = false;
+
+            var pieceRect = _piece.rectTransform;
+            pieceRect.SetParent(_positionRects[0], worldPositionStays: false);
+            pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
+            pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
+            pieceRect.pivot = new Vector2(0.5f, 0.5f);
+            pieceRect.sizeDelta = new Vector2(FrogPieceDiameter, FrogPieceDiameter);
+            pieceRect.anchoredPosition = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -7,7 +7,6 @@ using FrogColours = Frogs.Unity.UI.FrogColours;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
 using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
-using SharedButton = Frogs.Unity.UI.Button;
 
 namespace Frogs.Unity.Views
 {
@@ -38,8 +37,11 @@ namespace Frogs.Unity.Views
         public const float LaneHeight = 184f;
         public const float LilyPadDiameter = 112f;
         public const float FrogPieceDiameter = 88f;
+        public const float FrogPieceOutline = 4f;
         public const float LogWidth = 176f;
         public const float LogHeight = 120f;
+        public const float LogRadius = 24f;
+        public const float TrackOutline = 3f;
         public const float LanePositionGap = 48f;
         public const float LaneGutterWidth = 256f;
         public const float LaneGutterGap = 48f;
@@ -57,35 +59,52 @@ namespace Frogs.Unity.Views
         // whatever Lane reports; the denominator is Lane.LaneWinningPosition.
         const string PadCountFormat = "{0} of {1}";
 
-        // A log is "a flat rounded rectangle" (game-board.md's Shape-only
-        // note). The committed mockup draws it with the same 24 px corner the
-        // shared Button uses, so this names shared-components.md's own
-        // `ButtonRadius` rather than introducing a nineteenth number that
-        // game-board.md's tables do not have — see this issue's PR.
-        static readonly int LogCornerRadius = Mathf.RoundToInt(SharedButton.ButtonRadius);
-
         // Chrome colours copied verbatim from the committed mockup
         // (docs/specs/ui/mockups/game-board.html) — the same line Button.cs,
         // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
         // colours: not a geometry constant on any spec page's table, so not
         // declared as a named spec constant.
         static readonly Color LilyPadColor = new Color32(0xCF, 0xE0, 0xD2, 0xFF); // mockup's .pad fill
+        static readonly Color LilyPadOutlineColor = new Color32(0x9F, 0xB8, 0xA5, 0xFF); // mockup's .pad border
         static readonly Color LogColor = new Color32(0xE0, 0xD4, 0xC3, 0xFF); // mockup's .log fill
+        static readonly Color LogOutlineColor = new Color32(0xB9, 0xA7, 0x8E, 0xFF); // mockup's .log border
+        static readonly Color PieceOutlineColor = new Color(0f, 0f, 0f, 0.35f); // mockup's .frog border
 
         static Sprite s_logSprite;
+        static Sprite s_logFillSprite;
         static Sprite s_lilyPadSprite;
+        static Sprite s_lilyPadFillSprite;
         static Sprite s_pieceSprite;
+        static Sprite s_pieceFillSprite;
 
+        // Every outline is the element's own image with its fill inset inside
+        // it — the same two-image shape PlayerChip uses for its active ring.
+        // Each rounded shape gets a sprite generated at its own radius rather
+        // than one sprite stretched to two sizes, so the inset one keeps its
+        // curve instead of squaring off.
         static Sprite LogSprite
         {
             get
             {
                 if (s_logSprite == null)
                 {
-                    s_logSprite = RoundedRectSprite.CreateRoundedRect(LogCornerRadius);
+                    s_logSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LogRadius));
                 }
 
                 return s_logSprite;
+            }
+        }
+
+        static Sprite LogFillSprite
+        {
+            get
+            {
+                if (s_logFillSprite == null)
+                {
+                    s_logFillSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LogRadius - TrackOutline));
+                }
+
+                return s_logFillSprite;
             }
         }
 
@@ -105,6 +124,20 @@ namespace Frogs.Unity.Views
             }
         }
 
+        static Sprite LilyPadFillSprite
+        {
+            get
+            {
+                if (s_lilyPadFillSprite == null)
+                {
+                    s_lilyPadFillSprite = RoundedRectSprite.CreateRoundedRect(
+                        Mathf.RoundToInt((LilyPadDiameter - (2f * TrackOutline)) / 2f));
+                }
+
+                return s_lilyPadFillSprite;
+            }
+        }
+
         static Sprite PieceSprite
         {
             get
@@ -115,6 +148,20 @@ namespace Frogs.Unity.Views
                 }
 
                 return s_pieceSprite;
+            }
+        }
+
+        static Sprite PieceFillSprite
+        {
+            get
+            {
+                if (s_pieceFillSprite == null)
+                {
+                    s_pieceFillSprite = RoundedRectSprite.CreateRoundedRect(
+                        Mathf.RoundToInt((FrogPieceDiameter - (2f * FrogPieceOutline)) / 2f));
+                }
+
+                return s_pieceFillSprite;
             }
         }
 
@@ -162,6 +209,9 @@ namespace Frogs.Unity.Views
         RectTransform _trackRect;
         readonly List<RectTransform> _positionRects = new List<RectTransform>();
         readonly List<Image> _positionImages = new List<Image>();
+        readonly List<Image> _positionOutlines = new List<Image>();
+        RectTransform _pieceRect;
+        Image _pieceOutline;
         Image _piece;
 
         bool _initialized;
@@ -232,7 +282,45 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>`piece` — a flat circle in the frog's colour, sitting on its current position.</summary>
+        /// <summary>
+        /// The nine positions' outlines — <see cref="TrackOutline"/> thick,
+        /// drawn inside each element's own bounds so the track's width is
+        /// exactly the sum the spec's arithmetic gives.
+        /// </summary>
+        public IReadOnlyList<Image> PositionOutlines
+        {
+            get
+            {
+                EnsureInitialized();
+                return _positionOutlines;
+            }
+        }
+
+        /// <summary>
+        /// `piece` — the frog itself. This is the transform that gets
+        /// re-parented onto whichever track element Core reports, so its
+        /// parent is the answer to "which position is the frog on".
+        /// </summary>
+        public RectTransform PieceRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pieceRect;
+            }
+        }
+
+        /// <summary>The piece's outline — <see cref="FrogPieceOutline"/> thick.</summary>
+        public Image PieceOutline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pieceOutline;
+            }
+        }
+
+        /// <summary>The piece's fill — a circle in the frog's colour.</summary>
         public Image Piece
         {
             get
@@ -289,12 +377,11 @@ namespace Frogs.Unity.Views
 
             // Placed onto the element the track already holds for that index
             // — never at an offset this type worked out for itself.
-            var pieceRect = _piece.rectTransform;
-            pieceRect.SetParent(_positionRects[position], worldPositionStays: false);
-            pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
-            pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
-            pieceRect.pivot = new Vector2(0.5f, 0.5f);
-            pieceRect.anchoredPosition = Vector2.zero;
+            _pieceRect.SetParent(_positionRects[position], worldPositionStays: false);
+            _pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _pieceRect.pivot = new Vector2(0.5f, 0.5f);
+            _pieceRect.anchoredPosition = Vector2.zero;
 
             _chip.SetPadCount(string.Format(PadCountFormat, position, Lane.LaneWinningPosition));
 
@@ -379,13 +466,13 @@ namespace Frogs.Unity.Views
                     : position == Lane.LaneWinningPosition ? "EndLog" : "LilyPad" + position;
 
                 var positionGO = new GameObject(positionName, typeof(RectTransform), typeof(Image));
-                var image = positionGO.GetComponent<Image>();
-                image.sprite = isLog ? LogSprite : LilyPadSprite;
-                image.type = Image.Type.Sliced;
-                image.color = isLog ? LogColor : LilyPadColor;
-                image.raycastTarget = false;
+                var outline = positionGO.GetComponent<Image>();
+                outline.sprite = isLog ? LogSprite : LilyPadSprite;
+                outline.type = Image.Type.Sliced;
+                outline.color = isLog ? LogOutlineColor : LilyPadOutlineColor;
+                outline.raycastTarget = false;
 
-                var positionRect = image.rectTransform;
+                var positionRect = outline.rectTransform;
                 positionRect.SetParent(_trackRect, worldPositionStays: false);
                 positionRect.anchorMin = new Vector2(0f, 0.5f);
                 positionRect.anchorMax = new Vector2(0f, 0.5f);
@@ -393,29 +480,60 @@ namespace Frogs.Unity.Views
                 positionRect.sizeDelta = size;
                 positionRect.anchoredPosition = new Vector2(PositionCenterX(position), 0f);
 
+                var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+                var fill = fillGO.GetComponent<Image>();
+                fill.sprite = isLog ? LogFillSprite : LilyPadFillSprite;
+                fill.type = Image.Type.Sliced;
+                fill.color = isLog ? LogColor : LilyPadColor;
+                fill.raycastTarget = false;
+
+                var fillRect = fill.rectTransform;
+                fillRect.SetParent(positionRect, worldPositionStays: false);
+                fillRect.anchorMin = Vector2.zero;
+                fillRect.anchorMax = Vector2.one;
+                fillRect.offsetMin = new Vector2(TrackOutline, TrackOutline);
+                fillRect.offsetMax = new Vector2(-TrackOutline, -TrackOutline);
+
                 _positionRects.Add(positionRect);
-                _positionImages.Add(image);
+                _positionOutlines.Add(outline);
+                _positionImages.Add(fill);
             }
         }
 
         void BuildPiece()
         {
-            // piece — a flat circle in the frog's colour, per game-board.md's
-            // Shape-only note. It starts on the Start log and is moved onto
-            // whichever position Core reports on the first Render.
+            // piece — a flat-coloured circle in the frog's colour inside its
+            // own outline, per game-board.md's Shape-only note and the
+            // committed mockup's `.frog` ring. It starts on the Start log and
+            // is moved onto whichever position Core reports on the first
+            // Render.
             var pieceGO = new GameObject("Piece", typeof(RectTransform), typeof(Image));
-            _piece = pieceGO.GetComponent<Image>();
-            _piece.sprite = PieceSprite;
+            _pieceOutline = pieceGO.GetComponent<Image>();
+            _pieceOutline.sprite = PieceSprite;
+            _pieceOutline.type = Image.Type.Sliced;
+            _pieceOutline.color = PieceOutlineColor;
+            _pieceOutline.raycastTarget = false;
+
+            _pieceRect = _pieceOutline.rectTransform;
+            _pieceRect.SetParent(_positionRects[0], worldPositionStays: false);
+            _pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _pieceRect.pivot = new Vector2(0.5f, 0.5f);
+            _pieceRect.sizeDelta = new Vector2(FrogPieceDiameter, FrogPieceDiameter);
+            _pieceRect.anchoredPosition = Vector2.zero;
+
+            var pieceFillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            _piece = pieceFillGO.GetComponent<Image>();
+            _piece.sprite = PieceFillSprite;
             _piece.type = Image.Type.Sliced;
             _piece.raycastTarget = false;
 
-            var pieceRect = _piece.rectTransform;
-            pieceRect.SetParent(_positionRects[0], worldPositionStays: false);
-            pieceRect.anchorMin = new Vector2(0.5f, 0.5f);
-            pieceRect.anchorMax = new Vector2(0.5f, 0.5f);
-            pieceRect.pivot = new Vector2(0.5f, 0.5f);
-            pieceRect.sizeDelta = new Vector2(FrogPieceDiameter, FrogPieceDiameter);
-            pieceRect.anchoredPosition = Vector2.zero;
+            var pieceFillRect = _piece.rectTransform;
+            pieceFillRect.SetParent(_pieceRect, worldPositionStays: false);
+            pieceFillRect.anchorMin = Vector2.zero;
+            pieceFillRect.anchorMax = Vector2.one;
+            pieceFillRect.offsetMin = new Vector2(FrogPieceOutline, FrogPieceOutline);
+            pieceFillRect.offsetMax = new Vector2(-FrogPieceOutline, -FrogPieceOutline);
         }
     }
 }

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs.meta
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e564ef1e61c2412c818a2e76dc43c980
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -1,0 +1,565 @@
+using System;
+using System.Collections.Generic;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// ButtonTests.cs, TitleScreenView.cs and GameSetupScreenView.cs work around —
+// so these are pulled in by explicit alias rather than a wildcard
+// `using Frogs.Unity.UI;`, and a bare `Button`, `ButtonKind`, `FrogColours`
+// or `PlayerChip` in this file always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The pond — docs/specs/ui/game-board.md, built to that page and its
+    /// committed 1:1 mockup. Three horizontal bands filling the full height
+    /// with no gaps: <c>header</c> (whose turn it is, and the gear),
+    /// <c>pond</c> (one <see cref="GameBoardLaneView"/> per frog in the game,
+    /// stacked and vertically centred), and <c>controls</c> (the oversized
+    /// `Roll`).
+    ///
+    /// **It reads Core; it never computes.** Whose turn it is comes from
+    /// <see cref="Game.ActiveFrog"/>, and where every frog sits comes from
+    /// that frog's <see cref="Lane"/> — this view never counts a correct
+    /// answer, never decides who goes next, and never works out a pixel
+    /// offset from a roll or an answer.
+    ///
+    /// Two things it deliberately does not do:
+    ///
+    /// - **No motion.** Every frog is drawn at rest at whatever position Core
+    ///   reports. The hop that plays after the result dialog closes belongs
+    ///   to <c>answer-result</c> (#224), which owns the dialog that closes and
+    ///   starts it.
+    /// - **No end-of-game detection.** This board keeps rendering whatever
+    ///   Core reports for as long as it is shown; noticing that the last frog
+    ///   got home and moving off this screen is <c>unity-game-over</c> (#225),
+    ///   gated on <c>core-game-end</c> (#211).
+    ///
+    /// Both of game-board.md's open questions are left exactly as open as it
+    /// leaves them: only the lanes in play are drawn, and nothing anywhere
+    /// reports the last roll.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class GameBoardScreenView : MonoBehaviour
+    {
+        // docs/specs/ui/game-board.md#named-constants — the board's table.
+        public const float SafeMargin = 48f;
+        public const float BoardHeaderHeight = 128f;
+        public const float BoardControlsHeight = 176f;
+        public const float TurnBannerSize = 52f;
+        public const float SettingsButtonSize = 96f;
+        public const float RollButtonWidth = 480f;
+        public const float RollButtonHeight = 144f;
+        public const float RollButtonLabelSize = 56f;
+
+        // The other two rows of that table, `LanePositionCount` (9) and
+        // `LaneWinningPosition` (8), are Frogs.Core.Lane's own constants,
+        // referenced under the identical name rather than redeclared here —
+        // see GameBoardLaneView.
+
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float CanvasWidth = 1920f;
+        const float CanvasHeight = 1200f;
+
+        // "Whose turn it is is stated in words in the header, not only shown
+        // by a highlight." The wording is the frog's colour name, because
+        // frogs have no other name.
+        const string TurnBannerFormat = "{0} frog's turn";
+        const string RollLabel = "Roll";
+
+        // No imported font — matches Button.cs's, PlayerChip.cs's and
+        // GameSetupScreenView.cs's own choice, for the same reason (no
+        // external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockup
+        // (docs/specs/ui/mockups/game-board.html) — the same line Button.cs,
+        // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
+        // colours: not a geometry constant on any spec page's table, so not
+        // declared as a named spec constant.
+        static readonly Color BoardBackgroundColor = new Color32(0xED, 0xF1, 0xEF, 0xFF); // mockup's --bg
+        static readonly Color BandColor = new Color32(0xE2, 0xE8, 0xE5, 0xFF); // mockup's header/controls bands
+        static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
+
+        RectTransform _rect;
+
+        RectTransform _headerRect;
+        PlayerChip _turnBannerChip;
+        Text _turnBannerText;
+        GameBoardSettingsButton _settingsButton;
+
+        RectTransform _pondRect;
+        readonly List<GameBoardLaneView> _lanes = new List<GameBoardLaneView>();
+        readonly Dictionary<FrogColour, GameBoardLaneView> _lanesByColour = new Dictionary<FrogColour, GameBoardLaneView>();
+
+        RectTransform _controlsRect;
+        Button _rollButton;
+
+        bool _initialized;
+        Game _game;
+
+        /// <summary>
+        /// `Roll` was pressed. The board disables `Roll` before raising this
+        /// and leaves it disabled until <see cref="NotifyTurnResolved"/> — so
+        /// a double-tap cannot roll twice. What happens next (opening
+        /// docs/specs/ui/roll-and-card.md) is #221's; this view only says
+        /// that the press happened.
+        /// </summary>
+        public event Action RollPressed;
+
+        /// <summary>
+        /// Open the settings dialog. Raised by the gear and by hardware back,
+        /// which is the same request through two doors —
+        /// docs/specs/ui/game-board.md: "Hardware back opens the settings
+        /// dialog. It does not quit, and it never quits without the confirm."
+        /// The dialog's own contents are #222's.
+        /// </summary>
+        public event Action SettingsRequested;
+
+        /// <summary>The screen's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>`header` — pinned to the top, <see cref="BoardHeaderHeight"/> tall, full width.</summary>
+        public RectTransform HeaderRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _headerRect;
+            }
+        }
+
+        /// <summary>The active frog's chip, left of the turn banner.</summary>
+        public PlayerChip TurnBannerChip
+        {
+            get
+            {
+                EnsureInitialized();
+                return _turnBannerChip;
+            }
+        }
+
+        /// <summary>The turn banner — `Green frog's turn`, in words.</summary>
+        public Text TurnBannerText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _turnBannerText;
+            }
+        }
+
+        /// <summary>The gear, top right. Never disabled by turn state.</summary>
+        public GameBoardSettingsButton SettingsButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _settingsButton;
+            }
+        }
+
+        /// <summary>`pond` — everything between the two pinned bands.</summary>
+        public RectTransform PondRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pondRect;
+            }
+        }
+
+        /// <summary>One lane per frog in the game, in turn order. Two, three, or four — never a placeholder.</summary>
+        public IReadOnlyList<GameBoardLaneView> Lanes
+        {
+            get
+            {
+                EnsureInitialized();
+                return _lanes;
+            }
+        }
+
+        /// <summary>`controls` — pinned to the bottom, <see cref="BoardControlsHeight"/> tall, full width.</summary>
+        public RectTransform ControlsRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _controlsRect;
+            }
+        }
+
+        /// <summary>`Roll` — the only way to start a turn.</summary>
+        public Button RollButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rollButton;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        void Update()
+        {
+            // Android back arrives as Escape. The board owns this rather than
+            // delegating it, because "hardware back opens settings, never
+            // quits" is game-board.md's own rule about this screen — see
+            // HandleHardwareBack.
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                HandleHardwareBack();
+            }
+        }
+
+        /// <summary>
+        /// Points the board at the game it draws, and lays out one lane per
+        /// frog in that game's turn order. Everything the board shows is read
+        /// from here and nowhere else.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="game"/> is null.</exception>
+        public void Initialize(Game game)
+        {
+            EnsureInitialized();
+
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+
+            BuildLanes();
+            Refresh();
+        }
+
+        /// <summary>
+        /// Re-reads the game and redraws. Every value it draws is asked for
+        /// again — nothing is remembered from the last pass, so a frog that
+        /// moved, a turn that passed, or a frog that got home all show up
+        /// simply by asking.
+        /// </summary>
+        public void Refresh()
+        {
+            EnsureInitialized();
+
+            if (_game == null)
+            {
+                return;
+            }
+
+            var active = _game.ActiveFrog;
+
+            _turnBannerText.text = string.Format(TurnBannerFormat, active);
+            _turnBannerChip.SetFrog(FrogColours.For(active), active.ToString());
+            _turnBannerChip.SetState(PlayerChipState.Active);
+
+            foreach (var lane in _lanes)
+            {
+                lane.Render(_game.LaneFor(lane.Colour), lane.Colour == active);
+            }
+        }
+
+        /// <summary>
+        /// The turn that <see cref="RollPressed"/> started has resolved:
+        /// `Roll` becomes pressable again and the board redraws. This is the
+        /// only thing that re-enables `Roll` — never a timer, and never the
+        /// passage of time.
+        ///
+        /// Nothing calls this yet: roll-and-card, the working-out grid and
+        /// answer-result (#221/#223/#224) are what will. It is the seam those
+        /// issues wire into, and the stand-in this issue's tests drive
+        /// directly.
+        /// </summary>
+        public void NotifyTurnResolved()
+        {
+            EnsureInitialized();
+
+            _rollButton.SetDisabled(false);
+            Refresh();
+        }
+
+        /// <summary>
+        /// What hardware back does on this screen: exactly what the gear
+        /// does. It does not quit, and this type contains no path that could
+        /// — docs/specs/ui/game-board.md's Behaviour section.
+        /// </summary>
+        public void HandleHardwareBack()
+        {
+            EnsureInitialized();
+
+            RaiseSettingsRequested();
+        }
+
+        /// <summary>This frog's lane.</summary>
+        /// <exception cref="KeyNotFoundException"><paramref name="colour"/> is not in the game's roster.</exception>
+        public GameBoardLaneView LaneFor(FrogColour colour)
+        {
+            EnsureInitialized();
+            return _lanesByColour[colour];
+        }
+
+        // Unity does not guarantee Awake() has run before another
+        // component's Awake() or a test reaches this one right after
+        // AddComponent — the same reasoning as Button, PlayerChip and
+        // GameSetupScreenView's own EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.anchorMin = new Vector2(0.5f, 0.5f);
+            _rect.anchorMax = new Vector2(0.5f, 0.5f);
+            _rect.pivot = new Vector2(0.5f, 0.5f);
+            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+
+            BuildBackground();
+            BuildHeader();
+            BuildPond();
+            BuildControls();
+        }
+
+        void BuildBackground()
+        {
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            var background = backgroundGO.GetComponent<Image>();
+            background.color = BoardBackgroundColor;
+            background.raycastTarget = false;
+            var backgroundRect = background.rectTransform;
+            backgroundRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(backgroundRect);
+        }
+
+        void BuildHeader()
+        {
+            // header — pinned to the top, full width, not shrinking on a
+            // shorter screen.
+            var headerGO = new GameObject("Header", typeof(RectTransform), typeof(Image));
+            var headerImage = headerGO.GetComponent<Image>();
+            headerImage.color = BandColor;
+            headerImage.raycastTarget = false;
+
+            _headerRect = headerImage.rectTransform;
+            _headerRect.SetParent(_rect, worldPositionStays: false);
+            _headerRect.anchorMin = new Vector2(0f, 1f);
+            _headerRect.anchorMax = new Vector2(1f, 1f);
+            _headerRect.pivot = new Vector2(0.5f, 1f);
+            _headerRect.sizeDelta = new Vector2(0f, BoardHeaderHeight);
+            _headerRect.anchoredPosition = Vector2.zero;
+
+            var chipGO = new GameObject("TurnBannerChip", typeof(RectTransform));
+            var chipRect = (RectTransform)chipGO.transform;
+            chipRect.SetParent(_headerRect, worldPositionStays: false);
+            chipRect.anchorMin = new Vector2(0f, 0.5f);
+            chipRect.anchorMax = new Vector2(0f, 0.5f);
+            chipRect.pivot = new Vector2(0f, 0.5f);
+            chipRect.anchoredPosition = new Vector2(SafeMargin, 0f);
+            _turnBannerChip = chipGO.AddComponent<PlayerChip>();
+            chipRect.sizeDelta = new Vector2(GameBoardLaneView.LaneGutterWidth, PlayerChip.PlayerChipHeight);
+
+            var bannerGO = new GameObject("TurnBanner", typeof(RectTransform), typeof(Text));
+            _turnBannerText = bannerGO.GetComponent<Text>();
+            _turnBannerText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _turnBannerText.fontSize = (int)TurnBannerSize;
+            _turnBannerText.fontStyle = FontStyle.Bold;
+            _turnBannerText.color = InkColor;
+            _turnBannerText.alignment = TextAnchor.MiddleLeft;
+            _turnBannerText.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _turnBannerText.verticalOverflow = VerticalWrapMode.Overflow;
+            _turnBannerText.raycastTarget = false;
+
+            var bannerRect = _turnBannerText.rectTransform;
+            bannerRect.SetParent(_headerRect, worldPositionStays: false);
+            bannerRect.anchorMin = new Vector2(0f, 0.5f);
+            bannerRect.anchorMax = new Vector2(0f, 0.5f);
+            bannerRect.pivot = new Vector2(0f, 0.5f);
+            bannerRect.sizeDelta = Vector2.zero;
+
+            // The banner's words start where every lane's track starts: the
+            // header chip is a chip in a LaneGutterWidth gutter, and the gap
+            // after a chip before its content is LaneGutterGap. Composed from
+            // game-board.md's own constants rather than reaching for a
+            // nineteenth number — see this issue's PR.
+            bannerRect.anchoredPosition = new Vector2(
+                SafeMargin + GameBoardLaneView.LaneGutterWidth + GameBoardLaneView.LaneGutterGap,
+                0f);
+
+            var settingsGO = new GameObject("SettingsButton", typeof(RectTransform));
+            var settingsRect = (RectTransform)settingsGO.transform;
+            settingsRect.SetParent(_headerRect, worldPositionStays: false);
+            settingsRect.anchorMin = new Vector2(1f, 0.5f);
+            settingsRect.anchorMax = new Vector2(1f, 0.5f);
+            settingsRect.pivot = new Vector2(1f, 0.5f);
+            settingsRect.anchoredPosition = new Vector2(-SafeMargin, 0f);
+
+            _settingsButton = settingsGO.AddComponent<GameBoardSettingsButton>();
+            _settingsButton.SetSize(SettingsButtonSize);
+            _settingsButton.Clicked += HandleSettingsClicked;
+        }
+
+        void BuildPond()
+        {
+            // pond — everything between the other two bands. A shorter screen
+            // loses height from here and nothing else.
+            var pondGO = new GameObject("Pond", typeof(RectTransform));
+            _pondRect = (RectTransform)pondGO.transform;
+            _pondRect.SetParent(_rect, worldPositionStays: false);
+            _pondRect.anchorMin = Vector2.zero;
+            _pondRect.anchorMax = Vector2.one;
+            _pondRect.offsetMin = new Vector2(0f, BoardControlsHeight);
+            _pondRect.offsetMax = new Vector2(0f, -BoardHeaderHeight);
+        }
+
+        void BuildControls()
+        {
+            // controls — pinned to the bottom, full width. A smaller `Roll`
+            // is the wrong thing to trade away, so this band does not shrink.
+            var controlsGO = new GameObject("Controls", typeof(RectTransform), typeof(Image));
+            var controlsImage = controlsGO.GetComponent<Image>();
+            controlsImage.color = BandColor;
+            controlsImage.raycastTarget = false;
+
+            _controlsRect = controlsImage.rectTransform;
+            _controlsRect.SetParent(_rect, worldPositionStays: false);
+            _controlsRect.anchorMin = new Vector2(0f, 0f);
+            _controlsRect.anchorMax = new Vector2(1f, 0f);
+            _controlsRect.pivot = new Vector2(0.5f, 0f);
+            _controlsRect.sizeDelta = new Vector2(0f, BoardControlsHeight);
+            _controlsRect.anchoredPosition = Vector2.zero;
+
+            var rollGO = new GameObject("Roll", typeof(RectTransform));
+            rollGO.transform.SetParent(_controlsRect, worldPositionStays: false);
+
+            _rollButton = rollGO.AddComponent<Button>();
+            _rollButton.SetKind(ButtonKind.Primary);
+            _rollButton.SetLabelText(RollLabel);
+
+            // Primary, oversized — game-board.md's own named override of the
+            // shared Button's footprint, agreed at the spec level. The three
+            // Button kinds still share a footprint with each other; this one
+            // instance is bigger than all three.
+            _rollButton.SetSize(RollButtonWidth, RollButtonHeight);
+            _rollButton.SetLabelSize(RollButtonLabelSize);
+
+            var rollRect = _rollButton.RectTransform;
+            rollRect.anchorMin = new Vector2(0.5f, 0.5f);
+            rollRect.anchorMax = new Vector2(0.5f, 0.5f);
+            rollRect.pivot = new Vector2(0.5f, 0.5f);
+            rollRect.anchoredPosition = Vector2.zero;
+
+            _rollButton.Clicked += HandleRollClicked;
+        }
+
+        void BuildLanes()
+        {
+            foreach (var lane in _lanes)
+            {
+                if (lane != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(lane.gameObject);
+                }
+            }
+
+            _lanes.Clear();
+            _lanesByColour.Clear();
+
+            // One lane per frog in the game, in turn order — two, three, or
+            // four. Every frog is visible at once, with no scrolling, paging
+            // or zooming, and an absent frog gets no placeholder lane.
+            var turnOrder = _game.TurnOrder;
+            var laneWidth = CanvasWidth - (2f * SafeMargin);
+            var groupTop = (turnOrder.Count * GameBoardLaneView.LaneHeight) / 2f;
+
+            for (var index = 0; index < turnOrder.Count; index++)
+            {
+                var colour = turnOrder[index];
+
+                var laneGO = new GameObject(colour.ToString() + "Lane", typeof(RectTransform));
+                var laneRect = (RectTransform)laneGO.transform;
+                laneRect.SetParent(_pondRect, worldPositionStays: false);
+
+                // Stacked and vertically centred as a group within the pond,
+                // so a two-frog game sits centred rather than clinging to the
+                // top.
+                laneRect.anchorMin = new Vector2(0.5f, 0.5f);
+                laneRect.anchorMax = new Vector2(0.5f, 0.5f);
+                laneRect.pivot = new Vector2(0.5f, 0.5f);
+                laneRect.sizeDelta = new Vector2(laneWidth, GameBoardLaneView.LaneHeight);
+                laneRect.anchoredPosition = new Vector2(
+                    0f,
+                    groupTop - ((index + 0.5f) * GameBoardLaneView.LaneHeight));
+
+                var lane = laneGO.AddComponent<GameBoardLaneView>();
+                lane.Initialize(colour);
+
+                _lanes.Add(lane);
+                _lanesByColour[colour] = lane;
+            }
+        }
+
+        void HandleRollClicked()
+        {
+            // Disabled the moment the press resolves and left that way until
+            // told the turn resolved — the invariant that a double-tap cannot
+            // roll twice. Disabled *before* the event is raised, so nothing a
+            // listener does can arrive at a still-pressable button.
+            _rollButton.SetDisabled(true);
+
+            var handler = RollPressed;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        void HandleSettingsClicked()
+        {
+            RaiseSettingsRequested();
+        }
+
+        void RaiseSettingsRequested()
+        {
+            var handler = SettingsRequested;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -52,8 +52,12 @@ namespace Frogs.Unity.Views
         public const float SafeMargin = 48f;
         public const float BoardHeaderHeight = 128f;
         public const float BoardControlsHeight = 176f;
+        public const float BoardBandOutline = 3f;
         public const float TurnBannerSize = 52f;
+        public const float TurnBannerGap = 24f;
         public const float SettingsButtonSize = 96f;
+        public const float SettingsGlyphSize = 44f;
+        public const float SettingsButtonOutline = 4f;
         public const float RollButtonWidth = 480f;
         public const float RollButtonHeight = 144f;
         public const float RollButtonLabelSize = 56f;
@@ -86,11 +90,13 @@ namespace Frogs.Unity.Views
         // declared as a named spec constant.
         static readonly Color BoardBackgroundColor = new Color32(0xED, 0xF1, 0xEF, 0xFF); // mockup's --bg
         static readonly Color BandColor = new Color32(0xE2, 0xE8, 0xE5, 0xFF); // mockup's header/controls bands
+        static readonly Color BandOutlineColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockup's --faint
         static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
 
         RectTransform _rect;
 
         RectTransform _headerRect;
+        Image _headerHairline;
         PlayerChip _turnBannerChip;
         Text _turnBannerText;
         GameBoardSettingsButton _settingsButton;
@@ -100,6 +106,7 @@ namespace Frogs.Unity.Views
         readonly Dictionary<FrogColour, GameBoardLaneView> _lanesByColour = new Dictionary<FrogColour, GameBoardLaneView>();
 
         RectTransform _controlsRect;
+        Image _controlsHairline;
         Button _rollButton;
 
         bool _initialized;
@@ -140,6 +147,26 @@ namespace Frogs.Unity.Views
             {
                 EnsureInitialized();
                 return _headerRect;
+            }
+        }
+
+        /// <summary>The hairline under `header` — <see cref="BoardBandOutline"/> tall, drawn inside the band.</summary>
+        public Image HeaderHairline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _headerHairline;
+            }
+        }
+
+        /// <summary>The hairline over `controls` — <see cref="BoardBandOutline"/> tall, drawn inside the band.</summary>
+        public Image ControlsHairline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _controlsHairline;
             }
         }
 
@@ -383,7 +410,7 @@ namespace Frogs.Unity.Views
             chipRect.pivot = new Vector2(0f, 0.5f);
             chipRect.anchoredPosition = new Vector2(SafeMargin, 0f);
             _turnBannerChip = chipGO.AddComponent<PlayerChip>();
-            chipRect.sizeDelta = new Vector2(GameBoardLaneView.LaneGutterWidth, PlayerChip.PlayerChipHeight);
+            chipRect.sizeDelta = new Vector2(PlayerChip.PlayerChipWidth, PlayerChip.PlayerChipHeight);
 
             var bannerGO = new GameObject("TurnBanner", typeof(RectTransform), typeof(Text));
             _turnBannerText = bannerGO.GetComponent<Text>();
@@ -403,13 +430,11 @@ namespace Frogs.Unity.Views
             bannerRect.pivot = new Vector2(0f, 0.5f);
             bannerRect.sizeDelta = Vector2.zero;
 
-            // The banner's words start where every lane's track starts: the
-            // header chip is a chip in a LaneGutterWidth gutter, and the gap
-            // after a chip before its content is LaneGutterGap. Composed from
-            // game-board.md's own constants rather than reaching for a
-            // nineteenth number — see this issue's PR.
+            // The banner's words sit TurnBannerGap past the chip beside them —
+            // the chip is the shared Player chip, so its width is that
+            // component's own constant.
             bannerRect.anchoredPosition = new Vector2(
-                SafeMargin + GameBoardLaneView.LaneGutterWidth + GameBoardLaneView.LaneGutterGap,
+                SafeMargin + PlayerChip.PlayerChipWidth + TurnBannerGap,
                 0f);
 
             var settingsGO = new GameObject("SettingsButton", typeof(RectTransform));
@@ -421,8 +446,37 @@ namespace Frogs.Unity.Views
             settingsRect.anchoredPosition = new Vector2(-SafeMargin, 0f);
 
             _settingsButton = settingsGO.AddComponent<GameBoardSettingsButton>();
-            _settingsButton.SetSize(SettingsButtonSize);
+
+            // Unity does not run Awake() on AddComponent outside play mode,
+            // and the gear sizes itself when it builds. Touch its rect so it
+            // builds now, while the header is being laid out, rather than
+            // whenever something first happens to read it.
+            settingsRect = _settingsButton.RectTransform;
+
             _settingsButton.Clicked += HandleSettingsClicked;
+
+            _headerHairline = BuildBandHairline(_headerRect, "HeaderHairline", atTop: false);
+        }
+
+        // The hairline the mockup draws under `header` and over `controls`,
+        // BoardBandOutline tall and drawn inside the band's own bounds so the
+        // band's height is untouched.
+        Image BuildBandHairline(RectTransform band, string hairlineName, bool atTop)
+        {
+            var hairlineGO = new GameObject(hairlineName, typeof(RectTransform), typeof(Image));
+            var hairline = hairlineGO.GetComponent<Image>();
+            hairline.color = BandOutlineColor;
+            hairline.raycastTarget = false;
+
+            var hairlineRect = hairline.rectTransform;
+            hairlineRect.SetParent(band, worldPositionStays: false);
+            hairlineRect.anchorMin = new Vector2(0f, atTop ? 1f : 0f);
+            hairlineRect.anchorMax = new Vector2(1f, atTop ? 1f : 0f);
+            hairlineRect.pivot = new Vector2(0.5f, atTop ? 1f : 0f);
+            hairlineRect.sizeDelta = new Vector2(0f, BoardBandOutline);
+            hairlineRect.anchoredPosition = Vector2.zero;
+
+            return hairline;
         }
 
         void BuildPond()
@@ -454,6 +508,8 @@ namespace Frogs.Unity.Views
             _controlsRect.pivot = new Vector2(0.5f, 0f);
             _controlsRect.sizeDelta = new Vector2(0f, BoardControlsHeight);
             _controlsRect.anchoredPosition = Vector2.zero;
+
+            _controlsHairline = BuildBandHairline(_controlsRect, "ControlsHairline", atTop: true);
 
             var rollGO = new GameObject("Roll", typeof(RectTransform));
             rollGO.transform.SetParent(_controlsRect, worldPositionStays: false);

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs.meta
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3680ac3af02a41aca9df7a1e5df82496
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs
@@ -1,0 +1,195 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
+using SharedButton = Frogs.Unity.UI.Button;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The board's gear — docs/specs/ui/game-board.md's Elements section:
+    /// "top right, `SettingsButtonSize` square, a gear."
+    ///
+    /// Deliberately **not** the shared <see cref="SharedButton"/>. That
+    /// component is a pill with a text label, a corner radius and a minimum
+    /// width; the gear is a round icon square, and
+    /// docs/specs/ui/shared-components.md has no icon-button component today
+    /// to fit it into. Rather than force the gear into a Button it does not
+    /// fit, this is the board's own small square button — see this issue's
+    /// PR.
+    ///
+    /// Its size comes from the board's <c>SettingsButtonSize</c>, which
+    /// already equals shared-components.md's <see cref="SharedButton.MinTouchTarget"/>,
+    /// so the touch-target invariant is met by construction with no extra
+    /// number.
+    ///
+    /// Pointer handling mirrors <see cref="SharedButton"/>'s exactly: acts on
+    /// release, and only when the release lands over the button, so a finger
+    /// that lands wrong can slide off and cancel. It is never disabled — the
+    /// gear is "available on any turn, at any time, including while it is not
+    /// your turn."
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class GameBoardSettingsButton : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerExitHandler
+    {
+        // No imported texture, sprite, or font — docs/specs/ui/shared-components.md
+        // "no external assets", the same choice Button.cs and PlayerChip.cs made.
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // The gear itself, as a character rather than an imported icon —
+        // U+2699 GEAR, written as an escape so the source file's encoding
+        // can never be what decides whether the board draws one.
+        const string GearGlyph = "\u2699";
+
+        // Chrome colours copied verbatim from the committed mockup
+        // (docs/specs/ui/mockups/game-board.html) — not a geometry constant
+        // on any spec page's table, so not declared as a named spec constant.
+        static readonly Color BackgroundColor = Color.white; // mockup's --paper
+        static readonly Color GlyphColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
+
+        RectTransform _rect;
+        Image _background;
+        Text _glyph;
+
+        bool _initialized;
+        bool _isPressed;
+
+        /// <summary>Fires on release, only when the release lands over the button.</summary>
+        public event Action Clicked;
+
+        /// <summary>The button's own <see cref="RectTransform"/> — a square, and its hit-test bounds.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The round backdrop, drawn as a flat circle.</summary>
+        public Image Background
+        {
+            get
+            {
+                EnsureInitialized();
+                return _background;
+            }
+        }
+
+        /// <summary>The gear.</summary>
+        public Text Glyph
+        {
+            get
+            {
+                EnsureInitialized();
+                return _glyph;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>Sizes the square, and the circle drawn inside it.</summary>
+        public void SetSize(float size)
+        {
+            EnsureInitialized();
+            SetSizeInternal(size);
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            EnsureInitialized();
+            _isPressed = true;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            EnsureInitialized();
+
+            var wasPressed = _isPressed;
+            _isPressed = false;
+
+            if (!wasPressed)
+            {
+                return;
+            }
+
+            if (RectTransformUtility.RectangleContainsScreenPoint(_rect, eventData.position, eventData.pressEventCamera))
+            {
+                Clicked?.Invoke();
+            }
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            _isPressed = false;
+        }
+
+        // Unity does not guarantee Awake() has run before a caller reaches
+        // this right after AddComponent — the same reasoning as every other
+        // EnsureInitialized in this codebase.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            _background = backgroundGO.GetComponent<Image>();
+            _background.type = Image.Type.Sliced;
+            _background.color = BackgroundColor;
+            _background.raycastTarget = true;
+            var backgroundRect = _background.rectTransform;
+            backgroundRect.SetParent(_rect, worldPositionStays: false);
+            backgroundRect.anchorMin = Vector2.zero;
+            backgroundRect.anchorMax = Vector2.one;
+            backgroundRect.offsetMin = Vector2.zero;
+            backgroundRect.offsetMax = Vector2.zero;
+
+            var glyphGO = new GameObject("Glyph", typeof(RectTransform), typeof(Text));
+            _glyph = glyphGO.GetComponent<Text>();
+            _glyph.text = GearGlyph;
+            _glyph.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+
+            // The mockup draws the gear at the same 44 px the shared Button
+            // sets its own label at, so this names shared-components.md's
+            // `ButtonLabelSize` rather than adding a number game-board.md's
+            // tables do not have.
+            _glyph.fontSize = (int)SharedButton.ButtonLabelSize;
+            _glyph.color = GlyphColor;
+            _glyph.alignment = TextAnchor.MiddleCenter;
+            _glyph.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _glyph.verticalOverflow = VerticalWrapMode.Overflow;
+            _glyph.raycastTarget = false;
+            var glyphRect = _glyph.rectTransform;
+            glyphRect.SetParent(_rect, worldPositionStays: false);
+            glyphRect.anchorMin = Vector2.zero;
+            glyphRect.anchorMax = Vector2.one;
+            glyphRect.offsetMin = Vector2.zero;
+            glyphRect.offsetMax = Vector2.zero;
+
+            // A default circle, so the button is drawable before SetSize —
+            // the board always calls SetSize with SettingsButtonSize.
+            SetSizeInternal(SharedButton.MinTouchTarget);
+        }
+
+        void SetSizeInternal(float size)
+        {
+            _rect.sizeDelta = new Vector2(size, size);
+            _background.sprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(size / 2f));
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs
@@ -19,10 +19,16 @@ namespace Frogs.Unity.Views
     /// fit, this is the board's own small square button — see this issue's
     /// PR.
     ///
-    /// Its size comes from the board's <c>SettingsButtonSize</c>, which
-    /// already equals shared-components.md's <see cref="SharedButton.MinTouchTarget"/>,
-    /// so the touch-target invariant is met by construction with no extra
-    /// number.
+    /// Its size, ring and glyph are game-board.md's own
+    /// <see cref="GameBoardScreenView.SettingsButtonSize"/>,
+    /// <see cref="GameBoardScreenView.SettingsButtonOutline"/> and
+    /// <see cref="GameBoardScreenView.SettingsGlyphSize"/> — deliberately not
+    /// the Button's <c>ButtonRadius</c>/<c>ButtonLabelSize</c>, which happen
+    /// to hold the same numbers today but belong to a component that is free
+    /// to restyle without moving the pond's gear. <c>SettingsButtonSize</c>
+    /// already equals shared-components.md's
+    /// <see cref="SharedButton.MinTouchTarget"/>, so the touch-target
+    /// invariant is met by construction with no extra number.
     ///
     /// Pointer handling mirrors <see cref="SharedButton"/>'s exactly: acts on
     /// release, and only when the release lands over the button, so a finger
@@ -46,9 +52,11 @@ namespace Frogs.Unity.Views
         // (docs/specs/ui/mockups/game-board.html) — not a geometry constant
         // on any spec page's table, so not declared as a named spec constant.
         static readonly Color BackgroundColor = Color.white; // mockup's --paper
+        static readonly Color OutlineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockup's --line
         static readonly Color GlyphColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
 
         RectTransform _rect;
+        Image _outline;
         Image _background;
         Text _glyph;
 
@@ -68,7 +76,17 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>The round backdrop, drawn as a flat circle.</summary>
+        /// <summary>The gear's ring — <see cref="GameBoardScreenView.SettingsButtonOutline"/> thick.</summary>
+        public Image Outline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _outline;
+            }
+        }
+
+        /// <summary>The round backdrop inside the ring.</summary>
         public Image Background
         {
             get
@@ -91,13 +109,6 @@ namespace Frogs.Unity.Views
         void Awake()
         {
             EnsureInitialized();
-        }
-
-        /// <summary>Sizes the square, and the circle drawn inside it.</summary>
-        public void SetSize(float size)
-        {
-            EnsureInitialized();
-            SetSizeInternal(size);
         }
 
         public void OnPointerDown(PointerEventData eventData)
@@ -147,28 +158,52 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
+            _rect.sizeDelta = new Vector2(
+                GameBoardScreenView.SettingsButtonSize,
+                GameBoardScreenView.SettingsButtonSize);
+
+            // The ring, then the fill inset inside it — the same two-image
+            // shape PlayerChip uses for its active ring. Each circle gets a
+            // sprite generated at its own radius rather than one sprite
+            // stretched to two sizes, so the smaller one stays round.
+            var outlineGO = new GameObject("Outline", typeof(RectTransform), typeof(Image));
+            _outline = outlineGO.GetComponent<Image>();
+            _outline.sprite = RoundedRectSprite.CreateRoundedRect(
+                Mathf.RoundToInt(GameBoardScreenView.SettingsButtonSize / 2f));
+            _outline.type = Image.Type.Sliced;
+            _outline.color = OutlineColor;
+            _outline.raycastTarget = true;
+            var outlineRect = _outline.rectTransform;
+            outlineRect.SetParent(_rect, worldPositionStays: false);
+            outlineRect.anchorMin = Vector2.zero;
+            outlineRect.anchorMax = Vector2.one;
+            outlineRect.offsetMin = Vector2.zero;
+            outlineRect.offsetMax = Vector2.zero;
+
             var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
             _background = backgroundGO.GetComponent<Image>();
+            _background.sprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(
+                (GameBoardScreenView.SettingsButtonSize - (2f * GameBoardScreenView.SettingsButtonOutline)) / 2f));
             _background.type = Image.Type.Sliced;
             _background.color = BackgroundColor;
-            _background.raycastTarget = true;
+            _background.raycastTarget = false;
             var backgroundRect = _background.rectTransform;
             backgroundRect.SetParent(_rect, worldPositionStays: false);
             backgroundRect.anchorMin = Vector2.zero;
             backgroundRect.anchorMax = Vector2.one;
-            backgroundRect.offsetMin = Vector2.zero;
-            backgroundRect.offsetMax = Vector2.zero;
+            backgroundRect.offsetMin = new Vector2(
+                GameBoardScreenView.SettingsButtonOutline,
+                GameBoardScreenView.SettingsButtonOutline);
+            backgroundRect.offsetMax = new Vector2(
+                -GameBoardScreenView.SettingsButtonOutline,
+                -GameBoardScreenView.SettingsButtonOutline);
 
             var glyphGO = new GameObject("Glyph", typeof(RectTransform), typeof(Text));
             _glyph = glyphGO.GetComponent<Text>();
             _glyph.text = GearGlyph;
             _glyph.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
 
-            // The mockup draws the gear at the same 44 px the shared Button
-            // sets its own label at, so this names shared-components.md's
-            // `ButtonLabelSize` rather than adding a number game-board.md's
-            // tables do not have.
-            _glyph.fontSize = (int)SharedButton.ButtonLabelSize;
+            _glyph.fontSize = (int)GameBoardScreenView.SettingsGlyphSize;
             _glyph.color = GlyphColor;
             _glyph.alignment = TextAnchor.MiddleCenter;
             _glyph.horizontalOverflow = HorizontalWrapMode.Overflow;
@@ -180,16 +215,6 @@ namespace Frogs.Unity.Views
             glyphRect.anchorMax = Vector2.one;
             glyphRect.offsetMin = Vector2.zero;
             glyphRect.offsetMax = Vector2.zero;
-
-            // A default circle, so the button is drawable before SetSize —
-            // the board always calls SetSize with SettingsButtonSize.
-            SetSizeInternal(SharedButton.MinTouchTarget);
-        }
-
-        void SetSizeInternal(float size)
-        {
-            _rect.sizeDelta = new Vector2(size, size);
-            _background.sprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(size / 2f));
         }
     }
 }

--- a/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs.meta
+++ b/Assets/Scripts/Unity/Views/GameBoardSettingsButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f7b27fe59ec40619afeb3d95ccdccd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -15,6 +15,7 @@ using Frogs.Unity.Views;
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
 
 namespace Frogs.Unity.EditModeTests
@@ -86,6 +87,20 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(view.TurnBannerText.fontSize, Is.EqualTo((int)GameBoardScreenView.TurnBannerSize));
 
+                // The chip at the safe margin, and the words TurnBannerGap
+                // past it — the mockup's own 48/256/24, not an approximation
+                // composed out of the lane's gutter constants.
+                Assert.That(
+                    view.TurnBannerChip.RectTransform.anchoredPosition.x,
+                    Is.EqualTo(GameBoardScreenView.SafeMargin).Within(0.001f));
+                Assert.That(
+                    view.TurnBannerText.rectTransform.anchoredPosition.x,
+                    Is.EqualTo(GameBoardScreenView.SafeMargin + PlayerChip.PlayerChipWidth + GameBoardScreenView.TurnBannerGap).Within(0.001f));
+
+                Assert.That(
+                    view.HeaderHairline.rectTransform.rect.height,
+                    Is.EqualTo(GameBoardScreenView.BoardBandOutline).Within(0.001f));
+
                 var settings = view.SettingsButton.RectTransform;
                 Assert.That(
                     settings.sizeDelta,
@@ -126,12 +141,12 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(lane.RenderedPosition, Is.EqualTo(position));
                 Assert.That(
-                    lane.Piece.transform.parent,
+                    lane.PieceRect.parent,
                     Is.SameAs(lane.PositionRects[position].transform),
                     "the piece is placed onto the track element already drawn for that position");
-                Assert.That(lane.Piece.rectTransform.anchoredPosition, Is.EqualTo(Vector2.zero), "centred on it");
+                Assert.That(lane.PieceRect.anchoredPosition, Is.EqualTo(Vector2.zero), "centred on it");
                 Assert.That(
-                    lane.Piece.rectTransform.sizeDelta,
+                    lane.PieceRect.sizeDelta,
                     Is.EqualTo(new Vector2(GameBoardLaneView.FrogPieceDiameter, GameBoardLaneView.FrogPieceDiameter)));
                 Assert.That(lane.Piece.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
             }
@@ -201,6 +216,28 @@ namespace Frogs.Unity.EditModeTests
                 Assert.That(lane.Chip.RectTransform.anchorMin.x, Is.EqualTo(0f).Within(0.001f), "chip pinned left");
                 Assert.That(lane.Chip.RectTransform.pivot.x, Is.EqualTo(0f).Within(0.001f));
                 Assert.That(lane.Chip.RectTransform.rect.width, Is.EqualTo(GameBoardLaneView.LaneGutterWidth).Within(0.001f));
+
+                // Outlines are drawn inside each element's own bounds, so
+                // they cost the 1520 px track nothing.
+                for (var index = 0; index < positions.Count; index++)
+                {
+                    var fill = lane.PositionImages[index].rectTransform;
+
+                    Assert.That(lane.PositionOutlines[index].rectTransform, Is.SameAs(positions[index]));
+                    Assert.That(fill.parent, Is.SameAs(positions[index].transform));
+                    Assert.That(
+                        fill.offsetMin,
+                        Is.EqualTo(new Vector2(GameBoardLaneView.TrackOutline, GameBoardLaneView.TrackOutline)),
+                        $"position {index}'s fill is inset by TrackOutline");
+                    Assert.That(
+                        fill.offsetMax,
+                        Is.EqualTo(new Vector2(-GameBoardLaneView.TrackOutline, -GameBoardLaneView.TrackOutline)));
+                }
+
+                Assert.That(
+                    lane.Piece.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(GameBoardLaneView.FrogPieceOutline, GameBoardLaneView.FrogPieceOutline)),
+                    "the piece's fill is inset by FrogPieceOutline, so the piece is still FrogPieceDiameter across");
             }
             finally
             {
@@ -245,7 +282,7 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(game.LaneFor(FrogColour.Blue).IsHome, Is.True, "the fixture, not the assertion");
                 Assert.That(
-                    lane.Piece.transform.parent,
+                    lane.PieceRect.parent,
                     Is.SameAs(lane.PositionRects[Lane.LaneWinningPosition].transform),
                     "resting on the End log");
                 Assert.That(lane.Chip.State, Is.EqualTo(PlayerChipState.Home));
@@ -507,8 +544,12 @@ namespace Frogs.Unity.EditModeTests
                 { "SafeMargin", 48f },
                 { "BoardHeaderHeight", 128f },
                 { "BoardControlsHeight", 176f },
+                { "BoardBandOutline", 3f },
                 { "TurnBannerSize", 52f },
+                { "TurnBannerGap", 24f },
                 { "SettingsButtonSize", 96f },
+                { "SettingsGlyphSize", 44f },
+                { "SettingsButtonOutline", 4f },
                 { "RollButtonWidth", 480f },
                 { "RollButtonHeight", 144f },
                 { "RollButtonLabelSize", 56f }
@@ -519,8 +560,11 @@ namespace Frogs.Unity.EditModeTests
                 { "LaneHeight", 184f },
                 { "LilyPadDiameter", 112f },
                 { "FrogPieceDiameter", 88f },
+                { "FrogPieceOutline", 4f },
                 { "LogWidth", 176f },
                 { "LogHeight", 120f },
+                { "LogRadius", 24f },
+                { "TrackOutline", 3f },
                 { "LanePositionGap", 48f },
                 { "LaneGutterWidth", 256f },
                 { "LaneGutterGap", 48f }
@@ -529,7 +573,16 @@ namespace Frogs.Unity.EditModeTests
             AssertPublicConstantsAreExactly(typeof(GameBoardScreenView), boardConstants);
             AssertPublicConstantsAreExactly(typeof(GameBoardLaneView), laneConstants);
 
-            // The remaining two of game-board.md's eighteen are Lane's own,
+            // LogRadius and SettingsGlyphSize hold the same numbers as
+            // shared-components.md's ButtonRadius and ButtonLabelSize today,
+            // and are deliberately not those constants: the Button is free to
+            // restyle its corner and its label without moving the pond's logs
+            // or its gear. Asserted as equal-today so a future divergence is
+            // a visible, deliberate edit here rather than a silent drift.
+            Assert.That(GameBoardLaneView.LogRadius, Is.EqualTo(Button.ButtonRadius));
+            Assert.That(GameBoardScreenView.SettingsGlyphSize, Is.EqualTo(Button.ButtonLabelSize));
+
+            // The remaining two of game-board.md's constants are Lane's own,
             // reused under the same name rather than redeclared here.
             Assert.That(Lane.LanePositionCount, Is.EqualTo(9));
             Assert.That(Lane.LaneWinningPosition, Is.EqualTo(8));
@@ -617,11 +670,16 @@ namespace Frogs.Unity.EditModeTests
                 Assert.That(view.TurnBannerText.font, Is.Not.Null);
                 Assert.That(view.SettingsButton.Glyph.font, Is.Not.Null);
                 Assert.That(view.SettingsButton.Background.sprite, Is.Not.Null);
+                Assert.That(view.SettingsButton.Outline.sprite, Is.Not.Null);
+                Assert.That(view.SettingsButton.Glyph.fontSize, Is.EqualTo((int)GameBoardScreenView.SettingsGlyphSize));
 
                 var lane = view.LaneFor(FrogColour.Green);
                 Assert.That(lane.Piece.sprite, Is.Not.Null);
+                Assert.That(lane.PieceOutline.sprite, Is.Not.Null);
                 Assert.That(lane.PositionImages[0].sprite, Is.Not.Null);
                 Assert.That(lane.PositionImages[1].sprite, Is.Not.Null);
+                Assert.That(lane.PositionOutlines[0].sprite, Is.Not.Null);
+                Assert.That(lane.PositionOutlines[1].sprite, Is.Not.Null);
             }
             finally
             {

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -1,0 +1,745 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// ButtonTests.cs, TitleScreenView.cs and GameSetupScreenViewTests.cs work
+// around — so the shared components are pulled in by explicit alias, and a
+// bare `Button` in this file always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The game board — issue #220, built to docs/specs/ui/game-board.md and
+    /// its committed 1:1 mockup. Written before
+    /// <see cref="GameBoardScreenView"/> exists, per
+    /// docs/engineering/testing.md's sanctioned flow: pushed unexecuted, with
+    /// CI turning these red before green — there is no editor here to watch
+    /// them fail.
+    ///
+    /// Every fact about the game — whose turn it is, where each frog sits,
+    /// whether a frog is home — is read from a real <see cref="Game"/> driven
+    /// into the state under test through its own public API. Nothing here
+    /// hands the board a number it could have computed for itself.
+    /// </summary>
+    public sealed class GameBoardScreenViewTests
+    {
+        const ulong AnySeed = 20260810UL;
+
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float CanvasWidth = 1920f;
+        const float CanvasHeight = 1200f;
+
+        [Test]
+        public void TurnBanner_NamesWhicheverFrogCoreReportsActive_AndShowsItsChipActive()
+        {
+            var game = new Game(new[] { FrogColour.Blue, FrogColour.Green }, AnySeed);
+            var view = CreateView(game);
+
+            try
+            {
+                // Blue is first in turn order, so Core reports Blue active.
+                Assert.That(view.TurnBannerText.text, Is.EqualTo("Blue frog's turn"));
+                Assert.That(view.TurnBannerChip.Label.text, Is.EqualTo("Blue"));
+                Assert.That(view.TurnBannerChip.State, Is.EqualTo(PlayerChipState.Active));
+                Assert.That(view.TurnBannerChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Blue)));
+
+                // Hand the turn on in Core and ask the board again: the
+                // banner has to follow Core, not a value baked in at build.
+                PassTheTurn(game);
+                view.Refresh();
+
+                Assert.That(view.TurnBannerText.text, Is.EqualTo("Green frog's turn"));
+                Assert.That(view.TurnBannerChip.Label.text, Is.EqualTo("Green"));
+                Assert.That(view.TurnBannerChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Header_IsBoardHeaderHeightTall_FullWidth_WithTheBannerLeftAndSettingsRight()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var header = view.HeaderRect;
+
+                Assert.That(header.rect.height, Is.EqualTo(GameBoardScreenView.BoardHeaderHeight).Within(0.001f));
+                Assert.That(header.rect.width, Is.EqualTo(CanvasWidth).Within(0.001f), "full width");
+                Assert.That(header.anchorMin.y, Is.EqualTo(1f), "pinned to the top");
+                Assert.That(header.anchorMax.y, Is.EqualTo(1f));
+
+                Assert.That(view.TurnBannerText.fontSize, Is.EqualTo((int)GameBoardScreenView.TurnBannerSize));
+
+                var settings = view.SettingsButton.RectTransform;
+                Assert.That(
+                    settings.sizeDelta,
+                    Is.EqualTo(new Vector2(GameBoardScreenView.SettingsButtonSize, GameBoardScreenView.SettingsButtonSize)),
+                    "a SettingsButtonSize square, not the shared Button's pill");
+
+                // Left of the header, right of the header — measured in world
+                // space so anchoring choices cannot fake it.
+                Assert.That(CenterX(view.TurnBannerChip.RectTransform), Is.LessThan(CenterX(settings)));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Settings_IsAtLeastMinTouchTarget_ByConstruction()
+        {
+            // SettingsButtonSize (96) already equals MinTouchTarget, so the
+            // shared touch-target invariant is met with no extra number.
+            Assert.That(GameBoardScreenView.SettingsButtonSize, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+        }
+
+        [TestCase(0)]
+        [TestCase(3)]
+        [TestCase(Lane.LaneWinningPosition)]
+        public void FrogPiece_SitsOnTheTrackElementCoreReports_NotOnARecomputedOffset(int position)
+        {
+            var game = TwoFrogGame();
+            MoveTo(game, FrogColour.Green, position);
+
+            var view = CreateView(game);
+
+            try
+            {
+                var lane = view.LaneFor(FrogColour.Green);
+
+                Assert.That(lane.RenderedPosition, Is.EqualTo(position));
+                Assert.That(
+                    lane.Piece.transform.parent,
+                    Is.SameAs(lane.PositionRects[position].transform),
+                    "the piece is placed onto the track element already drawn for that position");
+                Assert.That(lane.Piece.rectTransform.anchoredPosition, Is.EqualTo(Vector2.zero), "centred on it");
+                Assert.That(
+                    lane.Piece.rectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(GameBoardLaneView.FrogPieceDiameter, GameBoardLaneView.FrogPieceDiameter)));
+                Assert.That(lane.Piece.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Track_IsStartLogSevenLilyPadsAndEndLog_AndTheLaneArithmeticLandsOn1920()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var lane = view.LaneFor(FrogColour.Green);
+                var positions = lane.PositionRects;
+
+                Assert.That(positions.Count, Is.EqualTo(Lane.LanePositionCount));
+
+                var logSize = new Vector2(GameBoardLaneView.LogWidth, GameBoardLaneView.LogHeight);
+                var padSize = new Vector2(GameBoardLaneView.LilyPadDiameter, GameBoardLaneView.LilyPadDiameter);
+
+                Assert.That(positions[0].sizeDelta, Is.EqualTo(logSize), "Start log");
+                Assert.That(positions[Lane.LaneWinningPosition].sizeDelta, Is.EqualTo(logSize), "End log");
+
+                for (var index = 1; index < Lane.LaneWinningPosition; index++)
+                {
+                    Assert.That(positions[index].sizeDelta, Is.EqualTo(padSize), $"lily pad {index}");
+                }
+
+                // Every neighbouring pair is exactly LanePositionGap apart.
+                for (var index = 1; index < positions.Count; index++)
+                {
+                    var previousRightEdge = positions[index - 1].anchoredPosition.x + (positions[index - 1].sizeDelta.x / 2f);
+                    var leftEdge = positions[index].anchoredPosition.x - (positions[index].sizeDelta.x / 2f);
+
+                    Assert.That(
+                        leftEdge - previousRightEdge,
+                        Is.EqualTo(GameBoardLaneView.LanePositionGap).Within(0.001f),
+                        $"gap before position {index}");
+                }
+
+                // The spec's own arithmetic, carried into the code as a check
+                // rather than trusted: two logs, seven pads and eight gaps is
+                // 1520 px of track; plus the chip gutter, one gutter gap and
+                // two safe margins, 1920 px on the nose.
+                var expectedTrackWidth = (2f * GameBoardLaneView.LogWidth)
+                    + ((Lane.LanePositionCount - 2) * GameBoardLaneView.LilyPadDiameter)
+                    + ((Lane.LanePositionCount - 1) * GameBoardLaneView.LanePositionGap);
+
+                Assert.That(GameBoardLaneView.TrackWidth, Is.EqualTo(expectedTrackWidth).Within(0.001f));
+                Assert.That(lane.TrackRect.sizeDelta.x, Is.EqualTo(expectedTrackWidth).Within(0.001f));
+
+                var laneWidth = GameBoardLaneView.LaneGutterWidth
+                    + GameBoardLaneView.LaneGutterGap
+                    + GameBoardLaneView.TrackWidth
+                    + (2f * GameBoardScreenView.SafeMargin);
+
+                Assert.That(laneWidth, Is.EqualTo(CanvasWidth).Within(0.001f), "the spec's 1920 px on the nose");
+                Assert.That(lane.RectTransform.rect.height, Is.EqualTo(GameBoardLaneView.LaneHeight).Within(0.001f));
+
+                // chip pinned left of the safe area, track pinned right of it.
+                Assert.That(lane.TrackRect.anchorMin.x, Is.EqualTo(1f).Within(0.001f), "track pinned right");
+                Assert.That(lane.TrackRect.pivot.x, Is.EqualTo(1f).Within(0.001f));
+                Assert.That(lane.Chip.RectTransform.anchorMin.x, Is.EqualTo(0f).Within(0.001f), "chip pinned left");
+                Assert.That(lane.Chip.RectTransform.pivot.x, Is.EqualTo(0f).Within(0.001f));
+                Assert.That(lane.Chip.RectTransform.rect.width, Is.EqualTo(GameBoardLaneView.LaneGutterWidth).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ChipPadCount_ReadsPositionFromCore_AndTheEightFromLaneWinningPosition()
+        {
+            var game = TwoFrogGame();
+            MoveTo(game, FrogColour.Green, 3);
+
+            var view = CreateView(game);
+
+            try
+            {
+                Assert.That(view.LaneFor(FrogColour.Green).Chip.PadCountText.text, Is.EqualTo("3 of 8"));
+                Assert.That(view.LaneFor(FrogColour.Blue).Chip.PadCountText.text, Is.EqualTo("0 of 8"));
+
+                // The denominator is Lane's own constant, never a literal the
+                // board keeps a second copy of.
+                Assert.That(Lane.LaneWinningPosition, Is.EqualTo(8));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void FrogCoreReportsHome_RestsOnTheEndLog_WithItsChipInTheHomeState()
+        {
+            var game = TwoFrogGame();
+            MoveTo(game, FrogColour.Blue, Lane.LaneWinningPosition);
+
+            var view = CreateView(game);
+
+            try
+            {
+                var lane = view.LaneFor(FrogColour.Blue);
+
+                Assert.That(game.LaneFor(FrogColour.Blue).IsHome, Is.True, "the fixture, not the assertion");
+                Assert.That(
+                    lane.Piece.transform.parent,
+                    Is.SameAs(lane.PositionRects[Lane.LaneWinningPosition].transform),
+                    "resting on the End log");
+                Assert.That(lane.Chip.State, Is.EqualTo(PlayerChipState.Home));
+                Assert.That(lane.Chip.PadCountText.text, Is.EqualTo("Home!"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void Pond_LaysOutOneLanePerFrog_WithTheGroupVerticallyCentred(int frogCount)
+        {
+            var roster = AllColours.Take(frogCount).ToArray();
+            var view = CreateView(new Game(roster, AnySeed));
+
+            try
+            {
+                Assert.That(view.Lanes.Count, Is.EqualTo(frogCount), "one lane per frog in the game — no placeholders");
+                Assert.That(view.Lanes.Select(lane => lane.Colour), Is.EqualTo(roster), "in turn order");
+
+                var pond = view.PondRect;
+                Assert.That(
+                    pond.rect.height,
+                    Is.EqualTo(CanvasHeight - GameBoardScreenView.BoardHeaderHeight - GameBoardScreenView.BoardControlsHeight).Within(0.001f),
+                    "pond is everything between the two pinned bands, with no gaps");
+
+                var ys = view.Lanes.Select(lane => lane.RectTransform.anchoredPosition.y).ToArray();
+
+                for (var index = 1; index < ys.Length; index++)
+                {
+                    Assert.That(ys[index], Is.LessThan(ys[index - 1]), "lanes stack downward in turn order");
+                    Assert.That(
+                        ys[index - 1] - ys[index],
+                        Is.EqualTo(GameBoardLaneView.LaneHeight).Within(0.001f),
+                        "LaneHeight per lane, stacked with no gaps");
+                }
+
+                // Centred as a group within the pond band, not top-pinned:
+                // the first lane's top edge and the last lane's bottom edge
+                // are the same distance from the pond's centre.
+                var topEdge = ys[0] + (GameBoardLaneView.LaneHeight / 2f);
+                var bottomEdge = ys[ys.Length - 1] - (GameBoardLaneView.LaneHeight / 2f);
+
+                Assert.That(topEdge + bottomEdge, Is.EqualTo(0f).Within(0.001f), "vertically centred in the pond");
+
+                if (frogCount < 4)
+                {
+                    var topPinnedY = (pond.rect.height / 2f) - (GameBoardLaneView.LaneHeight / 2f);
+                    Assert.That(ys[0], Is.Not.EqualTo(topPinnedY).Within(0.001f), "not clinging to the top");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Roll_StartsEnabledOnAFreshBoard_AndStaysEnabledUntilFirstPressed()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                Assert.That(view.RollButton.IsDisabled, Is.False, "entering from game setup, Roll is enabled");
+
+                view.Refresh();
+                Assert.That(view.RollButton.IsDisabled, Is.False, "redrawing the board does not disable it");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Roll_FiresExactlyOnceAndDisablesImmediately_SoADoubleTapCannotRollTwice()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var rolls = 0;
+                view.RollPressed += () => rolls++;
+
+                TapButton(view.RollButton);
+
+                Assert.That(rolls, Is.EqualTo(1));
+                Assert.That(view.RollButton.IsDisabled, Is.True, "disabled the instant the press resolves");
+
+                TapButton(view.RollButton);
+
+                Assert.That(rolls, Is.EqualTo(1), "a second press before the turn resolves does nothing");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Roll_BecomesInteractableAgain_OnlyOnTheTurnResolvedSignal()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var rolls = 0;
+                view.RollPressed += () => rolls++;
+
+                TapButton(view.RollButton);
+                Assert.That(view.RollButton.IsDisabled, Is.True);
+
+                view.NotifyTurnResolved();
+
+                Assert.That(view.RollButton.IsDisabled, Is.False, "re-enabled by the signal, not by a timer");
+
+                TapButton(view.RollButton);
+                Assert.That(rolls, Is.EqualTo(2));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Controls_IsBoardControlsHeightTall_WithRollOversizedAndCentred()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var controls = view.ControlsRect;
+
+                Assert.That(controls.rect.height, Is.EqualTo(GameBoardScreenView.BoardControlsHeight).Within(0.001f));
+                Assert.That(controls.rect.width, Is.EqualTo(CanvasWidth).Within(0.001f), "full width");
+                Assert.That(controls.anchorMin.y, Is.EqualTo(0f), "pinned to the bottom");
+                Assert.That(controls.anchorMax.y, Is.EqualTo(0f));
+
+                var roll = view.RollButton;
+
+                Assert.That(
+                    roll.RectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(GameBoardScreenView.RollButtonWidth, GameBoardScreenView.RollButtonHeight)),
+                    "primary, oversized — game-board.md's own named override of the shared footprint");
+                Assert.That(roll.RectTransform.sizeDelta.x, Is.Not.EqualTo(Button.ButtonMinWidth));
+                Assert.That(roll.RectTransform.sizeDelta.y, Is.Not.EqualTo(Button.ButtonHeight));
+                Assert.That(roll.Label.fontSize, Is.EqualTo((int)GameBoardScreenView.RollButtonLabelSize));
+                Assert.That(roll.Label.text, Is.EqualTo("Roll"));
+                Assert.That(roll.Kind, Is.EqualTo(ButtonKind.Primary));
+                Assert.That(roll.RectTransform.anchoredPosition.x, Is.EqualTo(0f).Within(0.001f), "centred");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Settings_FiresOnEveryTurnPhase_AndIsNeverDisabledByTurnState()
+        {
+            var game = TwoFrogGame();
+            var view = CreateView(game);
+
+            try
+            {
+                var opened = 0;
+                view.SettingsRequested += () => opened++;
+
+                // Every phase of a turn, including the ones representing "not
+                // this player's local action" — hiding the way out of a game
+                // "would be worse".
+                var phases = new List<TurnPhase>();
+
+                phases.Add(game.Phase);
+                TapSettings(view);
+
+                game.RollDie();
+                view.Refresh();
+                phases.Add(game.Phase);
+                TapSettings(view);
+
+                game.BeginAnswering();
+                view.Refresh();
+                phases.Add(game.Phase);
+                TapSettings(view);
+
+                game.ShowResult();
+                view.Refresh();
+                phases.Add(game.Phase);
+                TapSettings(view);
+
+                game.BeginHandOff();
+                view.Refresh();
+                phases.Add(game.Phase);
+                TapSettings(view);
+
+                Assert.That(phases, Is.Unique, "the five phases really were distinct");
+                Assert.That(opened, Is.EqualTo(phases.Count), "available on any turn, at any time");
+
+                // And still available while Roll itself is disabled mid-turn.
+                TapButton(view.RollButton);
+                Assert.That(view.RollButton.IsDisabled, Is.True);
+
+                TapSettings(view);
+                Assert.That(opened, Is.EqualTo(phases.Count + 1));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_InvokesTheSameOpenSettingsCallbackAsTheGear_AndNeverQuits()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                var opened = 0;
+                view.SettingsRequested += () => opened++;
+
+                TapSettings(view);
+                Assert.That(opened, Is.EqualTo(1));
+
+                view.HandleHardwareBack();
+
+                Assert.That(opened, Is.EqualTo(2), "back goes through the same open-settings callback the gear uses");
+                Assert.That(view.gameObject.activeInHierarchy, Is.True, "the board is still showing");
+
+                // "It does not quit, and it never quits without the confirm."
+                // Asserted structurally as well as behaviourally: the board
+                // owns no exit path at all for a future edit to reach for.
+                var quitLike = DeclaredMembers(typeof(GameBoardScreenView))
+                    .Concat(DeclaredMembers(typeof(GameBoardLaneView)))
+                    .Where(name => name.IndexOf("Quit", StringComparison.OrdinalIgnoreCase) >= 0
+                        || name.IndexOf("Exit", StringComparison.OrdinalIgnoreCase) >= 0)
+                    .ToArray();
+
+                Assert.That(quitLike, Is.Empty, "the board has no quit or exit path of its own");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryGeometryValue_IsANamedConstantFromGameBoardsTwoTables()
+        {
+            var boardConstants = new Dictionary<string, float>
+            {
+                { "SafeMargin", 48f },
+                { "BoardHeaderHeight", 128f },
+                { "BoardControlsHeight", 176f },
+                { "TurnBannerSize", 52f },
+                { "SettingsButtonSize", 96f },
+                { "RollButtonWidth", 480f },
+                { "RollButtonHeight", 144f },
+                { "RollButtonLabelSize", 56f }
+            };
+
+            var laneConstants = new Dictionary<string, float>
+            {
+                { "LaneHeight", 184f },
+                { "LilyPadDiameter", 112f },
+                { "FrogPieceDiameter", 88f },
+                { "LogWidth", 176f },
+                { "LogHeight", 120f },
+                { "LanePositionGap", 48f },
+                { "LaneGutterWidth", 256f },
+                { "LaneGutterGap", 48f }
+            };
+
+            AssertPublicConstantsAreExactly(typeof(GameBoardScreenView), boardConstants);
+            AssertPublicConstantsAreExactly(typeof(GameBoardLaneView), laneConstants);
+
+            // The remaining two of game-board.md's eighteen are Lane's own,
+            // reused under the same name rather than redeclared here.
+            Assert.That(Lane.LanePositionCount, Is.EqualTo(9));
+            Assert.That(Lane.LaneWinningPosition, Is.EqualTo(8));
+
+            foreach (var type in new[] { typeof(GameBoardScreenView), typeof(GameBoardLaneView) })
+            {
+                foreach (var name in new[] { "LanePositionCount", "LaneWinningPosition" })
+                {
+                    Assert.That(
+                        type.GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                        Is.Null,
+                        $"{type.Name} must reference Lane.{name}, not redeclare it");
+                }
+            }
+        }
+
+        [Test]
+        public void Board_HasNoHopAnimation_AndNoEndOfGameDetection()
+        {
+            // The hop is #224's and the game-over transition is #225's. This
+            // board draws every frog at rest, at whatever position Core
+            // reports, and keeps rendering whatever Core reports for as long
+            // as it is shown. This is the reviewer's grep, as a test.
+            var forbidden = new[]
+            {
+                "FrogHopDuration", "ResultHopDelay", "Hop", "Tween", "Coroutine",
+                "Animate", "Animation", "Duration", "Delay",
+                "GameOver", "IsOver", "Winner", "Standings", "FinishingOrder"
+            };
+
+            foreach (var type in new[] { typeof(GameBoardScreenView), typeof(GameBoardLaneView) })
+            {
+                foreach (var member in DeclaredMembers(type))
+                {
+                    foreach (var word in forbidden)
+                    {
+                        Assert.That(
+                            member.IndexOf(word, StringComparison.OrdinalIgnoreCase),
+                            Is.LessThan(0),
+                            $"{type.Name}.{member} looks like {word} — that belongs to a later issue");
+                    }
+                }
+
+                var coroutines = type
+                    .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Where(method => typeof(IEnumerator).IsAssignableFrom(method.ReturnType))
+                    .Select(method => method.Name)
+                    .ToArray();
+
+                Assert.That(coroutines, Is.Empty, $"{type.Name} starts no coroutine — nothing here moves on its own");
+            }
+        }
+
+        [Test]
+        public void Board_AddsNoPlaceholderLanes_AndNoLastRollReadout()
+        {
+            // Both of game-board.md's open questions are left exactly as open
+            // as it leaves them.
+            var view = CreateView(new Game(new[] { FrogColour.Green, FrogColour.Pink }, AnySeed));
+
+            try
+            {
+                Assert.That(view.Lanes.Count, Is.EqualTo(2), "only the lanes in play are drawn");
+
+                var lastRollLike = DeclaredMembers(typeof(GameBoardScreenView))
+                    .Where(name => name.IndexOf("LastRoll", StringComparison.OrdinalIgnoreCase) >= 0
+                        || name.IndexOf("Placeholder", StringComparison.OrdinalIgnoreCase) >= 0)
+                    .ToArray();
+
+                Assert.That(lastRollLike, Is.Empty, "no last-roll readout, no placeholder lane");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Board_WiresItsBuiltInSpritesAndFonts_RatherThanLeavingThemMissing()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                Assert.That(view.TurnBannerText.font, Is.Not.Null);
+                Assert.That(view.SettingsButton.Glyph.font, Is.Not.Null);
+                Assert.That(view.SettingsButton.Background.sprite, Is.Not.Null);
+
+                var lane = view.LaneFor(FrogColour.Green);
+                Assert.That(lane.Piece.sprite, Is.Not.Null);
+                Assert.That(lane.PositionImages[0].sprite, Is.Not.Null);
+                Assert.That(lane.PositionImages[1].sprite, Is.Not.Null);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        static readonly FrogColour[] AllColours =
+        {
+            FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink
+        };
+
+        static Game TwoFrogGame()
+        {
+            return new Game(new[] { FrogColour.Green, FrogColour.Blue }, AnySeed);
+        }
+
+        // Drives a real Lane to `position` through its own public API — the
+        // board is never handed a position it could not have read off Core.
+        static void MoveTo(Game game, FrogColour colour, int position)
+        {
+            var lane = game.LaneFor(colour);
+
+            for (var step = 0; step < position; step++)
+            {
+                lane.MoveForward();
+            }
+
+            Assert.That(lane.Position, Is.EqualTo(position), "the fixture, not the assertion");
+        }
+
+        static void PassTheTurn(Game game)
+        {
+            game.RollDie();
+            game.BeginAnswering();
+            game.ShowResult();
+            game.BeginHandOff();
+            game.CompleteHandOff();
+        }
+
+        static IEnumerable<string> DeclaredMembers(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name);
+        }
+
+        static void AssertPublicConstantsAreExactly(Type type, IDictionary<string, float> expected)
+        {
+            var constants = type
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(field => field.IsLiteral && !field.IsInitOnly)
+                .ToArray();
+
+            Assert.That(
+                constants.Select(field => field.Name).OrderBy(name => name),
+                Is.EqualTo(expected.Keys.OrderBy(name => name)),
+                $"{type.Name}'s public constants are exactly game-board.md's own, under the identical names");
+
+            foreach (var field in constants)
+            {
+                Assert.That(
+                    Convert.ToSingle(field.GetValue(null)),
+                    Is.EqualTo(expected[field.Name]).Within(0.001f),
+                    $"{type.Name}.{field.Name}");
+            }
+        }
+
+        static float CenterX(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return (corners[0].x + corners[2].x) / 2f;
+        }
+
+        static GameBoardScreenView CreateView(Game game)
+        {
+            var host = new GameObject(nameof(GameBoardScreenViewTests), typeof(RectTransform));
+            var view = host.AddComponent<GameBoardScreenView>();
+            view.Initialize(game);
+            return view;
+        }
+
+        static void TapButton(Button button)
+        {
+            var eventData = EventDataAt(button.RectTransform);
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static void TapSettings(GameBoardScreenView view)
+        {
+            var target = view.SettingsButton;
+            var eventData = EventDataAt(target.RectTransform);
+
+            target.OnPointerDown(eventData);
+            target.OnPointerUp(eventData);
+        }
+
+        static PointerEventData EventDataAt(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+
+            return new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+        }
+
+        static void Destroy(GameBoardScreenView view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs.meta
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 625916bf1d9e4c19843c5d78c89d443a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -87,8 +87,12 @@ lanes-across** after seeing both drawn.
 | Safe margin | `SafeMargin` | 48 px |
 | Header band height | `BoardHeaderHeight` | 128 px |
 | Controls band height | `BoardControlsHeight` | 176 px |
+| Hairline under `header`, over `controls` | `BoardBandOutline` | 3 px |
 | Turn banner text size | `TurnBannerSize` | 52 px |
+| Gap between the banner's chip and its words | `TurnBannerGap` | 24 px |
 | Settings button, square | `SettingsButtonSize` | 96 px |
+| Settings gear glyph size | `SettingsGlyphSize` | 44 px |
+| Settings button outline | `SettingsButtonOutline` | 4 px |
 | `Roll` button width | `RollButtonWidth` | 480 px |
 | `Roll` button height | `RollButtonHeight` | 144 px |
 | `Roll` label size | `RollButtonLabelSize` | 56 px |
@@ -110,8 +114,11 @@ The lane:
 | Lane band height | `LaneHeight` | 184 px |
 | Lily pad diameter | `LilyPadDiameter` | 112 px |
 | Frog piece diameter | `FrogPieceDiameter` | 88 px |
+| Frog piece outline | `FrogPieceOutline` | 4 px |
 | Log width | `LogWidth` | 176 px |
 | Log height | `LogHeight` | 120 px |
+| Log corner radius | `LogRadius` | 24 px |
+| Lily pad and log outline | `TrackOutline` | 3 px |
 | Gap between positions | `LanePositionGap` | 48 px |
 | Chip gutter width | `LaneGutterWidth` | 256 px |
 | Gap between chip and track | `LaneGutterGap` | 48 px |
@@ -120,6 +127,17 @@ That arithmetic is exact and worth keeping exact: two logs at 176, seven pads at
 112 and eight gaps at 48 is 1520 px of track; plus a 256 px chip gutter, a 48 px
 gap and two 48 px margins, that is 1920 px on the nose. If a constant here
 changes, one of the others has to move with it.
+
+Every outline is drawn **inside** the element's own bounds, so `TrackOutline`,
+`FrogPieceOutline`, `SettingsButtonOutline` and `BoardBandOutline` cost the
+layout nothing and the 1920 px sum above is unaffected by any of them.
+
+`LogRadius` is the log's own corner and `SettingsGlyphSize` the gear's own
+glyph. Both happen to equal a constant on
+[shared components](shared-components.md) today — `ButtonRadius` is also 24 px
+and `ButtonLabelSize` also 44 px — and neither is that constant. The Button's
+corner and label are the Button's to restyle; the pond's logs and its gear are
+not, and they must not move when it does.
 
 ## Elements
 


### PR DESCRIPTION
Closes #220

This is the pond — the screen the game actually lives on. Along the top it says whose turn it is in words, with that frog's chip beside it and a gear on the right. Down the middle sits one lane per frog in the game, each with a Start log, seven lily pads and an End log, and that frog sitting on whichever space it has got to. Along the bottom is the big green `Roll` button, which goes grey the instant you press it so a double-tap can never roll twice.

The board never works anything out for itself. Whose turn it is and where every frog sits are asked of the game rules each time it draws, and nothing on the board moves on its own — every frog is drawn sitting still.

**Docs:** `docs/specs/ui/game-board.md` — seven values the committed mockup already draws had no row on the page's Named constants tables, so they are named there now and the code reads them from there: `TurnBannerGap` (24 px), `SettingsGlyphSize` (44 px), `SettingsButtonOutline` (4 px), `BoardBandOutline` (3 px), `LogRadius` (24 px), `TrackOutline` (3 px) and `FrogPieceOutline` (4 px). No existing constant changed value, and the page's 1920 px arithmetic is untouched — a short note now says why (outlines are drawn inside each element's own bounds) and why `LogRadius`/`SettingsGlyphSize` are the board's own rather than the Button's.

## How the spec is changing

**Old rule:** `game-board.md`'s two constants tables held eighteen rows, and the committed mockup drew seven further values — the gap between the turn banner's chip and its words, the gear's glyph size, the log's corner radius, and four outline widths — that no row named.

**New rule:** all twenty-five are named. Every geometry value the board draws now comes from a row on that page.

**Why it is better:** those seven were already agreed — they are in the picture Derek signed off — so this is distilling a decision that was made, not making a new one, exactly as [ui-design-process.md](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought)`` intends. The alternative I tried first was worse in a specific, visible way: composing the banner gap out of `LaneGutterWidth + LaneGutterGap` put the header's words 24 px right of where the mockup draws them, so the built screen approximated the agreed picture instead of matching it.

## Spec invariants

| `game-board.md` invariant | How this PR keeps it true |
| --- | --- |
| Every frog in the game is visible at once, on its own lane, without scrolling | `Pond_LaysOutOneLanePerFrog_WithTheGroupVerticallyCentred` — one lane per roster entry for 2, 3 and 4 frogs, all inside the `pond` band, no scroll view anywhere |
| Frogs never share a lane and never interact | Each `GameBoardLaneView` is handed one `Lane` and reads nothing else; `Render` takes a single lane and a bool |
| The board never moves on its own | `Board_HasNoHopAnimation_AndNoEndOfGameDetection` — no member named for a hop, tween, animation, duration or delay, and no method returning `IEnumerator` |
| Whose turn it is is stated in words in the header | `TurnBanner_NamesWhicheverFrogCoreReportsActive_AndShowsItsChipActive` — reads `Green frog's turn`, and follows Core after the turn is handed on |
| `Roll` is disabled the moment it is pressed until the turn resolves; a double-tap cannot roll twice | `Roll_FiresExactlyOnceAndDisablesImmediately_SoADoubleTapCannotRollTwice` and `Roll_BecomesInteractableAgain_OnlyOnTheTurnResolvedSignal` |
| Nothing on this screen is destructive | `HardwareBack_InvokesTheSameOpenSettingsCallbackAsTheGear_AndNeverQuits` — asserts behaviourally *and* structurally that the board declares no quit or exit path at all |
| The pad a frog is on is drawn no differently from the others | Every lily pad is built from the same sprites and colours; only the piece's parent changes |
| Pad count is `3 of 8` | `ChipPadCount_ReadsPositionFromCore_AndTheEightFromLaneWinningPosition` — the numerator is `Lane.Position`, the denominator is `Lane.LaneWinningPosition` |
| The 1920 px lane arithmetic | `Track_IsStartLogSevenLilyPadsAndEndLog_AndTheLaneArithmeticLandsOn1920` — recomputes the spec's own sum from the constants, asserts it lands on 1920, and asserts every outline is inset inside its element so it costs the sum nothing |
| Touch target | `Settings_IsAtLeastMinTouchTarget_ByConstruction` — `SettingsButtonSize` already equals `MinTouchTarget` |

`EveryGeometryValue_IsANamedConstantFromGameBoardsTwoTables` asserts all twenty-three board/lane constants by name and value, asserts the two types declare *exactly* those and no others, and asserts neither redeclares `LanePositionCount` / `LaneWinningPosition` — both are referenced from `Frogs.Core.Lane`.

## Deviations and Decisions

- **The issue predicted `Spec pages touched: None`; it turned out to need a docs change.** Seven values the mockup draws had no constant row, and `ui-design-process.md` is explicit that a number the code needs and the table lacks is a row that was missed, not a number to work around. Same thing #217 and #225 hit. No `skip-docs` here — the reconciliation gate runs for real.
- **The tests drive a real `Frogs.Core.Game`, not a hand-written fake.** The issue asks for "a fake/stub `Game`" and "a fake `Lane`", but both types are `sealed` with no interface, so a subclass fake is not possible — and building an interface for the board to read through would have been a design decision the issue does not ask for. Instead each test constructs a real `Game` and drives it into the state under test through its own public API (`MoveForward`, `RollDie`/`BeginAnswering`/…). That is strictly stronger for what these tests exist to prove: the board is reading Core's real answers, not values a stub was told to hand back.
- **`Roll` raises an event rather than calling into Core or opening anything.** Roll-and-card (#221) does not exist, and having the board call `Game.RollDie()` would leave the phase stranded with nothing to advance it. The board disables `Roll`, raises `RollPressed`, and waits for `NotifyTurnResolved()` — the stand-in "turn resolved" signal the issue asks for, and the seam #221/#223/#224 will wire into. Nothing calls it yet except the tests.
- **The board owns its own hardware-back hook.** `HandleHardwareBack()` invokes the same open-settings callback the gear does, and `Update()` calls it on `Escape` while the board is showing. `ScreenRouterAdapter` (#213) also listens for `Escape` globally, but nothing parents these views under the router's roots yet, so the two cannot double-fire today. Reconciling them when a screen actually gets mounted is the wiring issue's job, per this issue's own note; the board does not name or depend on any router member.
- **`LogRadius` and `SettingsGlyphSize` are the board's own constants, not the Button's.** They hold 24 px and 44 px, the same as `shared-components.md`'s `ButtonRadius` and `ButtonLabelSize`, and are deliberately separate: the Button is free to restyle its corner and its label, and the pond's logs and gear must not move when it does. A test asserts they are equal *today*, so a future divergence shows up as a deliberate edit here rather than silent drift.
- **The gear is the `⚙` character in Unity's built-in font.** No imported icon is allowed and the spec has no icon-button component, so the board builds its own `SettingsButtonSize` circle with a ring and a text glyph. If `LegacyRuntime.ttf` has no glyph for U+2699 the button will render as an empty ringed circle in the graybox — worth a look on device, and a drawn gear would be a small follow-up.
- **EditMode tests written but not run locally** — no editor, per [testing.md](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/testing.md#known-limitation-editmode-tests-run-in-ci-not-in-agent-environments).`` CI is where these go red-then-green.

## Explicitly out of scope, as the issue asks

- No hop: no `FrogHopDuration`, no `ResultHopDelay`, no tween, no timer, no coroutine — #224's.
- No end-of-game detection: the board keeps rendering whatever Core reports — #225's, gated on #211.
- No placeholder lanes for absent frogs, and no "last roll" readout — both of `game-board.md`'s open questions are left exactly as open as it leaves them. There is a test for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t