### PR TITLE
feat(ui): show the die, the pile, and the card you drew

### DIFF
--- a/Assets/Scripts/Unity/GameRollAndCardReadout.cs
+++ b/Assets/Scripts/Unity/GameRollAndCardReadout.cs
@@ -1,0 +1,85 @@
+using System;
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The runtime <see cref="IRollAndCardReadout"/>: a live
+    /// <see cref="Game"/>, read at the moment it is asked. Every property is
+    /// a straight read of what Core already decided — there is no arithmetic
+    /// anywhere in this type, and no <c>Rng</c>.
+    ///
+    /// It reads the game each time rather than copying values at
+    /// construction, so a dialog built before <see cref="Game.RollDie"/> and
+    /// shown after it still shows the right roll.
+    /// </summary>
+    public sealed class GameRollAndCardReadout : IRollAndCardReadout
+    {
+        readonly Game _game;
+
+        /// <exception cref="ArgumentNullException"><paramref name="game"/> is null.</exception>
+        public GameRollAndCardReadout(Game game)
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+        }
+
+        /// <inheritdoc />
+        public FrogColour Frog
+        {
+            get { return _game.ActiveFrog; }
+        }
+
+        /// <inheritdoc />
+        public int Face
+        {
+            get { return RequireRoll().Face; }
+        }
+
+        /// <inheritdoc />
+        public Pile Pile
+        {
+            get { return RequireRoll().Pile; }
+        }
+
+        /// <inheritdoc />
+        public int Multiplicand
+        {
+            get { return RequireCard().Multiplicand; }
+        }
+
+        /// <inheritdoc />
+        public int Multiplier
+        {
+            get { return RequireCard().Multiplier; }
+        }
+
+        // The dialog only ever opens on a turn that has rolled. Asking before
+        // that is a wiring mistake, and it says so rather than reporting a
+        // face of zero that would draw a die with no pips on it.
+        Roll RequireRoll()
+        {
+            var roll = _game.DrawnRoll;
+
+            if (roll == null)
+            {
+                throw new InvalidOperationException(
+                    "this turn has not rolled yet; there is no face to show.");
+            }
+
+            return roll;
+        }
+
+        Card RequireCard()
+        {
+            var card = _game.DrawnCard;
+
+            if (card == null)
+            {
+                throw new InvalidOperationException(
+                    "this turn has not drawn a card yet; there is no problem to show.");
+            }
+
+            return card;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/GameRollAndCardReadout.cs.meta
+++ b/Assets/Scripts/Unity/GameRollAndCardReadout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96c5ebce8d3f44b7819529a042be9a4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/IRollAndCardReadout.cs
+++ b/Assets/Scripts/Unity/IRollAndCardReadout.cs
@@ -1,0 +1,44 @@
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The two questions docs/specs/ui/roll-and-card.md's dialog asks about a
+    /// turn that has already begun: what face was rolled, and what card was
+    /// drawn — plus whose turn it is, for the chip. Nothing here decides any
+    /// of those; the roll and the draw both happened in Core
+    /// (<see cref="Game.RollDie"/>) before the dialog existed.
+    ///
+    /// The pile is reported, not derived. The face-to-pile mapping is public
+    /// on <see cref="Roll.PileForFace"/> and the dialog could work it out for
+    /// itself — it deliberately does not, because "the roll selects the pile"
+    /// is a rule Core owns, and a second copy of it in a view is a second
+    /// copy that can drift.
+    ///
+    /// The problem arrives as its two operands rather than as a
+    /// <see cref="Card"/>, for the same reason <see cref="ISavedGameQuery"/>
+    /// exists: a test needs to state a fixed readout —
+    /// docs/specs/ui/roll-and-card.md's worked example is `331 × 41` — and a
+    /// <see cref="Card"/> can only come out of a draw against the game's
+    /// seeded generator. Asking for the numbers the dialog prints keeps the
+    /// die out of the test entirely, which is the point: the die is not
+    /// random *here*.
+    /// </summary>
+    public interface IRollAndCardReadout
+    {
+        /// <summary>The frog taking this turn — the chip in `whose`.</summary>
+        FrogColour Frog { get; }
+
+        /// <summary>The face that came up, <see cref="Roll.MinimumFace"/> to <see cref="Roll.MaximumFace"/>.</summary>
+        int Face { get; }
+
+        /// <summary>The pile that roll sent the turn to, as Core reported it.</summary>
+        Pile Pile { get; }
+
+        /// <summary>The drawn card's first operand — the `331` in `331 × 41`.</summary>
+        int Multiplicand { get; }
+
+        /// <summary>The drawn card's second operand — the `41` in `331 × 41`.</summary>
+        int Multiplier { get; }
+    }
+}

