### PR TITLE
feat(ui): build the settings dialog

### DIFF
--- a/Assets/Scripts/Unity/Views/SettingsDialogView.cs
+++ b/Assets/Scripts/Unity/Views/SettingsDialogView.cs
@@ -1,0 +1,449 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// TitleScreenView.cs and GameBoardScreenView.cs work around — so these are
+// pulled in by explicit alias rather than a wildcard `using Frogs.Unity.UI;`,
+// and a bare `Button`, `ButtonKind` or `DialogPanel` in this file always means
+// the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+// Only one Core type is reachable from this dialog at all, and it only parses
+// a string — pulled in by alias so that stays visible at a glance.
+using AppVersion = Frogs.Core.AppVersion;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The settings dialog — docs/specs/ui/settings-dialog.md, built to that
+    /// page and its committed 1:1 mockup. The one screen in the POC that
+    /// exists purely so a player can get *out* — of a confusing rule, or of
+    /// the game itself — without anything on the board underneath being
+    /// disturbed by the looking.
+    ///
+    /// It is a composition of the shared <see cref="DialogPanel"/> (#219) and
+    /// the shared <see cref="Button"/> (#214) and nothing else: no new visual
+    /// component, no sprite, no bitmap.
+    ///
+    /// Three things it deliberately does not do:
+    ///
+    /// - **It cannot change the game.** settings-dialog.md's own first
+    ///   invariant — "opening this changes nothing about the game. It is a
+    ///   menu, not a turn" — is structural here, not a promise: this type is
+    ///   never handed a <c>Game</c> or a <c>Lane</c>, so there is no method it
+    ///   could call. There is no difficulty setting, no player count, no undo,
+    ///   because there is nothing here that could reach one.
+    /// - **`End the game` never ends the game.** It raises
+    ///   <see cref="EndGameConfirmRequested"/> and stops. Ending the game —
+    ///   standings, leaving the board — belongs entirely to
+    ///   docs/specs/ui/end-game-confirm.md (#226), which is not built yet;
+    ///   this view wires the transition, not the target.
+    /// - **It does not listen for hardware back.** The router (#213) already
+    ///   routes back on <c>Dialog.Settings</c> to what `Back to the game`
+    ///   does; this view exposes that one action as
+    ///   <see cref="RequestClose"/> rather than adding a second opinion about
+    ///   the key.
+    ///
+    /// `How to play` ships present and disabled. That is the answer
+    /// settings-dialog.md's own open question already proposes — "present. A
+    /// disabled button that appears later is less confusing than a button that
+    /// appears from nowhere" — not a decision made here: the screen it would
+    /// open has no wireframe, so under rule 8 it cannot be built, and it is
+    /// wired to nothing at all.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class SettingsDialogView : MonoBehaviour
+    {
+        // docs/specs/ui/settings-dialog.md#named-constants.
+        public const float SettingsDialogWidth = 900f;
+        public const float SettingsDialogHeight = 760f;
+        public const float SettingsActionWidth = 788f;
+        public const float SettingsActionGap = 96f;
+        public const float SettingsVersionBottomOffset = 60f;
+
+        // The rest of that table is other pages' rows, referenced under the
+        // identical name rather than redeclared here — the same line #220 drew
+        // for `LanePositionCount`:
+        //
+        // - `ButtonDestructiveGap` is the shared Button's own constant
+        //   (shared-components.md#button); settings-dialog.md restates it
+        //   rather than inventing a second one.
+        // - the panel's padding, corner radius, title metrics, scrim and fade
+        //   are the shared Dialog's (shared-components.md#dialog).
+        // - `VersionLabelSize` is title-screen.md's — the same value doing the
+        //   same job, a quiet version readout bottom-left.
+
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float CanvasWidth = 1920f;
+        const float CanvasHeight = 1200f;
+
+        const string TitleLabel = "Settings";
+        const string HowToPlayLabel = "How to play";
+        const string EndGameLabel = "End the game";
+        const string BackToTheGameLabel = "Back to the game";
+
+        const string VersionPrefix = "v";
+
+        // No imported font — matches Button.cs's and TitleScreenView.cs's own
+        // choice, for the same reason (no external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colour copied verbatim from the committed mockup's CSS custom
+        // properties, the same line Button.cs and TitleScreenView.cs both draw:
+        // not a geometry constant on any spec page's table, so not declared as
+        // a named spec constant.
+        static readonly Color VersionColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockup's --line
+
+        RectTransform _rect;
+        DialogPanel _dialog;
+
+        RectTransform _actionsRect;
+        Button _howToPlayButton;
+        Button _endGameButton;
+
+        RectTransform _footprintRect;
+        Text _versionText;
+
+        Button _backToTheGameButton;
+
+        bool _initialized;
+
+        /// <summary>
+        /// `Back to the game` was pressed, or hardware back arrived through
+        /// <see cref="RequestClose"/>. Closing returns to exactly the board
+        /// state that was there — same turn, same positions, same enabled
+        /// `Roll` — which is free, because this view never touched it.
+        /// </summary>
+        public event Action CloseRequested;
+
+        /// <summary>
+        /// `End the game` was pressed: open
+        /// docs/specs/ui/end-game-confirm.md (#226). This is the whole of what
+        /// that button does. Nothing here ends a game.
+        /// </summary>
+        public event Action EndGameConfirmRequested;
+
+        /// <summary>The view's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The shared Dialog this screen is laid out on, at <see cref="SettingsDialogWidth"/> x <see cref="SettingsDialogHeight"/>.</summary>
+        public DialogPanel Dialog
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog;
+            }
+        }
+
+        /// <summary>`actions` — the single left-aligned column `How to play` and `End the game` sit in.</summary>
+        public RectTransform ActionsRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _actionsRect;
+            }
+        }
+
+        /// <summary>`footprint` — the region the version readout sits in, bottom-left.</summary>
+        public RectTransform FootprintRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _footprintRect;
+            }
+        }
+
+        /// <summary>`How to play` — secondary, <see cref="SettingsActionWidth"/> wide, present and disabled.</summary>
+        public Button HowToPlayButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _howToPlayButton;
+            }
+        }
+
+        /// <summary>`End the game` — destructive, <see cref="SettingsActionWidth"/> wide. Opens the confirm; ends nothing.</summary>
+        public Button EndGameButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _endGameButton;
+            }
+        }
+
+        /// <summary>`Back to the game` — primary, at the shared Button's own default footprint, bottom-right.</summary>
+        public Button BackToTheGameButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _backToTheGameButton;
+            }
+        }
+
+        /// <summary>The version readout — read from <see cref="AppVersion"/>, never typed.</summary>
+        public Text VersionText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _versionText;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>Opens the dialog — the shared Dialog's own cross-fade in.</summary>
+        public void Open()
+        {
+            EnsureInitialized();
+            _dialog.Open();
+        }
+
+        /// <summary>Closes the dialog — the shared Dialog's own cross-fade out.</summary>
+        public void Close()
+        {
+            EnsureInitialized();
+            _dialog.Close();
+        }
+
+        /// <summary>
+        /// The one action `Back to the game` and hardware back both invoke —
+        /// shared-components.md#dialog: "the hardware back button does what
+        /// the dialog's least destructive button does, and never what its most
+        /// destructive one does." Public so the router's back handling (#213)
+        /// can call it directly, which is also how an EditMode test simulates
+        /// hardware back. There is deliberately no second key handler here.
+        /// </summary>
+        public void RequestClose()
+        {
+            EnsureInitialized();
+
+            var handler = CloseRequested;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        /// <summary>
+        /// The line `footprint` shows — asserted the same way
+        /// <c>HelloWorldProbeTests</c> asserts <c>HelloWorldProbe.Describe</c>:
+        /// against this static, total formatting method taking the build-name
+        /// string as a parameter, not against a live <c>Application.version</c>
+        /// at test time.
+        ///
+        /// Total in the same sense <c>Describe</c> is. <c>ReadFromBuildName</c>
+        /// throws on a stamp it cannot parse, by design, so a bad value fails
+        /// loudly at the point of reading — but a broken build stamp must not
+        /// stop the settings dialog opening, because the settings dialog is
+        /// the way out of a game. settings-dialog.md does not say what an
+        /// unreadable version should display, so nothing new is invented here:
+        /// it shows what the build stamped, and does not throw.
+        ///
+        /// This mirrors <see cref="TitleScreenView.FormatVersionLabel"/> rather
+        /// than calling it: that one is #216's, already built and tested, and
+        /// folding both onto a shared helper is a refactor of a merged file
+        /// with no editor here to re-verify it — the same call #219 made about
+        /// <c>Button</c>'s inline rounded-rect generator. See this issue's PR.
+        /// </summary>
+        public static string FormatVersionLabel(string applicationVersion)
+        {
+            try
+            {
+                return VersionPrefix + AppVersion.ReadFromBuildName(applicationVersion);
+            }
+            catch (Exception error) when (error is FormatException || error is ArgumentNullException)
+            {
+                return VersionPrefix + applicationVersion;
+            }
+        }
+
+        // Unity does not guarantee Awake() has run before another component's
+        // Awake() or a test reaches this one right after AddComponent — the
+        // same reasoning as Button, DialogPanel and GameBoardScreenView's own
+        // EnsureInitialized. Every public entry point funnels through this
+        // idempotent guard instead of trusting Awake's timing.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.anchorMin = new Vector2(0.5f, 0.5f);
+            _rect.anchorMax = new Vector2(0.5f, 0.5f);
+            _rect.pivot = new Vector2(0.5f, 0.5f);
+            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+
+            BuildDialog();
+            BuildActions();
+            BuildFootprint();
+            BuildControls();
+        }
+
+        void BuildDialog()
+        {
+            var dialogGO = new GameObject("SettingsDialog", typeof(RectTransform));
+            dialogGO.transform.SetParent(_rect, worldPositionStays: false);
+
+            _dialog = dialogGO.AddComponent<DialogPanel>();
+            _dialog.SetTitle(TitleLabel);
+
+            // The shared Dialog at this screen's own size, in place of
+            // DialogMaxWidth/DialogMaxHeight. Everything else about it — the
+            // scrim, the corners, the padding, the title metrics, the
+            // cross-fade — is inherited unchanged.
+            _dialog.SetSize(SettingsDialogWidth, SettingsDialogHeight);
+        }
+
+        void BuildActions()
+        {
+            // The actions column is placed from the *bottom* of the panel up,
+            // not from the top down. That is what makes settings-dialog.md's
+            // Anchors section ("`End the game` is separated from everything
+            // below it by `ButtonDestructiveGap` — that gap is the layout, not
+            // decoration") a fact of the layout rather than a consequence of
+            // arithmetic: a longer label, a different title, or a shorter
+            // panel cannot squeeze it.
+            var columnBottom = DialogPanel.DialogPadding + Button.ButtonHeight + Button.ButtonDestructiveGap;
+            var columnHeight = (Button.ButtonHeight * 2f) + SettingsActionGap;
+
+            var actionsGO = new GameObject("Actions", typeof(RectTransform));
+            _actionsRect = (RectTransform)actionsGO.transform;
+            _actionsRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _actionsRect.anchorMin = Vector2.zero;
+            _actionsRect.anchorMax = Vector2.zero;
+            _actionsRect.pivot = Vector2.zero;
+            _actionsRect.sizeDelta = new Vector2(SettingsActionWidth, columnHeight);
+            _actionsRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, columnBottom);
+
+            // `How to play`, then `End the game` — the column's top and
+            // bottom, SettingsActionGap apart because that is what is left
+            // between them.
+            _howToPlayButton = CreateActionButton("HowToPlay", ButtonKind.Secondary, HowToPlayLabel, atTop: true);
+
+            // Present, and disabled — settings-dialog.md's own proposed answer
+            // to its open question. Deliberately wired to nothing: the screen
+            // it would open has no wireframe, so there is no destination to
+            // route to and none is invented here. A tap does nothing at all,
+            // silently, per the shared Button's own behaviour.
+            _howToPlayButton.SetDisabled(true);
+
+            _endGameButton = CreateActionButton("EndTheGame", ButtonKind.Destructive, EndGameLabel, atTop: false);
+            _endGameButton.Clicked += HandleEndGameClicked;
+        }
+
+        Button CreateActionButton(string name, ButtonKind kind, string label, bool atTop)
+        {
+            var buttonGO = new GameObject(name, typeof(RectTransform));
+            buttonGO.transform.SetParent(_actionsRect, worldPositionStays: false);
+
+            var button = buttonGO.AddComponent<Button>();
+            button.SetKind(kind);
+            button.SetLabelText(label);
+
+            // Only the width is overridden — the shared ButtonHeight and
+            // ButtonLabelSize both stand, per the mockup.
+            button.SetSize(SettingsActionWidth, Button.ButtonHeight);
+
+            var rect = button.RectTransform;
+            rect.anchorMin = new Vector2(0f, atTop ? 1f : 0f);
+            rect.anchorMax = new Vector2(0f, atTop ? 1f : 0f);
+            rect.pivot = new Vector2(0f, atTop ? 1f : 0f);
+            rect.anchoredPosition = Vector2.zero;
+
+            return button;
+        }
+
+        void BuildFootprint()
+        {
+            var footprintGO = new GameObject("Footprint", typeof(RectTransform));
+            _footprintRect = (RectTransform)footprintGO.transform;
+            _footprintRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            StretchToFill(_footprintRect);
+
+            var versionGO = new GameObject("Version", typeof(RectTransform), typeof(Text));
+            _versionText = versionGO.GetComponent<Text>();
+            _versionText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _versionText.fontSize = (int)TitleScreenView.VersionLabelSize;
+            _versionText.alignment = TextAnchor.LowerLeft;
+            _versionText.color = VersionColor;
+            _versionText.horizontalOverflow = HorizontalWrapMode.Overflow;
+            _versionText.verticalOverflow = VerticalWrapMode.Overflow;
+            _versionText.raycastTarget = false;
+
+            // What the build stamped, parsed by Core. Nothing here composes,
+            // stores, or hard-codes a version literal.
+            _versionText.text = FormatVersionLabel(Application.version);
+
+            var versionRect = _versionText.rectTransform;
+            versionRect.SetParent(_footprintRect, worldPositionStays: false);
+            versionRect.anchorMin = Vector2.zero;
+            versionRect.anchorMax = Vector2.zero;
+            versionRect.pivot = Vector2.zero;
+            versionRect.sizeDelta = Vector2.zero;
+            versionRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, SettingsVersionBottomOffset);
+        }
+
+        void BuildControls()
+        {
+            // The primary button, bottom-right, at the shared Dialog's own
+            // button row — and this dialog's least destructive button, which
+            // is the value the router reads for hardware back.
+            _backToTheGameButton = _dialog.AddButton(
+                ButtonKind.Primary,
+                BackToTheGameLabel,
+                RequestClose,
+                isLeastDestructive: true);
+        }
+
+        void HandleEndGameClicked()
+        {
+            // Opens the confirm. That is all — and all it *can* do.
+            var handler = EndGameConfirmRequested;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/SettingsDialogView.cs.meta
+++ b/Assets/Scripts/Unity/Views/SettingsDialogView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3cb1790f55f4bd299367c0b99ae1efc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/SettingsDialogViewTests.cs
+++ b/Assets/Tests/EditMode/SettingsDialogViewTests.cs
@@ -1,0 +1,585 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// ButtonTests.cs, TitleScreenView.cs and GameBoardScreenViewTests.cs work
+// around — so these are pulled in by explicit alias, and a bare `Button`,
+// `ButtonKind` or `DialogPanel` in this file always means the shared
+// component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The settings dialog — issue #222, built against
+    /// docs/specs/ui/settings-dialog.md and its committed 1:1 mockup.
+    ///
+    /// The three things these tests are really here to hold down:
+    ///
+    /// - **`End the game` never ends anything.** It opens
+    ///   docs/specs/ui/end-game-confirm.md (#226) and nothing else. The test
+    ///   below proves it structurally — the view is never handed a reference
+    ///   capable of ending a game, so there is no path by which it could.
+    /// - **`Back to the game` and hardware back are one action.** Not two
+    ///   handlers that agree today.
+    /// - **`ButtonDestructiveGap` does not shrink.** The gap under the
+    ///   destructive button is the layout, not decoration, so it is asserted
+    ///   against the named constant rather than against a pixel position.
+    /// </summary>
+    public sealed class SettingsDialogViewTests
+    {
+        const string ReadableBuildName = "0.2.3-abc1234";
+        const string UnreadableBuildName = "nightly";
+
+        [Test]
+        public void Layout_IsTheSharedDialogAtTheSpecsOwnSize_WithAllFourRegions()
+        {
+            var view = CreateView();
+
+            try
+            {
+                // A centred shared Dialog sized SettingsDialogWidth x
+                // SettingsDialogHeight — not DialogMaxWidth/DialogMaxHeight.
+                Assert.That(
+                    view.Dialog.PanelRect.sizeDelta,
+                    Is.EqualTo(new Vector2(
+                        SettingsDialogView.SettingsDialogWidth,
+                        SettingsDialogView.SettingsDialogHeight)));
+
+                // title
+                Assert.That(view.Dialog.TitleText.text, Is.EqualTo("Settings"));
+
+                // actions — `How to play`, then `End the game`, one
+                // left-aligned column.
+                Assert.That(view.HowToPlayButton, Is.Not.Null);
+                Assert.That(view.EndGameButton, Is.Not.Null);
+                Assert.That(LeftEdge(view.HowToPlayButton.RectTransform),
+                    Is.EqualTo(LeftEdge(view.EndGameButton.RectTransform)).Within(0.001f),
+                    "one left-aligned column");
+                Assert.That(
+                    LeftEdge(view.HowToPlayButton.RectTransform) - LeftEdge(view.Dialog.PanelRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    BottomEdge(view.HowToPlayButton.RectTransform),
+                    Is.GreaterThan(TopEdge(view.EndGameButton.RectTransform)),
+                    "`How to play`, then `End the game`");
+
+                // footprint — bottom-left.
+                Assert.That(view.VersionText, Is.Not.Null);
+                Assert.That(view.VersionText.alignment, Is.EqualTo(TextAnchor.LowerLeft));
+                Assert.That(
+                    LeftEdge(view.VersionText.rectTransform) - LeftEdge(view.Dialog.PanelRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    BottomEdge(view.VersionText.rectTransform) - BottomEdge(view.Dialog.PanelRect),
+                    Is.EqualTo(SettingsDialogView.SettingsVersionBottomOffset).Within(0.001f));
+
+                // controls — the primary button, bottom-right, per the shared
+                // Dialog's primary-on-the-right rule.
+                Assert.That(view.BackToTheGameButton, Is.Not.Null);
+                Assert.That(view.Dialog.Buttons, Has.Member(view.BackToTheGameButton));
+                Assert.That(
+                    RightEdge(view.Dialog.PanelRect) - RightEdge(view.BackToTheGameButton.RectTransform),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void PublicConstants_AreExactlySettingsDialogsOwn_UnderTheIdenticalNames()
+        {
+            // Everything else this screen measures itself with — the shared
+            // Dialog's padding and title metrics, the shared Button's height,
+            // label size and ButtonDestructiveGap, title-screen.md's
+            // VersionLabelSize — is referenced from where it already lives
+            // rather than redeclared here. This test is what proves that: a
+            // second copy of any of them would show up as an extra name.
+            AssertPublicConstantsAreExactly(typeof(SettingsDialogView), new Dictionary<string, float>
+            {
+                { nameof(SettingsDialogView.SettingsDialogWidth), 900f },
+                { nameof(SettingsDialogView.SettingsDialogHeight), 760f },
+                { nameof(SettingsDialogView.SettingsActionWidth), 788f },
+                { nameof(SettingsDialogView.SettingsActionGap), 96f },
+                { nameof(SettingsDialogView.SettingsVersionBottomOffset), 60f }
+            });
+        }
+
+        [Test]
+        public void BackToTheGame_IsPrimaryAtTheSharedFootprint_AndClosesExactlyOnce()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var closes = 0;
+                var confirms = 0;
+                view.CloseRequested += () => closes++;
+                view.EndGameConfirmRequested += () => confirms++;
+
+                Assert.That(view.BackToTheGameButton.Kind, Is.EqualTo(ButtonKind.Primary));
+
+                // "nothing about it is widened the way the two action buttons
+                // are" — the shared component's own default footprint.
+                Assert.That(
+                    view.BackToTheGameButton.RectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(Button.ButtonMinWidth, Button.ButtonHeight)));
+
+                TapButton(view.BackToTheGameButton);
+
+                Assert.That(closes, Is.EqualTo(1));
+                Assert.That(confirms, Is.Zero, "the least destructive button never opens the confirm");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_FiresTheIdenticalCloseCallbackBackToTheGameFires()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var closes = 0;
+                var confirms = 0;
+                view.CloseRequested += () => closes++;
+                view.EndGameConfirmRequested += () => confirms++;
+
+                // The router (#213) already routes hardware back on
+                // Dialog.Settings to "what `Back to the game` does". This view
+                // exposes that one action rather than listening for the key
+                // itself — so there is exactly one close path, not two that
+                // happen to agree.
+                view.RequestClose();
+
+                Assert.That(closes, Is.EqualTo(1));
+                Assert.That(confirms, Is.Zero, "never `End the game`'s");
+
+                TapButton(view.BackToTheGameButton);
+
+                Assert.That(closes, Is.EqualTo(2), "the same callback, not a second distinct one");
+                Assert.That(confirms, Is.Zero);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_IsNotListenedForTwice()
+        {
+            // The board (#220) owns the Escape key on the screen underneath,
+            // and the router owns what back means with a dialog open. A second
+            // Update()/Input handler here would be a third opinion.
+            var declared = DeclaredMemberNames(typeof(SettingsDialogView));
+
+            Assert.That(declared, Does.Not.Contain("Update"));
+        }
+
+        [Test]
+        public void BackToTheGame_IsTheDialogsLeastDestructiveButton()
+        {
+            var view = CreateView();
+
+            try
+            {
+                // The value the router reads for hardware back —
+                // shared-components.md#dialog: "the hardware back button does
+                // what the dialog's least destructive button does, and never
+                // what its most destructive one does."
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.SameAs(view.BackToTheGameButton));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HowToPlay_IsPresentAndDisabled_AndATapFiresNothing()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var fired = 0;
+                view.CloseRequested += () => fired++;
+                view.EndGameConfirmRequested += () => fired++;
+
+                // settings-dialog.md's open question proposes "present. A
+                // disabled button that appears later is less confusing than a
+                // button that appears from nowhere." The screen it would open
+                // has no wireframe, so under rule 8 it cannot be built and
+                // there is nothing to route to.
+                Assert.That(view.HowToPlayButton.IsHidden, Is.False, "present");
+                Assert.That(view.HowToPlayButton.IsDisabled, Is.True, "and disabled");
+                Assert.That(view.HowToPlayButton.Kind, Is.EqualTo(ButtonKind.Secondary));
+                Assert.That(
+                    view.HowToPlayButton.CanvasGroup.alpha,
+                    Is.EqualTo(Button.ButtonDisabledOpacity).Within(0.001f));
+                Assert.That(
+                    view.HowToPlayButton.RectTransform.sizeDelta.x,
+                    Is.EqualTo(SettingsDialogView.SettingsActionWidth).Within(0.001f));
+
+                TapButton(view.HowToPlayButton);
+
+                Assert.That(view.HowToPlayButton.IsPressed, Is.False, "no press response");
+                Assert.That(fired, Is.Zero, "a disabled button does nothing at all");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EndTheGame_OpensTheConfirmExactlyOnce_AndNeverEndsAnything()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var confirms = 0;
+                var closes = 0;
+                view.EndGameConfirmRequested += () => confirms++;
+                view.CloseRequested += () => closes++;
+
+                Assert.That(view.EndGameButton.Kind, Is.EqualTo(ButtonKind.Destructive));
+                Assert.That(
+                    view.EndGameButton.RectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(SettingsDialogView.SettingsActionWidth, Button.ButtonHeight)));
+
+                TapButton(view.EndGameButton);
+
+                Assert.That(confirms, Is.EqualTo(1), "it opens the confirm");
+                Assert.That(closes, Is.Zero, "and does not close the settings dialog itself");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EndingTheGame_IsNotACapabilityThisDialogHas()
+        {
+            // The other half of "it never ends the game itself", and the
+            // half a callback count cannot show: the view is never given a
+            // reference capable of ending one. No Game, no Lane, no standings
+            // — public or private — so there is no method it could call.
+            const BindingFlags everything = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            var forbidden = new[] { typeof(Game), typeof(Lane), typeof(StandingsRow) };
+
+            foreach (var field in typeof(SettingsDialogView).GetFields(everything))
+            {
+                Assert.That(
+                    forbidden.Any(type => type.IsAssignableFrom(field.FieldType)),
+                    Is.False,
+                    $"SettingsDialogView holds {field.FieldType.Name} in {field.Name}");
+            }
+
+            foreach (var method in typeof(SettingsDialogView).GetMethods(everything))
+            {
+                foreach (var parameter in method.GetParameters())
+                {
+                    Assert.That(
+                        forbidden.Any(type => type.IsAssignableFrom(parameter.ParameterType)),
+                        Is.False,
+                        $"SettingsDialogView.{method.Name} is handed a {parameter.ParameterType.Name}");
+                }
+            }
+        }
+
+        [Test]
+        public void Gaps_AreTwoDistinctNamedConstants_NotOneSharedNumber()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var actionGap = BottomEdge(view.HowToPlayButton.RectTransform)
+                    - TopEdge(view.EndGameButton.RectTransform);
+
+                var belowDestructive = BottomEdge(view.EndGameButton.RectTransform)
+                    - TopEdge(view.BackToTheGameButton.RectTransform);
+
+                Assert.That(actionGap, Is.EqualTo(SettingsDialogView.SettingsActionGap).Within(0.001f));
+                Assert.That(belowDestructive, Is.EqualTo(Button.ButtonDestructiveGap).Within(0.001f));
+
+                // The two happen to be 96 px today. They are two rows on two
+                // different tables, and the code keeps them distinct so either
+                // can move without dragging the other — this is the assertion
+                // that fails if they are ever collapsed into one field.
+                Assert.That(
+                    typeof(SettingsDialogView).GetField(
+                        nameof(SettingsDialogView.SettingsActionGap),
+                        BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    Is.Not.Null,
+                    "SettingsActionGap is settings-dialog.md's own");
+
+                Assert.That(
+                    typeof(Button).GetField(
+                        nameof(Button.ButtonDestructiveGap),
+                        BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    Is.Not.Null,
+                    "ButtonDestructiveGap is the shared Button's, referenced not redeclared");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheGapUnderTheDestructiveButton_SurvivesALongerLabel()
+        {
+            // "it must not drift closer to the destructive one above it, in
+            // either direction, for any reason (a longer label, a smaller
+            // dialog height, anything)."
+            var view = CreateView();
+
+            try
+            {
+                view.EndGameButton.SetLabelText("End the game for absolutely everybody right now");
+                view.BackToTheGameButton.SetLabelText("Back to the game, please");
+
+                var belowDestructive = BottomEdge(view.EndGameButton.RectTransform)
+                    - TopEdge(view.BackToTheGameButton.RectTransform);
+
+                Assert.That(belowDestructive, Is.EqualTo(Button.ButtonDestructiveGap).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Version_IsReadThroughAppVersion_NeverTyped()
+        {
+            // Asserted the same way HelloWorldProbeTests asserts
+            // HelloWorldProbe.Describe: against a static formatting method fed
+            // a fixed build-name string, not against a live
+            // Application.version at test time.
+            var expected = AppVersion.ReadFromBuildName(ReadableBuildName);
+
+            Assert.That(
+                SettingsDialogView.FormatVersionLabel(ReadableBuildName),
+                Is.EqualTo("v" + expected));
+        }
+
+        [Test]
+        public void Version_IsDrawnAtVersionLabelSize()
+        {
+            var view = CreateView();
+
+            try
+            {
+                // title-screen.md's own constant, the same value doing the
+                // same job — referenced, not redeclared.
+                Assert.That(view.VersionText.fontSize, Is.EqualTo((int)TitleScreenView.VersionLabelSize));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Version_DoesNotThrowOnAnUnreadableBuildStamp_AndTheDialogStaysUsable()
+        {
+            // Mirrors HelloWorldProbeTests'
+            // TheProbeSaysSoRatherThanThrowingWhenTheBuildStampIsUnreadable.
+            // No specific fallback wording is asserted — settings-dialog.md
+            // does not define one, so this issue does not invent one.
+            Assert.That(() => SettingsDialogView.FormatVersionLabel(UnreadableBuildName), Throws.Nothing);
+            Assert.That(() => SettingsDialogView.FormatVersionLabel(null), Throws.Nothing);
+
+            var view = CreateView();
+
+            try
+            {
+                var closes = 0;
+                view.CloseRequested += () => closes++;
+
+                Assert.That(view.VersionText.text, Is.Not.Null.And.Not.Empty);
+
+                TapButton(view.BackToTheGameButton);
+
+                Assert.That(closes, Is.EqualTo(1), "still usable");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void PublicSurface_IsOpeningClosingAndTheVersionRead_AndNothingElse()
+        {
+            // settings-dialog.md's first invariant: "opening this changes
+            // nothing about the game. It is a menu, not a turn." And: "nothing
+            // here can change a rule of the game mid-play. There is no
+            // difficulty setting, no player count, no undo." This is the test
+            // that carries both — as a claim about the type's surface, not a
+            // round-trip against a live game.
+            var expected = new[]
+            {
+                nameof(SettingsDialogView.SettingsDialogWidth),
+                nameof(SettingsDialogView.SettingsDialogHeight),
+                nameof(SettingsDialogView.SettingsActionWidth),
+                nameof(SettingsDialogView.SettingsActionGap),
+                nameof(SettingsDialogView.SettingsVersionBottomOffset),
+                // The two events, spelled out rather than via nameof — an
+                // event cannot be named from outside its declaring type in
+                // every context, and these two are the whole of what this
+                // dialog can ask anybody to do.
+                "CloseRequested",
+                "EndGameConfirmRequested",
+                nameof(SettingsDialogView.RectTransform),
+                nameof(SettingsDialogView.Dialog),
+                nameof(SettingsDialogView.ActionsRect),
+                nameof(SettingsDialogView.FootprintRect),
+                nameof(SettingsDialogView.HowToPlayButton),
+                nameof(SettingsDialogView.EndGameButton),
+                nameof(SettingsDialogView.BackToTheGameButton),
+                nameof(SettingsDialogView.VersionText),
+                nameof(SettingsDialogView.Open),
+                nameof(SettingsDialogView.Close),
+                nameof(SettingsDialogView.RequestClose),
+                nameof(SettingsDialogView.FormatVersionLabel)
+            };
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance
+                | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            var declared = typeof(SettingsDialogView)
+                .GetMembers(flags)
+                .Select(member => member.Name)
+                // Property getters and event add/remove accessors come back as
+                // methods of their own; the member they belong to is already
+                // in the list.
+                .Where(name => !name.StartsWith("get_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("set_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("add_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("remove_", StringComparison.Ordinal))
+                // MonoBehaviour subclasses get an implicit public constructor.
+                .Where(name => !name.StartsWith(".", StringComparison.Ordinal))
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal);
+
+            Assert.That(declared, Is.EqualTo(expected.OrderBy(name => name, StringComparer.Ordinal)));
+
+            foreach (var forbidden in new[] { "Difficulty", "PlayerCount", "Roster", "Undo", "Quit", "Finish" })
+            {
+                var word = forbidden;
+
+                Assert.That(
+                    DeclaredMemberNames(typeof(SettingsDialogView))
+                        .Where(name => name.IndexOf(word, StringComparison.Ordinal) >= 0),
+                    Is.Empty,
+                    $"nothing on this dialog reaches {word}");
+            }
+        }
+
+        static SettingsDialogView CreateView()
+        {
+            var host = new GameObject(nameof(SettingsDialogViewTests), typeof(RectTransform));
+            return host.AddComponent<SettingsDialogView>();
+        }
+
+        static void Destroy(SettingsDialogView view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+
+        static void TapButton(Button button)
+        {
+            var corners = new Vector3[4];
+            button.RectTransform.GetWorldCorners(corners);
+
+            var eventData = new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static float LeftEdge(RectTransform rect)
+        {
+            return Corners(rect)[0].x;
+        }
+
+        static float RightEdge(RectTransform rect)
+        {
+            return Corners(rect)[2].x;
+        }
+
+        static float BottomEdge(RectTransform rect)
+        {
+            return Corners(rect)[0].y;
+        }
+
+        static float TopEdge(RectTransform rect)
+        {
+            return Corners(rect)[1].y;
+        }
+
+        static Vector3[] Corners(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners;
+        }
+
+        static IEnumerable<string> DeclaredMemberNames(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name).ToArray();
+        }
+
+        static void AssertPublicConstantsAreExactly(Type type, IDictionary<string, float> expected)
+        {
+            var constants = type
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(field => field.IsLiteral && !field.IsInitOnly)
+                .ToArray();
+
+            Assert.That(
+                constants.Select(field => field.Name).OrderBy(name => name, StringComparer.Ordinal),
+                Is.EqualTo(expected.Keys.OrderBy(name => name, StringComparer.Ordinal)),
+                $"{type.Name}'s public constants are exactly settings-dialog.md's own, under the identical names");
+
+            foreach (var field in constants)
+            {
+                Assert.That(
+                    Convert.ToSingle(field.GetValue(null)),
+                    Is.EqualTo(expected[field.Name]).Within(0.001f),
+                    $"{type.Name}.{field.Name}");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SettingsDialogViewTests.cs.meta
+++ b/Assets/Tests/EditMode/SettingsDialogViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb7e8d33a2474916b56ae862c45f5d58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/mockups/settings-dialog.html
+++ b/docs/specs/ui/mockups/settings-dialog.html
@@ -7,6 +7,19 @@
   Shapes, sizes and positions only. The colours are placeholders so the frogs
   can be told apart in a picture; the palette is an area:art decision.
   Numbers here are the numbers in the spec page's constants table.
+
+  Two corrections, made by issue #222 when it built this dialog, both bringing
+  the picture back into line with the constants table it claims to draw:
+
+  1. `How to play` now carries the `.btn.off` disabled treatment. The screen it
+     would open has no wireframe yet, and the spec page's own open question
+     proposes "present and disabled" — this used to draw it at full opacity.
+  2. The two action buttons moved up 10 px. `.panel` is `box-sizing:border-box`
+     with a 3 px border, so absolutely positioned children resolve against a
+     754 px padding box: at the old offsets the gap under `End the game`
+     rendered as 86 px, not the 96 px `ButtonDestructiveGap` the table and
+     shared-components.md#button both state. `Back to the game` and the version
+     stayed put — they sit at `DialogPadding`, which is right.
 -->
 <html lang="en">
 <head>
@@ -71,8 +84,8 @@
     <div class="scrim"></div>
     <div class="abs panel" style="left:510px;top:220px;width:900px;height:760px">
       <div class="abs" style="left:56px;top:56px;font-size:56px;font-weight:700">Settings</div>
-      <div class="abs btn s" style="left:56px;top:180px;width:788px">How to play</div>
-      <div class="abs btn d" style="left:56px;top:388px;width:788px">End the game</div>
+      <div class="abs btn s off" style="left:56px;top:170px;width:788px">How to play</div>
+      <div class="abs btn d" style="left:56px;top:378px;width:788px">End the game</div>
       <div class="abs" style="left:56px;bottom:60px;font-size:28px;color:#6C7873">v0.1.0</div>
       <div class="abs btn p" style="right:56px;bottom:56px">Back to the game</div>
     </div>

--- a/docs/specs/ui/settings-dialog.md
+++ b/docs/specs/ui/settings-dialog.md
@@ -37,6 +37,13 @@ empty space. That gap is the layout, not decoration: `Back to the game` is the
 button people reach for without looking, and it must not be adjacent to the one
 that ends everybody's game.
 
+Because that gap is the load-bearing number, the actions column is positioned
+from the **bottom of the panel up** — `End the game` sits `ButtonDestructiveGap`
+above the button row, and `How to play` sits `SettingsActionGap` above `End the
+game`. The column's top edge is whatever is left over. Laid out the other way
+round, from the top down, the gap would be a consequence of arithmetic and a
+longer label or a shorter panel could quietly close it.
+
 ## Named constants
 
 | Element | Constant | Value |
@@ -46,6 +53,7 @@ that ends everybody's game.
 | Action button width | `SettingsActionWidth` | 788 px |
 | Gap between `How to play` and `End the game` | `SettingsActionGap` | 96 px |
 | Gap below `End the game` | `ButtonDestructiveGap` | 96 px |
+| Version label's offset from the panel's bottom edge | `SettingsVersionBottomOffset` | 60 px |
 
 ## Elements
 
@@ -55,7 +63,10 @@ that ends everybody's game.
   [end-game confirm](end-game-confirm.md). Never ends anything by itself.
 - **`Back to the game`** — primary button. Closes and returns to exactly the
   board state that was there.
-- **Version** — `v0.1.0`, quiet, bottom-left.
+- **Version** — `v0.1.0`, quiet, bottom-left, at
+  [`VersionLabelSize`](title-screen.md#named-constants). The same value doing
+  the same job as the title screen's own version readout, under the identical
+  name — not a second constant for the same number.
 
 ## Behaviour
 


### PR DESCRIPTION
Closes #222

The gear on the board now opens a real settings dialog: the rules, the way out
of a game, and which version you are running. It is deliberately thin — two
buttons, a version readout, and one way back. `How to play` is there but greyed
out, because the screen it would open hasn't been drawn yet. `End the game`
doesn't end anything; it opens the "are you sure?" box, which is a later piece
of work. `Back to the game` and the tablet's own back button do the same thing,
and neither disturbs the board underneath.

**Docs:** `docs/specs/ui/settings-dialog.md` — added the one named constant the
mockup draws and the table was missing (`SettingsVersionBottomOffset`, 60 px),
recorded that the actions column is positioned from the bottom of the panel up,
and pointed the Version element at title-screen.md's `VersionLabelSize` so
nobody adds a second constant for the same number.
`docs/specs/ui/mockups/settings-dialog.html` — the two corrections this issue
called for: `How to play` now draws disabled, and the gap under `End the game`
now renders as a true 96 px.

## Spec invariants

| Rule in `/docs` | How this PR knows it holds |
| --- | --- |
| "Opening this changes nothing about the game. It is a menu, not a turn." | `PublicSurface_IsOpeningClosingAndTheVersionRead_AndNothingElse` pins the type's entire public surface to an allowlist; `EndingTheGame_IsNotACapabilityThisDialogHas` walks every field and every method parameter, public and private, and fails if a `Game`, `Lane` or `StandingsRow` appears anywhere. |
| "Nothing here can change a rule of the game mid-play. There is no difficulty setting, no player count, no undo." | Same two tests — the surface allowlist, plus a name sweep for `Difficulty`/`PlayerCount`/`Roster`/`Undo`/`Quit`/`Finish`. |
| "The only destructive thing on it confirms." | `EndTheGame_OpensTheConfirmExactlyOnce_AndNeverEndsAnything`: one open-confirm callback per press, nothing else fired. |
| "Hardware back does what `Back to the game` does — the least destructive button." | `HardwareBack_FiresTheIdenticalCloseCallbackBackToTheGameFires` and `BackToTheGame_IsTheDialogsLeastDestructiveButton`. There is literally one method: `Back to the game`'s click handler *is* `RequestClose`, which is what the router calls. |
| "`End the game` is separated from everything below it by `ButtonDestructiveGap` … that gap is the layout, not decoration." | `Gaps_AreTwoDistinctNamedConstants_NotOneSharedNumber` measures both gaps against their named constants, and `TheGapUnderTheDestructiveButton_SurvivesALongerLabel` re-measures after both labels get longer. |
| "The version string comes from `/VERSION`." | `Version_IsReadThroughAppVersion_NeverTyped` and `Version_DoesNotThrowOnAnUnreadableBuildStamp_AndTheDialogStaysUsable`. No version literal exists anywhere in the diff. |
| `shared-components.md#button`'s Disabled state | `HowToPlay_IsPresentAndDisabled_AndATapFiresNothing`: present, disabled, at `ButtonDisabledOpacity`, no press response, no callback. |

## How the spec is changing

**One row added to `settings-dialog.md`'s constants table.** Old: the table had
five rows and the committed mockup drew a sixth number it did not name — the
version label's 60 px offset from the panel's bottom edge, which is
deliberately not `DialogPadding` (56 px). New:
`SettingsVersionBottomOffset` = 60 px. Per
[the named constants are the origin, not an afterthought](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought),``
a number the code needs and the table lacks is a row that was missed, not one to
invent — so it carries the value the mockup already draws.

**A paragraph added to `settings-dialog.md`'s Anchors section.** Old: the page
stated the gap under `End the game` but not where the actions column starts, so
the column's position was only implied. New: the page says the column is placed
from the bottom of the panel up, which is what makes `ButtonDestructiveGap` a
fact of the layout rather than a consequence of arithmetic — and is exactly what
this issue demands ("it must not drift closer … in either direction, for any
reason"). Laid out top-down instead, the gap is whatever is left over after the
title and the column, and a shorter panel closes it silently.

The page's two open questions are untouched. **"Present and disabled" is the
spec's own proposed answer, not a decision made here** — what `How to play`
opens, and whether it should be hidden instead, are left exactly as open as
`settings-dialog.md` leaves them. Epic #198 confirms a how-to-play screen is out
of v0.2 scope, so the button is wired to nothing at all rather than to a
placeholder destination.

## Deviations and Decisions

- **The mockup correction landed on the two action buttons, not on `Back to the
  game`, and it is 10 px rather than the issue's stated 4 px.** The issue asked
  for `Back to the game`'s offset to move 4 px. That number was computed in the
  "border ignored" frame the issue itself notes in parentheses; in the frame the
  browser actually renders — `.panel` is `box-sizing:border-box` with a 3 px
  border, so children resolve against a 754 px padding box — the gap draws as
  86 px and closing it needs 10 px. Moving `Back to the game` up by 10 px would
  have broken the thing it is currently right about: it sits at `DialogPadding`
  from the bottom, which is where the shared Dialog's button row is. So `How to
  play` (180 → 170) and `End the game` (388 → 378) moved up instead. Same
  outcome the checklist asked for — a rendered 96 px `ButtonDestructiveGap` —
  reached without introducing a new error. The gap between the two actions stays
  96 px, and the version and primary button did not move.
- **`settings-dialog.md`'s constants table *was* changed, which the issue said
  it would not be.** The issue treats the table as already complete. The mockup
  audit found one number it draws that the table does not name (the version's
  60 px bottom offset), and the code needs that number. Adding the row was a
  deliberate call, taken because the alternative was a bare literal or silently
  snapping the version to `DialogPadding` and drifting 4 px from the agreed
  picture. Flagging it here because the issue explicitly said otherwise.
- **The audit found no missing row for the actions column's vertical origin, on
  purpose.** The mockup draws `top:180px` for it, but that number is not
  independent — it is whatever the four constants below it leave over, and the
  mockup's value was 10 px adrift from that, which *is* the
  `ButtonDestructiveGap` conflict the issue documents. Giving it a row of its own
  would enshrine one of two answers that differ only by whether you count the
  mockup's 3 px border. The column is anchored from the bottom instead, so both
  frames come out right, and the spec page now says so.
- **`SettingsDialogView` has its own `FormatVersionLabel`, duplicating
  `TitleScreenView`'s.** Two views now format the same label the same way. Folding
  them onto a shared helper means refactoring #216's merged, tested file with no
  editor here to re-verify it — the same call #219 made when it left `Button`'s
  inline rounded-rect generator alone and put `RoundedRectSprite` beside it. Worth
  a follow-up when someone has an editor open; not worth bundling into this PR.
- **The mockup's `.panel` 3 px border is not reproduced in code.** The shared
  `DialogPanel` (#219) draws no border, and that border comes from CSS boilerplate
  every mockup in the folder shares — so it is a `shared-components.md#dialog`
  question, not a `settings-dialog.md` one, and adding a border constant to the
  shared Dialog is outside this issue.
- **The actions column is parented to the Dialog's `PanelRect`, not its
  `BodyRect`.** `BodyRect` starts below the title at `DialogPadding +
  DialogTitleSize + DialogTitleGap`; the actions column is measured from the
  panel's bottom, so hanging it off `BodyRect` would mean expressing that
  position as a difference between two unrelated chains of constants.

## Testing

The Core suite (190 tests), `check_core_isolation.py`,
`check_assembly_references.py`, `check_geometry_literals.py`,
`run_python_tests.py` and `mkdocs build --strict` all pass locally.

The eleven EditMode tests were written first and cannot be run in an agent
environment — no editor, no licence — so CI is where they are seen to go from
red to green ([why](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/testing.md#known-limitation-editmode-tests-run-in-ci-not-in-agent-environments)).``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_