### PR TITLE
feat(ui): build the end-game confirm dialog

### DIFF
--- a/Assets/Scripts/Unity/Views/EndGameConfirmView.cs
+++ b/Assets/Scripts/Unity/Views/EndGameConfirmView.cs
@@ -1,0 +1,479 @@
+using System;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// SettingsDialogView.cs and GameBoardScreenView.cs work around — so these are
+// pulled in by explicit alias rather than a wildcard `using Frogs.Unity.UI;`,
+// and a bare `Button`, `ButtonKind` or `DialogPanel` in this file always means
+// the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The end-game confirm — docs/specs/ui/end-game-confirm.md, built to that
+    /// page and its committed 1:1 mockup. The one dialog in the game that can
+    /// take something away from somebody who did nothing wrong: the only door
+    /// out of a game in progress, reached only from
+    /// <see cref="SettingsDialogView"/> (#222).
+    ///
+    /// It is a composition of the shared <see cref="DialogPanel"/> (#219) and
+    /// the shared <see cref="Button"/> (#214) and nothing else: no new visual
+    /// component, no sprite, no bitmap.
+    ///
+    /// Three things worth knowing before reading the rest:
+    ///
+    /// - **The cost sentence is the whole of the protection.** Anyone may end
+    ///   a game, on anyone's turn — Derek's recorded call in issue #186,
+    ///   because the tablet cannot tell who is holding it — so nothing here
+    ///   restricts who can tap. What stands in for that restriction is a
+    ///   sentence that says something true and specific every time, which is
+    ///   why <see cref="FormatCostSentence"/> takes *two* live numbers and
+    ///   hard-codes neither.
+    /// - **Ending is not losing.** <c>Game.EndGame()</c> (#211) marks the game
+    ///   over and leaves every frog's <c>Lane</c> exactly where it stands;
+    ///   nothing in this view resets, rewinds or rescores anything, and there
+    ///   is no member on it that could.
+    /// - **It does not listen for hardware back.** The router (#213) already
+    ///   routes back on <c>Dialog.EndGameConfirm</c> to what `Keep playing`
+    ///   does; this view exposes that one action as
+    ///   <see cref="RequestKeepPlaying"/> rather than adding a second opinion
+    ///   about the key. On this dialog in particular, a second opinion is the
+    ///   one that could end somebody's game by accident.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class EndGameConfirmView : MonoBehaviour
+    {
+        // docs/specs/ui/end-game-confirm.md#named-constants.
+        public const float ConfirmDialogWidth = 1160f;
+        public const float ConfirmDialogHeight = 540f;
+        public const float ConfirmQuestionSize = 56f;
+        public const float ConfirmBodySize = 40f;
+        public const float ConfirmBodyWidth = 1048f;
+        public const float ConfirmBodyLineHeight = 1.4f;
+
+        // The rest of what this dialog measures itself with is other pages'
+        // rows, referenced under the identical name rather than redeclared
+        // here — the same line #220 and #222 both drew:
+        //
+        // - the panel's padding, corner radius, title metrics, the
+        //   question -> cost gap (`DialogTitleGap`), the cost -> controls gap
+        //   (`DialogButtonRowGap`), the scrim and the fade are the shared
+        //   Dialog's (shared-components.md#dialog).
+        // - `ButtonDestructiveGap`, `ButtonHeight` and `ButtonMinWidth` are
+        //   the shared Button's (shared-components.md#button).
+
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float CanvasWidth = 1920f;
+        const float CanvasHeight = 1200f;
+
+        const string QuestionLabel = "End the game for everyone?";
+        const string EndTheGameLabel = "End the game";
+        const string KeepPlayingLabel = "Keep playing";
+
+        // end-game-confirm.md's cost table, as the two templates it is. The
+        // singular row is its own sentence rather than a plural with a "1" in
+        // it, because "1 frogs are still swimming" is the kind of thing that
+        // makes a warning easy to stop reading.
+        const string SwimmingClauseSingular = "One frog is still swimming.";
+        const string SwimmingClausePluralFormat = "{0} frogs are still swimming.";
+        const string CostSentenceFormat =
+            "{0} Ending it now stops the game for all {1} players and shows the results.";
+
+        // How many frogs are still swimming, capitalised because it opens the
+        // sentence. Index 0 is deliberately absent: there is no
+        // everybody-is-home wording, and there does not need to be — the game
+        // ends itself the moment the last frog lands on its End log, so this
+        // dialog can never open on zero.
+        static readonly string[] SwimmingCountWords = { null, "One", "Two", "Three", "Four" };
+
+        // How many frogs are in the game, lower-case because it sits mid
+        // sentence. Only Game.MinFrogsPerGame..Game.MaxFrogsPerGame are ever
+        // reachable; the shorter entries exist so the array indexes by count.
+        static readonly string[] RosterSizeWords = { null, "one", "two", "three", "four" };
+
+        // No imported font — matches Button.cs's and DialogPanel.cs's own
+        // choice, for the same reason (no external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colour copied verbatim from the committed mockup's CSS custom
+        // properties, the same line Button.cs, DialogPanel.cs and
+        // SettingsDialogView.cs all draw: not a geometry constant on any spec
+        // page's table, so not declared as a named spec constant.
+        static readonly Color CostColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockup's --line
+
+        Game _game;
+
+        RectTransform _rect;
+        DialogPanel _dialog;
+        Text _costText;
+        Button _endTheGameButton;
+        Button _keepPlayingButton;
+
+        bool _initialized;
+
+        /// <summary>
+        /// The game has been ended: <c>Game.EndGame()</c> has already run, so
+        /// the standings behind this are final. Whoever is listening drives
+        /// the router's `[End-game confirm] --End the game--&gt; Game over`
+        /// transition (#213) — this view moves no screens itself.
+        /// </summary>
+        public event Action GameEnded;
+
+        /// <summary>
+        /// `Keep playing` was pressed, or hardware back arrived through
+        /// <see cref="RequestKeepPlaying"/>. Whoever is listening drives the
+        /// router's `[End-game confirm] --Keep playing--&gt; Game board`
+        /// transition (#213), which returns to the exact board state — same
+        /// turn, same positions — which is free, because nothing on this path
+        /// touched it.
+        /// </summary>
+        public event Action KeepPlayingRequested;
+
+        /// <summary>The view's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The shared Dialog this confirm is laid out on, at <see cref="ConfirmDialogWidth"/> x <see cref="ConfirmDialogHeight"/>.</summary>
+        public DialogPanel Dialog
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog;
+            }
+        }
+
+        /// <summary>
+        /// `question` — `End the game for everyone?`. This is the shared
+        /// Dialog's own title slot rather than a second text of this
+        /// dialog's: the mockup draws the question at exactly the title's
+        /// place, size and weight, and `ConfirmQuestionSize` and
+        /// `DialogTitleSize` are the same 56 px.
+        /// </summary>
+        public Text QuestionText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog.TitleText;
+            }
+        }
+
+        /// <summary>`cost` — the live sentence from <see cref="FormatCostSentence"/>, <see cref="ConfirmBodyWidth"/> wide.</summary>
+        public Text CostText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _costText;
+            }
+        }
+
+        /// <summary>`controls` — the shared Dialog's own button row, bottom of the panel.</summary>
+        public RectTransform ControlsRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog.ButtonRowRect;
+            }
+        }
+
+        /// <summary>`End the game` — destructive, on the left edge of the padding box.</summary>
+        public Button EndTheGameButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _endTheGameButton;
+            }
+        }
+
+        /// <summary>`Keep playing` — primary, on the right edge of the padding box, where the thumb is.</summary>
+        public Button KeepPlayingButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _keepPlayingButton;
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>
+        /// Points the confirm at the game it is asking about. Both numbers in
+        /// the cost sentence are read from here and nowhere else — this view
+        /// walks no frog positions and counts no seats.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="game"/> is null.</exception>
+        public void Initialize(Game game)
+        {
+            EnsureInitialized();
+
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+
+            Refresh();
+        }
+
+        /// <summary>
+        /// Re-reads the game and rebuilds the cost sentence. Every value it
+        /// draws is asked for again — a frog that got home since the last look
+        /// shows up simply by asking.
+        /// </summary>
+        public void Refresh()
+        {
+            EnsureInitialized();
+
+            if (_game == null)
+            {
+                return;
+            }
+
+            _costText.text = FormatCostSentence(_game.FrogsStillSwimming, _game.TurnOrder.Count);
+        }
+
+        /// <summary>Opens the confirm — the shared Dialog's own cross-fade in, over a freshly read cost sentence.</summary>
+        public void Open()
+        {
+            EnsureInitialized();
+
+            Refresh();
+            _dialog.Open();
+        }
+
+        /// <summary>Closes the confirm — the shared Dialog's own cross-fade out.</summary>
+        public void Close()
+        {
+            EnsureInitialized();
+            _dialog.Close();
+        }
+
+        /// <summary>
+        /// The one action `Keep playing` and hardware back both invoke —
+        /// shared-components.md#dialog: "the hardware back button does what
+        /// the dialog's least destructive button does, and never what its most
+        /// destructive one does", and end-game-confirm.md: "back never ends a
+        /// game." Public so the router's back handling (#213) can call it
+        /// directly, which is also how an EditMode test simulates hardware
+        /// back. There is deliberately no second key handler here.
+        /// </summary>
+        public void RequestKeepPlaying()
+        {
+            EnsureInitialized();
+
+            var handler = KeepPlayingRequested;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        /// <summary>
+        /// end-game-confirm.md's cost table, rendered. Both numbers are handed
+        /// in — this method counts nothing and looks nothing up, the same way
+        /// <see cref="SettingsDialogView.FormatVersionLabel"/> parses a string
+        /// it is given rather than reading a live one — so it can be asserted
+        /// against every reachable pair without a game to build first.
+        ///
+        /// Both are spelled as words: the swimming count capitalised because
+        /// it opens the sentence, the roster size lower-case because it sits
+        /// mid sentence. Neither is ever a digit.
+        /// </summary>
+        /// <param name="frogsStillSwimming">
+        /// <c>Game.FrogsStillSwimming</c> — at least one, always, because the
+        /// game ends itself the moment the last frog is home.
+        /// </param>
+        /// <param name="rosterSize">
+        /// How many frogs are playing — <c>Game.TurnOrder.Count</c>, which is
+        /// <c>Game.MinFrogsPerGame</c> to <c>Game.MaxFrogsPerGame</c>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="rosterSize"/> is a roster no game can have, or
+        /// <paramref name="frogsStillSwimming"/> is not between one and it.
+        /// Zero throws on purpose: there is no everybody-is-home wording to
+        /// return, so the absence is structural rather than a comment.
+        /// </exception>
+        public static string FormatCostSentence(int frogsStillSwimming, int rosterSize)
+        {
+            if (rosterSize < Game.MinFrogsPerGame || rosterSize > Game.MaxFrogsPerGame)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(rosterSize),
+                    rosterSize,
+                    $"a game is {Game.MinFrogsPerGame} to {Game.MaxFrogsPerGame} frogs; {rosterSize} is neither.");
+            }
+
+            if (frogsStillSwimming < 1 || frogsStillSwimming > rosterSize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(frogsStillSwimming),
+                    frogsStillSwimming,
+                    "this dialog only ever opens with between one frog and the whole roster still swimming.");
+            }
+
+            var swimmingClause = frogsStillSwimming == 1
+                ? SwimmingClauseSingular
+                : string.Format(SwimmingClausePluralFormat, SwimmingCountWords[frogsStillSwimming]);
+
+            return string.Format(CostSentenceFormat, swimmingClause, RosterSizeWords[rosterSize]);
+        }
+
+        // Unity does not guarantee Awake() has run before another component's
+        // Awake() or a test reaches this one right after AddComponent — the
+        // same reasoning as Button, DialogPanel and SettingsDialogView's own
+        // EnsureInitialized. Every public entry point funnels through this
+        // idempotent guard instead of trusting Awake's timing.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _rect.anchorMin = new Vector2(0.5f, 0.5f);
+            _rect.anchorMax = new Vector2(0.5f, 0.5f);
+            _rect.pivot = new Vector2(0.5f, 0.5f);
+            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+
+            BuildDialog();
+            BuildCost();
+            BuildControls();
+        }
+
+        void BuildDialog()
+        {
+            var dialogGO = new GameObject("EndGameConfirmDialog", typeof(RectTransform));
+            dialogGO.transform.SetParent(_rect, worldPositionStays: false);
+
+            _dialog = dialogGO.AddComponent<DialogPanel>();
+
+            // The `question` region. It is the shared Dialog's title, not a
+            // text of this dialog's own — see QuestionText.
+            _dialog.SetTitle(QuestionLabel);
+
+            // The shared Dialog at this dialog's own size, in place of
+            // DialogMaxWidth/DialogMaxHeight. Everything else about it — the
+            // scrim, the corners, the padding, the title metrics, the
+            // cross-fade — is inherited unchanged.
+            _dialog.SetSize(ConfirmDialogWidth, ConfirmDialogHeight);
+        }
+
+        void BuildCost()
+        {
+            // The shared Dialog's body region already starts one
+            // DialogTitleGap under the title and stops one DialogButtonRowGap
+            // above the button row, so the two gaps this dialog needs are the
+            // shared component's own and no new spacing constant is declared.
+            //
+            // The mockup draws the cost 170 px down from the panel top rather
+            // than the 152 px that DialogPadding + ConfirmQuestionSize +
+            // DialogTitleGap comes to; the 18 px is the leading a browser puts
+            // under a 56 px line and not a spacing value of its own, which is
+            // why this composes the named gaps rather than the drawn offset.
+            var costGO = new GameObject("Cost", typeof(RectTransform), typeof(Text));
+            _costText = costGO.GetComponent<Text>();
+            _costText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            _costText.fontSize = (int)ConfirmBodySize;
+            _costText.lineSpacing = ConfirmBodyLineHeight;
+            _costText.alignment = TextAnchor.UpperLeft;
+            _costText.color = CostColor;
+            // Wrapping horizontally is the point of ConfirmBodyWidth — the
+            // sentence is two lines at 40 px. Vertically it overflows rather
+            // than truncating: a warning with its ending cut off is worse than
+            // a warning that runs long.
+            _costText.horizontalOverflow = HorizontalWrapMode.Wrap;
+            _costText.verticalOverflow = VerticalWrapMode.Overflow;
+            _costText.raycastTarget = false;
+
+            var costRect = _costText.rectTransform;
+            costRect.SetParent(_dialog.BodyRect, worldPositionStays: false);
+            costRect.anchorMin = new Vector2(0f, 0f);
+            costRect.anchorMax = new Vector2(0f, 1f);
+            costRect.pivot = new Vector2(0f, 1f);
+            costRect.sizeDelta = new Vector2(ConfirmBodyWidth, 0f);
+            costRect.anchoredPosition = Vector2.zero;
+        }
+
+        void BuildControls()
+        {
+            // Destructive first, primary second: the shared Dialog packs its
+            // button row from the right, so adding `Keep playing` last is what
+            // puts the safe option on the right, where the thumb is.
+            _endTheGameButton = _dialog.AddButton(
+                ButtonKind.Destructive,
+                EndTheGameLabel,
+                HandleEndTheGameClicked);
+
+            _keepPlayingButton = _dialog.AddButton(
+                ButtonKind.Primary,
+                KeepPlayingLabel,
+                RequestKeepPlaying,
+                isLeastDestructive: true);
+
+            // ...and then the destructive one is pinned to the *left* edge of
+            // the padding box, which is where the mockup draws it and further
+            // from the thumb than packing it rightward would leave it.
+            // ButtonDestructiveGap is the shared invariant's stated minimum
+            // separation, not the measurement these two are laid out from:
+            // what is left between them here is over 400 px, and a test
+            // asserts it never drops under the minimum.
+            var endRect = _endTheGameButton.RectTransform;
+            endRect.anchorMin = new Vector2(0f, 0.5f);
+            endRect.anchorMax = new Vector2(0f, 0.5f);
+            endRect.pivot = new Vector2(0f, 0.5f);
+            endRect.anchoredPosition = Vector2.zero;
+        }
+
+        void HandleEndTheGameClicked()
+        {
+            if (_game == null)
+            {
+                // Nothing to end, so nowhere to go: a confirm that was never
+                // pointed at a game cannot answer for one.
+                return;
+            }
+
+            // Two separate things, in this order. Core's own end-the-game
+            // action first — it marks the game over and leaves every frog's
+            // lane position exactly as it stands, because ending a game is not
+            // losing it...
+            _game.EndGame();
+
+            // ...and then the request to move the screen to game over, with
+            // those standings. This view does not move screens itself.
+            var handler = GameEnded;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/EndGameConfirmView.cs.meta
+++ b/Assets/Scripts/Unity/Views/EndGameConfirmView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb19247a50284ac1b8c65744bab937fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/EndGameConfirmViewTests.cs
+++ b/Assets/Tests/EditMode/EndGameConfirmViewTests.cs
@@ -1,0 +1,646 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// SettingsDialogViewTests.cs and ButtonTests.cs work around — so these are
+// pulled in by explicit alias, and a bare `Button`, `ButtonKind` or
+// `DialogPanel` in this file always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The end-game confirm — issue #226, built against
+    /// docs/specs/ui/end-game-confirm.md and its committed 1:1 mockup.
+    ///
+    /// This is the one dialog in the game that can take something away from
+    /// somebody who did nothing wrong, so four things these tests hold down
+    /// matter more than the layout:
+    ///
+    /// - **The cost sentence is true, every time.** Both of its numbers come
+    ///   from the live game — how many frogs are still swimming, and how many
+    ///   are playing — and every reachable pair of them is asserted, not just
+    ///   the two the spec table prints.
+    /// - **Ending is not losing.** Every frog keeps its lane position across
+    ///   the tap.
+    /// - **`Keep playing` and hardware back are one action**, and neither can
+    ///   reach Core's end-the-game call.
+    /// - **The destructive button is nowhere near the thumb**, by more than
+    ///   `ButtonDestructiveGap`.
+    /// </summary>
+    public sealed class EndGameConfirmViewTests
+    {
+        // Every reachable (frogs still swimming, roster size) pair, and the
+        // sentence end-game-confirm.md's cost table says each one renders.
+        // Written out rather than generated, so this table is an independent
+        // statement of the wording and not a second copy of the helper.
+        //
+        // Roster runs Game.MinFrogsPerGame..Game.MaxFrogsPerGame; still
+        // swimming runs 1..roster, because the game ends itself the moment the
+        // last frog is home, so this dialog can never open on zero.
+        static readonly object[] CostSentenceCases =
+        {
+            new object[] { 1, 2, "One frog is still swimming. Ending it now stops the game for all two players and shows the results." },
+            new object[] { 2, 2, "Two frogs are still swimming. Ending it now stops the game for all two players and shows the results." },
+            new object[] { 1, 3, "One frog is still swimming. Ending it now stops the game for all three players and shows the results." },
+            new object[] { 2, 3, "Two frogs are still swimming. Ending it now stops the game for all three players and shows the results." },
+            new object[] { 3, 3, "Three frogs are still swimming. Ending it now stops the game for all three players and shows the results." },
+            new object[] { 1, 4, "One frog is still swimming. Ending it now stops the game for all four players and shows the results." },
+            new object[] { 2, 4, "Two frogs are still swimming. Ending it now stops the game for all four players and shows the results." },
+            new object[] { 3, 4, "Three frogs are still swimming. Ending it now stops the game for all four players and shows the results." },
+            new object[] { 4, 4, "Four frogs are still swimming. Ending it now stops the game for all four players and shows the results." }
+        };
+
+        [TestCaseSource(nameof(CostSentenceCases))]
+        public void CostSentence_RendersBothLiveNumbersAsWords_ForEveryReachablePair(
+            int frogsStillSwimming,
+            int rosterSize,
+            string expected)
+        {
+            Assert.That(
+                EndGameConfirmView.FormatCostSentence(frogsStillSwimming, rosterSize),
+                Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void CostSentence_RendersTheSpecsTwoPrintedRowsVerbatim()
+        {
+            // The two rows end-game-confirm.md's cost table prints, in the
+            // four-player game the mockup is drawn in. Kept as their own test
+            // so a change to the wording has to walk past the spec's own
+            // sentences, not only a parameterised table.
+            Assert.That(
+                EndGameConfirmView.FormatCostSentence(3, 4),
+                Is.EqualTo("Three frogs are still swimming. Ending it now stops the game for all four players and shows the results."));
+
+            Assert.That(
+                EndGameConfirmView.FormatCostSentence(1, 4),
+                Is.EqualTo("One frog is still swimming. Ending it now stops the game for all four players and shows the results."));
+        }
+
+        [Test]
+        public void CostSentence_HasNoEverybodyIsHomeWording()
+        {
+            // "There is no everybody-is-home wording, and there does not need
+            // to be" — the game ends itself the moment the last frog lands, so
+            // this dialog can never open on zero. Structural rather than
+            // hoped-for: there is no string for it to return.
+            Assert.That(
+                () => EndGameConfirmView.FormatCostSentence(0, 4),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void CostSentence_RefusesARosterNoGameCanHave()
+        {
+            // game-setup.md#invariants: "a game cannot start with fewer than
+            // two frogs, or more than four." Nothing here invents wording for
+            // a roster Core would not have built.
+            Assert.That(
+                () => EndGameConfirmView.FormatCostSentence(1, Game.MinFrogsPerGame - 1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            Assert.That(
+                () => EndGameConfirmView.FormatCostSentence(1, Game.MaxFrogsPerGame + 1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            // More frogs swimming than are in the game is not a state Core can
+            // produce either.
+            Assert.That(
+                () => EndGameConfirmView.FormatCostSentence(3, 2),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Cost_IsReadFromTheLiveGame_NotComposedFromAFixedString()
+        {
+            // A three-frog game with one frog already home: the sentence has
+            // to say two still swimming and three players, which is a pair no
+            // fixed string in the spec table prints.
+            var game = CreateGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange);
+            SendHome(game, FrogColour.Orange);
+
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(game);
+                view.Open();
+
+                Assert.That(
+                    view.CostText.text,
+                    Is.EqualTo("Two frogs are still swimming. Ending it now stops the game for all three players and shows the results."));
+
+                // And it is asked again on every open, never remembered.
+                SendHome(game, FrogColour.Blue);
+                view.Close();
+                view.Open();
+
+                Assert.That(
+                    view.CostText.text,
+                    Is.EqualTo("One frog is still swimming. Ending it now stops the game for all three players and shows the results."));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Layout_IsTheSharedDialogAtTheSpecsOwnSize_WithAllThreeRegions()
+        {
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(CreateGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink));
+
+                // A centred shared Dialog at ConfirmDialogWidth x
+                // ConfirmDialogHeight — not DialogMaxWidth/DialogMaxHeight.
+                Assert.That(
+                    view.Dialog.PanelRect.sizeDelta,
+                    Is.EqualTo(new Vector2(
+                        EndGameConfirmView.ConfirmDialogWidth,
+                        EndGameConfirmView.ConfirmDialogHeight)));
+
+                // question — the shared Dialog's own title slot, at the top of
+                // the padding box, at the spec's ConfirmQuestionSize.
+                Assert.That(view.QuestionText.text, Is.EqualTo("End the game for everyone?"));
+                Assert.That(view.QuestionText.fontSize, Is.EqualTo((int)EndGameConfirmView.ConfirmQuestionSize));
+                Assert.That(
+                    LeftEdge(view.QuestionText.rectTransform) - LeftEdge(view.Dialog.PanelRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+
+                // cost — ConfirmBodyWidth wide, at ConfirmBodySize, wrapping,
+                // one DialogTitleGap below the question.
+                Assert.That(view.CostText.fontSize, Is.EqualTo((int)EndGameConfirmView.ConfirmBodySize));
+                Assert.That(
+                    view.CostText.rectTransform.rect.width,
+                    Is.EqualTo(EndGameConfirmView.ConfirmBodyWidth).Within(0.001f));
+                Assert.That(view.CostText.horizontalOverflow, Is.EqualTo(HorizontalWrapMode.Wrap));
+                Assert.That(
+                    view.CostText.lineSpacing,
+                    Is.EqualTo(EndGameConfirmView.ConfirmBodyLineHeight).Within(0.001f));
+                Assert.That(
+                    TopEdge(view.CostText.rectTransform),
+                    Is.EqualTo(TopEdge(view.Dialog.BodyRect)).Within(0.001f),
+                    "the cost sits at the top of the shared Dialog's body, one DialogTitleGap under the question");
+
+                // controls — the shared Dialog's own button row.
+                Assert.That(view.ControlsRect, Is.SameAs(view.Dialog.ButtonRowRect));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void CostColumn_IsThePaddingBoxWidth_NotASecondIndependentNumber()
+        {
+            // ConfirmBodyWidth (1048) is ConfirmDialogWidth (1160) inset by
+            // DialogPadding (56) on both sides. The spec table gives it its own
+            // row, so the code declares it under that name — this is what
+            // catches the day the two stop agreeing.
+            Assert.That(
+                EndGameConfirmView.ConfirmBodyWidth,
+                Is.EqualTo(EndGameConfirmView.ConfirmDialogWidth - (DialogPanel.DialogPadding * 2f)).Within(0.001f));
+        }
+
+        [Test]
+        public void PublicConstants_AreExactlyEndGameConfirmsOwn_UnderTheIdenticalNames()
+        {
+            // Everything else this dialog measures itself with — the shared
+            // Dialog's padding, title gap and button-row gap, the shared
+            // Button's height and ButtonDestructiveGap — is referenced from
+            // where it already lives rather than redeclared here. This test is
+            // what proves that: a second copy of any of them would show up as
+            // an extra name.
+            AssertPublicConstantsAreExactly(typeof(EndGameConfirmView), new Dictionary<string, float>
+            {
+                { nameof(EndGameConfirmView.ConfirmDialogWidth), 1160f },
+                { nameof(EndGameConfirmView.ConfirmDialogHeight), 540f },
+                { nameof(EndGameConfirmView.ConfirmQuestionSize), 56f },
+                { nameof(EndGameConfirmView.ConfirmBodySize), 40f },
+                { nameof(EndGameConfirmView.ConfirmBodyWidth), 1048f },
+                { nameof(EndGameConfirmView.ConfirmBodyLineHeight), 1.4f }
+            });
+        }
+
+        [Test]
+        public void Controls_AreDestructiveLeftAndPrimaryRight_OnTheDialogPaddingEdges()
+        {
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(CreateGame(FrogColour.Green, FrogColour.Blue));
+
+                Assert.That(view.EndTheGameButton.Kind, Is.EqualTo(ButtonKind.Destructive));
+                Assert.That(view.KeepPlayingButton.Kind, Is.EqualTo(ButtonKind.Primary));
+
+                // "sitting on the left and right edges of the DialogPadding
+                // box exactly as the mockup draws them".
+                Assert.That(
+                    LeftEdge(view.EndTheGameButton.RectTransform) - LeftEdge(view.Dialog.PanelRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    RightEdge(view.Dialog.PanelRect) - RightEdge(view.KeepPlayingButton.RectTransform),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+
+                // Both at the shared Button's own default footprint — nothing
+                // about this dialog widens either one.
+                Assert.That(
+                    view.EndTheGameButton.RectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(Button.ButtonMinWidth, Button.ButtonHeight)));
+                Assert.That(
+                    view.KeepPlayingButton.RectTransform.sizeDelta,
+                    Is.EqualTo(new Vector2(Button.ButtonMinWidth, Button.ButtonHeight)));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheDestructiveButton_ClearsButtonDestructiveGap_ByAWideMargin()
+        {
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(CreateGame(FrogColour.Green, FrogColour.Blue));
+
+                var gap = LeftEdge(view.KeepPlayingButton.RectTransform)
+                    - RightEdge(view.EndTheGameButton.RectTransform);
+
+                // ButtonDestructiveGap is the shared invariant's stated
+                // *minimum* separation, not the placement measurement —
+                // "the safe option is... a full ButtonDestructiveGap away".
+                Assert.That(
+                    gap,
+                    Is.GreaterThanOrEqualTo(Button.ButtonDestructiveGap),
+                    "the destructive button is never within ButtonGap of the thumb");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EndTheGame_EndsTheGameInCore_AndAsksForGameOver_Once()
+        {
+            var game = CreateGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange);
+            var view = CreateView();
+
+            try
+            {
+                var ended = 0;
+                var keptPlaying = 0;
+                view.GameEnded += () => ended++;
+                view.KeepPlayingRequested += () => keptPlaying++;
+
+                view.Initialize(game);
+                view.Open();
+
+                Assert.That(game.IsOver, Is.False);
+
+                TapButton(view.EndTheGameButton);
+
+                // Two separate things: Core's own end-the-game action...
+                Assert.That(game.IsOver, Is.True, "Core's end-the-game action ran");
+                // ...and the request to move the screen to game over.
+                Assert.That(ended, Is.EqualTo(1));
+                Assert.That(keptPlaying, Is.Zero, "and never the keep-playing transition");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EndingTheGame_IsNotLosingIt_EveryFrogKeepsItsPosition()
+        {
+            var game = CreateGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange);
+            game.LaneFor(FrogColour.Green).MoveForward();
+            game.LaneFor(FrogColour.Green).MoveForward();
+            game.LaneFor(FrogColour.Orange).MoveForward();
+
+            var before = game.TurnOrder.ToDictionary(colour => colour, colour => game.LaneFor(colour).Position);
+
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(game);
+                view.Open();
+
+                TapButton(view.EndTheGameButton);
+
+                foreach (var colour in game.TurnOrder)
+                {
+                    Assert.That(
+                        game.LaneFor(colour).Position,
+                        Is.EqualTo(before[colour]),
+                        $"{colour} kept the pads it had");
+                }
+
+                // And the standings it leaves behind are the ones that were
+                // on the board — nothing was reset on the way out.
+                Assert.That(
+                    game.Standings.Single(row => row.Colour == FrogColour.Green).Position,
+                    Is.EqualTo(before[FrogColour.Green]));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void KeepPlaying_AsksOnlyForTheBoard_AndEndsNothing()
+        {
+            var game = CreateGame(FrogColour.Green, FrogColour.Blue);
+            var view = CreateView();
+
+            try
+            {
+                var ended = 0;
+                var keptPlaying = 0;
+                view.GameEnded += () => ended++;
+                view.KeepPlayingRequested += () => keptPlaying++;
+
+                view.Initialize(game);
+                view.Open();
+
+                var activeBefore = game.ActiveFrog;
+                var phaseBefore = game.Phase;
+
+                TapButton(view.KeepPlayingButton);
+
+                Assert.That(keptPlaying, Is.EqualTo(1));
+                Assert.That(ended, Is.Zero, "the safe button never ends a game");
+                Assert.That(game.IsOver, Is.False, "and never calls Core's end-the-game action");
+
+                // "cancelling returns to the exact board state — same turn,
+                // same positions."
+                Assert.That(game.ActiveFrog, Is.EqualTo(activeBefore), "no turn advanced");
+                Assert.That(game.Phase, Is.EqualTo(phaseBefore));
+                foreach (var colour in game.TurnOrder)
+                {
+                    Assert.That(game.LaneFor(colour).Position, Is.Zero, "no frog moved");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_DrivesTheIdenticalActionKeepPlayingDrives()
+        {
+            var game = CreateGame(FrogColour.Green, FrogColour.Blue);
+            var view = CreateView();
+
+            try
+            {
+                var ended = 0;
+                var keptPlaying = 0;
+                view.GameEnded += () => ended++;
+                view.KeepPlayingRequested += () => keptPlaying++;
+
+                view.Initialize(game);
+                view.Open();
+
+                // The router (#213) already routes hardware back on
+                // Dialog.EndGameConfirm to "what `Keep playing` does". This
+                // view exposes that one action rather than listening for the
+                // key itself — so there is exactly one keep-playing path, not
+                // two that happen to agree today.
+                view.RequestKeepPlaying();
+
+                Assert.That(keptPlaying, Is.EqualTo(1));
+                Assert.That(ended, Is.Zero, "back never ends a game");
+                Assert.That(game.IsOver, Is.False);
+
+                TapButton(view.KeepPlayingButton);
+
+                Assert.That(keptPlaying, Is.EqualTo(2), "the same callback, not a second distinct one");
+                Assert.That(ended, Is.Zero);
+                Assert.That(game.IsOver, Is.False);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_IsNotListenedForTwice()
+        {
+            // The board (#220) owns the Escape key on the screen underneath,
+            // and the router owns what back means with a dialog open. A second
+            // Update()/Input handler here would be a third opinion — and on
+            // this dialog, the one that could end a game by accident.
+            var declared = DeclaredMemberNames(typeof(EndGameConfirmView));
+
+            Assert.That(declared, Does.Not.Contain("Update"));
+        }
+
+        [Test]
+        public void KeepPlaying_IsTheDialogsLeastDestructiveButton()
+        {
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(CreateGame(FrogColour.Green, FrogColour.Blue));
+
+                // The value the router reads for hardware back —
+                // shared-components.md#dialog: "the hardware back button does
+                // what the dialog's least destructive button does, and never
+                // what its most destructive one does."
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.SameAs(view.KeepPlayingButton));
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.Not.SameAs(view.EndTheGameButton));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void PublicSurface_IsTheTwoAnswersAndTheCostSentence_AndNothingElse()
+        {
+            // In particular: nothing that resets, restarts, quits or scores.
+            // Ending a game stops it and shows the results; it does not undo
+            // it.
+            var expected = new[]
+            {
+                nameof(EndGameConfirmView.ConfirmDialogWidth),
+                nameof(EndGameConfirmView.ConfirmDialogHeight),
+                nameof(EndGameConfirmView.ConfirmQuestionSize),
+                nameof(EndGameConfirmView.ConfirmBodySize),
+                nameof(EndGameConfirmView.ConfirmBodyWidth),
+                nameof(EndGameConfirmView.ConfirmBodyLineHeight),
+                // The two events, spelled out rather than via nameof — an
+                // event cannot be named from outside its declaring type in
+                // every context, and these two are the whole of what this
+                // dialog can ask anybody to do.
+                "GameEnded",
+                "KeepPlayingRequested",
+                nameof(EndGameConfirmView.RectTransform),
+                nameof(EndGameConfirmView.Dialog),
+                nameof(EndGameConfirmView.QuestionText),
+                nameof(EndGameConfirmView.CostText),
+                nameof(EndGameConfirmView.ControlsRect),
+                nameof(EndGameConfirmView.EndTheGameButton),
+                nameof(EndGameConfirmView.KeepPlayingButton),
+                nameof(EndGameConfirmView.Initialize),
+                nameof(EndGameConfirmView.Open),
+                nameof(EndGameConfirmView.Close),
+                nameof(EndGameConfirmView.Refresh),
+                nameof(EndGameConfirmView.RequestKeepPlaying),
+                nameof(EndGameConfirmView.FormatCostSentence)
+            };
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance
+                | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            var declared = typeof(EndGameConfirmView)
+                .GetMembers(flags)
+                .Select(member => member.Name)
+                // Property getters and event add/remove accessors come back as
+                // methods of their own; the member they belong to is already
+                // in the list.
+                .Where(name => !name.StartsWith("get_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("set_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("add_", StringComparison.Ordinal))
+                .Where(name => !name.StartsWith("remove_", StringComparison.Ordinal))
+                // MonoBehaviour subclasses get an implicit public constructor.
+                .Where(name => !name.StartsWith(".", StringComparison.Ordinal))
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal);
+
+            Assert.That(declared, Is.EqualTo(expected.OrderBy(name => name, StringComparer.Ordinal)));
+
+            foreach (var forbidden in new[] { "Reset", "Restart", "Quit", "Undo", "Score", "Winner" })
+            {
+                var word = forbidden;
+
+                Assert.That(
+                    DeclaredMemberNames(typeof(EndGameConfirmView))
+                        .Where(name => name.IndexOf(word, StringComparison.Ordinal) >= 0),
+                    Is.Empty,
+                    $"nothing on this dialog reaches {word}");
+            }
+        }
+
+        static Game CreateGame(params FrogColour[] turnOrder)
+        {
+            return new Game(turnOrder, seed: 226UL);
+        }
+
+        static void SendHome(Game game, FrogColour colour)
+        {
+            var lane = game.LaneFor(colour);
+
+            while (!lane.IsHome)
+            {
+                lane.MoveForward();
+            }
+        }
+
+        static EndGameConfirmView CreateView()
+        {
+            var host = new GameObject(nameof(EndGameConfirmViewTests), typeof(RectTransform));
+            return host.AddComponent<EndGameConfirmView>();
+        }
+
+        static void Destroy(EndGameConfirmView view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+
+        static void TapButton(Button button)
+        {
+            var corners = new Vector3[4];
+            button.RectTransform.GetWorldCorners(corners);
+
+            var eventData = new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static float LeftEdge(RectTransform rect)
+        {
+            return Corners(rect)[0].x;
+        }
+
+        static float RightEdge(RectTransform rect)
+        {
+            return Corners(rect)[2].x;
+        }
+
+        static float TopEdge(RectTransform rect)
+        {
+            return Corners(rect)[1].y;
+        }
+
+        static Vector3[] Corners(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners;
+        }
+
+        static IEnumerable<string> DeclaredMemberNames(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name).ToArray();
+        }
+
+        static void AssertPublicConstantsAreExactly(Type type, IDictionary<string, float> expected)
+        {
+            var constants = type
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(field => field.IsLiteral && !field.IsInitOnly)
+                .ToArray();
+
+            Assert.That(
+                constants.Select(field => field.Name).OrderBy(name => name, StringComparer.Ordinal),
+                Is.EqualTo(expected.Keys.OrderBy(name => name, StringComparer.Ordinal)),
+                $"{type.Name}'s public constants are exactly end-game-confirm.md's own, under the identical names");
+
+            foreach (var field in constants)
+            {
+                Assert.That(
+                    Convert.ToSingle(field.GetValue(null)),
+                    Is.EqualTo(expected[field.Name]).Within(0.001f),
+                    $"{type.Name}.{field.Name}");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/EndGameConfirmViewTests.cs.meta
+++ b/Assets/Tests/EditMode/EndGameConfirmViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc1a7130f4f5496e9e0be41807600357
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/end-game-confirm.md
+++ b/docs/specs/ui/end-game-confirm.md
@@ -41,17 +41,33 @@ right.
 | Question size | `ConfirmQuestionSize` | 56 px |
 | Body size | `ConfirmBodySize` | 40 px |
 | Body column width | `ConfirmBodyWidth` | 1048 px |
+| Cost line spacing | `ConfirmBodyLineHeight` | 1.4× |
 
 ## Elements
 
 - **Question** — `End the game for everyone?` The words *for everyone* are the
   point of the sentence.
-- **Cost** — built from the live game state, not a fixed string:
+- **Cost** — built from the live game state, not a fixed string. **Two** of its
+  numbers are live, not one: how many frogs are still swimming, and how many
+  frogs are in the game.
 
     | Situation | Body |
     | --- | --- |
-    | Some frogs still going | `Three frogs are still swimming. Ending it now stops the game for all four players and shows the results.` |
-    | Only one frog left going | `One frog is still swimming. Ending it now stops the game for all four players and shows the results.` |
+    | Some frogs still going | `<Count> frogs are still swimming. Ending it now stops the game for all <roster> players and shows the results.` |
+    | Only one frog left going | `One frog is still swimming. Ending it now stops the game for all <roster> players and shows the results.` |
+
+    `<Count>` is how many frogs are still swimming, spelled as a capitalised
+    word — `Two`, `Three`, `Four`. `<roster>` is how many frogs are in the
+    game, spelled as a lower-case word — `two`, `three`, `four`. Neither is
+    ever a digit, and neither is ever a fixed string: a game is
+    [two to four frogs](game-setup.md#invariants), so *all four players* is
+    simply false in a game of two or three, in the one dialog whose entire
+    protection is that it says something true and specific every time.
+
+    Three frogs still swimming in a four-player game therefore reads *Three
+    frogs are still swimming. Ending it now stops the game for all four players
+    and shows the results.* — the sentence
+    [the mockup](mockups/end-game-confirm.html) draws.
 
     There is no everybody-is-home wording, and there does not need to be:
     [the game ends itself](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open)


### PR DESCRIPTION
Closes #226

When somebody taps `End the game` in settings, this is the box that asks first — and instead of a vague "Are you sure?", it says what ending it actually costs: *Three frogs are still swimming. Ending it now stops the game for all four players and shows the results.* Both of those numbers are read from the game as it stands right now, so the sentence is still true in a two- or three-player game. `Keep playing` is the green button on the right where the thumb is, `End the game` is the red one all the way over on the left, and the hardware back button does exactly what `Keep playing` does. Ending a game is not losing it: every frog keeps the lily pads it has, and the results screen shows the order they were in.

**Docs:** `docs/specs/ui/end-game-confirm.md` — the cost table's two rows are now templates with the roster size as a live value, instead of hardcoding "all four players"; and the Named constants table gains `ConfirmBodyLineHeight` (1.4×), the cost paragraph's line spacing, which the mockup draws but the table was missing.

## Spec invariants this had to keep true

| Invariant (`end-game-confirm.md`) | The test that asserts it |
| --- | --- |
| "the confirm **names the cost** — how many frogs are still swimming" | `CostSentence_RendersBothLiveNumbersAsWords_ForEveryReachablePair` (all nine reachable pairs), `Cost_IsReadFromTheLiveGame_NotComposedFromAFixedString` |
| "the safe option is the primary button and is on the right… the destructive option is the outlined one, on the left, a full `ButtonDestructiveGap` away" | `Controls_AreDestructiveLeftAndPrimaryRight_OnTheDialogPaddingEdges`, `TheDestructiveButton_ClearsButtonDestructiveGap_ByAWideMargin` |
| "the hardware back button keeps playing. Back never ends a game." | `HardwareBack_DrivesTheIdenticalActionKeepPlayingDrives`, `HardwareBack_IsNotListenedForTwice`, `KeepPlaying_IsTheDialogsLeastDestructiveButton` |
| "cancelling returns to the exact board state — same turn, same positions" | `KeepPlaying_AsksOnlyForTheBoard_AndEndsNothing` |
| "Ending the game is **not** the same as losing it. Every frog keeps the pads it has" | `EndingTheGame_IsNotLosingIt_EveryFrogKeepsItsPosition` |
| "There is no everybody-is-home wording" | `CostSentence_HasNoEverybodyIsHomeWording` — zero throws, so the absence is structural rather than a comment |
| "no new spacing constant is needed for this dialog" (issue #226) | `PublicConstants_AreExactlyEndGameConfirmsOwn_UnderTheIdenticalNames` — a second copy of any shared constant shows up as an extra name |

The view holds no navigation of its own: `End the game` calls `Game.EndGame()` (#211) and then raises `GameEnded`; `Keep playing` and `RequestKeepPlaying()` (what the router calls on hardware back) raise `KeepPlayingRequested`. Both transitions are the router's (#213), which already has the edges and the back-button row for `Dialog.EndGameConfirm`. Nothing is instantiated outside tests — no composition root exists yet, and this PR does not add one.

## How the spec is changing

**Old rule.** The cost table printed two fixed sentences, both ending *"…stops the game for all four players and shows the results."*

**New rule.** Both rows are templates: the still-swimming count is a capitalised word (`One`…`Four`) and the roster size is a lower-case word (`two`/`three`/`four`), both read live from Core, neither ever a digit.

**Why the new one is better.** A game is [two to four frogs](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/game-setup.md), not always four, so *"all four players"* is simply false in a two- or three-player game — in the one dialog whose entire protection is that it says something true and specific every time. This is a parameterisation of an already-agreed sentence shape, not a new wording decision, and it is what issue #226 explicitly asked for.

**And one added row.** The mockup draws the cost paragraph at `line-height: 1.4`, a number the code needs (the sentence wraps to two lines at 40 px) that the Named constants table did not have. Per `ui-design-process.md`'s "the named constants are the origin, not an afterthought", that is a row that was missed rather than a value to invent, so it is added as `ConfirmBodyLineHeight` with the value the mockup draws. That is the only such value in this mockup — every other number in it maps to an existing row on this page or to a shared `Dialog`/`Button` constant.

## Deviations and Decisions

- **"…stops the game for all two players…" reads awkwardly, and I left it that way.** Issue #226 spells the substitution out — *"spelled as a lower-case word… (`two`/`three`/`four`)"* — so `two` is what the template renders in a two-player game, even though *both players* is the more natural English. Changing it would be a wording decision the issue did not make, so it is flagged here rather than invented. If Connor prefers *both*, that is a one-line change to `RosterSizeWords`.
- **The destructive button is re-anchored after the shared Dialog lays out its button row.** `DialogPanel.AddButton` packs right-to-left, which would leave `End the game` sitting exactly `ButtonDestructiveGap` (96 px) from `Keep playing`; the mockup pins it to the left edge of the padding box instead, over 400 px away. Both buttons still go through `AddButton` (so `Dialog.Buttons` and `LeastDestructiveButton` are correct), and the destructive one's `RectTransform` is then anchored left. The alternative was teaching the shared `DialogPanel` a "spread" button row, which is a change to a merged shared component with no editor here to re-verify it against the four dialogs already using it. A test asserts the resulting gap never drops below `ButtonDestructiveGap`.
- **The cost sits 152 px below the panel top, where the mockup draws it at 170 px.** The 18 px is the leading a browser puts under a 56 px line, not a spacing value — and issue #226 is explicit that the question→cost gap is the shared `DialogTitleGap`, with no confirm-only spacing constant to invent. Composing the named gaps was preferred to hard-coding the drawn offset; noted because a reviewer measuring the mockup would otherwise wonder.
- **The `question` region is the shared Dialog's own title, not a second text.** The mockup draws it at the title's exact place, size and weight, and `ConfirmQuestionSize` and `DialogTitleSize` are both 56 px — a test asserts the two agree, so the page's row cannot silently drift from what the shared component renders.
- **`docs/specs/ui/shared-components.md` is untouched.** Every dialog mockup's shared CSS draws a 3 px `.panel` border that the shared `DialogPanel` does not reproduce; #222 found this and correctly left it as a `shared-components.md` question tracked separately, and so does this PR.

## Verification

`dotnet test Tests/Core/Frogs.Core.Tests.csproj` (190 passed — regression only, no Core change), `check_core_isolation.py`, `check_assembly_references.py`, `check_geometry_literals.py`, `run_python_tests.py` and `mkdocs build --strict` all pass locally.

The EditMode tests were written first, per strict TDD, but could not be executed locally — no editor, no licence. CI carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_