--- a/Assets/Scripts/Unity/IRollAndCardReadout.cs.meta
+++ b/Assets/Scripts/Unity/IRollAndCardReadout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5bf6fb29d154af6b1afe9ab944714bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs
+++ b/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs
@@ -1,0 +1,1067 @@
+using System;
+using System.Collections.Generic;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// GameBoardScreenView.cs and TitleScreenView.cs work around — so the shared
+// components are pulled in by explicit alias, and a bare `Button`,
+// `ButtonKind`, `DialogPanel`, `FrogColours` or `PlayerChip` in this file
+// always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The die that landed, the pile it sends you to, and the card you drew —
+    /// docs/specs/ui/roll-and-card.md, built to that page and its committed
+    /// 1:1 mockup, on the shared <see cref="DialogPanel"/> (#219).
+    ///
+    /// **It is a readout, not a source of randomness.** The roll and the draw
+    /// both happened in Core (<c>Game.RollDie</c>) before this dialog opened.
+    /// This view asks an <see cref="IRollAndCardReadout"/> what face came up,
+    /// what pile Core reported, and what the two operands are — and draws
+    /// them. It contains no generator, and it does not re-derive the pile
+    /// from the face even though that mapping is public on
+    /// <see cref="Roll.PileForFace"/>: Core reports the pile, and this
+    /// displays what Core reports.
+    ///
+    /// Three things it deliberately does not do:
+    ///
+    /// - **It does not handle hardware back.** Back is inert on this dialog,
+    ///   and it is inert because the alternative is losing a drawn card. The
+    ///   router already knows that (<c>ScreenRouter.HandleBack</c> does
+    ///   nothing for <see cref="Frogs.Core.Dialog.RollAndCard"/>), so the way
+    ///   to be inert here is to add no handler at all — and to nominate no
+    ///   least-destructive button on the shared Dialog, which is what would
+    ///   otherwise turn a back press into a `Solve it`.
+    /// - **It does not build the working-out grid** (#223) or the answer
+    ///   result (#224). `Solve it` opens the next dialog through the router
+    ///   and says the press happened; what that dialog contains is not this
+    ///   issue's.
+    /// - **It does not advance Core's turn phase.** Moving from
+    ///   <c>RolledAndCardDrawn</c> to <c>Answering</c> belongs to whoever
+    ///   owns the screen that answering happens on, not to the screen being
+    ///   left.
+    ///
+    /// Both of roll-and-card.md's open questions are left exactly as open as
+    /// it leaves them: this is its own beat rather than the top of the grid,
+    /// and the pile is named here and nowhere else.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class RollAndCardDialogView : MonoBehaviour
+    {
+        // docs/specs/ui/roll-and-card.md#named-constants — the page's own
+        // table, under the identical names.
+        public const float RollDialogWidth = 1280f;
+        public const float RollDialogHeight = 760f;
+        public const float RolledLabelSize = 40f;
+        public const float RolledLabelGap = 24f;
+        public const float DieColumnWidth = 400f;
+        public const float DieGroupTop = 220f;
+        public const float DieFaceSize = 240f;
+        public const float DieCornerRadius = 40f;
+        public const float DieBorderWidth = 4f;
+        public const float DiePipInset = 34f;
+        public const float DiePipDiameter = 40f;
+        public const float DiePileGap = 32f;
+        public const float PileLabelSize = 40f;
+        public const float CardTop = 180f;
+        public const float CardWidth = 560f;
+        public const float CardHeight = 420f;
+        public const float CardRadius = 24f;
+        public const float CardBorderWidth = 4f;
+        public const float CardProblemSize = 120f;
+        public const float CardRuleGap = 8f;
+        public const float CardRuleThickness = 8f;
+        public const float CardRuleLength = 360f;
+        public const float RollCardGap = 208f;
+        public const float DieRollDuration = 0.8f;
+        public const float CardDealDuration = 0.3f;
+
+        // The dialog's own scrim, corners, padding and cross-fade are the
+        // shared Dialog's constants, referenced rather than redeclared —
+        // DialogPanel.DialogPadding, DialogRadius, DialogScrimOpacity and
+        // DialogFadeDuration. DialogTitleSize and DialogTitleGap are the two
+        // this dialog does not use: it has no title text, and `whose` does
+        // that job instead.
+
+        // How long the whole entry runs: the die settles, then the card
+        // deals. A relationship between two named constants rather than a
+        // third number — the spec's own "total about 1.2 s" is this plus the
+        // shared Dialog's fade.
+        const float EntryDuration = DieRollDuration + CardDealDuration;
+
+        // Three pips across a die face; two lines to a pile label; two lines
+        // to a problem. Counts, not measurements — but named all the same,
+        // because they are what turn DiePipInset, PileLabelSize and
+        // CardProblemSize into positions.
+        const int DiePipAcross = 3;
+        const int PileLabelLines = 2;
+        const int ProblemLines = 2;
+
+        // A pip sits centred in one cell of the three-across lattice inside
+        // the die's border and inset.
+        const float PipCellSize =
+            (DieFaceSize - (2f * DieBorderWidth) - (2f * DiePipInset)) / DiePipAcross;
+
+        const string RolledLabel = "rolled";
+        const string SolveItLabel = "Solve it";
+
+        // docs/specs/ui/roll-and-card.md § Elements — the pile label names
+        // both the pile and the two faces that reach it, "how the board
+        // itself is labelled". The separator is what makes the two halves one
+        // label: `Hard pile · 5 or 6`.
+        const string PileLabelSeparator = " · ";
+        const string EasyPileName = "Easy pile";
+        const string MediumPileName = "Medium pile";
+        const string HardPileName = "Hard pile";
+        const string EasyPileFaces = "1 or 2";
+        const string MediumPileFaces = "3 or 4";
+        const string HardPileFaces = "5 or 6";
+
+        // `×` to the left of the second number, the way the classroom cards
+        // are written.
+        const string MultiplierFormat = "× {0}";
+
+        // No imported font — matches Button.cs's, PlayerChip.cs's and
+        // GameBoardScreenView.cs's own choice, for the same reason (no
+        // external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockup
+        // (docs/specs/ui/mockups/roll-and-card.html) — the same line
+        // Button.cs, PlayerChip.cs and GameBoardScreenView.cs each draw for
+        // their own colours: not a geometry constant on any spec page's
+        // table, so not declared as a named spec constant.
+        static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
+        static readonly Color LineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockup's --line
+        static readonly Color PaperColor = Color.white; // mockup's --paper / #fff
+
+        // The pip lattice, in cell units: -1, 0 and 1 across and down, y up.
+        // These are the ordinary die-face arrangements — a universal
+        // convention for what a die face looks like, not a rule about this
+        // game — and the six is the two columns of three the mockup draws for
+        // its hard-pile worked example.
+        static readonly Vector2[][] PipLayouts =
+        {
+            new[] { new Vector2(0f, 0f) },
+            new[] { new Vector2(-1f, 1f), new Vector2(1f, -1f) },
+            new[] { new Vector2(-1f, 1f), new Vector2(0f, 0f), new Vector2(1f, -1f) },
+            new[] { new Vector2(-1f, 1f), new Vector2(1f, 1f), new Vector2(-1f, -1f), new Vector2(1f, -1f) },
+            new[] { new Vector2(-1f, 1f), new Vector2(1f, 1f), new Vector2(0f, 0f), new Vector2(-1f, -1f), new Vector2(1f, -1f) },
+            new[]
+            {
+                new Vector2(-1f, 1f), new Vector2(1f, 1f),
+                new Vector2(-1f, 0f), new Vector2(1f, 0f),
+                new Vector2(-1f, -1f), new Vector2(1f, -1f)
+            }
+        };
+
+        static Sprite s_dieSprite;
+        static Sprite s_cardSprite;
+        static Sprite s_pipSprite;
+
+        static Sprite DieSprite
+        {
+            get
+            {
+                if (s_dieSprite == null)
+                {
+                    s_dieSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(DieCornerRadius));
+                }
+
+                return s_dieSprite;
+            }
+        }
+
+        static Sprite CardSprite
+        {
+            get
+            {
+                if (s_cardSprite == null)
+                {
+                    s_cardSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(CardRadius));
+                }
+
+                return s_cardSprite;
+            }
+        }
+
+        static Sprite PipSprite
+        {
+            get
+            {
+                if (s_pipSprite == null)
+                {
+                    // A rounded rect whose radius is half its own size is a
+                    // circle — the same trick PlayerChip's swatch uses.
+                    s_pipSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(DiePipDiameter / 2f));
+                }
+
+                return s_pipSprite;
+            }
+        }
+
+        RectTransform _rect;
+        DialogPanel _dialog;
+        RollAndCardSkipCatcher _scrimSkipCatcher;
+        RollAndCardSkipCatcher _panelSkipCatcher;
+
+        RectTransform _whoseRect;
+        PlayerChip _whoseChip;
+        Text _rolledText;
+
+        RectTransform _dieGroupRect;
+        RectTransform _dieRect;
+        Image _dieBorder;
+        Image _dieFace;
+        readonly List<Image> _pips = new List<Image>();
+        readonly List<Vector2> _pipLattice = new List<Vector2>();
+        readonly List<Image> _visiblePips = new List<Image>();
+
+        RectTransform _pileRect;
+        CanvasGroup _pileCanvasGroup;
+        Text _pileNameText;
+        Text _pileFacesText;
+
+        RectTransform _cardRect;
+        CanvasGroup _cardCanvasGroup;
+        Image _cardBorder;
+        Image _cardFace;
+        Text _multiplicandText;
+        Text _multiplierText;
+        RectTransform _cardRuleRect;
+
+        Button _solveItButton;
+
+        bool _initialized;
+        IRollAndCardReadout _readout;
+        ScreenRouter _router;
+        float _elapsed;
+
+        /// <summary>
+        /// `Solve it` was pressed, on release, per the shared Button. The
+        /// transition to the working-out grid has already been asked of the
+        /// router by the time this fires; this only says the press happened.
+        /// </summary>
+        public event Action SolveItPressed;
+
+        /// <summary>The view's own <see cref="RectTransform"/> — the full canvas the dialog covers.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The shared Dialog this is built on — its scrim, corners, padding and cross-fade.</summary>
+        public DialogPanel Dialog
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog;
+            }
+        }
+
+        /// <summary>A tap on the dimmed board behind the dialog. Skips the entry, and can do nothing else.</summary>
+        public RollAndCardSkipCatcher ScrimSkipCatcher
+        {
+            get
+            {
+                EnsureInitialized();
+                return _scrimSkipCatcher;
+            }
+        }
+
+        /// <summary>A tap on the panel itself. Skips the entry, and can do nothing else.</summary>
+        public RollAndCardSkipCatcher PanelSkipCatcher
+        {
+            get
+            {
+                EnsureInitialized();
+                return _panelSkipCatcher;
+            }
+        }
+
+        /// <summary>`whose` — the chip and the word `rolled`, above the row.</summary>
+        public RectTransform WhoseRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _whoseRect;
+            }
+        }
+
+        /// <summary>The player chip of the frog taking this turn, active state.</summary>
+        public PlayerChip WhoseChip
+        {
+            get
+            {
+                EnsureInitialized();
+                return _whoseChip;
+            }
+        }
+
+        /// <summary>The word beside the chip that makes `whose` a sentence.</summary>
+        public Text RolledText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rolledText;
+            }
+        }
+
+        /// <summary>`die` and `pile` as one group, <see cref="DieColumnWidth"/> wide.</summary>
+        public RectTransform DieGroupRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dieGroupRect;
+            }
+        }
+
+        /// <summary>`die` — a <see cref="DieFaceSize"/> square with <see cref="DieCornerRadius"/> corners.</summary>
+        public RectTransform DieRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dieRect;
+            }
+        }
+
+        /// <summary>The die's outline, <see cref="DieBorderWidth"/> of it.</summary>
+        public Image DieBorder
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dieBorder;
+            }
+        }
+
+        /// <summary>The die's face, inside its outline. The pips sit on this.</summary>
+        public Image DieFace
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dieFace;
+            }
+        }
+
+        /// <summary>Every pip position on the face, whether or not this face uses it.</summary>
+        public IReadOnlyList<Image> Pips
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pips;
+            }
+        }
+
+        /// <summary>The pips currently drawn — the rolled face's own arrangement, and empty while the die is still rolling.</summary>
+        public IReadOnlyList<Image> VisiblePips
+        {
+            get
+            {
+                EnsureInitialized();
+                return _visiblePips;
+            }
+        }
+
+        /// <summary>`pile` — the label, and the fade that holds it back until the die settles.</summary>
+        public CanvasGroup PileCanvasGroup
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pileCanvasGroup;
+            }
+        }
+
+        /// <summary>The pile's name — `Hard pile`.</summary>
+        public Text PileNameText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pileNameText;
+            }
+        }
+
+        /// <summary>The two faces that reach that pile — `5 or 6`.</summary>
+        public Text PileFacesText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pileFacesText;
+            }
+        }
+
+        /// <summary>The whole label as the spec writes it — `Hard pile · 5 or 6`.</summary>
+        public string PileLabel
+        {
+            get
+            {
+                EnsureInitialized();
+                return _pileNameText.text + PileLabelSeparator + _pileFacesText.text;
+            }
+        }
+
+        /// <summary>`card` — <see cref="CardWidth"/> by <see cref="CardHeight"/>. A picture of a card; nothing is typed here.</summary>
+        public RectTransform CardRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardRect;
+            }
+        }
+
+        /// <summary>The card's deal-in fade, over <see cref="CardDealDuration"/>.</summary>
+        public CanvasGroup CardCanvasGroup
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardCanvasGroup;
+            }
+        }
+
+        /// <summary>The card's outline, <see cref="CardBorderWidth"/> of it.</summary>
+        public Image CardBorder
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardBorder;
+            }
+        }
+
+        /// <summary>The card's face, inside its outline.</summary>
+        public Image CardFace
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardFace;
+            }
+        }
+
+        /// <summary>The problem's first line — the `331` in `331 × 41`.</summary>
+        public Text MultiplicandText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _multiplicandText;
+            }
+        }
+
+        /// <summary>The problem's second line — the `× 41` in `331 × 41`.</summary>
+        public Text MultiplierText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _multiplierText;
+            }
+        }
+
+        /// <summary>The rule under the problem, <see cref="CardRuleLength"/> by <see cref="CardRuleThickness"/>.</summary>
+        public RectTransform CardRuleRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardRuleRect;
+            }
+        }
+
+        /// <summary>`Solve it` — the only way out, at the shared Button's own size.</summary>
+        public Button SolveItButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _solveItButton;
+            }
+        }
+
+        /// <summary>How far through its entry the dialog is.</summary>
+        public RollAndCardEntryPhase Phase
+        {
+            get
+            {
+                EnsureInitialized();
+
+                if (_elapsed < DieRollDuration)
+                {
+                    return RollAndCardEntryPhase.Rolling;
+                }
+
+                return _elapsed < EntryDuration
+                    ? RollAndCardEntryPhase.Dealing
+                    : RollAndCardEntryPhase.Settled;
+            }
+        }
+
+        /// <summary>True while the die is still rolling and no face is shown.</summary>
+        public bool DieIsRolling
+        {
+            get { return Phase == RollAndCardEntryPhase.Rolling; }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        void Update()
+        {
+            if (_readout == null)
+            {
+                return;
+            }
+
+            Advance(Time.deltaTime);
+        }
+
+        /// <summary>
+        /// Points the dialog at the roll and card Core already drew, and at
+        /// the router `Solve it` navigates through, then opens it — the die
+        /// starts rolling immediately, per the spec's "the dialog fades in
+        /// already showing the die rolling".
+        ///
+        /// The router is optional for the same reason
+        /// <c>TitleScreenView.Initialize</c>'s query is: a test that only
+        /// cares what the dialog draws should not have to hand it a
+        /// navigation graph.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="readout"/> is null.</exception>
+        public void Initialize(IRollAndCardReadout readout, ScreenRouter router = null)
+        {
+            EnsureInitialized();
+
+            _readout = readout ?? throw new ArgumentNullException(nameof(readout));
+            _router = router;
+            _elapsed = 0f;
+
+            Refresh();
+            _dialog.Open();
+            ApplyEntry();
+        }
+
+        /// <summary>
+        /// Re-reads the readout and redraws. Every value it draws is asked
+        /// for again — the face, the pile, and the two operands all come back
+        /// from Core, and none of them is remembered from the last pass.
+        /// </summary>
+        public void Refresh()
+        {
+            EnsureInitialized();
+
+            if (_readout == null)
+            {
+                return;
+            }
+
+            var frog = _readout.Frog;
+            _whoseChip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _whoseChip.SetState(PlayerChipState.Active);
+
+            var pile = _readout.Pile;
+            _pileNameText.text = PileNameFor(pile);
+            _pileFacesText.text = PileFacesFor(pile);
+
+            _multiplicandText.text = _readout.Multiplicand.ToString();
+            _multiplierText.text = string.Format(MultiplierFormat, _readout.Multiplier);
+
+            ApplyEntry();
+        }
+
+        /// <summary>
+        /// Advances the entry by <paramref name="deltaSeconds"/>, clamped to
+        /// <see cref="DieRollDuration"/> + <see cref="CardDealDuration"/>. A
+        /// public method of its own, rather than reachable only through
+        /// <see cref="Update"/>, so an EditMode test can simulate elapsed
+        /// time directly — the same reasoning as
+        /// <c>TitleScreenView.AdvanceFade</c>.
+        /// </summary>
+        public void Advance(float deltaSeconds)
+        {
+            EnsureInitialized();
+
+            var delta = Mathf.Max(deltaSeconds, 0f);
+            _elapsed = Mathf.Clamp(_elapsed + delta, 0f, EntryDuration);
+
+            _dialog.AdvanceFade(delta);
+            ApplyEntry();
+        }
+
+        /// <summary>
+        /// Jumps straight to the settled state — face shown, pile label
+        /// shown, card in place. This is all a tap anywhere outside
+        /// `Solve it` does: it hurries the readout along and decides nothing,
+        /// so it never opens the working-out grid and never dismisses
+        /// anything.
+        /// </summary>
+        public void SkipEntry()
+        {
+            EnsureInitialized();
+
+            _elapsed = EntryDuration;
+            _dialog.AdvanceFade(DialogPanel.DialogFadeDuration);
+            ApplyEntry();
+        }
+
+        // Unity does not guarantee Awake() has run before another
+        // component's Awake() or a test reaches this one right after
+        // AddComponent — the same reasoning as Button, DialogPanel and
+        // GameBoardScreenView's own EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+            ApplyEntry();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _dialog = GetComponent<DialogPanel>();
+            if (_dialog == null)
+            {
+                _dialog = gameObject.AddComponent<DialogPanel>();
+            }
+
+            // Its own named size, comfortably inside the shared Dialog's
+            // maxima — not an override of a default footprint, because the
+            // maxima were never one.
+            _dialog.SetSize(RollDialogWidth, RollDialogHeight);
+
+            _scrimSkipCatcher = AddSkipCatcher(_dialog.Scrim.gameObject);
+            _panelSkipCatcher = AddSkipCatcher(_dialog.PanelRect.gameObject);
+
+            BuildWhose();
+            BuildDieGroup();
+            BuildCard();
+            BuildControls();
+        }
+
+        RollAndCardSkipCatcher AddSkipCatcher(GameObject target)
+        {
+            var catcher = target.GetComponent<RollAndCardSkipCatcher>();
+            if (catcher == null)
+            {
+                catcher = target.AddComponent<RollAndCardSkipCatcher>();
+            }
+
+            catcher.Tapped += SkipEntry;
+            return catcher;
+        }
+
+        void BuildWhose()
+        {
+            var whoseGO = new GameObject("Whose", typeof(RectTransform));
+            _whoseRect = (RectTransform)whoseGO.transform;
+            _whoseRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _whoseRect.anchorMin = new Vector2(0f, 1f);
+            _whoseRect.anchorMax = new Vector2(0f, 1f);
+            _whoseRect.pivot = new Vector2(0f, 1f);
+            _whoseRect.sizeDelta = new Vector2(DieColumnWidth, PlayerChip.PlayerChipHeight);
+            _whoseRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, -DialogPanel.DialogPadding);
+
+            var chipGO = new GameObject("WhoseChip", typeof(RectTransform));
+            var chipRect = (RectTransform)chipGO.transform;
+            chipRect.SetParent(_whoseRect, worldPositionStays: false);
+            chipRect.anchorMin = new Vector2(0f, 0.5f);
+            chipRect.anchorMax = new Vector2(0f, 0.5f);
+            chipRect.pivot = new Vector2(0f, 0.5f);
+            chipRect.anchoredPosition = Vector2.zero;
+            _whoseChip = chipGO.AddComponent<PlayerChip>();
+
+            // Unity does not run Awake() on AddComponent outside play mode,
+            // and the chip sizes itself when it builds. Touch its rect so it
+            // builds now, while `whose` is being laid out.
+            chipRect = _whoseChip.RectTransform;
+
+            _rolledText = BuildText("Rolled", _whoseRect, RolledLabelSize, LineColor, TextAnchor.MiddleLeft);
+            _rolledText.text = RolledLabel;
+            var rolledRect = _rolledText.rectTransform;
+            rolledRect.anchorMin = new Vector2(0f, 0.5f);
+            rolledRect.anchorMax = new Vector2(0f, 0.5f);
+            rolledRect.pivot = new Vector2(0f, 0.5f);
+            rolledRect.sizeDelta = Vector2.zero;
+            rolledRect.anchoredPosition = new Vector2(PlayerChip.PlayerChipWidth + RolledLabelGap, 0f);
+        }
+
+        void BuildDieGroup()
+        {
+            // die and pile as one group: the die on top, the label
+            // DiePileGap under it, both centred in a DieColumnWidth column
+            // that starts where the chip above it does.
+            var groupHeight = DieFaceSize + DiePileGap + (PileLabelSize * PileLabelLines);
+
+            var groupGO = new GameObject("DieGroup", typeof(RectTransform));
+            _dieGroupRect = (RectTransform)groupGO.transform;
+            _dieGroupRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _dieGroupRect.anchorMin = new Vector2(0f, 1f);
+            _dieGroupRect.anchorMax = new Vector2(0f, 1f);
+            _dieGroupRect.pivot = new Vector2(0f, 1f);
+            _dieGroupRect.sizeDelta = new Vector2(DieColumnWidth, groupHeight);
+            _dieGroupRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, -DieGroupTop);
+
+            BuildDie();
+            BuildPileLabel();
+        }
+
+        void BuildDie()
+        {
+            var dieGO = new GameObject("Die", typeof(RectTransform), typeof(Image));
+            _dieBorder = dieGO.GetComponent<Image>();
+            _dieBorder.sprite = DieSprite;
+            _dieBorder.type = Image.Type.Sliced;
+            _dieBorder.color = LineColor;
+            _dieBorder.raycastTarget = false;
+
+            _dieRect = _dieBorder.rectTransform;
+            _dieRect.SetParent(_dieGroupRect, worldPositionStays: false);
+            _dieRect.anchorMin = new Vector2(0.5f, 1f);
+            _dieRect.anchorMax = new Vector2(0.5f, 1f);
+            _dieRect.pivot = new Vector2(0.5f, 1f);
+            _dieRect.sizeDelta = new Vector2(DieFaceSize, DieFaceSize);
+            _dieRect.anchoredPosition = Vector2.zero;
+
+            var faceGO = new GameObject("DieFace", typeof(RectTransform), typeof(Image));
+            _dieFace = faceGO.GetComponent<Image>();
+            _dieFace.sprite = DieSprite;
+            _dieFace.type = Image.Type.Sliced;
+            _dieFace.color = PaperColor;
+            _dieFace.raycastTarget = false;
+
+            var faceRect = _dieFace.rectTransform;
+            faceRect.SetParent(_dieRect, worldPositionStays: false);
+            faceRect.anchorMin = Vector2.zero;
+            faceRect.anchorMax = Vector2.one;
+            faceRect.offsetMin = new Vector2(DieBorderWidth, DieBorderWidth);
+            faceRect.offsetMax = new Vector2(-DieBorderWidth, -DieBorderWidth);
+
+            BuildPips(faceRect);
+        }
+
+        // One pip per lattice position, built once and shown or hidden per
+        // face — no pip is created or destroyed as the face changes.
+        void BuildPips(RectTransform faceRect)
+        {
+            const int extent = (DiePipAcross - 1) / 2;
+
+            for (var row = extent; row >= -extent; row--)
+            {
+                for (var column = -extent; column <= extent; column++)
+                {
+                    var pipGO = new GameObject("Pip", typeof(RectTransform), typeof(Image));
+                    var pip = pipGO.GetComponent<Image>();
+                    pip.sprite = PipSprite;
+                    pip.color = InkColor;
+                    pip.raycastTarget = false;
+
+                    var pipRect = pip.rectTransform;
+                    pipRect.SetParent(faceRect, worldPositionStays: false);
+                    pipRect.anchorMin = new Vector2(0.5f, 0.5f);
+                    pipRect.anchorMax = new Vector2(0.5f, 0.5f);
+                    pipRect.pivot = new Vector2(0.5f, 0.5f);
+                    pipRect.sizeDelta = new Vector2(DiePipDiameter, DiePipDiameter);
+                    pipRect.anchoredPosition = new Vector2(column * PipCellSize, row * PipCellSize);
+
+                    pipGO.SetActive(false);
+                    _pips.Add(pip);
+                    _pipLattice.Add(new Vector2(column, row));
+                }
+            }
+        }
+
+        void BuildPileLabel()
+        {
+            var labelGO = new GameObject("PileLabel", typeof(RectTransform), typeof(CanvasGroup));
+            _pileRect = (RectTransform)labelGO.transform;
+            _pileRect.SetParent(_dieGroupRect, worldPositionStays: false);
+            _pileRect.anchorMin = new Vector2(0.5f, 1f);
+            _pileRect.anchorMax = new Vector2(0.5f, 1f);
+            _pileRect.pivot = new Vector2(0.5f, 1f);
+            _pileRect.sizeDelta = new Vector2(DieColumnWidth, PileLabelSize * PileLabelLines);
+            _pileRect.anchoredPosition = new Vector2(0f, -(DieFaceSize + DiePileGap));
+
+            _pileCanvasGroup = labelGO.GetComponent<CanvasGroup>();
+
+            // The pile's name, then the two faces that reach it. Two lines
+            // because the mockup draws two; one label because the spec writes
+            // one — see PileLabel.
+            _pileNameText = BuildText("PileName", _pileRect, PileLabelSize, InkColor, TextAnchor.UpperCenter);
+            _pileNameText.fontStyle = FontStyle.Bold;
+            StackLine(_pileNameText.rectTransform, 0);
+
+            _pileFacesText = BuildText("PileFaces", _pileRect, PileLabelSize, LineColor, TextAnchor.UpperCenter);
+            StackLine(_pileFacesText.rectTransform, 1);
+        }
+
+        static void StackLine(RectTransform rect, int line)
+        {
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(1f, 1f);
+            rect.pivot = new Vector2(0.5f, 1f);
+            rect.sizeDelta = new Vector2(0f, PileLabelSize);
+            rect.anchoredPosition = new Vector2(0f, -(line * PileLabelSize));
+        }
+
+        void BuildCard()
+        {
+            var cardGO = new GameObject("Card", typeof(RectTransform), typeof(CanvasGroup), typeof(Image));
+            _cardBorder = cardGO.GetComponent<Image>();
+            _cardBorder.sprite = CardSprite;
+            _cardBorder.type = Image.Type.Sliced;
+            _cardBorder.color = LineColor;
+            _cardBorder.raycastTarget = false;
+
+            _cardCanvasGroup = cardGO.GetComponent<CanvasGroup>();
+
+            _cardRect = _cardBorder.rectTransform;
+            _cardRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _cardRect.anchorMin = new Vector2(1f, 1f);
+            _cardRect.anchorMax = new Vector2(1f, 1f);
+            _cardRect.pivot = new Vector2(1f, 1f);
+            _cardRect.sizeDelta = new Vector2(CardWidth, CardHeight);
+            _cardRect.anchoredPosition = new Vector2(-DialogPanel.DialogPadding, -CardTop);
+
+            var faceGO = new GameObject("CardFace", typeof(RectTransform), typeof(Image));
+            _cardFace = faceGO.GetComponent<Image>();
+            _cardFace.sprite = CardSprite;
+            _cardFace.type = Image.Type.Sliced;
+            _cardFace.color = PaperColor;
+            _cardFace.raycastTarget = false;
+
+            var faceRect = _cardFace.rectTransform;
+            faceRect.SetParent(_cardRect, worldPositionStays: false);
+            faceRect.anchorMin = Vector2.zero;
+            faceRect.anchorMax = Vector2.one;
+            faceRect.offsetMin = new Vector2(CardBorderWidth, CardBorderWidth);
+            faceRect.offsetMax = new Vector2(-CardBorderWidth, -CardBorderWidth);
+
+            BuildProblem(faceRect);
+        }
+
+        // The problem, written the way the classroom cards are written: the
+        // two numbers stacked and right-aligned, × to the left of the second,
+        // a rule underneath. The block is centred on the card.
+        void BuildProblem(RectTransform faceRect)
+        {
+            var blockHeight = (CardProblemSize * ProblemLines) + CardRuleGap + CardRuleThickness;
+
+            var blockGO = new GameObject("Problem", typeof(RectTransform));
+            var blockRect = (RectTransform)blockGO.transform;
+            blockRect.SetParent(faceRect, worldPositionStays: false);
+            blockRect.anchorMin = new Vector2(0.5f, 0.5f);
+            blockRect.anchorMax = new Vector2(0.5f, 0.5f);
+            blockRect.pivot = new Vector2(0.5f, 0.5f);
+            blockRect.sizeDelta = new Vector2(CardRuleLength, blockHeight);
+            blockRect.anchoredPosition = Vector2.zero;
+
+            _multiplicandText = BuildText("Multiplicand", blockRect, CardProblemSize, InkColor, TextAnchor.MiddleRight);
+            _multiplicandText.fontStyle = FontStyle.Bold;
+            ProblemLine(_multiplicandText.rectTransform, 0);
+
+            _multiplierText = BuildText("Multiplier", blockRect, CardProblemSize, InkColor, TextAnchor.MiddleRight);
+            _multiplierText.fontStyle = FontStyle.Bold;
+            ProblemLine(_multiplierText.rectTransform, 1);
+
+            var ruleGO = new GameObject("Rule", typeof(RectTransform), typeof(Image));
+            var rule = ruleGO.GetComponent<Image>();
+            rule.color = InkColor;
+            rule.raycastTarget = false;
+
+            _cardRuleRect = rule.rectTransform;
+            _cardRuleRect.SetParent(blockRect, worldPositionStays: false);
+            _cardRuleRect.anchorMin = new Vector2(1f, 0f);
+            _cardRuleRect.anchorMax = new Vector2(1f, 0f);
+            _cardRuleRect.pivot = new Vector2(1f, 0f);
+            _cardRuleRect.sizeDelta = new Vector2(CardRuleLength, CardRuleThickness);
+            _cardRuleRect.anchoredPosition = Vector2.zero;
+        }
+
+        static void ProblemLine(RectTransform rect, int line)
+        {
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(1f, 1f);
+            rect.pivot = new Vector2(0.5f, 1f);
+            rect.sizeDelta = new Vector2(0f, CardProblemSize);
+            rect.anchoredPosition = new Vector2(0f, -(line * CardProblemSize));
+        }
+
+        void BuildControls()
+        {
+            // A plain primary Button at the shared component's own size,
+            // added through the shared Dialog so it lands in the button row,
+            // primary-on-the-right. It is deliberately *not* nominated as
+            // this dialog's least destructive button: that is the value the
+            // router would invoke on hardware back, and back is inert here.
+            _solveItButton = _dialog.AddButton(ButtonKind.Primary, SolveItLabel, HandleSolveItClicked);
+        }
+
+        void HandleSolveItClicked()
+        {
+            // The only way out. What the working-out grid contains is #223's;
+            // this asks the router to open it and says the press happened.
+            if (_router != null)
+            {
+                _router.OpenDialog(Frogs.Core.Dialog.WorkingOutGrid);
+            }
+
+            var handler = SolveItPressed;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        // The entry, drawn at whatever moment it has reached: the die's face
+        // appears when it stops rolling, the pile label with it, and the card
+        // fades in over CardDealDuration after that.
+        void ApplyEntry()
+        {
+            var rolling = _elapsed < DieRollDuration;
+
+            _visiblePips.Clear();
+
+            var layout = LayoutForFace();
+
+            for (var index = 0; index < _pips.Count; index++)
+            {
+                var pip = _pips[index];
+                var used = !rolling && IsIn(layout, index);
+
+                pip.gameObject.SetActive(used);
+
+                if (used)
+                {
+                    _visiblePips.Add(pip);
+                }
+            }
+
+            _pileCanvasGroup.alpha = rolling ? 0f : 1f;
+            _cardCanvasGroup.alpha = Mathf.Clamp01((_elapsed - DieRollDuration) / CardDealDuration);
+        }
+
+        // The lattice positions this face uses, or none at all when there is
+        // nothing to draw yet — a dialog built but not yet pointed at a roll.
+        Vector2[] LayoutForFace()
+        {
+            if (_readout == null)
+            {
+                return null;
+            }
+
+            var face = _readout.Face;
+
+            if (face < Roll.MinimumFace || face > Roll.MaximumFace)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(face),
+                    face,
+                    $"a die face is {Roll.MinimumFace} to {Roll.MaximumFace}; {face} is not a face.");
+            }
+
+            return PipLayouts[face - Roll.MinimumFace];
+        }
+
+        bool IsIn(Vector2[] layout, int pipIndex)
+        {
+            if (layout == null)
+            {
+                return false;
+            }
+
+            var lattice = _pipLattice[pipIndex];
+
+            foreach (var offset in layout)
+            {
+                if (offset == lattice)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static string PileNameFor(Pile pile)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    return EasyPileName;
+                case Pile.Medium:
+                    return MediumPileName;
+                case Pile.Hard:
+                    return HardPileName;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(pile), pile, "unhandled pile.");
+            }
+        }
+
+        static string PileFacesFor(Pile pile)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    return EasyPileFaces;
+                case Pile.Medium:
+                    return MediumPileFaces;
+                case Pile.Hard:
+                    return HardPileFaces;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(pile), pile, "unhandled pile.");
+            }
+        }
+
+        static Text BuildText(string name, RectTransform parent, float size, Color colour, TextAnchor alignment)
+        {
+            var textGO = new GameObject(name, typeof(RectTransform), typeof(Text));
+            var text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            text.fontSize = (int)size;
+            text.color = colour;
+            text.alignment = alignment;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false;
+            text.rectTransform.SetParent(parent, worldPositionStays: false);
+            return text;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs.meta
+++ b/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ad5b0cc7fda4fa8b5a149626bcae161
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/RollAndCardEntryPhase.cs
+++ b/Assets/Scripts/Unity/Views/RollAndCardEntryPhase.cs
@@ -1,0 +1,25 @@
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// How far through its entry the roll-and-card dialog is —
+    /// docs/specs/ui/roll-and-card.md's Behaviour section, which describes
+    /// the entry as three moments in a fixed order.
+    ///
+    /// This is a *presentation* state, not a turn state: Core's
+    /// <see cref="Frogs.Core.TurnPhase"/> is already
+    /// <c>RolledAndCardDrawn</c> throughout all three of these. Nothing here
+    /// decides anything — the roll and the draw both happened before the
+    /// dialog opened.
+    /// </summary>
+    public enum RollAndCardEntryPhase
+    {
+        /// <summary>The die is still rolling. No face is shown yet, and neither is the pile or the card.</summary>
+        Rolling,
+
+        /// <summary>The die has settled and the pile label has appeared; the card is dealing in.</summary>
+        Dealing,
+
+        /// <summary>Face shown, pile label shown, card in place — where a tap anywhere jumps to.</summary>
+        Settled
+    }
+}

--- a/Assets/Scripts/Unity/Views/RollAndCardEntryPhase.cs.meta
+++ b/Assets/Scripts/Unity/Views/RollAndCardEntryPhase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c441165ad13246b38a71691a75363e1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/RollAndCardSkipCatcher.cs
+++ b/Assets/Scripts/Unity/Views/RollAndCardSkipCatcher.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// A tap, anywhere on the surface it is attached to —
+    /// docs/specs/ui/roll-and-card.md: "the whole sequence can be skipped by
+    /// tapping anywhere, which jumps straight to the settled state. A
+    /// four-player game plays this animation forty times, and the fortieth
+    /// time nobody wants to watch it."
+    ///
+    /// It exists as its own component, attached by
+    /// <see cref="RollAndCardDialogView"/> to the shared Dialog's scrim and
+    /// panel, rather than as a handler on the shared
+    /// <see cref="Frogs.Unity.UI.DialogPanel"/> itself: that type states
+    /// plainly that its scrim "carries no click handler of any kind", because
+    /// a dialog that decides something has no tap-outside-to-dismiss. This is
+    /// not a dismiss — it hurries an animation along and can do nothing else,
+    /// which is why it can live over the top of a dialog that cannot be
+    /// dismissed at all.
+    ///
+    /// A click that began on `Solve it` reaches this too, since the shared
+    /// Button handles press and release rather than click and so does not
+    /// consume one. That is harmless: skipping is idempotent, and skipping an
+    /// already-settled dialog does nothing.
+    /// </summary>
+    public sealed class RollAndCardSkipCatcher : MonoBehaviour, IPointerClickHandler
+    {
+        /// <summary>A tap landed. The only thing this component can say.</summary>
+        public event Action Tapped;
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            var handler = Tapped;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/RollAndCardSkipCatcher.cs.meta
+++ b/Assets/Scripts/Unity/Views/RollAndCardSkipCatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1dfc987eddb4f38af2c89e78cc32d15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs
+++ b/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs
@@ -1,0 +1,799 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// ButtonTests.cs and GameBoardScreenViewTests.cs work around — so the shared
+// components are pulled in by explicit alias, and a bare `Button` in this file
+// always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The roll-and-card dialog — issue #221, built to
+    /// docs/specs/ui/roll-and-card.md and its committed 1:1 mockup. Written
+    /// before <see cref="RollAndCardDialogView"/> exists, per
+    /// docs/engineering/testing.md's sanctioned flow: pushed unexecuted, with
+    /// CI turning these red before green — there is no editor here to watch
+    /// them fail.
+    ///
+    /// **There is no randomness in this file, and none in what it tests.**
+    /// The roll and the draw both happened in Core before this dialog opened,
+    /// so every test drives the view from a <see cref="StubReadout"/>
+    /// reporting a fixed face, a fixed pile and a fixed pair of operands.
+    /// No seed, no distribution, nothing flaky to chase.
+    /// </summary>
+    public sealed class RollAndCardDialogViewTests
+    {
+        // docs/specs/ui/roll-and-card.md's worked example, and the mockup's:
+        // Green, the hard pile, and the widest problem the card ever holds.
+        const int WorkedExampleFace = 6;
+        const int WorkedExampleMultiplicand = 331;
+        const int WorkedExampleMultiplier = 41;
+
+        [Test]
+        public void Die_ShowsTheFaceCoreReported_AndPileReadsTheLabelForTheReportedPile()
+        {
+            // The checklist's first case: a readout reporting a rolled face of
+            // 5 and a stub card.
+            var view = CreateView(new StubReadout
+            {
+                Frog = FrogColour.Green,
+                Face = 5,
+                Pile = Pile.Hard,
+                Multiplicand = 331,
+                Multiplier = 41
+            });
+
+            try
+            {
+                view.SkipEntry();
+
+                Assert.That(view.VisiblePips.Count, Is.EqualTo(5), "five pips for a five");
+                Assert.That(PipPattern(view), Is.EquivalentTo(FivePipLayout), "the five-pip layout");
+                Assert.That(view.PileLabel, Is.EqualTo("Hard pile · 5 or 6"));
+
+                // Not a numeral anywhere in the die — a pip is a circle, and
+                // the spec's own line is "drawn with pips rather than a
+                // numeral".
+                Assert.That(
+                    view.DieRect.GetComponentsInChildren<Text>(true),
+                    Is.Empty,
+                    "no numeral anywhere in the die region");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Pile_IsReadFromWhatCoreReported_NotReDerivedFromTheFace()
+        {
+            // A deliberately inconsistent readout: a face of 5 with the Easy
+            // pile. Nothing in the real game can produce this — Core's
+            // mapping sends a 5 to the hard pile — and that is exactly why it
+            // is the test. A view that re-derives the pile from the face
+            // would print "Hard pile · 5 or 6" here; a view that displays
+            // what Core reported prints the easy pile's label.
+            var view = CreateView(new StubReadout
+            {
+                Frog = FrogColour.Blue,
+                Face = 5,
+                Pile = Pile.Easy,
+                Multiplicand = 68,
+                Multiplier = 5
+            });
+
+            try
+            {
+                view.SkipEntry();
+
+                Assert.That(view.PileLabel, Is.EqualTo("Easy pile · 1 or 2"));
+                Assert.That(view.VisiblePips.Count, Is.EqualTo(5), "the die still shows the reported face");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryFace_RendersItsOwnDistinctPipPattern_AndNeverANumeral()
+        {
+            var patterns = new List<Vector2[]>();
+
+            for (var face = Roll.MinimumFace; face <= Roll.MaximumFace; face++)
+            {
+                var view = CreateView(WorkedExample(face: face));
+
+                try
+                {
+                    view.SkipEntry();
+
+                    Assert.That(view.VisiblePips.Count, Is.EqualTo(face), $"a {face} shows {face} pips");
+                    Assert.That(
+                        view.DieRect.GetComponentsInChildren<Text>(true),
+                        Is.Empty,
+                        $"no numeral in the die region for a face of {face}");
+
+                    foreach (var pip in view.VisiblePips)
+                    {
+                        Assert.That(
+                            pip.rectTransform.sizeDelta,
+                            Is.EqualTo(new Vector2(RollAndCardDialogView.DiePipDiameter, RollAndCardDialogView.DiePipDiameter)),
+                            "a pip is a DiePipDiameter circle");
+                    }
+
+                    patterns.Add(PipPattern(view));
+                }
+                finally
+                {
+                    Destroy(view);
+                }
+            }
+
+            for (var first = 0; first < patterns.Count; first++)
+            {
+                for (var second = first + 1; second < patterns.Count; second++)
+                {
+                    Assert.That(
+                        patterns[first].OrderBy(Sortable).SequenceEqual(patterns[second].OrderBy(Sortable)),
+                        Is.False,
+                        $"a face of {first + 1} and a face of {second + 1} must not draw the same pattern");
+                }
+            }
+
+            // The mockup's own worked example: the hard pile's 6, drawn as two
+            // columns of three.
+            Assert.That(patterns[WorkedExampleFace - 1], Is.EquivalentTo(SixPipLayout));
+        }
+
+        [Test]
+        public void Card_RendersTheWidestProblem_StackedAndRightAlignedWithARuleUnderneath()
+        {
+            var view = CreateView(WorkedExample());
+
+            try
+            {
+                view.SkipEntry();
+
+                Assert.That(
+                    view.CardRect.rect.size,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.CardWidth, RollAndCardDialogView.CardHeight)));
+
+                Assert.That(view.MultiplicandText.text, Is.EqualTo("331"));
+                Assert.That(view.MultiplierText.text, Is.EqualTo("× 41"), "× to the left of the second number");
+
+                Assert.That(view.MultiplicandText.fontSize, Is.EqualTo((int)RollAndCardDialogView.CardProblemSize));
+                Assert.That(view.MultiplierText.fontSize, Is.EqualTo((int)RollAndCardDialogView.CardProblemSize));
+
+                foreach (var line in new[] { view.MultiplicandText, view.MultiplierText })
+                {
+                    Assert.That(
+                        line.alignment.ToString(),
+                        Does.EndWith("Right"),
+                        "the two numbers are right-aligned against each other");
+                }
+
+                // Stacked: the multiplicand sits above the multiplier, and the
+                // rule sits under both.
+                Assert.That(CenterY(view.MultiplicandText.rectTransform), Is.GreaterThan(CenterY(view.MultiplierText.rectTransform)));
+                Assert.That(CenterY(view.CardRuleRect), Is.LessThan(CenterY(view.MultiplierText.rectTransform)));
+
+                Assert.That(
+                    view.CardRuleRect.rect.size,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.CardRuleLength, RollAndCardDialogView.CardRuleThickness)));
+
+                // Inside the card, with room to spare — CardProblemSize is
+                // sized so the widest problem in the game fits.
+                foreach (var part in new[] { view.MultiplicandText.rectTransform, view.MultiplierText.rectTransform, view.CardRuleRect })
+                {
+                    Assert.That(Contains(view.CardRect, part), Is.True, $"{part.name} sits inside the card");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Entering_StartsTheDieRolling_AndSettlesOnlyAfterBothDurationsElapse()
+        {
+            var view = CreateView(WorkedExample());
+
+            try
+            {
+                Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Rolling));
+                Assert.That(view.DieIsRolling, Is.True);
+                Assert.That(view.VisiblePips, Is.Empty, "no face is shown while the die is still rolling");
+                Assert.That(view.PileCanvasGroup.alpha, Is.EqualTo(0f), "the pile label has not appeared yet");
+                Assert.That(view.CardCanvasGroup.alpha, Is.EqualTo(0f), "the card has not dealt in yet");
+
+                var halfRoll = RollAndCardDialogView.DieRollDuration / 2f;
+                view.Advance(halfRoll);
+
+                Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Rolling), "still rolling halfway through");
+                Assert.That(view.VisiblePips, Is.Empty);
+
+                view.Advance(halfRoll);
+
+                Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Dealing));
+                Assert.That(view.DieIsRolling, Is.False);
+                Assert.That(view.VisiblePips.Count, Is.EqualTo(WorkedExampleFace), "the face is shown once the die settles");
+                Assert.That(view.PileCanvasGroup.alpha, Is.EqualTo(1f), "then the pile label appears");
+                Assert.That(view.CardCanvasGroup.alpha, Is.EqualTo(0f), "then, and only then, the card starts dealing");
+
+                var halfDeal = RollAndCardDialogView.CardDealDuration / 2f;
+                view.Advance(halfDeal);
+
+                Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Dealing));
+                Assert.That(view.CardCanvasGroup.alpha, Is.EqualTo(0.5f).Within(0.001f));
+
+                view.Advance(halfDeal);
+
+                Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Settled), "settled after DieRollDuration + CardDealDuration");
+                Assert.That(view.CardCanvasGroup.alpha, Is.EqualTo(1f));
+
+                // No tap was needed to get here.
+                Assert.That(view.VisiblePips.Count, Is.EqualTo(WorkedExampleFace));
+                Assert.That(view.PileLabel, Is.EqualTo("Hard pile · 5 or 6"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TapOutsideSolveIt_JumpsStraightToSettled_AndTriggersNoTransition()
+        {
+            foreach (var tapTheScrim in new[] { true, false })
+            {
+                var router = new ScreenRouter();
+                router.OpenDialog(Frogs.Core.Dialog.RollAndCard);
+
+                var presses = 0;
+                var view = CreateView(WorkedExample(), router);
+                view.SolveItPressed += () => presses++;
+
+                try
+                {
+                    Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Rolling), "the fixture, not the assertion");
+
+                    var catcher = tapTheScrim ? view.ScrimSkipCatcher : view.PanelSkipCatcher;
+                    catcher.OnPointerClick(new PointerEventData(null));
+
+                    Assert.That(view.Phase, Is.EqualTo(RollAndCardEntryPhase.Settled));
+                    Assert.That(view.VisiblePips.Count, Is.EqualTo(WorkedExampleFace));
+                    Assert.That(view.PileCanvasGroup.alpha, Is.EqualTo(1f));
+                    Assert.That(view.CardCanvasGroup.alpha, Is.EqualTo(1f));
+
+                    // Skipping the animation is not answering the card.
+                    Assert.That(presses, Is.EqualTo(0));
+                    Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.RollAndCard), "still on this dialog");
+                }
+                finally
+                {
+                    Destroy(view);
+                }
+            }
+        }
+
+        [Test]
+        public void SolveIt_OpensTheWorkingOutGridExactlyOnce_AndHardwareBackDoesNothingAtAll()
+        {
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.RollAndCard);
+
+            var presses = 0;
+            var view = CreateView(WorkedExample(), router);
+            view.SolveItPressed += () => presses++;
+
+            try
+            {
+                view.SkipEntry();
+
+                // Hardware back first, while the dialog is open: nothing at
+                // all happens. This is the one place in the game where back is
+                // inert, and it is inert because the alternative is losing a
+                // drawn card.
+                router.HandleBack();
+
+                Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.RollAndCard), "back does not dismiss");
+                Assert.That(presses, Is.EqualTo(0), "back does not press `Solve it` either");
+                Assert.That(view.Dialog.IsOpen, Is.True);
+
+                // The shared Dialog routes back to whichever button an
+                // instance nominates as least destructive. This dialog
+                // nominates none, which is what makes back inert rather than
+                // a `Solve it` in disguise.
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.Null);
+
+                // The router owns hardware back (#213); this view must not add
+                // a second handler that could disagree with it.
+                Assert.That(
+                    DeclaredMembers(typeof(RollAndCardDialogView))
+                        .Where(name => name.IndexOf("Back", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty,
+                    "hardware back is the router's, not this view's");
+
+                Assert.That(view.SolveItButton.Kind, Is.EqualTo(ButtonKind.Primary));
+                Assert.That(view.SolveItButton.Label.text, Is.EqualTo("Solve it"));
+
+                Tap(view.SolveItButton);
+
+                Assert.That(presses, Is.EqualTo(1), "acts on release, exactly once");
+                Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.WorkingOutGrid), "the only way out");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Panel_LaysOutWhoseDiePileCardAndControls_AtTheMockupsOwnGeometry()
+        {
+            var view = CreateView(WorkedExample());
+
+            try
+            {
+                view.SkipEntry();
+
+                var panel = view.Dialog.PanelRect;
+
+                Assert.That(
+                    panel.rect.size,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.RollDialogWidth, RollAndCardDialogView.RollDialogHeight)));
+                Assert.That(RollAndCardDialogView.RollDialogWidth, Is.LessThanOrEqualTo(DialogPanel.DialogMaxWidth));
+                Assert.That(RollAndCardDialogView.RollDialogHeight, Is.LessThanOrEqualTo(DialogPanel.DialogMaxHeight));
+
+                // whose — the active frog's chip, DialogPadding in from the
+                // panel's top-left, with `rolled` RolledLabelGap past it.
+                Assert.That(view.WhoseChip.State, Is.EqualTo(PlayerChipState.Active));
+                Assert.That(view.WhoseChip.Label.text, Is.EqualTo("Green"));
+                Assert.That(view.WhoseChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
+                Assert.That(view.RolledText.text, Is.EqualTo("rolled"));
+                Assert.That(view.RolledText.fontSize, Is.EqualTo((int)RollAndCardDialogView.RolledLabelSize));
+                Assert.That(
+                    LeftEdge(view.RolledText.rectTransform) - RightEdge(view.WhoseChip.RectTransform),
+                    Is.EqualTo(RollAndCardDialogView.RolledLabelGap).Within(0.001f));
+                Assert.That(
+                    LeftEdge(view.WhoseChip.RectTransform) - LeftEdge(panel),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.WhoseChip.RectTransform),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+
+                // die + pile — one group, DieColumnWidth wide, DieGroupTop
+                // down from the inside top of the panel, left-aligned with the
+                // chip above it.
+                Assert.That(view.DieGroupRect.rect.width, Is.EqualTo(RollAndCardDialogView.DieColumnWidth).Within(0.001f));
+                Assert.That(
+                    LeftEdge(view.DieGroupRect) - LeftEdge(panel),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.DieGroupRect),
+                    Is.EqualTo(RollAndCardDialogView.DieGroupTop).Within(0.001f));
+
+                Assert.That(
+                    view.DieRect.rect.size,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.DieFaceSize, RollAndCardDialogView.DieFaceSize)));
+                Assert.That(
+                    view.DieFace.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.DieBorderWidth, RollAndCardDialogView.DieBorderWidth)),
+                    "the die is outlined, not flat — DieBorderWidth of it");
+
+                Assert.That(view.PileNameText.fontSize, Is.EqualTo((int)RollAndCardDialogView.PileLabelSize));
+                Assert.That(view.PileFacesText.fontSize, Is.EqualTo((int)RollAndCardDialogView.PileLabelSize));
+                Assert.That(
+                    BottomEdge(view.DieRect) - TopEdge(view.PileNameText.rectTransform),
+                    Is.EqualTo(RollAndCardDialogView.DiePileGap).Within(0.001f));
+
+                // card — CardTop down from the inside top of the panel,
+                // DialogPadding in from its right edge, outlined the same way
+                // the die is.
+                Assert.That(
+                    RightEdge(panel) - RightEdge(view.CardRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.CardRect),
+                    Is.EqualTo(RollAndCardDialogView.CardTop).Within(0.001f));
+                Assert.That(
+                    view.CardFace.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(RollAndCardDialogView.CardBorderWidth, RollAndCardDialogView.CardBorderWidth)));
+
+                // The gap the mockup actually draws: 208, not the table's
+                // stale 96 — corrected in this issue's spec change.
+                Assert.That(
+                    LeftEdge(view.CardRect) - RightEdge(view.DieGroupRect),
+                    Is.EqualTo(RollAndCardDialogView.RollCardGap).Within(0.001f));
+                Assert.That(RollAndCardDialogView.RollCardGap, Is.EqualTo(208f));
+
+                // The left group is deliberately the smaller of the two.
+                Assert.That(view.DieGroupRect.rect.width, Is.LessThan(view.CardRect.rect.width));
+
+                // controls — `Solve it` in the shared Dialog's own button row,
+                // primary-on-the-right, at the shared Button's own size.
+                Assert.That(view.SolveItButton.transform.parent, Is.EqualTo(view.Dialog.ButtonRowRect));
+                Assert.That(
+                    view.SolveItButton.RectTransform.rect.size,
+                    Is.EqualTo(new Vector2(Button.ButtonMinWidth, Button.ButtonHeight)),
+                    "nothing about `Solve it` is oversized the way `Roll` is");
+                Assert.That(CenterY(view.SolveItButton.RectTransform), Is.LessThan(CenterY(view.CardRect)));
+
+                // This dialog has no title — `whose` does that job.
+                Assert.That(view.Dialog.TitleText.text, Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryPile_IsWorthTheSameOneLilyPad_AndNothingSaysOtherwise()
+        {
+            var labels = new Dictionary<Pile, string>
+            {
+                { Pile.Easy, "Easy pile · 1 or 2" },
+                { Pile.Medium, "Medium pile · 3 or 4" },
+                { Pile.Hard, "Hard pile · 5 or 6" }
+            };
+
+            var sizes = new List<int>();
+            var colours = new List<Color>();
+            var weights = new List<FontStyle>();
+
+            foreach (var pair in labels)
+            {
+                var view = CreateView(WorkedExample(pile: pair.Key));
+
+                try
+                {
+                    view.SkipEntry();
+
+                    Assert.That(view.PileLabel, Is.EqualTo(pair.Value));
+
+                    // The three labels differ only in name and the two faces
+                    // each one lists — same size, same colour, same weight.
+                    sizes.Add(view.PileNameText.fontSize);
+                    colours.Add(view.PileNameText.color);
+                    weights.Add(view.PileNameText.fontStyle);
+
+                    var words = view.DieGroupRect.GetComponentsInChildren<Text>(true)
+                        .Select(text => text.text)
+                        .ToArray();
+
+                    Assert.That(words.Length, Is.EqualTo(2), "a pile name and its two faces, and nothing else");
+                }
+                finally
+                {
+                    Destroy(view);
+                }
+            }
+
+            Assert.That(sizes.Distinct().Count(), Is.EqualTo(1), "no pile is drawn bigger than another");
+            Assert.That(colours.Distinct().Count(), Is.EqualTo(1), "no pile is drawn in a louder colour than another");
+            Assert.That(weights.Distinct().Count(), Is.EqualTo(1), "no pile is drawn heavier than another");
+
+            // No points, no bonus, no difficulty weighting — the reviewer's
+            // grep, as a test.
+            var forbidden = new[] { "Point", "Bonus", "Score", "Reward", "Difficulty", "Tier" };
+
+            foreach (var member in DeclaredMembers(typeof(RollAndCardDialogView)))
+            {
+                foreach (var word in forbidden)
+                {
+                    Assert.That(
+                        member.IndexOf(word, StringComparison.OrdinalIgnoreCase),
+                        Is.LessThan(0),
+                        $"RollAndCardDialogView.{member} looks like {word} — every pile is worth the same one lily pad");
+                }
+            }
+        }
+
+        [Test]
+        public void Dialog_IsAReadout_WithNoRandomnessAndNoWorkingOutGridOfItsOwn()
+        {
+            // "A reviewer can confirm no Random/RNG type appears anywhere in
+            // this issue's code" — and that the grid (#223) and the answer
+            // result (#224) are not being built here.
+            var forbidden = new[]
+            {
+                "Random", "Rng", "Seed", "Shuffle",
+                "WorkingOut", "Grid", "Keypad", "Carry", "Answer", "Correct", "Verdict"
+            };
+
+            foreach (var type in new[] { typeof(RollAndCardDialogView), typeof(GameRollAndCardReadout) })
+            {
+                foreach (var member in DeclaredMembers(type))
+                {
+                    foreach (var word in forbidden)
+                    {
+                        Assert.That(
+                            member.IndexOf(word, StringComparison.OrdinalIgnoreCase),
+                            Is.LessThan(0),
+                            $"{type.Name}.{member} looks like {word} — this dialog is a readout, and the grid is #223's");
+                    }
+                }
+
+                var coroutines = type
+                    .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Where(method => typeof(IEnumerator).IsAssignableFrom(method.ReturnType))
+                    .ToArray();
+
+                Assert.That(coroutines, Is.Empty, $"{type.Name} starts no coroutine — the entry sequence is advanced, not scheduled");
+            }
+        }
+
+        [Test]
+        public void EveryGeometryValue_IsANamedConstantFromRollAndCardsTable()
+        {
+            // docs/specs/ui/roll-and-card.md#named-constants, in full: the
+            // fourteen the page always had — with `RollCardGap` corrected from
+            // its stale 96 px to the 208 px the committed mockup draws — plus
+            // the eleven this issue added to the table for values the mockup
+            // draws and the page had never named.
+            var expected = new Dictionary<string, float>
+            {
+                { "RollDialogWidth", 1280f },
+                { "RollDialogHeight", 760f },
+                { "RolledLabelSize", 40f },
+                { "RolledLabelGap", 24f },
+                { "DieColumnWidth", 400f },
+                { "DieGroupTop", 220f },
+                { "DieFaceSize", 240f },
+                { "DieCornerRadius", 40f },
+                { "DieBorderWidth", 4f },
+                { "DiePipInset", 34f },
+                { "DiePipDiameter", 40f },
+                { "DiePileGap", 32f },
+                { "PileLabelSize", 40f },
+                { "CardTop", 180f },
+                { "CardWidth", 560f },
+                { "CardHeight", 420f },
+                { "CardRadius", 24f },
+                { "CardBorderWidth", 4f },
+                { "CardProblemSize", 120f },
+                { "CardRuleGap", 8f },
+                { "CardRuleThickness", 8f },
+                { "CardRuleLength", 360f },
+                { "RollCardGap", 208f },
+                { "DieRollDuration", 0.8f },
+                { "CardDealDuration", 0.3f }
+            };
+
+            var constants = typeof(RollAndCardDialogView)
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(field => field.IsLiteral && !field.IsInitOnly)
+                .ToArray();
+
+            Assert.That(
+                constants.Select(field => field.Name).OrderBy(name => name),
+                Is.EqualTo(expected.Keys.OrderBy(name => name)),
+                "RollAndCardDialogView's public constants are exactly roll-and-card.md's own, under the identical names");
+
+            foreach (var field in constants)
+            {
+                Assert.That(
+                    Convert.ToSingle(field.GetValue(null)),
+                    Is.EqualTo(expected[field.Name]).Within(0.001f),
+                    $"RollAndCardDialogView.{field.Name}");
+            }
+
+            // The row across the panel adds up exactly, which is what fixes
+            // RollCardGap at 208: the panel less DialogPadding on each side is
+            // the die column, the gap, and the card.
+            Assert.That(
+                RollAndCardDialogView.DieColumnWidth
+                    + RollAndCardDialogView.RollCardGap
+                    + RollAndCardDialogView.CardWidth,
+                Is.EqualTo(RollAndCardDialogView.RollDialogWidth - (2f * DialogPanel.DialogPadding)).Within(0.001f));
+
+            // The shared Dialog's own constants are referenced, never
+            // redeclared here — this dialog inherits its scrim, corners,
+            // padding and cross-fade.
+            foreach (var name in new[] { "DialogPadding", "DialogRadius", "DialogScrimOpacity", "DialogFadeDuration", "DialogTitleSize", "DialogTitleGap" })
+            {
+                Assert.That(
+                    typeof(RollAndCardDialogView).GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    Is.Null,
+                    $"RollAndCardDialogView must reference DialogPanel.{name}, not redeclare it");
+            }
+
+            // DieBorderWidth and CardBorderWidth hold the same number as the
+            // shared Button's outline today and are deliberately not that
+            // constant. Asserted as equal-today so a future divergence is a
+            // visible, deliberate edit here rather than a silent drift.
+            Assert.That(RollAndCardDialogView.DieBorderWidth, Is.EqualTo(Button.ButtonBorderWidth));
+            Assert.That(RollAndCardDialogView.CardBorderWidth, Is.EqualTo(Button.ButtonBorderWidth));
+        }
+
+        [Test]
+        public void Dialog_WiresItsBuiltInSpritesAndFonts_RatherThanLeavingThemMissing()
+        {
+            var view = CreateView(WorkedExample());
+
+            try
+            {
+                Assert.That(view.RolledText.font, Is.Not.Null);
+                Assert.That(view.PileNameText.font, Is.Not.Null);
+                Assert.That(view.PileFacesText.font, Is.Not.Null);
+                Assert.That(view.MultiplicandText.font, Is.Not.Null);
+                Assert.That(view.MultiplierText.font, Is.Not.Null);
+                Assert.That(view.DieBorder.sprite, Is.Not.Null);
+                Assert.That(view.DieFace.sprite, Is.Not.Null);
+                Assert.That(view.CardBorder.sprite, Is.Not.Null);
+                Assert.That(view.CardFace.sprite, Is.Not.Null);
+                Assert.That(view.Pips[0].sprite, Is.Not.Null);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void GameReadout_ReportsWhatCoreDecided_AndComputesNothingItself()
+        {
+            var game = new Game(new[] { FrogColour.Orange, FrogColour.Pink }, 20260810UL);
+            game.RollDie();
+
+            var readout = new GameRollAndCardReadout(game);
+
+            Assert.That(readout.Frog, Is.EqualTo(game.ActiveFrog));
+            Assert.That(readout.Face, Is.EqualTo(game.DrawnRoll.Face));
+            Assert.That(readout.Pile, Is.EqualTo(game.DrawnRoll.Pile), "the pile Core reported, not one worked out from the face");
+            Assert.That(readout.Multiplicand, Is.EqualTo(game.DrawnCard.Multiplicand));
+            Assert.That(readout.Multiplier, Is.EqualTo(game.DrawnCard.Multiplier));
+
+            // Whatever face this seed produced, the dialog draws it — every
+            // face is a face this view can show.
+            Assert.That(readout.Face, Is.InRange(Roll.MinimumFace, Roll.MaximumFace));
+        }
+
+        // The pip grid, in cell units: -1, 0, 1 across and down, with y up.
+        // These are the ordinary die-face arrangements, and the six-pip one is
+        // the two columns of three the mockup draws.
+        static readonly Vector2[] FivePipLayout =
+        {
+            new Vector2(-1f, 1f), new Vector2(1f, 1f),
+            new Vector2(0f, 0f),
+            new Vector2(-1f, -1f), new Vector2(1f, -1f)
+        };
+
+        static readonly Vector2[] SixPipLayout =
+        {
+            new Vector2(-1f, 1f), new Vector2(1f, 1f),
+            new Vector2(-1f, 0f), new Vector2(1f, 0f),
+            new Vector2(-1f, -1f), new Vector2(1f, -1f)
+        };
+
+        static Vector2[] PipPattern(RollAndCardDialogView view)
+        {
+            var cell = (RollAndCardDialogView.DieFaceSize
+                - (2f * RollAndCardDialogView.DieBorderWidth)
+                - (2f * RollAndCardDialogView.DiePipInset)) / 3f;
+
+            return view.VisiblePips
+                .Select(pip => pip.rectTransform.anchoredPosition / cell)
+                .Select(offset => new Vector2(Mathf.Round(offset.x), Mathf.Round(offset.y)))
+                .ToArray();
+        }
+
+        static float Sortable(Vector2 offset)
+        {
+            const float rowStride = 10f;
+            return (offset.y * rowStride) + offset.x;
+        }
+
+        static StubReadout WorkedExample(int face = WorkedExampleFace, Pile pile = Pile.Hard)
+        {
+            return new StubReadout
+            {
+                Frog = FrogColour.Green,
+                Face = face,
+                Pile = pile,
+                Multiplicand = WorkedExampleMultiplicand,
+                Multiplier = WorkedExampleMultiplier
+            };
+        }
+
+        /// <summary>
+        /// A fixed roll and a fixed card. There is no die in here and no
+        /// generator — the whole point of the readout seam is that this
+        /// dialog's tests never touch randomness.
+        /// </summary>
+        sealed class StubReadout : IRollAndCardReadout
+        {
+            public FrogColour Frog { get; set; }
+            public int Face { get; set; }
+            public Pile Pile { get; set; }
+            public int Multiplicand { get; set; }
+            public int Multiplier { get; set; }
+        }
+
+        static IEnumerable<string> DeclaredMembers(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name);
+        }
+
+        static Vector3[] Corners(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners;
+        }
+
+        static float LeftEdge(RectTransform rect) => Corners(rect)[0].x;
+
+        static float RightEdge(RectTransform rect) => Corners(rect)[2].x;
+
+        static float TopEdge(RectTransform rect) => Corners(rect)[2].y;
+
+        static float BottomEdge(RectTransform rect) => Corners(rect)[0].y;
+
+        static float CenterY(RectTransform rect)
+        {
+            var corners = Corners(rect);
+            return (corners[0].y + corners[2].y) / 2f;
+        }
+
+        static bool Contains(RectTransform outer, RectTransform inner)
+        {
+            const float tolerance = 0.001f;
+
+            return LeftEdge(inner) >= LeftEdge(outer) - tolerance
+                && RightEdge(inner) <= RightEdge(outer) + tolerance
+                && BottomEdge(inner) >= BottomEdge(outer) - tolerance
+                && TopEdge(inner) <= TopEdge(outer) + tolerance;
+        }
+
+        static RollAndCardDialogView CreateView(IRollAndCardReadout readout, ScreenRouter router = null)
+        {
+            var host = new GameObject(nameof(RollAndCardDialogViewTests), typeof(RectTransform));
+            var view = host.AddComponent<RollAndCardDialogView>();
+            view.Initialize(readout, router);
+            return view;
+        }
+
+        static void Tap(Button button)
+        {
+            var corners = Corners(button.RectTransform);
+            var eventData = new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static void Destroy(RollAndCardDialogView view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs.meta
+++ b/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65abd09645304048a3f5649931da35f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/roll-and-card.md
+++ b/docs/specs/ui/roll-and-card.md
@@ -46,16 +46,27 @@ the card; the card is what you now have to do.
 | --- | --- | --- |
 | Dialog width | `RollDialogWidth` | 1280 px |
 | Dialog height | `RollDialogHeight` | 760 px |
+| `rolled` label size | `RolledLabelSize` | 40 px |
+| Gap between the player chip and `rolled` | `RolledLabelGap` | 24 px |
+| Die group column width | `DieColumnWidth` | 400 px |
+| Die group top offset | `DieGroupTop` | 220 px |
 | Die face, square | `DieFaceSize` | 240 px |
 | Die corner radius | `DieCornerRadius` | 40 px |
+| Die border width | `DieBorderWidth` | 4 px |
+| Inset from the die's edge to the pip grid | `DiePipInset` | 34 px |
 | Die pip diameter | `DiePipDiameter` | 40 px |
 | Gap between die and pile label | `DiePileGap` | 32 px |
 | Pile label size | `PileLabelSize` | 40 px |
+| Card top offset | `CardTop` | 180 px |
 | Card width | `CardWidth` | 560 px |
 | Card height | `CardHeight` | 420 px |
 | Card corner radius | `CardRadius` | 24 px |
+| Card border width | `CardBorderWidth` | 4 px |
 | Problem text size on the card | `CardProblemSize` | 120 px |
-| Gap between the die group and the card | `RollCardGap` | 96 px |
+| Gap between the problem and its rule | `CardRuleGap` | 8 px |
+| Rule under the problem, thickness | `CardRuleThickness` | 8 px |
+| Rule under the problem, length | `CardRuleLength` | 360 px |
+| Gap between the die group and the card | `RollCardGap` | 208 px |
 | Die roll animation | `DieRollDuration` | 0.8 s |
 | Card deal animation | `CardDealDuration` | 0.3 s |
 
@@ -64,11 +75,39 @@ game — sits inside `CardWidth` with room to spare, written the way the classro
 cards are written: the two numbers stacked and right-aligned, `×` to the left of
 the second, a rule underneath.
 
+The three horizontal values across the panel add up exactly, and that is what
+fixes `RollCardGap`: the panel is `RollDialogWidth` (1280 px) less
+`DialogPadding` (56 px) on each side, so 1168 px of content, and
+`DieColumnWidth` (400) + `RollCardGap` (208) + `CardWidth` (560) is that 1168.
+`RollCardGap` read 96 px until issue #221 and could not: it left 208 px of
+content unaccounted for, and the committed mockup — the agreed wireframe — has
+always drawn 208. The mockup was treated as authoritative and the table
+corrected to match it.
+
+`DieGroupTop` and `CardTop` are measured from the inside top of the panel, the
+same way [game over](game-over.md)'s `GameOverHeadlineTop` and
+`StandingsColumnTop` are measured from the top of the canvas. They differ by
+40 px because the two groups are different heights: the taller card sits higher
+so that it and the die group are vertically centred against each other.
+
+`DieBorderWidth` and `CardBorderWidth` hold the same number as
+[shared components](shared-components.md#button)' `ButtonBorderWidth` today and
+are deliberately not that constant — the button is free to restyle its outline
+without redrawing the die or the card. The die's own vertical stack adds up the
+same way the row does: `DiePipInset` (34) either side of a three-across pip grid
+inside a `DieFaceSize` (240) square bounded by `DieBorderWidth` (4) leaves 164 px
+of grid, so each of the nine cells is 54⅔ px and a `DiePipDiameter` (40) pip sits
+centred in one with room around it.
+
 ## Elements
 
 - **Player chip** — [shared](shared-components.md#player-chip), active state.
   Four players share a tablet; the dialog says whose turn this is because the
   header behind it is dimmed.
+- **`rolled`** — the word beside the chip, `RolledLabelSize`, `RolledLabelGap`
+  past it, in the same quiet grey as a chip's second line. It is what makes
+  `whose` a sentence — *Green rolled* — rather than a chip sitting on its own,
+  and it is why this dialog needs no title of its own.
 - **Die** — one six-sided die, drawn with pips rather than a numeral. There is
   exactly one die: the rules card says "Dice", and three piles × two faces
   accounts for all six faces of one — see


### PR DESCRIPTION
Closes #221

When you press `Roll`, this is what you see: the die that landed, drawn with
pips rather than a number, the pile that face sends you to, and the card you
drew — then `Solve it` to go and do the multiplication. Nothing on it can be
changed and nothing is graded here; the roll and the card already happened
before the dialog opened, and its whole job is to say so clearly enough that
the other three players at the table know what just happened too.

**Docs:** `docs/specs/ui/roll-and-card.md` — `RollCardGap` corrected from a
stale 96 px to the 208 px the committed mockup has always drawn, eleven
constants the mockup needs added to the table, and the `rolled` label added to
Elements.

## How the spec is changing

- **`RollCardGap`: 96 px → 208 px.** The old rule could not be built. The panel
  is 1280 px wide less `DialogPadding` (56) on each side, so 1168 px of content,
  and the mockup's die column (400) plus card (560) leaves exactly 208 for
  whatever sits between them. 96 left 112 px unaccounted for and could not be
  reconciled by nudging anything. Rule 8 makes the agreed wireframe
  authoritative, so the mockup won and the table was corrected. A test asserts
  the three values still add up, so the next edit that breaks the arithmetic
  fails rather than quietly re-opening the same gap.
- **Eleven constants added**, each for a number the mockup already draws and the
  page had never named: `RolledLabelSize` (40), `RolledLabelGap` (24),
  `DieColumnWidth` (400), `DieGroupTop` (220), `DieBorderWidth` (4),
  `DiePipInset` (34), `CardTop` (180), `CardBorderWidth` (4), `CardRuleGap` (8),
  `CardRuleThickness` (8), `CardRuleLength` (360). The issue named six of these;
  the mockup audit found five more (see Deviations).
- **The `rolled` label added to Elements.** The mockup draws the word beside the
  chip and the page named neither its size nor the element.

## Spec invariants

- *The die face shown is the roll, and the pile shown is the pile that roll maps
  to.* The view reads both off an `IRollAndCardReadout` and re-derives neither.
  `Pile_IsReadFromWhatCoreReported_NotReDerivedFromTheFace` hands it a
  deliberately impossible pairing — a face of 5 with the easy pile — and asserts
  it prints the easy pile's label: a view that worked the pile out from the face
  would print the hard pile's and fail.
- *Nothing on this screen can change which pile was drawn.* There is no
  generator, no `Random` and no `Rng` anywhere in this code, asserted by
  `Dialog_IsAReadout_WithNoRandomnessAndNoWorkingOutGridOfItsOwn`.
- *The pile is worth the same one lily pad whichever it is.*
  `EveryPile_IsWorthTheSameOneLilyPad_AndNothingSaysOtherwise` builds all three
  and asserts they differ only in words — same size, colour and weight — and
  that no member anywhere is named for a point, a bonus or a difficulty.
- *This dialog cannot be dismissed; hardware back does nothing.* The view adds
  no back handler at all (asserted by name) and nominates no least-destructive
  button, which is what would otherwise turn a back press into a `Solve it`.
  `SolveIt_OpensTheWorkingOutGridExactlyOnce_AndHardwareBackDoesNothingAtAll`
  presses back through the real router and asserts nothing moves.
- *Both open questions stay open.* This is its own beat, and the pile is named
  here and nowhere else.

EditMode tests were written first and could not be executed locally; CI is where
they go red-then-green. The Core suite (190 tests), core isolation, assembly
references, geometry lint, the Python suites and `mkdocs build --strict` all pass
locally.

## Deviations and Decisions

- **Five constants added beyond the six the issue listed.** Auditing the mockup
  against the table turned up `DieColumnWidth` (400), `CardBorderWidth` (4) —
  the card is outlined exactly as the die is — `CardRuleGap` (8), and split the
  issue's "rule thickness and length" into the two rows it is. Adding them is
  the same call the issue makes for the six it named: a number the code needs
  and the table lacks is a row that was missed.
- **A readout seam rather than the view holding a `Game`.** The dialog reads an
  `IRollAndCardReadout` — frog, face, pile, and the two operands —
  implemented at runtime by `GameRollAndCardReadout` over `Game`. The operands
  arrive as numbers rather than as a `Card` because a `Card` can only come out
  of a draw against the seeded generator, and every test here needs a fixed
  `331 × 41` with no die involved.
- **"The die is rolling" is drawn as a die with no pips on it.** The spec says
  the die is rolling and then settles; it does not say what rolling looks like.
  Hiding the face until it settles is the smallest reading that makes "the face
  is shown only once it settles" true, and it invents no motion path and no
  constant. A tumbling animation is a visual decision worth Connor's opinion
  rather than mine.
- **Nothing composes the board and this dialog yet.** There is no composition
  root in the project that assembles screens, so `Roll` still only raises
  `RollPressed` and this dialog is still only reachable by being built directly.
  The seam is those two types, unchanged.
- **`Solve it` does not advance Core's turn phase.** It opens the working-out
  grid through the router and says the press happened; moving Core from
  `RolledAndCardDrawn` to `Answering` belongs to whoever owns the screen that
  answering happens on (#223), not to the screen being left.
- **The mockup's `letter-spacing: 24px` on `× 41` is not reproduced.** uGUI's
  `Text` has no letter spacing, and the alternative is per-character layout for
  a typographic flourish. Everything the spec states about the problem — stacked,
  right-aligned, `×` to the left of the second number, rule underneath — is
  built.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_