### PR TITLE
feat(working-out-grid): draw the grid and keypad from Core's grid model

### DIFF
--- a/Assets/Scripts/Unity/IWorkingOutTurn.cs
+++ b/Assets/Scripts/Unity/IWorkingOutTurn.cs
@@ -1,0 +1,44 @@
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// Everything the working-out grid needs of the turn it was opened on —
+    /// docs/specs/ui/working-out-grid.md: whose turn it is, the card being
+    /// worked, and the one place the answer goes when `Check it` is pressed.
+    ///
+    /// It is not called a *readout* the way <see cref="IRollAndCardReadout"/>
+    /// is, because it is not only read from: <see cref="SubmitAnswer"/> is the
+    /// seam the answer row's digits leave this screen through, on their way to
+    /// Core's turn resolution (<see cref="Lane.Resolve"/>, #210). Grading them
+    /// happens there and is shown on
+    /// [answer result](docs/specs/ui/answer-result.md) (#224); nothing on this
+    /// side of the seam ever learns whether the answer was right, which is
+    /// what keeps ADR-0002's "nothing in the grid is marked" true by
+    /// construction rather than by discipline.
+    ///
+    /// The card arrives as a <see cref="Card"/> rather than as two operands —
+    /// unlike <see cref="IRollAndCardReadout"/>, which prints them — because
+    /// this screen does not print the problem so much as *derive its grid
+    /// from* it, and <see cref="WorkingOutGrid.For"/> takes a card.
+    /// </summary>
+    public interface IWorkingOutTurn
+    {
+        /// <summary>The frog taking this turn — the chip in the header.</summary>
+        FrogColour Frog { get; }
+
+        /// <summary>The pile the card came from, as Core reported it. Named in the header, never re-derived here.</summary>
+        Pile Pile { get; }
+
+        /// <summary>The card being worked. The grid's columns and printed digits are a function of this.</summary>
+        Card Card { get; }
+
+        /// <summary>
+        /// Hands the answer row's digits, read left to right as one number, to
+        /// Core's turn resolution. Called exactly once per press of an enabled
+        /// `Check it`, and never with an empty answer — an empty answer is not
+        /// a wrong answer, so it cannot be submitted at all.
+        /// </summary>
+        void SubmitAnswer(int answer);
+    }
+}

--- a/Assets/Scripts/Unity/IWorkingOutTurn.cs.meta
+++ b/Assets/Scripts/Unity/IWorkingOutTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e564715b1d0549a7a244f6ce5322c16b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/KeypadKeyKind.cs
+++ b/Assets/Scripts/Unity/Views/KeypadKeyKind.cs
@@ -1,0 +1,24 @@
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// What one key of the working-out grid's keypad does —
+    /// docs/specs/ui/working-out-grid.md § Elements: "`1`–`9`, `0`, backspace,
+    /// `clear`. No decimal point, no minus: every answer in this game is a
+    /// positive whole number."
+    ///
+    /// There is deliberately no <c>Undo</c> and no <c>Equals</c> entry: "there
+    /// is no `undo`, only backspace and `clear`", and open question 6 answers
+    /// the `=` key with "no, `Check it` is the commit".
+    /// </summary>
+    public enum KeypadKeyKind
+    {
+        /// <summary>One of the ten digit keys, `0` to `9`.</summary>
+        Digit,
+
+        /// <summary>Backspace — takes one digit away and nothing else.</summary>
+        Backspace,
+
+        /// <summary>`clear` — empties the cell block the caret is in, and only that.</summary>
+        Clear
+    }
+}

--- a/Assets/Scripts/Unity/Views/KeypadKeyKind.cs.meta
+++ b/Assets/Scripts/Unity/Views/KeypadKeyKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b041962d03444a2ab092df300b3c1fd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/WorkingOutGridCell.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridCell.cs
@@ -1,0 +1,120 @@
+using System;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// One drawn cell of the working-out grid — the rectangle, the digit in
+    /// it, and a tap.
+    ///
+    /// It knows which <see cref="GridRowKind"/> it was drawn for and which
+    /// <see cref="GridCellKind"/> Core reported for it, and it decides
+    /// nothing from either: <see cref="WorkingOutGridView"/> derives the whole
+    /// grid's shape from Core's model and stamps the answers onto each cell as
+    /// it builds them. The cell carries them so a tap can be answered — "tapping
+    /// any cell moves the caret there" applies to editable cells, and a printed
+    /// digit or an empty operator column is not one.
+    ///
+    /// Nothing here is ever marked right or wrong
+    /// (docs/adr/0002-structured-working-out-grid.md): this type has no notion
+    /// of a correct value, no second colour for one, and no member that names
+    /// one.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class WorkingOutGridCell : MonoBehaviour, IPointerClickHandler
+    {
+        /// <summary>This cell was tapped. Whether that moves the caret is the view's call, not this cell's.</summary>
+        public event Action<WorkingOutGridCell> Tapped;
+
+        /// <summary>The kind of row this cell was drawn in, as Core reported it.</summary>
+        public GridRowKind RowKind { get; private set; }
+
+        /// <summary>The kind of cell Core reported at this position.</summary>
+        public GridCellKind Kind { get; private set; }
+
+        /// <summary>Which column this is, column zero being the operator column.</summary>
+        public int Column { get; private set; }
+
+        /// <summary>
+        /// Which row of its own kind this is — the second carry strip is
+        /// <c>1</c>, the fourth addition row <c>3</c>. Stable while the
+        /// addition section grows and shrinks underneath it, which the display
+        /// row index is not.
+        /// </summary>
+        public int RowOrdinal { get; private set; }
+
+        /// <summary>The cell's outline, or null where the drawing has none — a printed digit and the operator column are both unboxed.</summary>
+        public Image Border { get; private set; }
+
+        /// <summary>The cell's fill, inside its outline, or null where there is no box.</summary>
+        public Image Fill { get; private set; }
+
+        /// <summary>The text drawn in the cell — a printed digit, an operator glyph, a typed digit, or empty.</summary>
+        public Text Label { get; private set; }
+
+        /// <summary>The cell's own <see cref="RectTransform"/>.</summary>
+        public RectTransform RectTransform
+        {
+            get { return (RectTransform)transform; }
+        }
+
+        /// <summary>
+        /// Whether the player may put a digit here. True of the addition
+        /// rows, the answer row and the carry boxes; false of the card's own
+        /// printed digits, the blank leading columns and the operator column.
+        /// </summary>
+        public bool IsEditable
+        {
+            get { return Kind == GridCellKind.Editable || Kind == GridCellKind.CarryBox; }
+        }
+
+        /// <summary>What is currently drawn in the cell, or the empty string.</summary>
+        public string Content
+        {
+            get { return Label == null ? string.Empty : Label.text; }
+        }
+
+        /// <summary>
+        /// Records what this cell is, as the view builds it. Called once, by
+        /// the view, immediately after the cell's objects exist.
+        /// </summary>
+        public void Describe(
+            GridRowKind rowKind,
+            int rowOrdinal,
+            GridCellKind kind,
+            int column,
+            Image border,
+            Image fill,
+            Text label)
+        {
+            RowKind = rowKind;
+            RowOrdinal = rowOrdinal;
+            Kind = kind;
+            Column = column;
+            Border = border;
+            Fill = fill;
+            Label = label;
+        }
+
+        /// <summary>Sets the text drawn in the cell — a digit, a glyph, or nothing.</summary>
+        public void SetText(string text)
+        {
+            if (Label != null)
+            {
+                Label.text = text;
+            }
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            var handler = Tapped;
+            if (handler != null)
+            {
+                handler(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/WorkingOutGridCell.cs.meta
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridCell.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ea20b0164ca4b3abd32206782fe3e13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
@@ -1,0 +1,1632 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// RollAndCardDialogView.cs and GameBoardScreenView.cs work around — so the
+// shared components are pulled in by explicit alias, and a bare `Button`,
+// `ButtonKind`, `DialogPanel`, `FrogColours` or `PlayerChip` in this file
+// always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// The screen the multiplication actually gets done on —
+    /// docs/specs/ui/working-out-grid.md, built to that page and its three
+    /// committed 1:1 mockups, on the shared <see cref="DialogPanel"/> (#219).
+    ///
+    /// **It decides no part of the grid's shape.** Which columns exist, which
+    /// rows exist and which cells in each are printed rather than fillable all
+    /// come from <see cref="WorkingOutGrid.For"/> (#204), asked afresh for the
+    /// card and the addition-row count as they are right now — ADR-0002:
+    /// "which cells exist for a given problem is game logic and belongs in
+    /// Core; only drawing them belongs in the Unity shell." There is no loop
+    /// here that re-derives a row count from the multiplier's digits, and no
+    /// column arithmetic of any kind.
+    ///
+    /// Two pieces of *drawing* it does derive, both from the row kinds Core
+    /// already reports and from nothing else:
+    ///
+    /// - **The rule lines.** A rule is a drawn separator with no cells, so
+    ///   Core never reports one. One goes under the multiplier row and one
+    ///   under the bottom of the addition section, which are the two
+    ///   adjacencies the reported row kinds fix.
+    /// - **The operator glyphs.** Core reports that column zero exists and is
+    ///   never fillable, not what sits in it: `×` on the multiplier row, `+`
+    ///   on the bottom row of the addition section, `=` on the answer row,
+    ///   nothing anywhere else.
+    ///
+    /// **Nothing on this screen is graded.** No cell is marked, coloured or
+    /// checked against a correct value while it is being filled in, and this
+    /// type has no notion of a correct value to check against. The only thing
+    /// that ever leaves is the answer row's digits, handed to
+    /// <see cref="IWorkingOutTurn.SubmitAnswer"/> when `Check it` is pressed;
+    /// grading them is #210's and showing the verdict is #224's.
+    ///
+    /// **Hardware back is inert here**, and it is inert the same way it is on
+    /// the roll-and-card dialog: by this view adding no handler at all and
+    /// nominating no least-destructive button on the shared Dialog. The router
+    /// (#213) already knows back does nothing over
+    /// <see cref="Frogs.Core.Dialog.WorkingOutGrid"/>; a second handler here
+    /// could only disagree with it.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class WorkingOutGridView : MonoBehaviour
+    {
+        // docs/specs/ui/working-out-grid.md#named-constants — the page's own
+        // table, under the identical names. GridAdditionRowsAtStart and
+        // GridAdditionRowsMax are on that table too and are deliberately not
+        // redeclared here: they are counts Core owns
+        // (WorkingOutGrid.GridAdditionRowsAtStart / GridAdditionRowsMax), and
+        // a second copy in the shell is the exact drift the page warns about.
+        public const float GridCellSize = 104f;
+        public const float GridCellGap = 8f;
+        public const float GridCellBorderWidth = 3f;
+        public const float GridCellRadius = 10f;
+        public const float GridCarryRowHeight = 56f;
+        public const float GridCarryBoxBorderWidth = 3f;
+        public const float GridCarryBoxRadius = 8f;
+        public const float GridRuleThickness = 6f;
+        public const float GridAdditionRowHeight = 56f;
+        public const float GridAnswerRowHeight = 128f;
+        public const float GridAnswerBorderWidth = 6f;
+        public const float GridDigitSize = 56f;
+        public const float GridSmallDigitSize = 28f;
+        public const float GridEqualsSize = 28f;
+        public const float GridHeaderHeight = 140f;
+        public const float GridHeaderTop = 44f;
+        public const float GridHeaderGap = 32f;
+        public const float GridPromptSize = 44f;
+        public const float GridCardReadoutHeight = 96f;
+        public const float GridCardReadoutPaddingX = 32f;
+        public const float GridCardReadoutRadius = 20f;
+        public const float GridCardReadoutBorderWidth = 3f;
+        public const float GridCardReadoutLabelSize = 40f;
+        public const float KeypadTop = 216f;
+        public const float KeypadKeySize = 140f;
+        public const float KeypadKeyGap = 16f;
+        public const float KeypadKeyRadius = 20f;
+        public const float KeypadKeyBorderWidth = 3f;
+        public const float KeypadKeyLabelSize = 56f;
+        public const float KeypadBackspaceLabelSize = 40f;
+        public const float KeypadClearLabelSize = 32f;
+        public const float KeypadWidth = 452f;
+        public const float KeypadSubmitGap = 24f;
+        public const float CheckButtonHeight = 128f;
+
+        /// <summary>
+        /// The carry box inside a carry strip's slot —
+        /// docs/specs/ui/working-out-grid.md's table writes it as one row,
+        /// `56 × 52 px`, so it is one value here too rather than two
+        /// half-named ones.
+        /// </summary>
+        public static readonly Vector2 GridCarryBoxSize = new Vector2(56f, 52f);
+
+        // The dialog's own scrim, corners, padding, radius and cross-fade are
+        // the shared Dialog's constants, referenced rather than redeclared —
+        // DialogPanel.DialogPadding, DialogMaxWidth, DialogMaxHeight,
+        // DialogRadius, DialogScrimOpacity and DialogFadeDuration. This dialog
+        // is full-bleed: the panel *is* DialogMaxWidth by DialogMaxHeight,
+        // which is the canvas inset by SafeMargin on every side.
+
+        // The keypad's shape: three keys across, four rows down —
+        // `1`–`9`, then backspace, `0`, `clear`. Counts, not measurements.
+        const int KeypadColumns = 3;
+        const int KeypadRows = 4;
+
+        // Column zero is the operator column, in every row Core reports.
+        const int OperatorColumn = 0;
+
+        const string PromptLabel = "Work it out";
+        const string CheckItLabel = "Check it";
+        const string BackspaceLabel = "⌫";
+        const string ClearLabel = "clear";
+
+        const string MultiplyGlyph = "×";
+        const string AddGlyph = "+";
+        const string EqualsGlyph = "=";
+        const string NoGlyph = "";
+
+        // The header's card readout, as the mockups write it: the problem, a
+        // separator, and the pile it came from in lower case — `331 × 41 ·
+        // hard pile`.
+        const string CardReadoutFormat = "{0} × {1} · {2}";
+        const string EasyPileName = "easy pile";
+        const string MediumPileName = "medium pile";
+        const string HardPileName = "hard pile";
+
+        // No imported font — matches Button.cs's, PlayerChip.cs's,
+        // DialogPanel.cs's and RollAndCardDialogView.cs's own choice, for the
+        // same reason (no external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockups
+        // (docs/specs/ui/mockups/working-out-grid-*.html) — the same line
+        // Button.cs, PlayerChip.cs, DialogPanel.cs and RollAndCardDialogView.cs
+        // each draw for their own colours: not a geometry constant on any spec
+        // page's table, so not declared as a named spec constant.
+        static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
+        static readonly Color LineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' --line
+        static readonly Color FaintColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockups' --faint
+        static readonly Color AccentColor = new Color32(0x2E, 0x7D, 0x4F, 0xFF); // mockups' --accent
+        static readonly Color PaperColor = Color.white; // mockups' --paper / #fff
+        static readonly Color AnswerTintColor = new Color32(0xF3, 0xF8, 0xF5, 0xFF); // mockups' answer-row fill
+
+        static Sprite s_cellSprite;
+        static Sprite s_carryBoxSprite;
+        static Sprite s_keySprite;
+        static Sprite s_readoutSprite;
+
+        static Sprite CellSprite
+        {
+            get
+            {
+                if (s_cellSprite == null)
+                {
+                    s_cellSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(GridCellRadius));
+                }
+
+                return s_cellSprite;
+            }
+        }
+
+        static Sprite CarryBoxSprite
+        {
+            get
+            {
+                if (s_carryBoxSprite == null)
+                {
+                    s_carryBoxSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(GridCarryBoxRadius));
+                }
+
+                return s_carryBoxSprite;
+            }
+        }
+
+        static Sprite KeySprite
+        {
+            get
+            {
+                if (s_keySprite == null)
+                {
+                    s_keySprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(KeypadKeyRadius));
+                }
+
+                return s_keySprite;
+            }
+        }
+
+        static Sprite ReadoutSprite
+        {
+            get
+            {
+                if (s_readoutSprite == null)
+                {
+                    s_readoutSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(GridCardReadoutRadius));
+                }
+
+                return s_readoutSprite;
+            }
+        }
+
+        RectTransform _rect;
+        DialogPanel _dialog;
+
+        RectTransform _headerRect;
+        PlayerChip _whoseChip;
+        Text _promptText;
+        RectTransform _cardReadoutRect;
+        Image _cardReadoutBorder;
+        Image _cardReadoutFill;
+        Text _cardReadoutText;
+
+        RectTransform _gridRect;
+        readonly List<GridRowKind> _rowKinds = new List<GridRowKind>();
+        readonly List<RectTransform> _rowRects = new List<RectTransform>();
+        readonly List<RectTransform> _ruleRects = new List<RectTransform>();
+        readonly List<IReadOnlyList<WorkingOutGridCell>> _cells = new List<IReadOnlyList<WorkingOutGridCell>>();
+
+        RectTransform _keypadRect;
+        RectTransform _keyGridRect;
+        readonly List<WorkingOutKeypadKey> _keys = new List<WorkingOutKeypadKey>();
+        Button _checkItButton;
+
+        // What the player has typed, held by row *identity* rather than by
+        // display index: growing the section shifts every row below it down by
+        // one, and a digit must not move with it.
+        readonly List<RowContents> _carryRows = new List<RowContents>();
+        readonly List<RowContents> _additionRows = new List<RowContents>();
+        RowContents _answerRow;
+        int _columnCount;
+        int _nextStamp;
+
+        GridRowKind _caretRowKind = GridRowKind.AnswerRow;
+        int _caretRowOrdinal;
+        int _caretColumn;
+
+        bool _initialized;
+        IWorkingOutTurn _turn;
+        ScreenRouter _router;
+
+        /// <summary>
+        /// `Check it` was pressed, on release, with the answer the row spells
+        /// out. The answer has already been handed to
+        /// <see cref="IWorkingOutTurn.SubmitAnswer"/> by the time this fires;
+        /// this only says the press happened, and carries no verdict, because
+        /// this screen never learns one.
+        /// </summary>
+        public event Action<int> AnswerSubmitted;
+
+        /// <summary>The view's own <see cref="RectTransform"/> — the full canvas the dialog covers.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The shared Dialog this is built on — full-bleed, and with no way to dismiss it.</summary>
+        public DialogPanel Dialog
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog;
+            }
+        }
+
+        /// <summary>`header` — whose turn it is, and the card being worked.</summary>
+        public RectTransform HeaderRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _headerRect;
+            }
+        }
+
+        /// <summary>The chip of the frog whose turn this is, active state.</summary>
+        public PlayerChip WhoseChip
+        {
+            get
+            {
+                EnsureInitialized();
+                return _whoseChip;
+            }
+        }
+
+        /// <summary>`Work it out` — the words beside the chip.</summary>
+        public Text PromptText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _promptText;
+            }
+        }
+
+        /// <summary>The pill around the card readout.</summary>
+        public RectTransform CardReadoutRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardReadoutRect;
+            }
+        }
+
+        /// <summary>The readout pill's outline, <see cref="GridCardReadoutBorderWidth"/> of it.</summary>
+        public Image CardReadoutBorder
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardReadoutBorder;
+            }
+        }
+
+        /// <summary>The readout pill's fill, inside its outline.</summary>
+        public Image CardReadoutFill
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardReadoutFill;
+            }
+        }
+
+        /// <summary>The card being worked — `331 × 41 · hard pile`.</summary>
+        public Text CardReadoutText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cardReadoutText;
+            }
+        }
+
+        /// <summary>`grid` — the working-out itself, sized to whatever Core reports.</summary>
+        public RectTransform GridRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _gridRect;
+            }
+        }
+
+        /// <summary>The row kinds drawn, top to bottom — exactly Core's own list, in Core's own order.</summary>
+        public IReadOnlyList<GridRowKind> RowKinds
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rowKinds;
+            }
+        }
+
+        /// <summary>One rect per drawn row, top to bottom, matching <see cref="RowKinds"/>.</summary>
+        public IReadOnlyList<RectTransform> RowRects
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rowRects;
+            }
+        }
+
+        /// <summary>The drawn rule lines, top to bottom. Two of them, and they are not rows.</summary>
+        public IReadOnlyList<RectTransform> RuleRects
+        {
+            get
+            {
+                EnsureInitialized();
+                return _ruleRects;
+            }
+        }
+
+        /// <summary>Every drawn cell, by row then column — column zero being the operator column.</summary>
+        public IReadOnlyList<IReadOnlyList<WorkingOutGridCell>> Cells
+        {
+            get
+            {
+                EnsureInitialized();
+                return _cells;
+            }
+        }
+
+        /// <summary>`keypad` — the twelve keys, fixed in place for every problem.</summary>
+        public RectTransform KeypadRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _keypadRect;
+            }
+        }
+
+        /// <summary>The keys, in reading order: `1`–`9`, then backspace, `0`, `clear`.</summary>
+        public IReadOnlyList<WorkingOutKeypadKey> Keys
+        {
+            get
+            {
+                EnsureInitialized();
+                return _keys;
+            }
+        }
+
+        /// <summary>`submit` — `Check it`, full keypad width, disabled until the answer row has a digit.</summary>
+        public Button CheckItButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _checkItButton;
+            }
+        }
+
+        /// <summary>How many rows the addition section currently holds — the count Core's model is asked for.</summary>
+        public int AdditionRowCount
+        {
+            get
+            {
+                EnsureInitialized();
+                return _additionRows.Count;
+            }
+        }
+
+        /// <summary>The cell the caret is in. Every typed digit lands here.</summary>
+        public WorkingOutGridCell CaretCell
+        {
+            get
+            {
+                EnsureInitialized();
+                return FindCell(_caretRowKind, _caretRowOrdinal, _caretColumn);
+            }
+        }
+
+        /// <summary>
+        /// The answer row's digits, read left to right, with empty cells
+        /// contributing nothing — the string `Check it` submits. Empty when
+        /// nothing has been typed into the answer row.
+        /// </summary>
+        public string AnswerText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _answerRow == null ? string.Empty : _answerRow.ReadLeftToRight();
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        /// <summary>
+        /// Points the grid at the turn it was opened on, and at the router
+        /// `Check it` navigates through, then opens it. The caret starts in
+        /// the rightmost answer cell — "the first empty answer cell is the
+        /// focused one; typing fills the answer row right to left."
+        ///
+        /// The router is optional for the same reason
+        /// <c>RollAndCardDialogView.Initialize</c>'s is: a test that only
+        /// cares what the grid draws should not have to hand it a navigation
+        /// graph.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="turn"/> is null.</exception>
+        public void Initialize(IWorkingOutTurn turn, ScreenRouter router = null)
+        {
+            EnsureInitialized();
+
+            _turn = turn ?? throw new ArgumentNullException(nameof(turn));
+            _router = router;
+
+            _carryRows.Clear();
+            _additionRows.Clear();
+            _answerRow = null;
+            _columnCount = 0;
+            _nextStamp = 0;
+
+            Refresh();
+
+            // The rightmost answer cell, which on a grid nobody has typed in
+            // yet is also the first empty one.
+            MoveCaretTo(GridRowKind.AnswerRow, 0, _columnCount - 1);
+
+            _dialog.Open();
+        }
+
+        /// <summary>
+        /// Re-reads the turn and redraws: the chip, the card readout, and the
+        /// whole grid, asked of <see cref="WorkingOutGrid.For"/> again at the
+        /// addition-row count the section currently holds.
+        /// </summary>
+        public void Refresh()
+        {
+            EnsureInitialized();
+
+            if (_turn == null)
+            {
+                return;
+            }
+
+            var frog = _turn.Frog;
+            _whoseChip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _whoseChip.SetState(PlayerChipState.Active);
+
+            var card = _turn.Card;
+            _cardReadoutText.text = string.Format(
+                CardReadoutFormat,
+                card.Multiplicand,
+                card.Multiplier,
+                PileNameFor(_turn.Pile));
+
+            LayoutHeader();
+            RebuildGrid();
+        }
+
+        // Unity does not guarantee Awake() has run before another component's
+        // Awake() or a test reaches this one right after AddComponent — the
+        // same reasoning as Button, DialogPanel and RollAndCardDialogView's
+        // own EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _dialog = GetComponent<DialogPanel>();
+            if (_dialog == null)
+            {
+                _dialog = gameObject.AddComponent<DialogPanel>();
+            }
+
+            // Full-bleed: the panel is the shared Dialog's maximum, which is
+            // the canvas inset by SafeMargin on every side.
+            _dialog.SetSize(DialogPanel.DialogMaxWidth, DialogPanel.DialogMaxHeight);
+
+            BuildHeader();
+            BuildGridContainer();
+            BuildKeypad();
+        }
+
+        void BuildHeader()
+        {
+            var headerGO = new GameObject("Header", typeof(RectTransform));
+            _headerRect = (RectTransform)headerGO.transform;
+            _headerRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _headerRect.anchorMin = new Vector2(0f, 1f);
+            _headerRect.anchorMax = new Vector2(0f, 1f);
+            _headerRect.pivot = new Vector2(0f, 1f);
+            _headerRect.sizeDelta = new Vector2(
+                _dialog.PanelRect.rect.width - (2f * DialogPanel.DialogPadding),
+                PlayerChip.PlayerChipHeight);
+            _headerRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, -GridHeaderTop);
+
+            var chipGO = new GameObject("WhoseChip", typeof(RectTransform));
+            var chipRect = (RectTransform)chipGO.transform;
+            chipRect.SetParent(_headerRect, worldPositionStays: false);
+            chipRect.anchorMin = new Vector2(0f, 0.5f);
+            chipRect.anchorMax = new Vector2(0f, 0.5f);
+            chipRect.pivot = new Vector2(0f, 0.5f);
+            chipRect.anchoredPosition = Vector2.zero;
+            _whoseChip = chipGO.AddComponent<PlayerChip>();
+
+            // Unity does not run Awake() on AddComponent outside play mode,
+            // and the chip sizes itself when it builds. Touch its rect so it
+            // builds now, while the header is being laid out.
+            chipRect = _whoseChip.RectTransform;
+
+            _promptText = BuildText("Prompt", _headerRect, GridPromptSize, LineColor, TextAnchor.MiddleLeft);
+            _promptText.text = PromptLabel;
+
+            var promptRect = _promptText.rectTransform;
+            promptRect.anchorMin = new Vector2(0f, 0.5f);
+            promptRect.anchorMax = new Vector2(0f, 0.5f);
+            promptRect.pivot = new Vector2(0f, 0.5f);
+
+            var readoutGO = new GameObject("CardReadout", typeof(RectTransform), typeof(Image));
+            _cardReadoutBorder = readoutGO.GetComponent<Image>();
+            _cardReadoutBorder.sprite = ReadoutSprite;
+            _cardReadoutBorder.type = Image.Type.Sliced;
+            _cardReadoutBorder.color = FaintColor;
+            _cardReadoutBorder.raycastTarget = false;
+
+            _cardReadoutRect = _cardReadoutBorder.rectTransform;
+            _cardReadoutRect.SetParent(_headerRect, worldPositionStays: false);
+            _cardReadoutRect.anchorMin = new Vector2(0f, 0.5f);
+            _cardReadoutRect.anchorMax = new Vector2(0f, 0.5f);
+            _cardReadoutRect.pivot = new Vector2(0f, 0.5f);
+
+            var readoutFillGO = new GameObject("CardReadoutFill", typeof(RectTransform), typeof(Image));
+            _cardReadoutFill = readoutFillGO.GetComponent<Image>();
+            _cardReadoutFill.sprite = ReadoutSprite;
+            _cardReadoutFill.type = Image.Type.Sliced;
+            _cardReadoutFill.color = PaperColor;
+            _cardReadoutFill.raycastTarget = false;
+
+            var readoutFillRect = _cardReadoutFill.rectTransform;
+            readoutFillRect.SetParent(_cardReadoutRect, worldPositionStays: false);
+            readoutFillRect.anchorMin = Vector2.zero;
+            readoutFillRect.anchorMax = Vector2.one;
+            readoutFillRect.offsetMin = new Vector2(GridCardReadoutBorderWidth, GridCardReadoutBorderWidth);
+            readoutFillRect.offsetMax = new Vector2(-GridCardReadoutBorderWidth, -GridCardReadoutBorderWidth);
+
+            _cardReadoutText = BuildText("CardReadoutLabel", _cardReadoutRect, GridCardReadoutLabelSize, InkColor, TextAnchor.MiddleCenter);
+            _cardReadoutText.fontStyle = FontStyle.Bold;
+            var readoutTextRect = _cardReadoutText.rectTransform;
+            readoutTextRect.anchorMin = Vector2.zero;
+            readoutTextRect.anchorMax = Vector2.one;
+            readoutTextRect.offsetMin = Vector2.zero;
+            readoutTextRect.offsetMax = Vector2.zero;
+
+            LayoutHeader();
+        }
+
+        // The header is one row: the chip, the prompt, then the card readout,
+        // GridHeaderGap apart. The two labels are content-sized, so the row is
+        // laid out again whenever the card changes rather than positioned once
+        // at build time.
+        void LayoutHeader()
+        {
+            var promptWidth = _promptText.preferredWidth;
+            var promptRect = _promptText.rectTransform;
+            promptRect.sizeDelta = new Vector2(promptWidth, GridPromptSize);
+            promptRect.anchoredPosition = new Vector2(PlayerChip.PlayerChipWidth + GridHeaderGap, 0f);
+
+            var readoutWidth = _cardReadoutText.preferredWidth + (2f * GridCardReadoutPaddingX);
+            _cardReadoutRect.sizeDelta = new Vector2(readoutWidth, GridCardReadoutHeight);
+            _cardReadoutRect.anchoredPosition = new Vector2(
+                PlayerChip.PlayerChipWidth + GridHeaderGap + promptWidth + GridHeaderGap,
+                0f);
+        }
+
+        void BuildGridContainer()
+        {
+            var gridGO = new GameObject("Grid", typeof(RectTransform));
+            _gridRect = (RectTransform)gridGO.transform;
+            _gridRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _gridRect.anchorMin = new Vector2(0f, 1f);
+            _gridRect.anchorMax = new Vector2(0f, 1f);
+            _gridRect.pivot = new Vector2(0f, 1f);
+        }
+
+        // Everything about the grid, from Core's model outward. Called once
+        // per shape change — a card, or the addition section growing or
+        // shrinking — and never per keystroke.
+        void RebuildGrid()
+        {
+            var model = WorkingOutGrid.For(_turn.Card, _additionRows.Count == 0
+                ? WorkingOutGrid.GridAdditionRowsAtStart
+                : _additionRows.Count);
+
+            EnsureContents(model.ColumnCount);
+
+            for (var index = _gridRect.childCount - 1; index >= 0; index--)
+            {
+                UnityEngine.Object.DestroyImmediate(_gridRect.GetChild(index).gameObject);
+            }
+
+            _rowKinds.Clear();
+            _rowRects.Clear();
+            _ruleRects.Clear();
+            _cells.Clear();
+
+            var width = (model.ColumnCount * GridCellSize) + ((model.ColumnCount - 1) * GridCellGap);
+            var height = GridHeightFor(model);
+
+            _gridRect.sizeDelta = new Vector2(width, height);
+            _gridRect.anchoredPosition = GridOrigin(width, height);
+
+            var ordinals = new Dictionary<GridRowKind, int>();
+            var cursor = 0f;
+
+            for (var index = 0; index < model.Rows.Count; index++)
+            {
+                var row = model.Rows[index];
+
+                var ordinal = 0;
+                if (ordinals.ContainsKey(row.Kind))
+                {
+                    ordinal = ordinals[row.Kind];
+                }
+
+                ordinals[row.Kind] = ordinal + 1;
+
+                var rowHeight = RowHeightFor(row.Kind);
+                var rowRect = BuildRow(row, ordinal, IsBottomOfSection(model, index), width, rowHeight, cursor);
+
+                _rowKinds.Add(row.Kind);
+                _rowRects.Add(rowRect);
+
+                cursor += rowHeight + GridCellGap;
+
+                if (!RuleFollows(model, index))
+                {
+                    continue;
+                }
+
+                _ruleRects.Add(BuildRule(width, cursor));
+                cursor += GridRuleThickness + GridCellGap;
+            }
+
+            RefreshCells();
+        }
+
+        // A rule line goes under the multiplier row, and under the bottom row
+        // of the addition section. Both adjacencies are read off the row kinds
+        // Core reports — this is the one piece of shape the shell derives, and
+        // it derives nothing else.
+        static bool RuleFollows(WorkingOutGrid model, int index)
+        {
+            if (index + 1 >= model.Rows.Count)
+            {
+                return false;
+            }
+
+            var kind = model.Rows[index].Kind;
+            var next = model.Rows[index + 1].Kind;
+
+            if (kind == GridRowKind.Multiplier)
+            {
+                return true;
+            }
+
+            return kind == GridRowKind.AdditionRow && next != GridRowKind.AdditionRow;
+        }
+
+        // The `+` sits in the operator column of the bottom row of the
+        // addition section, wherever the bottom currently is — growing the
+        // section moves the glyph down with it rather than stamping a `+` on
+        // every row.
+        static bool IsBottomOfSection(WorkingOutGrid model, int index)
+        {
+            if (model.Rows[index].Kind != GridRowKind.AdditionRow)
+            {
+                return false;
+            }
+
+            return index + 1 >= model.Rows.Count
+                || model.Rows[index + 1].Kind != GridRowKind.AdditionRow;
+        }
+
+        float GridHeightFor(WorkingOutGrid model)
+        {
+            var total = 0f;
+            var parts = 0;
+
+            for (var index = 0; index < model.Rows.Count; index++)
+            {
+                total += RowHeightFor(model.Rows[index].Kind);
+                parts++;
+
+                if (!RuleFollows(model, index))
+                {
+                    continue;
+                }
+
+                total += GridRuleThickness;
+                parts++;
+            }
+
+            return total + ((parts - 1) * GridCellGap);
+        }
+
+        // docs/specs/ui/working-out-grid.md#anchors: the keypad and `Check it`
+        // are pinned right, DialogPadding from the panel edge, and the grid is
+        // centred in the space left over — which is the panel inside its
+        // padding, less the keypad column, and below the header band.
+        Vector2 GridOrigin(float width, float height)
+        {
+            var panel = _dialog.PanelRect.rect;
+
+            var regionLeft = DialogPanel.DialogPadding;
+            var regionRight = panel.width - DialogPanel.DialogPadding - KeypadWidth;
+            var regionTop = GridHeaderHeight;
+            var regionBottom = panel.height - DialogPanel.DialogPadding;
+
+            var left = regionLeft + ((regionRight - regionLeft - width) / 2f);
+            var top = regionTop + ((regionBottom - regionTop - height) / 2f);
+
+            return new Vector2(left, -top);
+        }
+
+        /// <summary>
+        /// How tall one row of <paramref name="kind"/> is drawn.
+        ///
+        /// The addition section is the only kind whose height is not fixed:
+        /// Derek's call on #223 — "smaller cells for addition rows only" —
+        /// gives it <see cref="GridAdditionRowHeight"/> once the player has
+        /// grown it past the count every card is dealt, and leaves the
+        /// multiplicand, the multiplier, the rules, the carry strips and the
+        /// answer row at their full size at every count. That is what keeps
+        /// the section inside the dialog at <c>GridAdditionRowsMax</c>: six
+        /// grown rows make an 892 px grid in the 908 px the panel has below
+        /// its header.
+        /// </summary>
+        public float RowHeightFor(GridRowKind kind)
+        {
+            switch (kind)
+            {
+                case GridRowKind.CarryStrip:
+                    return GridCarryRowHeight;
+
+                case GridRowKind.AnswerRow:
+                    return GridAnswerRowHeight;
+
+                case GridRowKind.AdditionRow:
+                    return _additionRows.Count > WorkingOutGrid.GridAdditionRowsAtStart
+                        ? GridAdditionRowHeight
+                        : GridCellSize;
+
+                default:
+                    return GridCellSize;
+            }
+        }
+
+        float DigitSizeFor(GridRowKind kind)
+        {
+            if (kind == GridRowKind.CarryStrip)
+            {
+                return GridSmallDigitSize;
+            }
+
+            return RowHeightFor(kind) < GridCellSize ? GridSmallDigitSize : GridDigitSize;
+        }
+
+        RectTransform BuildRow(
+            GridRow row,
+            int ordinal,
+            bool isBottomOfSection,
+            float width,
+            float rowHeight,
+            float top)
+        {
+            var rowGO = new GameObject(row.Kind + "Row", typeof(RectTransform));
+            var rowRect = (RectTransform)rowGO.transform;
+            rowRect.SetParent(_gridRect, worldPositionStays: false);
+            rowRect.anchorMin = new Vector2(0f, 1f);
+            rowRect.anchorMax = new Vector2(0f, 1f);
+            rowRect.pivot = new Vector2(0f, 1f);
+            rowRect.sizeDelta = new Vector2(width, rowHeight);
+            rowRect.anchoredPosition = new Vector2(0f, -top);
+
+            var cells = new List<WorkingOutGridCell>();
+
+            for (var column = 0; column < row.Cells.Count; column++)
+            {
+                cells.Add(BuildCell(row, ordinal, isBottomOfSection, column, rowRect, rowHeight));
+            }
+
+            _cells.Add(cells);
+            return rowRect;
+        }
+
+        WorkingOutGridCell BuildCell(
+            GridRow row,
+            int ordinal,
+            bool isBottomOfSection,
+            int column,
+            RectTransform rowRect,
+            float rowHeight)
+        {
+            var cellGO = new GameObject("Cell" + column, typeof(RectTransform));
+            var cellRect = (RectTransform)cellGO.transform;
+            cellRect.SetParent(rowRect, worldPositionStays: false);
+            cellRect.anchorMin = new Vector2(0f, 1f);
+            cellRect.anchorMax = new Vector2(0f, 1f);
+            cellRect.pivot = new Vector2(0f, 1f);
+            cellRect.sizeDelta = new Vector2(GridCellSize, rowHeight);
+            cellRect.anchoredPosition = new Vector2(column * (GridCellSize + GridCellGap), 0f);
+
+            var cell = cellGO.AddComponent<WorkingOutGridCell>();
+            var kind = row.Cells[column].Kind;
+
+            Image border = null;
+            Image fill = null;
+            Text label = null;
+
+            switch (kind)
+            {
+                case GridCellKind.CarryBox:
+                    border = BuildBox(
+                        cellRect,
+                        CarryBoxSprite,
+                        GridCarryBoxSize,
+                        GridCarryBoxBorderWidth,
+                        FaintColor,
+                        out fill);
+                    label = BuildText("Digit", border.rectTransform, GridSmallDigitSize, InkColor, TextAnchor.MiddleCenter);
+                    StretchToFill(label.rectTransform);
+                    break;
+
+                case GridCellKind.Editable:
+                    var borderWidth = row.Kind == GridRowKind.AnswerRow
+                        ? GridAnswerBorderWidth
+                        : GridCellBorderWidth;
+
+                    border = BuildBox(
+                        cellRect,
+                        CellSprite,
+                        new Vector2(GridCellSize, rowHeight),
+                        borderWidth,
+                        LineColor,
+                        out fill);
+
+                    if (row.Kind == GridRowKind.AnswerRow)
+                    {
+                        fill.color = AnswerTintColor;
+                    }
+
+                    label = BuildText("Digit", border.rectTransform, DigitSizeFor(row.Kind), InkColor, TextAnchor.MiddleCenter);
+                    StretchToFill(label.rectTransform);
+                    break;
+
+                case GridCellKind.Printed:
+                    // The card's own digits: no box, no fill — the mockups'
+                    // `.cell.fix` is border:none on a transparent background.
+                    label = BuildText("Digit", cellRect, DigitSizeFor(row.Kind), InkColor, TextAnchor.MiddleCenter);
+                    label.fontStyle = FontStyle.Bold;
+                    StretchToFill(label.rectTransform);
+                    label.text = row.Cells[column].Digit.ToString();
+                    break;
+
+                default:
+                    // Blank: the leading columns of a printed row, and the
+                    // operator column of every row. Only the operator column
+                    // ever has anything drawn in it, and what that is comes
+                    // from the row kind.
+                    if (column == OperatorColumn)
+                    {
+                        var glyph = OperatorGlyphFor(row.Kind, isBottomOfSection);
+
+                        if (glyph.Length > 0)
+                        {
+                            var isEquals = glyph == EqualsGlyph;
+                            label = BuildText(
+                                "Operator",
+                                cellRect,
+                                isEquals ? GridEqualsSize : GridDigitSize,
+                                isEquals ? LineColor : InkColor,
+                                TextAnchor.MiddleCenter);
+                            label.fontStyle = FontStyle.Bold;
+                            StretchToFill(label.rectTransform);
+                            label.text = glyph;
+                        }
+                    }
+
+                    break;
+            }
+
+            cell.Describe(row.Kind, ordinal, kind, column, border, fill, label);
+            cell.Tapped += HandleCellTapped;
+            return cell;
+        }
+
+        // `×` on the multiplier row, `+` on the bottom row of the addition
+        // section, `=` on the answer row, and nothing on the carry strips or
+        // the multiplicand row — derived from the row kind being drawn, never
+        // from a per-card lookup.
+        static string OperatorGlyphFor(GridRowKind kind, bool isBottomOfSection)
+        {
+            switch (kind)
+            {
+                case GridRowKind.Multiplier:
+                    return MultiplyGlyph;
+
+                case GridRowKind.AdditionRow:
+                    return isBottomOfSection ? AddGlyph : NoGlyph;
+
+                case GridRowKind.AnswerRow:
+                    return EqualsGlyph;
+
+                default:
+                    return NoGlyph;
+            }
+        }
+
+        // An outlined box: the border image, with the fill inset by the
+        // border's own width. "Flat" in these mockups means flat-coloured,
+        // not borderless.
+        static Image BuildBox(
+            RectTransform parent,
+            Sprite sprite,
+            Vector2 size,
+            float borderWidth,
+            Color borderColor,
+            out Image fill)
+        {
+            var borderGO = new GameObject("Box", typeof(RectTransform), typeof(Image));
+            var border = borderGO.GetComponent<Image>();
+            border.sprite = sprite;
+            border.type = Image.Type.Sliced;
+            border.color = borderColor;
+            border.raycastTarget = false;
+
+            var borderRect = border.rectTransform;
+            borderRect.SetParent(parent, worldPositionStays: false);
+            borderRect.anchorMin = new Vector2(0.5f, 0.5f);
+            borderRect.anchorMax = new Vector2(0.5f, 0.5f);
+            borderRect.pivot = new Vector2(0.5f, 0.5f);
+            borderRect.sizeDelta = size;
+            borderRect.anchoredPosition = Vector2.zero;
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            fill = fillGO.GetComponent<Image>();
+            fill.sprite = sprite;
+            fill.type = Image.Type.Sliced;
+            fill.color = PaperColor;
+            fill.raycastTarget = false;
+
+            var fillRect = fill.rectTransform;
+            fillRect.SetParent(borderRect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(borderWidth, borderWidth);
+            fillRect.offsetMax = new Vector2(-borderWidth, -borderWidth);
+
+            return border;
+        }
+
+        RectTransform BuildRule(float width, float top)
+        {
+            var ruleGO = new GameObject("Rule", typeof(RectTransform), typeof(Image));
+            var rule = ruleGO.GetComponent<Image>();
+            rule.color = InkColor;
+            rule.raycastTarget = false;
+
+            var ruleRect = rule.rectTransform;
+            ruleRect.SetParent(_gridRect, worldPositionStays: false);
+            ruleRect.anchorMin = new Vector2(0f, 1f);
+            ruleRect.anchorMax = new Vector2(0f, 1f);
+            ruleRect.pivot = new Vector2(0f, 1f);
+            ruleRect.sizeDelta = new Vector2(width, GridRuleThickness);
+            ruleRect.anchoredPosition = new Vector2(0f, -top);
+
+            return ruleRect;
+        }
+
+        void BuildKeypad()
+        {
+            var keyGridHeight = (KeypadRows * KeypadKeySize) + ((KeypadRows - 1) * KeypadKeyGap);
+            var columnHeight = keyGridHeight + KeypadSubmitGap + CheckButtonHeight;
+
+            var keypadGO = new GameObject("Keypad", typeof(RectTransform));
+            _keypadRect = (RectTransform)keypadGO.transform;
+            _keypadRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _keypadRect.anchorMin = new Vector2(1f, 1f);
+            _keypadRect.anchorMax = new Vector2(1f, 1f);
+            _keypadRect.pivot = new Vector2(1f, 1f);
+            _keypadRect.sizeDelta = new Vector2(KeypadWidth, columnHeight);
+            _keypadRect.anchoredPosition = new Vector2(-DialogPanel.DialogPadding, -KeypadTop);
+
+            var keyGridGO = new GameObject("Keys", typeof(RectTransform));
+            _keyGridRect = (RectTransform)keyGridGO.transform;
+            _keyGridRect.SetParent(_keypadRect, worldPositionStays: false);
+            _keyGridRect.anchorMin = new Vector2(0f, 1f);
+            _keyGridRect.anchorMax = new Vector2(0f, 1f);
+            _keyGridRect.pivot = new Vector2(0f, 1f);
+            _keyGridRect.sizeDelta = new Vector2(KeypadWidth, keyGridHeight);
+            _keyGridRect.anchoredPosition = Vector2.zero;
+
+            // `1`–`9`, then backspace, `0`, `clear` — the mockups' own order.
+            for (var digit = 1; digit <= 9; digit++)
+            {
+                BuildKey(KeypadKeyKind.Digit, digit, digit.ToString(), KeypadKeyLabelSize);
+            }
+
+            BuildKey(KeypadKeyKind.Backspace, -1, BackspaceLabel, KeypadBackspaceLabelSize);
+            BuildKey(KeypadKeyKind.Digit, 0, "0", KeypadKeyLabelSize);
+            BuildKey(KeypadKeyKind.Clear, -1, ClearLabel, KeypadClearLabelSize);
+
+            _checkItButton = BuildCheckIt(keyGridHeight);
+        }
+
+        void BuildKey(KeypadKeyKind kind, int digit, string label, float labelSize)
+        {
+            var index = _keys.Count;
+            var column = index % KeypadColumns;
+            var row = index / KeypadColumns;
+
+            var keyGO = new GameObject("Key" + label, typeof(RectTransform));
+            var keyRect = (RectTransform)keyGO.transform;
+            keyRect.SetParent(_keyGridRect, worldPositionStays: false);
+            keyRect.anchorMin = new Vector2(0f, 1f);
+            keyRect.anchorMax = new Vector2(0f, 1f);
+            keyRect.pivot = new Vector2(0f, 1f);
+            keyRect.sizeDelta = new Vector2(KeypadKeySize, KeypadKeySize);
+            keyRect.anchoredPosition = new Vector2(
+                column * (KeypadKeySize + KeypadKeyGap),
+                -(row * (KeypadKeySize + KeypadKeyGap)));
+
+            Image fill;
+            var border = BuildBox(
+                keyRect,
+                KeySprite,
+                new Vector2(KeypadKeySize, KeypadKeySize),
+                KeypadKeyBorderWidth,
+                LineColor,
+                out fill);
+
+            var text = BuildText("Label", border.rectTransform, labelSize, InkColor, TextAnchor.MiddleCenter);
+            text.fontStyle = FontStyle.Bold;
+            text.text = label;
+            StretchToFill(text.rectTransform);
+
+            var key = keyGO.AddComponent<WorkingOutKeypadKey>();
+            key.Describe(kind, digit, border, fill, text);
+            key.Tapped += HandleKeyTapped;
+
+            _keys.Add(key);
+        }
+
+        Button BuildCheckIt(float keyGridHeight)
+        {
+            var buttonGO = new GameObject(CheckItLabel, typeof(RectTransform));
+            buttonGO.transform.SetParent(_keypadRect, worldPositionStays: false);
+
+            // A shared primary Button, parented into the keypad column rather
+            // than the shared Dialog's button row: this page pins `Check it`
+            // under the keypad, at full keypad width, so the row's
+            // right-aligned layout is not what puts it where it goes.
+            var button = buttonGO.AddComponent<Button>();
+            button.SetKind(ButtonKind.Primary);
+            button.SetLabelText(CheckItLabel);
+            button.SetSize(KeypadWidth, CheckButtonHeight);
+            button.Clicked += HandleCheckItClicked;
+
+            var buttonRect = button.RectTransform;
+            buttonRect.anchorMin = new Vector2(0f, 1f);
+            buttonRect.anchorMax = new Vector2(0f, 1f);
+            buttonRect.pivot = new Vector2(0f, 1f);
+            buttonRect.anchoredPosition = new Vector2(0f, -(keyGridHeight + KeypadSubmitGap));
+
+            // An empty answer is not a wrong answer, so it cannot be
+            // submitted at all.
+            button.SetDisabled(true);
+
+            return button;
+        }
+
+        void EnsureContents(int columnCount)
+        {
+            if (_columnCount == columnCount && _answerRow != null)
+            {
+                return;
+            }
+
+            _columnCount = columnCount;
+            _carryRows.Clear();
+            _additionRows.Clear();
+
+            for (var index = 0; index < WorkingOutGrid.CarryStripCount; index++)
+            {
+                _carryRows.Add(new RowContents(columnCount));
+            }
+
+            for (var index = 0; index < WorkingOutGrid.GridAdditionRowsAtStart; index++)
+            {
+                _additionRows.Add(new RowContents(columnCount));
+            }
+
+            _answerRow = new RowContents(columnCount);
+        }
+
+        void HandleCellTapped(WorkingOutGridCell cell)
+        {
+            // "Tapping any cell moves the caret there, so the grid can be
+            // filled in any order." A printed digit and the operator column
+            // are not cells anything can be typed into, so a tap on one moves
+            // nothing.
+            if (!cell.IsEditable)
+            {
+                return;
+            }
+
+            MoveCaretTo(cell.RowKind, cell.RowOrdinal, cell.Column);
+        }
+
+        void HandleKeyTapped(WorkingOutKeypadKey key)
+        {
+            switch (key.Kind)
+            {
+                case KeypadKeyKind.Digit:
+                    TypeDigit(key.Digit);
+                    break;
+
+                case KeypadKeyKind.Backspace:
+                    Backspace();
+                    break;
+
+                case KeypadKeyKind.Clear:
+                    ClearBlock();
+                    break;
+            }
+        }
+
+        void TypeDigit(int digit)
+        {
+            var contents = CaretContents();
+
+            if (contents == null)
+            {
+                return;
+            }
+
+            contents.Write(_caretColumn, digit, _nextStamp++);
+
+            var grew = GrowSectionIfWrittenAtItsBottom();
+
+            if (grew)
+            {
+                RebuildGrid();
+            }
+
+            // Right to left, "which is the direction the digits are worked
+            // out in": the next digit goes in the cell to the left, until
+            // there is no cell to the left.
+            var nextColumn = Mathf.Max(_caretColumn - 1, OperatorColumn + 1);
+            MoveCaretTo(_caretRowKind, _caretRowOrdinal, nextColumn);
+        }
+
+        // "Typing a single digit into the section's current bottom row appends
+        // another row beneath it, still above the answer row. That repeats
+        // each time the new bottom row is written in, until the section holds
+        // GridAdditionRowsMax rows, after which nothing more is appended."
+        bool GrowSectionIfWrittenAtItsBottom()
+        {
+            if (_caretRowKind != GridRowKind.AdditionRow)
+            {
+                return false;
+            }
+
+            if (_caretRowOrdinal != _additionRows.Count - 1)
+            {
+                return false;
+            }
+
+            if (_additionRows.Count >= WorkingOutGrid.GridAdditionRowsMax)
+            {
+                return false;
+            }
+
+            _additionRows.Add(new RowContents(_columnCount));
+            return true;
+        }
+
+        void Backspace()
+        {
+            var contents = CaretContents();
+
+            if (contents == null)
+            {
+                return;
+            }
+
+            // "Backspace removes the digit in the caret's current cell, or the
+            // last-entered digit of the current block if the caret's own cell
+            // is empty" — and nothing outside that block, ever.
+            var column = contents.HasDigit(_caretColumn)
+                ? _caretColumn
+                : contents.LastEnteredColumn();
+
+            if (column < 0)
+            {
+                return;
+            }
+
+            contents.Erase(column);
+            MoveCaretTo(_caretRowKind, _caretRowOrdinal, column);
+
+            ShrinkSectionIfEmptiedAtItsBottom();
+        }
+
+        // Derek's call on #204, open question 5: backspacing the last digit
+        // out of a grown row removes the row. Only the section's *bottom* row
+        // can go, and only a grown one — GridAdditionRowsAtStart is the floor,
+        // because no card is ever dealt fewer.
+        void ShrinkSectionIfEmptiedAtItsBottom()
+        {
+            if (_caretRowKind != GridRowKind.AdditionRow)
+            {
+                return;
+            }
+
+            if (_additionRows.Count <= WorkingOutGrid.GridAdditionRowsAtStart)
+            {
+                return;
+            }
+
+            var bottom = _additionRows.Count - 1;
+
+            if (_caretRowOrdinal != bottom || !_additionRows[bottom].IsEmpty())
+            {
+                return;
+            }
+
+            _additionRows.RemoveAt(bottom);
+            RebuildGrid();
+
+            // The row the caret was in is gone; it lands in the same column of
+            // whatever is the bottom of the section now.
+            MoveCaretTo(GridRowKind.AdditionRow, _additionRows.Count - 1, _caretColumn);
+        }
+
+        void ClearBlock()
+        {
+            var contents = CaretContents();
+
+            if (contents == null)
+            {
+                return;
+            }
+
+            // "`clear` empties only the cell block you are in, not the whole
+            // grid." The narrowest reading of "block" that satisfies that
+            // sentence is the row the caret is in — see this issue's PR.
+            contents.EraseAll();
+            RefreshCells();
+        }
+
+        void HandleCheckItClicked()
+        {
+            var answer = AnswerText;
+
+            if (answer.Length == 0)
+            {
+                return;
+            }
+
+            var value = int.Parse(answer);
+
+            // Out through the one seam, ungraded. What it comes back as is
+            // #210's to decide and #224's to draw.
+            _turn.SubmitAnswer(value);
+
+            if (_router != null)
+            {
+                _router.OpenDialog(Frogs.Core.Dialog.AnswerResult);
+            }
+
+            var handler = AnswerSubmitted;
+            if (handler != null)
+            {
+                handler(value);
+            }
+        }
+
+        RowContents CaretContents()
+        {
+            return ContentsFor(_caretRowKind, _caretRowOrdinal);
+        }
+
+        RowContents ContentsFor(GridRowKind kind, int ordinal)
+        {
+            switch (kind)
+            {
+                case GridRowKind.CarryStrip:
+                    return ordinal >= 0 && ordinal < _carryRows.Count ? _carryRows[ordinal] : null;
+
+                case GridRowKind.AdditionRow:
+                    return ordinal >= 0 && ordinal < _additionRows.Count ? _additionRows[ordinal] : null;
+
+                case GridRowKind.AnswerRow:
+                    return _answerRow;
+
+                default:
+                    return null;
+            }
+        }
+
+        void MoveCaretTo(GridRowKind kind, int ordinal, int column)
+        {
+            _caretRowKind = kind;
+            _caretRowOrdinal = ordinal;
+            _caretColumn = column;
+
+            RefreshCells();
+        }
+
+        // Every cell's text and outline, from what has been typed and where
+        // the caret is. No cell's colour depends on whether what is in it is
+        // right — this view has no idea what right would be.
+        void RefreshCells()
+        {
+            for (var row = 0; row < _cells.Count; row++)
+            {
+                var cells = _cells[row];
+
+                for (var column = 0; column < cells.Count; column++)
+                {
+                    var cell = cells[column];
+
+                    if (!cell.IsEditable)
+                    {
+                        continue;
+                    }
+
+                    var contents = ContentsFor(cell.RowKind, cell.RowOrdinal);
+                    cell.SetText(contents == null ? string.Empty : contents.TextAt(column));
+
+                    if (cell.Border == null)
+                    {
+                        continue;
+                    }
+
+                    var focused = cell.RowKind == _caretRowKind
+                        && cell.RowOrdinal == _caretRowOrdinal
+                        && cell.Column == _caretColumn;
+
+                    cell.Border.color = focused
+                        ? AccentColor
+                        : cell.Kind == GridCellKind.CarryBox ? FaintColor : LineColor;
+                }
+            }
+
+            if (_checkItButton != null)
+            {
+                _checkItButton.SetDisabled(AnswerText.Length == 0);
+            }
+        }
+
+        static string PileNameFor(Pile pile)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    return EasyPileName;
+                case Pile.Medium:
+                    return MediumPileName;
+                case Pile.Hard:
+                    return HardPileName;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(pile), pile, "unhandled pile.");
+            }
+        }
+
+        WorkingOutGridCell FindCell(GridRowKind kind, int ordinal, int column)
+        {
+            for (var row = 0; row < _cells.Count; row++)
+            {
+                var cells = _cells[row];
+
+                if (cells.Count <= column || column < 0)
+                {
+                    continue;
+                }
+
+                var cell = cells[column];
+
+                if (cell.RowKind == kind && cell.RowOrdinal == ordinal)
+                {
+                    return cell;
+                }
+            }
+
+            return null;
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        static Text BuildText(string name, RectTransform parent, float size, Color colour, TextAnchor alignment)
+        {
+            var textGO = new GameObject(name, typeof(RectTransform), typeof(Text));
+            var text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            text.fontSize = (int)size;
+            text.color = colour;
+            text.alignment = alignment;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false;
+            text.rectTransform.SetParent(parent, worldPositionStays: false);
+            return text;
+        }
+
+        /// <summary>
+        /// What one row of the grid holds, and in what order it was typed.
+        /// Kept per row *identity* — the second carry strip, the fourth
+        /// addition row — rather than per drawn row, so a digit stays where it
+        /// was put when the section grows or shrinks underneath it.
+        ///
+        /// It holds digits and nothing else: no correct value, no flag for
+        /// whether a digit is right, nothing that could be rendered as a mark.
+        /// </summary>
+        sealed class RowContents
+        {
+            readonly int?[] _digits;
+            readonly int[] _stamps;
+
+            internal RowContents(int columnCount)
+            {
+                _digits = new int?[columnCount];
+                _stamps = new int[columnCount];
+            }
+
+            internal bool HasDigit(int column)
+            {
+                return column >= 0 && column < _digits.Length && _digits[column].HasValue;
+            }
+
+            internal string TextAt(int column)
+            {
+                return HasDigit(column) ? _digits[column].Value.ToString() : string.Empty;
+            }
+
+            internal void Write(int column, int digit, int stamp)
+            {
+                if (column < 0 || column >= _digits.Length)
+                {
+                    return;
+                }
+
+                _digits[column] = digit;
+                _stamps[column] = stamp;
+            }
+
+            internal void Erase(int column)
+            {
+                if (column < 0 || column >= _digits.Length)
+                {
+                    return;
+                }
+
+                _digits[column] = null;
+                _stamps[column] = 0;
+            }
+
+            internal void EraseAll()
+            {
+                for (var column = 0; column < _digits.Length; column++)
+                {
+                    _digits[column] = null;
+                    _stamps[column] = 0;
+                }
+            }
+
+            internal bool IsEmpty()
+            {
+                for (var column = 0; column < _digits.Length; column++)
+                {
+                    if (_digits[column].HasValue)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            // The digit typed most recently anywhere in this row, which is
+            // what backspace takes away when the caret's own cell is already
+            // empty.
+            internal int LastEnteredColumn()
+            {
+                var best = -1;
+
+                for (var column = 0; column < _digits.Length; column++)
+                {
+                    if (!_digits[column].HasValue)
+                    {
+                        continue;
+                    }
+
+                    if (best < 0 || _stamps[column] > _stamps[best])
+                    {
+                        best = column;
+                    }
+                }
+
+                return best;
+            }
+
+            internal string ReadLeftToRight()
+            {
+                var builder = new StringBuilder();
+
+                for (var column = 0; column < _digits.Length; column++)
+                {
+                    if (_digits[column].HasValue)
+                    {
+                        builder.Append(_digits[column].Value);
+                    }
+                }
+
+                return builder.ToString();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
@@ -969,11 +969,15 @@ namespace Frogs.Unity.Views
 
                         if (glyph.Length > 0)
                         {
+                            // `=` has a size of its own; `×` and `+` are the
+                            // size of a digit in the row they sit beside,
+                            // which is what shrinks the `+` along with the
+                            // section it belongs to.
                             var isEquals = glyph == EqualsGlyph;
                             label = BuildText(
                                 "Operator",
                                 cellRect,
-                                isEquals ? GridEqualsSize : GridDigitSize,
+                                isEquals ? GridEqualsSize : DigitSizeFor(row.Kind),
                                 isEquals ? LineColor : InkColor,
                                 TextAnchor.MiddleCenter);
                             label.fontStyle = FontStyle.Bold;

--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs.meta
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb17d5d9d0df4e69b942529a5f86a28e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/WorkingOutKeypadKey.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutKeypadKey.cs
@@ -1,0 +1,64 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// One key of the working-out grid's keypad — a
+    /// <c>KeypadKeySize</c> square with a border and a label, and a tap.
+    ///
+    /// It is deliberately not the shared <see cref="Frogs.Unity.UI.Button"/>:
+    /// that component is 112 px tall with a 320 px minimum width and a press
+    /// offset, and docs/specs/ui/working-out-grid.md gives the keypad its own
+    /// square key with its own named size. The one shared Button on this
+    /// screen is `Check it`.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class WorkingOutKeypadKey : MonoBehaviour, IPointerClickHandler
+    {
+        /// <summary>This key was tapped.</summary>
+        public event Action<WorkingOutKeypadKey> Tapped;
+
+        /// <summary>What the key does.</summary>
+        public KeypadKeyKind Kind { get; private set; }
+
+        /// <summary>The digit this key types, or <c>-1</c> when it is not a digit key.</summary>
+        public int Digit { get; private set; }
+
+        /// <summary>The key's outline.</summary>
+        public Image Border { get; private set; }
+
+        /// <summary>The key's fill, inside its outline.</summary>
+        public Image Fill { get; private set; }
+
+        /// <summary>The key's label — a numeral, `⌫`, or `clear`.</summary>
+        public Text Label { get; private set; }
+
+        /// <summary>The key's own <see cref="RectTransform"/>.</summary>
+        public RectTransform RectTransform
+        {
+            get { return (RectTransform)transform; }
+        }
+
+        /// <summary>Records what this key is, as the view builds it.</summary>
+        public void Describe(KeypadKeyKind kind, int digit, Image border, Image fill, Text label)
+        {
+            Kind = kind;
+            Digit = digit;
+            Border = border;
+            Fill = fill;
+            Label = label;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            var handler = Tapped;
+            if (handler != null)
+            {
+                handler(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/WorkingOutKeypadKey.cs.meta
+++ b/Assets/Scripts/Unity/Views/WorkingOutKeypadKey.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b43ee45ebac347038e5546bfc27ea887
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
@@ -1,0 +1,1273 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// RollAndCardDialogViewTests.cs works around — so the shared components are
+// pulled in by explicit alias, and a bare `Button` in this file always means
+// the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The working-out grid — issue #223, built to
+    /// docs/specs/ui/working-out-grid.md and its three committed 1:1 mockups.
+    /// Written before <see cref="WorkingOutGridView"/> exists, per
+    /// docs/engineering/testing.md's sanctioned flow: pushed unexecuted, with
+    /// CI turning these red before green — there is no editor here to watch
+    /// them fail.
+    ///
+    /// **Nothing in this file knows a correct answer**, except the one test
+    /// that hands a submitted answer to <see cref="Lane.Resolve"/> to prove
+    /// the digits arrive intact. The grid itself is never asked whether
+    /// anything in it is right, because it has no way to answer that.
+    ///
+    /// The two card shapes are the spec's own worked examples: `68 × 5` from
+    /// the easy pile (three digit columns) and `331 × 41` from the hard pile
+    /// (five). They are drawn from a seeded <see cref="Rng"/> rather than
+    /// constructed, because <see cref="Card"/> only builds through
+    /// <see cref="Card.Draw"/> — and the *shape* is all these tests need, which
+    /// is exactly what the pile fixes.
+    /// </summary>
+    public sealed class WorkingOutGridViewTests
+    {
+        const ulong Seed = 20260810UL;
+
+        // docs/specs/ui/working-out-grid.md: "`331 × 41` needs five digit
+        // columns (`13571`); `68 × 5` needs three (`340`)" — plus the operator
+        // column, in both.
+        const int EasyColumnCount = 4;
+        const int HardColumnCount = 6;
+
+        [Test]
+        public void Grid_ForTheEasyShape_DrawsCoresOwnRowSequence_WithARuleUnderTheMultiplierAndUnderTheSection()
+        {
+            // #223's checklist was written before the addition section became
+            // growable (#234) and asks for "four rows for a 1-digit
+            // multiplier". The spec page and #204's merged model now give
+            // every card the same seven rows at the starting count, and the
+            // easy card is a *narrower* grid rather than a shorter one. This
+            // asserts what Core actually reports, which is the boundary the
+            // issue is really about.
+            var view = CreateView(Turn(Pile.Easy));
+
+            try
+            {
+                Assert.That(view.RowKinds, Is.EqualTo(new[]
+                {
+                    GridRowKind.CarryStrip,
+                    GridRowKind.Multiplicand,
+                    GridRowKind.Multiplier,
+                    GridRowKind.AdditionRow,
+                    GridRowKind.AdditionRow,
+                    GridRowKind.CarryStrip,
+                    GridRowKind.AnswerRow
+                }));
+
+                foreach (var row in view.Cells)
+                {
+                    Assert.That(row.Count, Is.EqualTo(EasyColumnCount), "one operator column plus three digit columns");
+                }
+
+                // Two rules, and they are not rows: one under the multiplier,
+                // one under the bottom of the addition section.
+                Assert.That(view.RuleRects.Count, Is.EqualTo(2));
+
+                var multiplier = view.RowRects[RowIndexOf(view, GridRowKind.Multiplier)];
+                var firstAddition = view.RowRects[RowIndexOf(view, GridRowKind.AdditionRow)];
+                var lastAddition = view.RowRects[RowIndexOf(view, GridRowKind.AdditionRow, 1)];
+                var secondStrip = view.RowRects[RowIndexOf(view, GridRowKind.CarryStrip, 1)];
+
+                AssertRuleBetween(view.RuleRects[0], multiplier, firstAddition);
+                AssertRuleBetween(view.RuleRects[1], lastAddition, secondStrip);
+
+                foreach (var rule in view.RuleRects)
+                {
+                    Assert.That(rule.rect.height, Is.EqualTo(WorkingOutGridView.GridRuleThickness).Within(0.001f));
+                    Assert.That(rule.rect.width, Is.EqualTo(view.GridRect.rect.width).Within(0.001f));
+                }
+
+                // Sized with the named constants, from the column count Core
+                // reported — not from a count this view worked out.
+                var expectedWidth = (EasyColumnCount * WorkingOutGridView.GridCellSize)
+                    + ((EasyColumnCount - 1) * WorkingOutGridView.GridCellGap);
+
+                Assert.That(view.GridRect.rect.width, Is.EqualTo(expectedWidth).Within(0.001f));
+                Assert.That(view.GridRect.rect.height, Is.EqualTo(DealtGridHeight()).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Grid_ForTheHardShape_IsWiderThanTheEasyOne_AndOnlyBecauseCoresModelSaysSo()
+        {
+            var easy = CreateView(Turn(Pile.Easy));
+            var hard = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                // The same view code, the same row kinds, a different model.
+                Assert.That(hard.RowKinds, Is.EqualTo(easy.RowKinds));
+                Assert.That(hard.RuleRects.Count, Is.EqualTo(easy.RuleRects.Count));
+
+                foreach (var row in hard.Cells)
+                {
+                    Assert.That(row.Count, Is.EqualTo(HardColumnCount));
+                }
+
+                Assert.That(hard.GridRect.rect.width, Is.GreaterThan(easy.GridRect.rect.width));
+
+                // Same rows, so the same height — "the grid is sized to the
+                // card in its columns", and no longer in its rows.
+                Assert.That(hard.GridRect.rect.height, Is.EqualTo(easy.GridRect.rect.height).Within(0.001f));
+
+                // The keypad and `Check it` do not move between the two.
+                Assert.That(
+                    hard.KeypadRect.anchoredPosition,
+                    Is.EqualTo(easy.KeypadRect.anchoredPosition));
+                Assert.That(
+                    hard.CheckItButton.RectTransform.rect.size,
+                    Is.EqualTo(easy.CheckItButton.RectTransform.rect.size));
+            }
+            finally
+            {
+                Destroy(easy);
+                Destroy(hard);
+            }
+        }
+
+        [Test]
+        public void OperatorColumn_ReadsMultiplyPlusAndEquals_FromTheRowKindAndNothingElse()
+        {
+            foreach (var pile in new[] { Pile.Easy, Pile.Medium, Pile.Hard })
+            {
+                var view = CreateView(Turn(pile));
+
+                try
+                {
+                    var glyphs = view.Cells.Select(row => row[0].Content).ToArray();
+
+                    Assert.That(glyphs, Is.EqualTo(new[]
+                    {
+                        string.Empty, // carry strip
+                        string.Empty, // multiplicand
+                        "×",          // multiplier
+                        string.Empty, // first addition row
+                        "+",          // the bottom row of the section
+                        string.Empty, // second carry strip
+                        "="           // answer row
+                    }), "the operator column, top to bottom, for " + pile);
+
+                    // The operator column is never fillable, whatever is drawn
+                    // in it.
+                    foreach (var row in view.Cells)
+                    {
+                        Assert.That(row[0].IsEditable, Is.False);
+                    }
+                }
+                finally
+                {
+                    Destroy(view);
+                }
+            }
+        }
+
+        [Test]
+        public void OperatorColumn_KeepsThePlusOnTheBottomRow_AsTheSectionGrows()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                GrowSectionBy(view, 1);
+
+                var glyphs = view.Cells.Select(row => row[0].Content).ToArray();
+
+                Assert.That(glyphs, Is.EqualTo(new[]
+                {
+                    string.Empty, string.Empty, "×",
+                    string.Empty, string.Empty, "+",
+                    string.Empty, "="
+                }), "growing the section moves the `+` down with it rather than stamping one on every row");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void PrintedRows_AreTheCardsOwnDigitsRightAligned_AndNothingTypedTouchesThem()
+        {
+            var turn = Turn(Pile.Hard);
+            var view = CreateView(turn);
+
+            try
+            {
+                var multiplicand = view.Cells[RowIndexOf(view, GridRowKind.Multiplicand)];
+                var multiplier = view.Cells[RowIndexOf(view, GridRowKind.Multiplier)];
+
+                Assert.That(
+                    string.Concat(multiplicand.Select(cell => cell.Content)),
+                    Is.EqualTo(turn.Card.Multiplicand.ToString()));
+                Assert.That(
+                    string.Concat(multiplier.Skip(1).Select(cell => cell.Content)),
+                    Is.EqualTo(turn.Card.Multiplier.ToString()),
+                    "the multiplier's digits, right-aligned, past the `×`");
+
+                foreach (var cell in multiplicand.Concat(multiplier))
+                {
+                    Assert.That(cell.IsEditable, Is.False, "these two rows *are* the card");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void CheckIt_IsDisabledUntilTheAnswerRowHasADigit()
+        {
+            var view = CreateView(Turn(Pile.Easy));
+
+            try
+            {
+                Assert.That(view.CheckItButton.Kind, Is.EqualTo(ButtonKind.Primary));
+                Assert.That(view.CheckItButton.Label.text, Is.EqualTo("Check it"));
+                Assert.That(view.CheckItButton.IsDisabled, Is.True, "an empty answer is not a wrong answer");
+                Assert.That(
+                    view.CheckItButton.CanvasGroup.alpha,
+                    Is.EqualTo(Button.ButtonDisabledOpacity).Within(0.001f),
+                    "the shared Button's own Disabled state, not a bespoke grey");
+
+                // A digit in an addition row is not an answer.
+                Tap(CellAt(view, GridRowKind.AdditionRow, 0, 1));
+                Type(view, 7);
+                Assert.That(view.CheckItButton.IsDisabled, Is.True);
+
+                // A digit in a carry box is not an answer either.
+                Tap(CellAt(view, GridRowKind.CarryStrip, 0, 1));
+                Type(view, 1);
+                Assert.That(view.CheckItButton.IsDisabled, Is.True);
+
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, EasyColumnCount - 1));
+                Type(view, 4);
+                Assert.That(view.CheckItButton.IsDisabled, Is.False);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Caret_OpensOnTheRightmostAnswerCell_AndEachDigitFillsTheNextCellToItsLeft()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var answerRow = RowIndexOf(view, GridRowKind.AnswerRow);
+
+                Assert.That(
+                    view.CaretCell,
+                    Is.EqualTo(view.Cells[answerRow][HardColumnCount - 1]),
+                    "the first empty answer cell, filling right to left");
+
+                Type(view, 1);
+                Assert.That(view.Cells[answerRow][HardColumnCount - 1].Content, Is.EqualTo("1"));
+                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][HardColumnCount - 2]));
+
+                Type(view, 7);
+                Assert.That(view.Cells[answerRow][HardColumnCount - 2].Content, Is.EqualTo("7"));
+
+                Type(view, 5);
+                Type(view, 3);
+                Type(view, 1);
+
+                // Typed units-first, which is the direction the digits are
+                // worked out in — and reads left to right as the answer.
+                Assert.That(view.AnswerText, Is.EqualTo("13571"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TappingAnyEditableCell_MovesTheCaretThere_AndTheNextDigitLandsThere()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                // An addition row, out of order: the player who does the
+                // partial products first is not fighting the caret.
+                var additionCell = CellAt(view, GridRowKind.AdditionRow, 0, 3);
+                Tap(additionCell);
+                Assert.That(view.CaretCell, Is.EqualTo(additionCell));
+
+                Type(view, 9);
+                Assert.That(additionCell.Content, Is.EqualTo("9"));
+
+                // A carry box on the top strip.
+                var carryCell = CellAt(view, GridRowKind.CarryStrip, 0, 2);
+                Tap(carryCell);
+                Assert.That(view.CaretCell, Is.EqualTo(carryCell));
+
+                Type(view, 2);
+                Assert.That(carryCell.Content, Is.EqualTo("2"));
+
+                // And back to the answer row, mid-row.
+                var answerCell = CellAt(view, GridRowKind.AnswerRow, 0, 2);
+                Tap(answerCell);
+                Type(view, 6);
+                Assert.That(answerCell.Content, Is.EqualTo("6"));
+
+                // Tapping a printed digit or the operator column moves
+                // nothing: they are not cells anything can be typed into.
+                var caretBefore = view.CaretCell;
+                Tap(view.Cells[RowIndexOf(view, GridRowKind.Multiplicand)][HardColumnCount - 1]);
+                Tap(view.Cells[RowIndexOf(view, GridRowKind.AnswerRow)][0]);
+                Assert.That(view.CaretCell, Is.EqualTo(caretBefore));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Backspace_TakesTheCaretsDigit_OrTheLastEnteredInItsBlock_AndNothingOutsideIt()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var additionCell = CellAt(view, GridRowKind.AdditionRow, 0, 2);
+                Tap(additionCell);
+                Type(view, 4);
+
+                // The answer row: two digits, then backspace with the caret on
+                // an empty cell — it takes the last one entered in this row,
+                // and leaves the addition row alone.
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Type(view, 2);
+                Type(view, 8);
+
+                Assert.That(view.AnswerText, Is.EqualTo("82"));
+
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, 1));
+                Backspace(view);
+
+                Assert.That(view.AnswerText, Is.EqualTo("2"), "the last digit entered in this block, and only it");
+                Assert.That(additionCell.Content, Is.EqualTo("4"), "nothing outside the caret's block moved");
+
+                // Now with the caret's own cell filled: that digit goes.
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Backspace(view);
+
+                Assert.That(view.AnswerText, Is.Empty);
+                Assert.That(additionCell.Content, Is.EqualTo("4"));
+
+                // Backspace on an empty block does nothing at all.
+                Backspace(view);
+                Assert.That(view.AnswerText, Is.Empty);
+                Assert.That(additionCell.Content, Is.EqualTo("4"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Clear_EmptiesTheCaretsBlockOnly_AndThereIsNoUndoAnywhere()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var carryCell = CellAt(view, GridRowKind.CarryStrip, 0, 1);
+                Tap(carryCell);
+                Type(view, 3);
+
+                var additionCell = CellAt(view, GridRowKind.AdditionRow, 0, 4);
+                Tap(additionCell);
+                Type(view, 6);
+
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Type(view, 1);
+                Type(view, 2);
+                Type(view, 3);
+
+                Assert.That(view.AnswerText, Is.EqualTo("321"));
+
+                Clear(view);
+
+                Assert.That(view.AnswerText, Is.Empty, "the block the caret is in");
+                Assert.That(carryCell.Content, Is.EqualTo("3"), "and nothing outside it");
+                Assert.That(additionCell.Content, Is.EqualTo("6"));
+
+                // "There is no `undo`, only backspace and `clear`."
+                Assert.That(
+                    view.Keys.Select(key => key.Kind).Distinct().OrderBy(kind => kind),
+                    Is.EqualTo(new[] { KeypadKeyKind.Digit, KeypadKeyKind.Backspace, KeypadKeyKind.Clear }.OrderBy(kind => kind)));
+                Assert.That(
+                    view.Keys.Count(key => key.Kind == KeypadKeyKind.Digit),
+                    Is.EqualTo(10),
+                    "`1`–`9` and `0`, and no decimal point or minus");
+                Assert.That(
+                    DeclaredMembers(typeof(WorkingOutGridView))
+                        .Where(name => name.IndexOf("Undo", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+                Assert.That(
+                    view.KeypadRect.GetComponentsInChildren<Text>(true).Select(text => text.text),
+                    Has.No.Member("undo"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void CheckIt_ReadsTheAnswerLeftToRight_HandsItToTurnResolution_AndMarksNothing()
+        {
+            var turn = Turn(Pile.Easy);
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.WorkingOutGrid);
+
+            var view = CreateView(turn, router);
+            var submitted = new List<int>();
+            view.AnswerSubmitted += answer => submitted.Add(answer);
+
+            try
+            {
+                // A deliberately wrong answer, so the test cannot pass by the
+                // grid quietly grading anything: `340` is the largest product
+                // the easy shape can hold and is not this card's.
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, EasyColumnCount - 1));
+                Type(view, 0);
+                Type(view, 4);
+                Type(view, 3);
+
+                Assert.That(view.AnswerText, Is.EqualTo("340"));
+
+                var before = CellColours(view);
+
+                Tap(view.CheckItButton);
+
+                Assert.That(turn.Submitted, Is.EqualTo(new[] { 340 }), "read left to right, handed over once");
+                Assert.That(submitted, Is.EqualTo(new[] { 340 }));
+                Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.AnswerResult), "the way out");
+
+                // Not one cell changed colour on the way out: the verdict is
+                // #224's to draw, on its own dialog.
+                Assert.That(CellColours(view), Is.EqualTo(before));
+
+                // The digits that left are the digits Core grades — proved by
+                // grading them here, which is the one place in this file that
+                // knows a right answer from a wrong one.
+                var lane = new Lane();
+                var resolution = lane.Resolve(turn.Submitted[0], turn.Card);
+                Assert.That(resolution.CorrectAnswer, Is.EqualTo(turn.Card.Product));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void HardwareBack_LeavesTheGridOpenAndUnchanged_AndNothingHereDismissesTheDialog()
+        {
+            var turn = Turn(Pile.Hard);
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.WorkingOutGrid);
+
+            var view = CreateView(turn, router);
+
+            try
+            {
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Type(view, 5);
+
+                var before = CellTexts(view);
+
+                router.HandleBack();
+
+                Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.WorkingOutGrid), "back does not dismiss");
+                Assert.That(view.Dialog.IsOpen, Is.True);
+                Assert.That(CellTexts(view), Is.EqualTo(before), "and changes no cell");
+                Assert.That(turn.Submitted, Is.Empty, "back does not press `Check it` either");
+
+                // The shared Dialog routes back to whichever button an
+                // instance nominates as least destructive. This dialog
+                // nominates none, which is what makes back inert rather than a
+                // `Check it` in disguise.
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.Null);
+
+                // The router owns hardware back (#213); this view must not add
+                // a second handler that could disagree with it.
+                Assert.That(
+                    DeclaredMembers(typeof(WorkingOutGridView))
+                        .Where(name => name.IndexOf("Back", StringComparison.OrdinalIgnoreCase) >= 0
+                            && name.IndexOf("Backspace", StringComparison.OrdinalIgnoreCase) < 0),
+                    Is.Empty,
+                    "hardware back is the router's, not this view's");
+
+                // No tap-outside, no close cross: the only affordances on this
+                // dialog are the keys, the cells and `Check it`.
+                Assert.That(
+                    view.Dialog.Scrim.GetComponents<MonoBehaviour>()
+                        .OfType<IPointerClickHandler>()
+                        .ToArray(),
+                    Is.Empty,
+                    "no tap-outside-to-dismiss");
+                Assert.That(
+                    DeclaredMembers(typeof(WorkingOutGridView))
+                        .Where(name => name.IndexOf("Dismiss", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Close", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Cancel", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void AdditionSection_GrowsADigitAtATime_StopsAtTheCap_AndGivesTheRowBackWhenItIsBackspacedEmpty()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart));
+
+                // A digit in the section's *bottom* row appends another row
+                // beneath it. A digit in the row above does not.
+                Tap(CellAt(view, GridRowKind.AdditionRow, 0, 1));
+                Type(view, 1);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart));
+
+                GrowSectionBy(view, 1);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart + 1));
+                Assert.That(
+                    view.RowKinds.Count(kind => kind == GridRowKind.AdditionRow),
+                    Is.EqualTo(view.AdditionRowCount),
+                    "the drawn rows are the model's rows");
+
+                // The new row is appended to the bottom of the section, still
+                // above the answer row.
+                Assert.That(
+                    view.RowKinds.Last(),
+                    Is.EqualTo(GridRowKind.AnswerRow));
+
+                // And it stops at the cap, however much is typed into it.
+                GrowSectionBy(view, WorkingOutGrid.GridAdditionRowsMax);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax));
+
+                // Backspacing the last digit out of a grown row gives the row
+                // back — Derek's call on #204's open question 5.
+                var bottom = view.AdditionRowCount - 1;
+                Tap(CellAt(view, GridRowKind.AdditionRow, bottom, 1));
+                Backspace(view);
+
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax - 1));
+
+                // The floor is what every card is dealt: emptying the rows the
+                // card came with never takes one away.
+                while (view.AdditionRowCount > WorkingOutGrid.GridAdditionRowsAtStart)
+                {
+                    Tap(CellAt(view, GridRowKind.AdditionRow, view.AdditionRowCount - 1, 1));
+                    Backspace(view);
+                }
+
+                Tap(CellAt(view, GridRowKind.AdditionRow, WorkingOutGrid.GridAdditionRowsAtStart - 1, 1));
+                Backspace(view);
+                Backspace(view);
+
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart));
+
+                // A grown row is indistinguishable from a dealt one: same
+                // cells, same size, same colours, no badge.
+                GrowSectionBy(view, 1);
+                var rows = Enumerable.Range(0, view.AdditionRowCount)
+                    .Select(ordinal => view.Cells[RowIndexOf(view, GridRowKind.AdditionRow, ordinal)])
+                    .ToArray();
+
+                foreach (var row in rows)
+                {
+                    Assert.That(row.Count, Is.EqualTo(rows[0].Count));
+                    Assert.That(
+                        row[1].RectTransform.rect.size,
+                        Is.EqualTo(rows[0][1].RectTransform.rect.size));
+                    Assert.That(row[1].Fill.color, Is.EqualTo(rows[0][1].Fill.color));
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void GrownAdditionRows_TakeTheirOwnSmallerHeight_SoTheWholeGridStillFitsAtTheCap()
+        {
+            // Derek's call on #223, open question 3: "smaller cells for
+            // addition rows only." Everything else — the multiplicand and
+            // multiplier rows, the rules, both carry strips and the answer row
+            // — keeps its size at every count.
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var panel = view.Dialog.PanelRect;
+
+                // As dealt, at today's numbers: a 732 px grid, unchanged from
+                // the committed mockups.
+                Assert.That(view.GridRect.rect.height, Is.EqualTo(732f).Within(0.001f));
+                Assert.That(view.GridRect.rect.height, Is.EqualTo(DealtGridHeight()).Within(0.001f));
+                Assert.That(
+                    view.RowRects[RowIndexOf(view, GridRowKind.AdditionRow)].rect.height,
+                    Is.EqualTo(WorkingOutGridView.GridCellSize).Within(0.001f),
+                    "the section is full size until the player grows it");
+
+                GrowSectionBy(view, WorkingOutGrid.GridAdditionRowsMax);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax));
+
+                // Six grown rows at GridAdditionRowHeight: 892 px, in the
+                // 908 px the panel has between the header and DialogPadding.
+                Assert.That(view.GridRect.rect.height, Is.EqualTo(892f).Within(0.001f));
+                Assert.That(view.GridRect.rect.height, Is.EqualTo(GrownGridHeight()).Within(0.001f));
+                Assert.That(GridBand(panel), Is.EqualTo(908f).Within(0.001f));
+                Assert.That(view.GridRect.rect.height, Is.LessThanOrEqualTo(GridBand(panel)));
+
+                foreach (var kind in new[] { GridRowKind.CarryStrip, GridRowKind.Multiplicand, GridRowKind.Multiplier, GridRowKind.AnswerRow })
+                {
+                    Assert.That(
+                        view.RowRects[RowIndexOf(view, kind)].rect.height,
+                        Is.EqualTo(view.RowHeightFor(kind)).Within(0.001f),
+                        kind + " keeps its size once the section shrinks");
+                }
+
+                Assert.That(
+                    view.RowRects[RowIndexOf(view, GridRowKind.AdditionRow)].rect.height,
+                    Is.EqualTo(WorkingOutGridView.GridAdditionRowHeight).Within(0.001f));
+
+                foreach (var rule in view.RuleRects)
+                {
+                    Assert.That(rule.rect.height, Is.EqualTo(WorkingOutGridView.GridRuleThickness).Within(0.001f));
+                }
+
+                // Nothing is off the bottom of the tablet, and nothing is
+                // under the header — including the answer row, which is what
+                // the third mockup drew falling off the screen.
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.GridRect),
+                    Is.GreaterThanOrEqualTo(WorkingOutGridView.GridHeaderHeight - 0.001f));
+                Assert.That(
+                    BottomEdge(view.GridRect) - BottomEdge(panel),
+                    Is.GreaterThanOrEqualTo(DialogPanel.DialogPadding - 0.001f));
+
+                var answerRow = view.RowRects[RowIndexOf(view, GridRowKind.AnswerRow)];
+                Assert.That(
+                    BottomEdge(answerRow) - BottomEdge(panel),
+                    Is.GreaterThanOrEqualTo(DialogPanel.DialogPadding - 0.001f),
+                    "the answer row is on the screen at the cap");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Panel_LaysOutHeaderGridAndKeypad_AtTheMockupsOwnGeometry()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var panel = view.Dialog.PanelRect;
+
+                // Full-bleed: the canvas inset by SafeMargin on every side,
+                // which is what the shared Dialog's maxima are.
+                Assert.That(
+                    panel.rect.size,
+                    Is.EqualTo(new Vector2(DialogPanel.DialogMaxWidth, DialogPanel.DialogMaxHeight)));
+
+                // header — the chip, `Work it out`, and the card readout, one
+                // GridHeaderGap apart, DialogPadding in from the left.
+                Assert.That(view.WhoseChip.State, Is.EqualTo(PlayerChipState.Active));
+                Assert.That(view.PromptText.text, Is.EqualTo("Work it out"));
+                Assert.That(view.PromptText.fontSize, Is.EqualTo((int)WorkingOutGridView.GridPromptSize));
+                Assert.That(view.CardReadoutText.fontSize, Is.EqualTo((int)WorkingOutGridView.GridCardReadoutLabelSize));
+                Assert.That(view.CardReadoutRect.rect.height, Is.EqualTo(WorkingOutGridView.GridCardReadoutHeight).Within(0.001f));
+                Assert.That(
+                    view.CardReadoutFill.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.GridCardReadoutBorderWidth, WorkingOutGridView.GridCardReadoutBorderWidth)),
+                    "the readout is outlined, not flat");
+
+                Assert.That(
+                    LeftEdge(view.WhoseChip.RectTransform) - LeftEdge(panel),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.WhoseChip.RectTransform),
+                    Is.EqualTo(WorkingOutGridView.GridHeaderTop).Within(0.001f));
+                Assert.That(
+                    LeftEdge(view.PromptText.rectTransform) - RightEdge(view.WhoseChip.RectTransform),
+                    Is.EqualTo(WorkingOutGridView.GridHeaderGap).Within(0.001f));
+                Assert.That(
+                    LeftEdge(view.CardReadoutRect) - RightEdge(view.PromptText.rectTransform),
+                    Is.EqualTo(WorkingOutGridView.GridHeaderGap).Within(0.001f));
+
+                // The header band the grid is measured against: the top of the
+                // panel down to the bottom of the chip.
+                Assert.That(
+                    WorkingOutGridView.GridHeaderTop + PlayerChip.PlayerChipHeight,
+                    Is.EqualTo(WorkingOutGridView.GridHeaderHeight).Within(0.001f));
+
+                // keypad — pinned right, DialogPadding from the panel edge,
+                // KeypadTop down, and the same place on every problem.
+                Assert.That(
+                    RightEdge(panel) - RightEdge(view.KeypadRect),
+                    Is.EqualTo(DialogPanel.DialogPadding).Within(0.001f));
+                Assert.That(
+                    TopEdge(panel) - TopEdge(view.KeypadRect),
+                    Is.EqualTo(WorkingOutGridView.KeypadTop).Within(0.001f));
+                Assert.That(view.KeypadRect.rect.width, Is.EqualTo(WorkingOutGridView.KeypadWidth).Within(0.001f));
+
+                Assert.That(view.Keys.Count, Is.EqualTo(12));
+                Assert.That(
+                    view.Keys.Select(key => key.Label.text),
+                    Is.EqualTo(new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "⌫", "0", "clear" }));
+
+                foreach (var key in view.Keys)
+                {
+                    Assert.That(
+                        key.RectTransform.rect.size,
+                        Is.EqualTo(new Vector2(WorkingOutGridView.KeypadKeySize, WorkingOutGridView.KeypadKeySize)));
+                    Assert.That(
+                        key.Fill.rectTransform.offsetMin,
+                        Is.EqualTo(new Vector2(WorkingOutGridView.KeypadKeyBorderWidth, WorkingOutGridView.KeypadKeyBorderWidth)),
+                        "a key is outlined, not flat");
+                }
+
+                Assert.That(
+                    LeftEdge(view.Keys[1].RectTransform) - RightEdge(view.Keys[0].RectTransform),
+                    Is.EqualTo(WorkingOutGridView.KeypadKeyGap).Within(0.001f));
+                Assert.That(
+                    BottomEdge(view.Keys[0].RectTransform) - TopEdge(view.Keys[3].RectTransform),
+                    Is.EqualTo(WorkingOutGridView.KeypadKeyGap).Within(0.001f));
+
+                // submit — `Check it`, full keypad width, KeypadSubmitGap
+                // under the bottom row of keys.
+                Assert.That(
+                    view.CheckItButton.RectTransform.rect.size,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.KeypadWidth, WorkingOutGridView.CheckButtonHeight)));
+                Assert.That(
+                    BottomEdge(view.Keys[9].RectTransform) - TopEdge(view.CheckItButton.RectTransform),
+                    Is.EqualTo(WorkingOutGridView.KeypadSubmitGap).Within(0.001f));
+                Assert.That(
+                    LeftEdge(view.CheckItButton.RectTransform),
+                    Is.EqualTo(LeftEdge(view.KeypadRect)).Within(0.001f));
+
+                // grid — centred in what is left: inside the padding, right of
+                // nothing, left of the keypad column, below the header band.
+                var regionLeft = LeftEdge(panel) + DialogPanel.DialogPadding;
+                var regionRight = RightEdge(panel) - DialogPanel.DialogPadding - WorkingOutGridView.KeypadWidth;
+                var regionTop = TopEdge(panel) - WorkingOutGridView.GridHeaderHeight;
+                var regionBottom = BottomEdge(panel) + DialogPanel.DialogPadding;
+
+                Assert.That(
+                    LeftEdge(view.GridRect) - regionLeft,
+                    Is.EqualTo(regionRight - RightEdge(view.GridRect)).Within(0.001f),
+                    "the grid is centred in the space the keypad leaves");
+                Assert.That(
+                    regionTop - TopEdge(view.GridRect),
+                    Is.EqualTo(BottomEdge(view.GridRect) - regionBottom).Within(0.001f),
+                    "and centred in the space under the header");
+
+                // Cells: a square GridCellSize digit cell, GridCellGap apart,
+                // outlined; the answer row taller and heavier.
+                var additionRow = view.Cells[RowIndexOf(view, GridRowKind.AdditionRow)];
+                Assert.That(
+                    additionRow[1].RectTransform.rect.size,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.GridCellSize, WorkingOutGridView.GridCellSize)));
+                Assert.That(
+                    LeftEdge(additionRow[2].RectTransform) - RightEdge(additionRow[1].RectTransform),
+                    Is.EqualTo(WorkingOutGridView.GridCellGap).Within(0.001f));
+                Assert.That(
+                    additionRow[1].Fill.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.GridCellBorderWidth, WorkingOutGridView.GridCellBorderWidth)));
+                Assert.That(additionRow[1].Label.fontSize, Is.EqualTo((int)WorkingOutGridView.GridDigitSize));
+
+                var answerRow = view.Cells[RowIndexOf(view, GridRowKind.AnswerRow)];
+                Assert.That(
+                    answerRow[1].RectTransform.rect.size,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.GridCellSize, WorkingOutGridView.GridAnswerRowHeight)));
+                Assert.That(
+                    answerRow[1].Fill.rectTransform.offsetMin,
+                    Is.EqualTo(new Vector2(WorkingOutGridView.GridAnswerBorderWidth, WorkingOutGridView.GridAnswerBorderWidth)),
+                    "the answer row's border is the heavier one");
+
+                // Carry strip: a GridCarryRowHeight row of GridCarryBoxSize
+                // boxes, one per digit column and none in the operator column.
+                var carryRow = view.Cells[RowIndexOf(view, GridRowKind.CarryStrip)];
+                Assert.That(
+                    view.RowRects[RowIndexOf(view, GridRowKind.CarryStrip)].rect.height,
+                    Is.EqualTo(WorkingOutGridView.GridCarryRowHeight).Within(0.001f));
+                Assert.That(
+                    carryRow[1].Border.rectTransform.rect.size,
+                    Is.EqualTo(WorkingOutGridView.GridCarryBoxSize));
+                Assert.That(carryRow[0].Border, Is.Null, "no carry box over the operator column");
+                Assert.That(
+                    carryRow.Skip(1).Count(cell => cell.Kind == GridCellKind.CarryBox),
+                    Is.EqualTo(HardColumnCount - 1));
+
+                // Both strips are always on screen, on every card.
+                Assert.That(
+                    view.RowKinds.Count(kind => kind == GridRowKind.CarryStrip),
+                    Is.EqualTo(WorkingOutGrid.CarryStripCount));
+
+                // This dialog has no title — the header does that job.
+                Assert.That(view.Dialog.TitleText.text, Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Header_NamesTheFrogAndTheCard_AndTakesThePileFromWhatCoreReported()
+        {
+            var turn = Turn(Pile.Easy, FrogColour.Pink);
+            var view = CreateView(turn);
+
+            try
+            {
+                Assert.That(view.WhoseChip.Label.text, Is.EqualTo("Pink"));
+                Assert.That(view.WhoseChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Pink)));
+                Assert.That(
+                    view.CardReadoutText.text,
+                    Is.EqualTo(turn.Card.Multiplicand + " × " + turn.Card.Multiplier + " · easy pile"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryGeometryValue_IsANamedConstantFromWorkingOutGridsTable()
+        {
+            // docs/specs/ui/working-out-grid.md#named-constants, in full: the
+            // thirteen pixel values the page always had, plus the twenty this
+            // issue added to the table for values the mockups draw and the
+            // page had never named, plus GridAdditionRowHeight and
+            // GridSmallDigitSize, which are Derek's answer to open question 3.
+            var expected = new Dictionary<string, float>
+            {
+                { "GridCellSize", 104f },
+                { "GridCellGap", 8f },
+                { "GridCellBorderWidth", 3f },
+                { "GridCellRadius", 10f },
+                { "GridCarryRowHeight", 56f },
+                { "GridCarryBoxBorderWidth", 3f },
+                { "GridCarryBoxRadius", 8f },
+                { "GridRuleThickness", 6f },
+                { "GridAdditionRowHeight", 56f },
+                { "GridAnswerRowHeight", 128f },
+                { "GridAnswerBorderWidth", 6f },
+                { "GridDigitSize", 56f },
+                { "GridSmallDigitSize", 28f },
+                { "GridEqualsSize", 28f },
+                { "GridHeaderHeight", 140f },
+                { "GridHeaderTop", 44f },
+                { "GridHeaderGap", 32f },
+                { "GridPromptSize", 44f },
+                { "GridCardReadoutHeight", 96f },
+                { "GridCardReadoutPaddingX", 32f },
+                { "GridCardReadoutRadius", 20f },
+                { "GridCardReadoutBorderWidth", 3f },
+                { "GridCardReadoutLabelSize", 40f },
+                { "KeypadTop", 216f },
+                { "KeypadKeySize", 140f },
+                { "KeypadKeyGap", 16f },
+                { "KeypadKeyRadius", 20f },
+                { "KeypadKeyBorderWidth", 3f },
+                { "KeypadKeyLabelSize", 56f },
+                { "KeypadBackspaceLabelSize", 40f },
+                { "KeypadClearLabelSize", 32f },
+                { "KeypadWidth", 452f },
+                { "KeypadSubmitGap", 24f },
+                { "CheckButtonHeight", 128f }
+            };
+
+            var constants = typeof(WorkingOutGridView)
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(field => field.IsLiteral && !field.IsInitOnly)
+                .ToArray();
+
+            Assert.That(
+                constants.Select(field => field.Name).OrderBy(name => name),
+                Is.EqualTo(expected.Keys.OrderBy(name => name)),
+                "WorkingOutGridView's public constants are exactly working-out-grid.md's own, under the identical names");
+
+            foreach (var field in constants)
+            {
+                Assert.That(
+                    Convert.ToSingle(field.GetValue(null)),
+                    Is.EqualTo(expected[field.Name]).Within(0.001f),
+                    "WorkingOutGridView." + field.Name);
+            }
+
+            // The one two-number row on the table stays one value here.
+            Assert.That(WorkingOutGridView.GridCarryBoxSize, Is.EqualTo(new Vector2(56f, 52f)));
+
+            // The keypad's width is its keys and gaps, not a fourth number
+            // that could disagree with them.
+            Assert.That(
+                (3f * WorkingOutGridView.KeypadKeySize) + (2f * WorkingOutGridView.KeypadKeyGap),
+                Is.EqualTo(WorkingOutGridView.KeypadWidth).Within(0.001f));
+
+            // The counts on the same table are Core's, and are referenced
+            // rather than copied — a second `2` in the shell and a `2` in Core
+            // is exactly the drift the page warns about.
+            foreach (var name in new[] { "GridAdditionRowsAtStart", "GridAdditionRowsMax", "CarryStripCount" })
+            {
+                Assert.That(
+                    typeof(WorkingOutGridView).GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    Is.Null,
+                    "WorkingOutGridView must reference WorkingOutGrid." + name + ", not redeclare it");
+            }
+
+            // The shared Dialog's and Button's own constants are referenced,
+            // never redeclared here.
+            foreach (var name in new[] { "DialogPadding", "DialogMaxWidth", "DialogMaxHeight", "DialogRadius", "SafeMargin", "ButtonHeight", "ButtonLabelSize" })
+            {
+                Assert.That(
+                    typeof(WorkingOutGridView).GetField(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    Is.Null,
+                    "WorkingOutGridView must not redeclare " + name);
+            }
+        }
+
+        [Test]
+        public void Grid_WiresItsBuiltInSpritesAndFonts_RatherThanLeavingThemMissing()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                Assert.That(view.PromptText.font, Is.Not.Null);
+                Assert.That(view.CardReadoutText.font, Is.Not.Null);
+                Assert.That(view.CardReadoutBorder.sprite, Is.Not.Null);
+                Assert.That(view.Keys[0].Border.sprite, Is.Not.Null);
+                Assert.That(view.Keys[0].Label.font, Is.Not.Null);
+
+                var answerCell = CellAt(view, GridRowKind.AnswerRow, 0, 1);
+                Assert.That(answerCell.Border.sprite, Is.Not.Null);
+                Assert.That(answerCell.Fill.sprite, Is.Not.Null);
+                Assert.That(answerCell.Label.font, Is.Not.Null);
+
+                var carryCell = CellAt(view, GridRowKind.CarryStrip, 0, 1);
+                Assert.That(carryCell.Border.sprite, Is.Not.Null);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Grid_MarksNothing_AndHasNoWayToKnowWhatWouldBeCorrect()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                // Every editable cell is drawn the same way whatever is typed
+                // into it — the grid looks identical whether every digit so
+                // far is right or wrong.
+                var before = CellColours(view);
+
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Type(view, 9);
+                Type(view, 9);
+                Type(view, 9);
+
+                Tap(CellAt(view, GridRowKind.CarryStrip, 1, 1));
+                Type(view, 8);
+
+                var after = CellColours(view);
+
+                // Only the caret's own cell differs, and it differs because it
+                // is the caret's, not because of what is in it.
+                var differences = before.Zip(after, (first, second) => first == second).Count(same => !same);
+                Assert.That(differences, Is.LessThanOrEqualTo(2), "nothing is marked; only the caret moves");
+
+                var forbidden = new[] { "Correct", "Wrong", "Grade", "Verdict", "Score", "Marked", "Valid", "Product" };
+
+                foreach (var type in new[] { typeof(WorkingOutGridView), typeof(WorkingOutGridCell), typeof(WorkingOutKeypadKey) })
+                {
+                    foreach (var member in DeclaredMembers(type))
+                    {
+                        foreach (var word in forbidden)
+                        {
+                            Assert.That(
+                                member.IndexOf(word, StringComparison.OrdinalIgnoreCase),
+                                Is.LessThan(0),
+                                type.Name + "." + member + " looks like " + word + " — nothing on this screen is graded");
+                        }
+                    }
+
+                    var coroutines = type
+                        .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                        .Where(method => typeof(IEnumerator).IsAssignableFrom(method.ReturnType))
+                        .ToArray();
+
+                    Assert.That(coroutines, Is.Empty, type.Name + " starts no coroutine");
+                }
+
+                // No timer, ever.
+                Assert.That(
+                    DeclaredMembers(typeof(WorkingOutGridView))
+                        .Where(name => name.IndexOf("Timer", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Countdown", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Deadline", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // docs/specs/ui/working-out-grid.md#mockup's own arithmetic, rebuilt
+        // from the constants rather than quoted: the grid as every card deals
+        // it, and the grid with the section grown to the cap.
+        static float DealtGridHeight()
+        {
+            return FixedRowsHeight()
+                + (WorkingOutGrid.GridAdditionRowsAtStart * WorkingOutGridView.GridCellSize)
+                + ((6 + WorkingOutGrid.GridAdditionRowsAtStart) * WorkingOutGridView.GridCellGap);
+        }
+
+        static float GrownGridHeight()
+        {
+            return FixedRowsHeight()
+                + (WorkingOutGrid.GridAdditionRowsMax * WorkingOutGridView.GridAdditionRowHeight)
+                + ((6 + WorkingOutGrid.GridAdditionRowsMax) * WorkingOutGridView.GridCellGap);
+        }
+
+        // Everything that is the same height at every addition-row count: two
+        // carry strips, the multiplicand, the multiplier, two rules and the
+        // answer row.
+        static float FixedRowsHeight()
+        {
+            return (2f * WorkingOutGridView.GridCarryRowHeight)
+                + (2f * WorkingOutGridView.GridCellSize)
+                + (2f * WorkingOutGridView.GridRuleThickness)
+                + WorkingOutGridView.GridAnswerRowHeight;
+        }
+
+        static float GridBand(RectTransform panel)
+        {
+            return panel.rect.height - WorkingOutGridView.GridHeaderHeight - DialogPanel.DialogPadding;
+        }
+
+        static void AssertRuleBetween(RectTransform rule, RectTransform above, RectTransform below)
+        {
+            Assert.That(
+                BottomEdge(above) - TopEdge(rule),
+                Is.EqualTo(WorkingOutGridView.GridCellGap).Within(0.001f));
+            Assert.That(
+                BottomEdge(rule) - TopEdge(below),
+                Is.EqualTo(WorkingOutGridView.GridCellGap).Within(0.001f));
+        }
+
+        static int RowIndexOf(WorkingOutGridView view, GridRowKind kind, int ordinal = 0)
+        {
+            var seen = 0;
+
+            for (var index = 0; index < view.RowKinds.Count; index++)
+            {
+                if (view.RowKinds[index] != kind)
+                {
+                    continue;
+                }
+
+                if (seen == ordinal)
+                {
+                    return index;
+                }
+
+                seen++;
+            }
+
+            throw new AssertionException("no row of kind " + kind + " at ordinal " + ordinal);
+        }
+
+        static WorkingOutGridCell CellAt(WorkingOutGridView view, GridRowKind kind, int ordinal, int column)
+        {
+            return view.Cells[RowIndexOf(view, kind, ordinal)][column];
+        }
+
+        static string[] CellTexts(WorkingOutGridView view)
+        {
+            return view.Cells.SelectMany(row => row).Select(cell => cell.Content).ToArray();
+        }
+
+        static Color[] CellColours(WorkingOutGridView view)
+        {
+            return view.Cells
+                .SelectMany(row => row)
+                .Where(cell => cell.Border != null)
+                .SelectMany(cell => new[] { cell.Border.color, cell.Fill.color, cell.Label.color })
+                .ToArray();
+        }
+
+        // Grows the addition section by typing one digit into whatever its
+        // bottom row currently is, `times` times — which is the only thing
+        // that grows it.
+        static void GrowSectionBy(WorkingOutGridView view, int times)
+        {
+            for (var step = 0; step < times; step++)
+            {
+                Tap(CellAt(view, GridRowKind.AdditionRow, view.AdditionRowCount - 1, 1));
+                Type(view, 1);
+            }
+        }
+
+        static void Type(WorkingOutGridView view, int digit)
+        {
+            Tap(view.Keys.Single(key => key.Kind == KeypadKeyKind.Digit && key.Digit == digit));
+        }
+
+        static void Backspace(WorkingOutGridView view)
+        {
+            Tap(view.Keys.Single(key => key.Kind == KeypadKeyKind.Backspace));
+        }
+
+        static void Clear(WorkingOutGridView view)
+        {
+            Tap(view.Keys.Single(key => key.Kind == KeypadKeyKind.Clear));
+        }
+
+        static void Tap(WorkingOutKeypadKey key)
+        {
+            key.OnPointerClick(new PointerEventData(null));
+        }
+
+        static void Tap(WorkingOutGridCell cell)
+        {
+            cell.OnPointerClick(new PointerEventData(null));
+        }
+
+        static void Tap(Button button)
+        {
+            var corners = Corners(button.RectTransform);
+            var eventData = new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static StubTurn Turn(Pile pile, FrogColour frog = FrogColour.Green)
+        {
+            return new StubTurn
+            {
+                Frog = frog,
+                Pile = pile,
+                Card = Card.Draw(pile, Rng.FromSeed(Seed))
+            };
+        }
+
+        /// <summary>
+        /// A fixed card, and somewhere for the answer to go. There is no
+        /// grading in here: <see cref="Submitted"/> records what the grid
+        /// handed over, and nothing tells the grid what came of it.
+        /// </summary>
+        sealed class StubTurn : IWorkingOutTurn
+        {
+            public FrogColour Frog { get; set; }
+
+            public Pile Pile { get; set; }
+
+            public Card Card { get; set; }
+
+            public List<int> Submitted { get; } = new List<int>();
+
+            public void SubmitAnswer(int answer)
+            {
+                Submitted.Add(answer);
+            }
+        }
+
+        static IEnumerable<string> DeclaredMembers(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name);
+        }
+
+        static Vector3[] Corners(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners;
+        }
+
+        static float LeftEdge(RectTransform rect) => Corners(rect)[0].x;
+
+        static float RightEdge(RectTransform rect) => Corners(rect)[2].x;
+
+        static float TopEdge(RectTransform rect) => Corners(rect)[2].y;
+
+        static float BottomEdge(RectTransform rect) => Corners(rect)[0].y;
+
+        static WorkingOutGridView CreateView(IWorkingOutTurn turn, ScreenRouter router = null)
+        {
+            var host = new GameObject(nameof(WorkingOutGridViewTests), typeof(RectTransform));
+            var view = host.AddComponent<WorkingOutGridView>();
+            view.Initialize(turn, router);
+            return view;
+        }
+
+        static void Destroy(WorkingOutGridView view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs.meta
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b96aa90eed2247b3b28c1bef6553fae4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -30,14 +30,15 @@ at the biggest and the smallest problem the game can deal, and the result
 dialog is drawn right and wrong. Both files in each pair are agreed pictures of
 the same screen.
 
-The grid's **third** file is neither: it is the widest card with its addition
-section grown to the cap, drawn to find out what the cap costs at today's
-constants. The answer is that it does not fit — the answer row ends up below the
-bottom of the tablet. That is
-[an open question on the spec page](../working-out-grid.md#open-questions), and
-the mockup is its input rather than an agreed picture. A mockup that overflows
-is doing its job here; it is cheaper to find this in a picture than in a built
-screen.
+The grid's **third** file is the widest card with its addition section grown to
+the cap. It was drawn to find out what the cap costs, and at full-size addition
+rows the answer was that it does not fit — the answer row ended up below the
+bottom of the tablet. That overflowing drawing was the input to
+[open question 3 on the spec page](../working-out-grid.md#open-questions), and
+it did its job: it is cheaper to find that in a picture than in a built screen.
+Derek settled the question — smaller cells for the addition rows only — so the
+file now draws the answer instead: the same six rows at
+`GridAdditionRowHeight`, fitting with 16 px to spare.
 
 The title screen used to have a pair too — `title-screen.html` and
 `title-screen-resume-primary.html`, differing in exactly which of `RESUME` and

--- a/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
+++ b/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
@@ -8,15 +8,19 @@
   can be told apart in a picture; the palette is an area:art decision.
   Numbers here are the numbers in the spec page's constants table.
 
-  THIS MOCKUP IS A QUESTION, NOT AN AGREED PICTURE.
+  THIS DRAWING USED TO BE THE QUESTION. IT IS NOW THE ANSWER.
 
   It is the same screen as working-out-grid-331x41.html with the addition
-  section drawn at its cap of six rows instead of the two it starts with,
-  at today's constants and nothing else changed. At those constants it does
-  not fit: the answer row ends up below the bottom of the tablet.
+  section drawn at its cap of six rows instead of the two it starts with. At
+  full-size addition rows it did not fit — 1180 px of grid in 908 px of panel,
+  with the answer row below the bottom edge of the tablet — and that overflow
+  was drawn deliberately, as the input to open question 3.
 
-  That overrun is the point of the drawing. What to do about it is an open
-  question on the spec page, and this picture is its input, not its answer.
+  Derek settled that question: smaller cells for the addition rows only. The
+  section takes GridAdditionRowHeight (56 px) once it holds more rows than the
+  card dealt it, and every other row keeps the size it has at two rows. Six
+  grown rows now make an 892 px grid in the 908 px available, and the grid
+  re-centres in that space as it grows, per the page's Anchors rule.
 -->
 <html lang="en">
 <head>
@@ -62,6 +66,11 @@
   .cell{width:104px;height:104px;border:3px solid var(--line);border-radius:10px;background:#fff;
         display:flex;align-items:center;justify-content:center;font-size:56px}
   .cell.fix{border:none;background:transparent;font-weight:700}
+  /* A grown section's row: GridAdditionRowHeight tall, with GridSmallDigitSize
+     digits in it. Same width, same border, same colours — only the height and
+     the digit shrink, and they shrink for every row in the section, the two
+     the card dealt included. */
+  .cell.sm{height:56px;font-size:28px}
   .carry{width:104px;height:56px;display:flex;align-items:center;justify-content:center}
   .carry i{display:block;width:56px;height:52px;border:3px dashed var(--faint);border-radius:8px}
   .key{width:140px;height:140px;border:3px solid var(--line);border-radius:20px;background:#fff;
@@ -75,11 +84,9 @@
         justify-content:center;font-size:44px}
   /* Measurement annotations. Not part of the screen — they are the drawing
      talking about itself, and none of them is an element to be built. */
-  .limit{position:absolute;left:0;right:0;height:0;border-top:4px dashed var(--warn)}
-  .limit span{position:absolute;right:0;top:-38px;font-size:24px;font-weight:700;color:var(--warn)}
-  .overrun{position:absolute;left:0;right:0;background:rgba(176,58,46,.10);
-           border-top:4px dashed var(--warn)}
-  .tag{font-size:24px;color:var(--warn);font-weight:700}
+  .limit{position:absolute;left:0;right:0;height:0;border-top:4px dashed var(--accent)}
+  .limit span{position:absolute;right:0;top:-38px;font-size:24px;font-weight:700;color:var(--accent)}
+  .tag{font-size:24px;color:var(--accent);font-weight:700}
   .brace{position:absolute;border:4px solid var(--accent);border-right:none;border-radius:20px 0 0 20px}
 </style>
 </head>
@@ -95,26 +102,27 @@
         <div class="row" style="height:96px;padding:0 32px;border-radius:20px;border:3px solid var(--faint);font-size:40px;font-weight:700">331 × 41 · hard pile</div>
       </div>
 
-      <!-- grid: the committed origin, left 370 / top 216, unchanged.
-           Only the addition section's row count differs from
-           working-out-grid-331x41.html. -->
-      <div class="abs col" style="left:370px;top:216px;gap:8px">
+      <!-- grid: the committed left, 370, unchanged. The top is 148 rather than
+           the as-dealt drawing's 216, because a 892 px grid centres higher in
+           the 908 px between the header band and DialogPadding than a 732 px
+           one does — the grid moves, the keypad does not. -->
+      <div class="abs col" style="left:370px;top:148px;gap:8px">
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">3</div><div class="cell fix">3</div><div class="cell fix">1</div></div>
         <div class="row" style="gap:8px"><div class="cell fix">×</div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix"></div><div class="cell fix">4</div><div class="cell fix">1</div></div>
         <div style="height:6px;background:var(--ink);width:664px"></div>
 
         <!-- addition section: the two rows every card starts with … -->
-        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
-        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
         <!-- … and the four a player can grow it by, to the cap of six. A grown
-             row is an ordinary row: same cells, same size, no marking. The `+`
-             stays on the bottom row of the section, where the committed
-             two-row drawing puts it. -->
-        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
-        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
-        <div class="row" style="gap:8px"><div class="cell fix"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
-        <div class="row" style="gap:8px"><div class="cell fix">+</div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div><div class="cell"></div></div>
+             row is an ordinary row: same cells, same size as the rest of the
+             section, no marking. The `+` stays on the bottom row of the
+             section, where the committed two-row drawing puts it. -->
+        <div class="row" style="gap:8px"><div class="cell fix sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
+        <div class="row" style="gap:8px"><div class="cell fix sm">+</div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div><div class="cell sm"></div></div>
 
         <div style="height:6px;background:var(--ink);width:664px"></div>
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
@@ -130,45 +138,46 @@
 
       <!-- Left margin: which rows are the addition section, and where it
            starts and stops. Annotation, not an element. -->
-      <div class="abs brace" style="left:300px;top:518px;width:44px;height:664px"></div>
-      <div class="abs col" style="left:64px;top:530px;width:224px;gap:10px">
+      <div class="abs brace" style="left:300px;top:450px;width:44px;height:376px"></div>
+      <div class="abs col" style="left:64px;top:452px;width:224px;gap:10px">
         <div style="font-size:26px;font-weight:700;color:var(--accent)">addition section</div>
         <div style="font-size:24px;color:#6C7873;line-height:1.3">rows 1–2 are what<br>every card starts with</div>
       </div>
-      <div class="abs" style="left:64px;top:748px;width:224px;font-size:24px;color:#6C7873;line-height:1.3">
-        rows 3–6 are grown by the player, one at a time, and stop here
+      <div class="abs" style="left:64px;top:600px;width:224px;font-size:24px;color:#6C7873;line-height:1.3">
+        rows 3–6 are grown by the player, one at a time, and stop here. The
+        whole section is 56 px a row from the third onward, dealt rows
+        included
       </div>
 
       <!-- Right of the grid: what the drawing measures. -->
       <div class="abs col" style="left:1060px;top:216px;width:240px;gap:18px">
-        <div style="font-size:28px;font-weight:700;color:var(--warn)">This does not fit.</div>
+        <div style="font-size:28px;font-weight:700;color:var(--accent)">This fits.</div>
         <div style="font-size:24px;color:#6C7873;line-height:1.35">
-          Two rows: the grid is 732 px tall and ends 948 px into the panel,
-          with about 100 px to spare.
+          There are 908 px between the header band and
+          <code>DialogPadding</code>. The rows that never change size come to
+          460 px, and the gaps to 96 px.
         </div>
         <div style="font-size:24px;color:#6C7873;line-height:1.35">
-          Six rows: 1180 px tall, ending 1396 px into the panel. There are
-          908 px between the header and <code>DialogPadding</code>, so it is
-          272 px too tall even pushed right up under the header.
-        </div>
-        <div style="font-size:24px;color:var(--warn);line-height:1.35;font-weight:700">
-          The second rule line, the second carry strip and the answer row are
-          all below the bottom of the tablet.
+          Six rows at <code>GridAdditionRowHeight</code>: 336 px. The grid is
+          892 px tall and ends 1040 px into the panel — 16 px to spare.
         </div>
         <div style="font-size:24px;color:#6C7873;line-height:1.35">
-          What gives — scroll, smaller cells, something else — is an open
-          question on the spec page. This picture is the question, not the
-          answer.
+          At full-size rows it was 1180 px, 272 px too tall, with the second
+          rule line, the second carry strip and the answer row all below the
+          bottom of the tablet. That drawing was the question; this one is
+          Derek's answer to it.
+        </div>
+        <div style="font-size:24px;color:#6C7873;line-height:1.35">
+          The problem, both rule lines, both carry strips and the answer row
+          are the size they are on the as-dealt drawing. Only the scratch
+          paper shrank.
         </div>
       </div>
     </div>
 
-    <!-- Everything from the DialogPadding limit down to the bottom of the
-         tablet: outside the dialog, and past the panel edge, off the screen. -->
-    <div class="abs overrun" style="left:0;right:0;top:1096px;height:104px"></div>
-
     <!-- The last usable pixel inside the dialog: DialogMaxHeight less
-         DialogPadding, 1096 px down the canvas. -->
+         DialogPadding, 1096 px down the canvas. The grid's bottom edge is
+         8 px above it. -->
     <div class="abs limit" style="left:48px;right:48px;top:1096px">
       <span>DialogPadding — the last usable pixel inside the dialog</span>
     </div>

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -102,10 +102,23 @@ It does **not** fit with room to spare — the phrase this paragraph used to end
 with, and the one ADR-0002 still ends with, both written before the addition
 section could grow. As dealt, the grid ends 948 px
 into a panel whose last usable pixel is 1048 px — about 100 px of slack against
-112 px per extra row, so the section stops fitting on the *third* of its six
-allowed rows. What to do about that is
-[open question 3](#open-questions); the numbers are worked through under
-[Mockup](#mockup), and the third mockup is the picture of them.
+112 px per extra row, so at full-size rows the section stops fitting on the
+*third* of its six allowed. What gives is
+[open question 3](#open-questions), settled: the addition rows take
+`GridAdditionRowHeight` once the section grows, and the grid fits at every
+count up to the cap. The numbers are worked through under [Mockup](#mockup),
+and the third mockup is the picture of them.
+
+**"Centred in the space left over" is the rule, in both directions.**
+Horizontally that space runs from `DialogPadding` to the keypad column's left
+edge; vertically from the bottom of the header band (`GridHeaderHeight`) to the
+panel's last usable pixel (`DialogMaxHeight` less `DialogPadding`) — 908 px.
+The grid moves within that space as it grows and shrinks, which is what lets a
+six-row section sit higher up the panel than a two-row one. The two committed
+drawings hand-place the as-dealt grid at `top: 216`, about 12 px above where
+centring puts it, and 2 px apart from each other horizontally; that is what
+hand placement looks like, and the rule — not either drawing's origin — is what
+the screen is built to.
 
 ## Named constants
 
@@ -113,16 +126,38 @@ allowed rows. What to do about that is
 | --- | --- | --- |
 | Digit cell, square | `GridCellSize` | 104 px |
 | Gap between cells and between rows | `GridCellGap` | 8 px |
+| Digit cell outline | `GridCellBorderWidth` | 3 px |
+| Digit cell corner radius | `GridCellRadius` | 10 px |
 | Carry strip height | `GridCarryRowHeight` | 56 px |
 | Carry box inside the strip | `GridCarryBoxSize` | 56 × 52 px |
+| Carry box outline | `GridCarryBoxBorderWidth` | 3 px |
+| Carry box corner radius | `GridCarryBoxRadius` | 8 px |
 | Rule line thickness | `GridRuleThickness` | 6 px |
+| Addition row height, once the section is grown | `GridAdditionRowHeight` | 56 px |
 | Answer row height | `GridAnswerRowHeight` | 128 px |
 | Answer cell border | `GridAnswerBorderWidth` | 6 px |
 | Digit size in a cell | `GridDigitSize` | 56 px |
+| Digit size in a 56 px box — a grown addition row, a carry box | `GridSmallDigitSize` | 28 px |
+| `=` in the operator column | `GridEqualsSize` | 28 px |
+| Header band, panel top down to the bottom of the chip | `GridHeaderHeight` | 140 px |
+| Header row, down from the panel's top edge | `GridHeaderTop` | 44 px |
+| Gap between the header's three items | `GridHeaderGap` | 32 px |
+| `Work it out` | `GridPromptSize` | 44 px |
+| Card readout pill height | `GridCardReadoutHeight` | 96 px |
+| Card readout pill padding, each side | `GridCardReadoutPaddingX` | 32 px |
+| Card readout pill corner radius | `GridCardReadoutRadius` | 20 px |
+| Card readout pill outline | `GridCardReadoutBorderWidth` | 3 px |
+| Card readout label | `GridCardReadoutLabelSize` | 40 px |
 | Addition rows a card is dealt | `GridAdditionRowsAtStart` | 2 rows |
 | Most addition rows the section can hold | `GridAdditionRowsMax` | 6 rows |
+| Keypad, down from the panel's top edge | `KeypadTop` | 216 px |
 | Keypad key, square | `KeypadKeySize` | 140 px |
 | Gap between keys | `KeypadKeyGap` | 16 px |
+| Key corner radius | `KeypadKeyRadius` | 20 px |
+| Key outline | `KeypadKeyBorderWidth` | 3 px |
+| Digit key label | `KeypadKeyLabelSize` | 56 px |
+| Backspace glyph | `KeypadBackspaceLabelSize` | 40 px |
+| `clear` label | `KeypadClearLabelSize` | 32 px |
 | Keypad width (3 keys + 2 gaps) | `KeypadWidth` | 452 px |
 | Gap between keypad and `Check it` | `KeypadSubmitGap` | 24 px |
 | `Check it` height | `CheckButtonHeight` | 128 px |
@@ -131,12 +166,31 @@ allowed rows. What to do about that is
 are in this table anyway, because the number of rows the addition section starts
 and stops at is exactly the kind of number that otherwise ends up as an unnamed
 `2` in `Core` and an unnamed `6` in the Unity shell, and then only one of them
-gets changed.
+gets changed. They are the two rows on this table `Core` owns
+([`WorkingOutGrid`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/Assets/Scripts/Core/WorkingOutGrid.cs)),
+and the shell references them rather than keeping a copy.
 
-**A grown row has no size constant of its own.** It is an ordinary row of
-ordinary cells: `GridCellSize` tall, `GridCellGap` below the row above it, the
-same cells the section already has. Growing the section costs
-`GridCellSize` + `GridCellGap` = 112 px of height per row and nothing else.
+**Every value above is a number a drawing already fixed**, except two:
+`GridAdditionRowHeight`, which is Derek's answer to
+[open question 3](#open-questions), and `GridSmallDigitSize`, which is what a
+digit has to shrink to in order to sit inside a 56 px-tall box. No committed
+drawing shows a digit in one — no mockup fills a carry box, and the grown
+drawing's rows are empty — so it is the one number here read off a proportion
+instead of a picture: the same share of its box's height that `GridDigitSize`
+(56 px) is of `GridCellSize` (104 px), which lands on the 28 px the drawings
+already use for their smallest glyph.
+
+**A grown row has a size constant of its own**, and did not until
+[#223](https://github.com/derekwinters/connor-multiplying-frogs/issues/223).
+Once the section holds more rows than a card is dealt, every row in it —
+including the two that were dealt — is `GridAdditionRowHeight` tall rather than
+`GridCellSize`, with `GridSmallDigitSize` digits inside. Nothing else in the
+grid changes size, ever: the multiplicand and multiplier rows, both rule lines,
+both carry strips and the answer row are the same height at two rows as at six.
+Growing the section therefore costs `GridAdditionRowHeight` + `GridCellGap` =
+64 px per row instead of the 112 px it would cost at full size, and the first
+grown row *shrinks* the grid rather than stretching it — see
+[Mockup](#mockup) for the whole sum.
 
 ### How many columns and rows
 
@@ -237,6 +291,10 @@ past it.
   - **A grown row is indistinguishable from a dealt one.** Same cells, same
     size, same border, no tint, no badge, nothing that says "you added this".
     The section is scratch paper and scratch paper does not annotate itself.
+    The smaller `GridAdditionRowHeight` a grown section takes applies to *every*
+    row in it, the two dealt ones included — a section where the first two rows
+    were taller than the four below them would be exactly the "you added this"
+    marking this bullet rules out.
   - The `+` glyph sits in the operator column of the **bottom row of the
     section**, wherever the bottom currently is, which is where the committed
     two-row drawing already puts it. Growing the section moves the glyph down
@@ -259,18 +317,36 @@ past it.
   current bottom row appends another row beneath it, still above the answer row.
   That repeats each time the new bottom row is written in, until the section
   holds `GridAdditionRowsMax` rows, after which nothing more is appended. A
-  single digit is enough; the row does not have to be finished first.
+  single digit is enough; the row does not have to be finished first. The whole
+  section takes `GridAdditionRowHeight` from the moment it holds more rows than
+  the card dealt it, and keeps it until it is back to that count.
 - Nothing prompts the player to grow the section and nothing rewards it. A
   player who carries with the superscript boxes never sees a third addition row,
   and a player who has never been shown the superscript boxes never has to use
   them.
-- **Whether a grown row can be taken away again is not specified here.** Neither
-  `backspace` nor `clear` is described as removing a row, and neither is
-  described as leaving one behind. It is a question, not an omission — see
-  [open question 5](#open-questions).
+- **Shrinking it again.** Backspacing the last digit out of a grown row removes
+  the row ([open question 5](#open-questions), settled). Only the section's
+  *bottom* row can go, and only a grown one: `GridAdditionRowsAtStart` is the
+  floor, because no card is ever dealt fewer, and emptying a row further up the
+  section leaves an empty row where it is. `clear` never removes a row — it is
+  described as emptying a block, not as taking one away, and the settled answer
+  is about backspace.
 - No timer, ever. `331 × 41` on paper takes as long as it takes.
 - There is no `undo`, only backspace and `clear` — and `clear` empties only the
-  cell block you are in, not the whole grid.
+  cell block you are in, not the whole grid. **A block is a row**: `clear`
+  empties every cell of the row the caret is in and touches nothing above or
+  below it. That is the narrowest reading of the sentence above, chosen in
+  [#223](https://github.com/derekwinters/connor-multiplying-frogs/issues/223)
+  rather than invented — the wider readings (the section, the grid) are the ones
+  the sentence rules out.
+- Backspace takes the digit in the caret's own cell, or — if that cell is
+  already empty — the digit most recently typed anywhere in the same block, and
+  moves the caret to wherever it just took one from. It never reaches outside
+  the block.
+- After a digit lands, the caret steps one cell to the left, in whatever row it
+  is in, and stops at the leftmost digit column. That is the answer row's
+  right-to-left fill applied everywhere, because the addition rows and the carry
+  strips are worked out in the same direction.
 - Hardware back does nothing.
 
 ## Mockup
@@ -287,34 +363,49 @@ claim best checked by looking at the biggest and the smallest next to each
 other. The easy one is now the same height as the hard one and narrower, which
 is what that claim has been reduced to.
 
-**The third is a question, not an agreed picture.** It is the same screen as the
-first with the addition section at `GridAdditionRowsMax` instead of
-`GridAdditionRowsAtStart`, everything else identical, at today's constants — and
-at today's constants it does not fit:
+**The third is the answer to [open question 3](#open-questions), and it used to
+be the question.** It is the same screen as the first with the addition section
+at `GridAdditionRowsMax` instead of `GridAdditionRowsAtStart`. Drawn at
+full-size addition rows — which is how it was first committed, deliberately
+overflowing, as the input to that question — it did not fit. Drawn at
+`GridAdditionRowHeight`, which is what Derek settled, it does.
 
-| | Grid height | Ends, measured into the panel |
-| --- | --- | --- |
-| `GridAdditionRowsAtStart` (2 rows) | 732 px | 948 px, about 100 px of slack |
-| `GridAdditionRowsMax` (6 rows) | 1180 px | 1396 px |
+The space: the dialog is `DialogMaxHeight` (1104 px) tall and `DialogPadding`
+(56 px) of that is not usable, so the last usable pixel is 1048 px into the
+panel, and the header band takes the first `GridHeaderHeight` (140 px). That
+leaves **908 px**.
 
-The dialog is `DialogMaxHeight` (1104 px) tall and `DialogPadding` (56 px) of
-that is not usable, so the last usable pixel is 1048 px into the panel. The
-header takes the first 140 px. That leaves **908 px for a grid that wants
-1180 px** — 272 px too tall even shoved right up under the header, with the grid
-free to re-centre upward under the [Anchors](#anchors) rule. The second rule
-line, the second carry strip and **the answer row itself** all end up below the
-bottom edge of the tablet.
+Everything that is the same height at every count — two carry strips (56 each),
+the multiplicand and multiplier rows (104 each), two rule lines (6 each) and the
+answer row (128) — comes to **460 px**. The gaps are `GridCellGap` (8 px) between
+every pair of the 7 + *n* things stacked, so 8 × (6 + *n*). The addition rows are
+whatever *n* rows at whatever height the section is currently drawn at:
 
-That overrun is drawn rather than described because it is the input to
-[open question 3](#open-questions). A mockup that visibly overflows is the
-correct result here: the wireframe's job was to find out what the cap costs at
-today's numbers, not to pick the fix.
+| Addition rows | Row height | Grid height | Against the 908 px available |
+| --- | --- | --- | --- |
+| 2 — as dealt | `GridCellSize`, 104 px | 460 + 208 + 64 = **732 px** | fits, 176 px spare |
+| 3 | `GridAdditionRowHeight`, 56 px | 460 + 168 + 72 = **700 px** | fits, 208 px spare |
+| 4 | 56 px | 460 + 224 + 80 = **764 px** | fits, 144 px spare |
+| 5 | 56 px | 460 + 280 + 88 = **828 px** | fits, 80 px spare |
+| 6 — the cap | 56 px | 460 + 336 + 96 = **892 px** | fits, **16 px spare** |
+| *6, at full-size rows* | *104 px* | *460 + 624 + 96 = 1180 px* | *272 px too tall — the old third mockup* |
+
+Two things worth saying out loud about that column of sums. **The margin at the
+cap is 16 px**, so this fits and does not fit comfortably: anything that grows
+the fixed 460 px — a taller answer row, a third carry strip, a heavier rule —
+pushes the six-row grid off the bottom again, and the sum above is where to
+check that. And **the grid gets shorter before it gets taller**: the third row
+takes the whole section down to 56 px, so growing it the first time shrinks the
+grid from 732 px to 700 px, and it only passes its as-dealt height at the fifth
+row. That is the cost of one shrunk height for the whole section rather than a
+different height at every count, and it is a visible jump the first time a
+player grows a row.
 
 ## Open questions
 
 Questions 2 to 5 arrived with the growable addition section
 ([#234](https://github.com/derekwinters/connor-multiplying-frogs/issues/234)).
-Question 6 is older. Questions 1 and 5 are settled; 2, 3, 4 and 6 are not
+Question 6 is older. Questions 1, 3 and 5 are settled; 2, 4 and 6 are not
 answered by anything Derek has said yet.
 
 - **1. Which carry convention does Connor's class use? Settled: shared
@@ -349,14 +440,30 @@ answered by anything Derek has said yet.
   arriving through the back door. The third mockup draws it pinned above the
   answer, because that is where the committed drawing has it.
 
-- **3. What happens when the section outgrows the dialog?** Not decided, and by
-  the measurements above this is not a distant edge case: the section stops
-  fitting on its **third** row, and at the cap the answer row is off the bottom
-  of the tablet entirely. Options include scrolling the `grid` region, shrinking
-  `GridCellSize` once the section passes some count, shrinking it for the whole
+- **3. What happens when the section outgrows the dialog? Settled: smaller
+  cells for the addition rows only.** At full-size rows the section stopped
+  fitting on its **third**, and at the cap the answer row was off the bottom of
+  the tablet entirely. The options were scrolling the `grid` region, shrinking
+  `GridCellSize` once the section passed some count, shrinking it for the whole
   grid up front, giving the addition section its own smaller row height, or
-  lowering `GridAdditionRowsMax` to what fits — which is 2 today. Each one costs
-  something different, and picking one is a layout decision.
+  lowering `GridAdditionRowsMax` to the 2 that fitted.
+
+    Derek's call on [#223](https://github.com/derekwinters/connor-multiplying-frogs/issues/223):
+    "Smaller cells for addition rows only." The section gets
+    `GridAdditionRowHeight` (56 px) the moment it holds more rows than the card
+    dealt it; the multiplicand and multiplier rows, both rule lines, both carry
+    strips and the answer row stay exactly the size they are today, at every
+    count. The problem stays full-size and legible, and the scratch paper is
+    what shrinks — which is the right way round, since the scratch paper is the
+    part nobody checks.
+
+    The sum is in [Mockup](#mockup) and it was re-run rather than assumed: six
+    grown rows make an **892 px** grid in **908 px** of space, so it fits with
+    16 px to spare, and the third mockup now draws that instead of the overflow.
+    Two consequences worth knowing: the margin at the cap is thin enough that
+    any future growth in the fixed rows breaks it again, and the grid gets
+    *shorter* when the third row appears before it gets taller again at the
+    fifth.
 
 - **4. Does the one-digit card's addition section get the second rule line and
   the second carry strip?** `68 × 5` now gets the addition rows. It is not
@@ -375,10 +482,15 @@ answered by anything Derek has said yet.
   shrink is nothing more than the next snapshot's count being one lower — it
   does not need an operation of its own. `GridAdditionRowsAtStart` is the
   floor: no snapshot may ask for fewer, because no card is ever dealt fewer.
-  What is not settled, and is not this page's or `Core`'s to settle: whether
-  removing a row the player isn't currently at (not the section's bottom row)
-  is reachable at all — that is the caret-and-keypad interaction policy, owned
-  by whichever issue builds turn interaction.
+
+    The interaction policy this left open — whether removing a row the player
+    isn't currently at is reachable at all — was owned by whichever issue built
+    turn interaction, which is
+    [#223](https://github.com/derekwinters/connor-multiplying-frogs/issues/223),
+    and it answered **no**. Only the section's bottom row is ever removed, and
+    only by backspacing its last digit out; emptying a row further up leaves an
+    empty row exactly where it is, and `clear` never removes a row at all. See
+    [Behaviour](#behaviour).
 
 - **6. Should the keypad have an `=`?** No, currently: `Check it` is the commit,
   and two ways to submit is one too many.


### PR DESCRIPTION
Closes #223

This builds the screen you actually do the multiplication on: the grid with its
carry boxes, the keypad, and `Check it`. The grid draws exactly the rows and
columns Core works out for the card — the easy card gets a narrower grid, the
hard card a wider one, from the same code — and you can tap any box and type in
any order. Nothing you type is ever marked right or wrong here; pressing
`Check it` just hands the answer row's digits on and opens the next screen.

It also settles the question the third mockup was asking. Derek's call was
"smaller cells for addition rows only", so once you grow the addition section it
takes a shorter row height, and the whole grid now fits on the tablet even with
all six rows — which it did not before.

**Docs:** `docs/specs/ui/working-out-grid.md` — open question 3 is answered
(the addition section takes `GridAdditionRowHeight`, 56 px, once grown; the
overrun arithmetic is re-run in full under Mockup), open question 5's leftover
interaction policy is answered (only the section's bottom row is ever removed,
by backspacing its last digit out), `clear`'s "cell block" is pinned to the
caret's row, and the Named-constants table gains 22 rows. Plus
`docs/specs/ui/mockups/working-out-grid-331x41-grown.html`, redrawn from the
question to the answer, and `docs/specs/ui/mockups/index.md`, which described it
as an open question.

## The overrun arithmetic, re-run

The space: `DialogMaxHeight` 1104, less `DialogPadding` 56 = last usable pixel
1048 into the panel; less the 140 px header band = **908 px**.

The rows that never change size — two carry strips (56 each), multiplicand and
multiplier (104 each), two rule lines (6 each), answer row (128) — are **460 px**.
The gaps are 8 × (6 + *n*).

| Addition rows | Row height | Grid height | Against 908 px |
| --- | --- | --- | --- |
| 2, as dealt | 104 | 460 + 208 + 64 = **732** | fits, 176 spare |
| 3 | 56 | 460 + 168 + 72 = **700** | fits, 208 spare |
| 4 | 56 | 460 + 224 + 80 = **764** | fits, 144 spare |
| 5 | 56 | 460 + 280 + 88 = **828** | fits, 80 spare |
| 6, the cap | 56 | 460 + 336 + 96 = **892** | fits, **16 spare** |
| *6, unshrunk* | *104* | *460 + 624 + 96 = 1180* | *272 too tall — the old drawing* |

Smaller did **not** automatically fit: the ceiling is `6A ≤ 908 − 556`, i.e.
**A ≤ 58.67 px**, so any addition-row height above 58 px still overflows at the
cap. 56 px is the largest value already in this page's vocabulary that clears
it, and it leaves 16 px. Two things fall out of that and are written into the
spec: the margin at the cap is thin enough that any future growth in the fixed
460 px breaks it again, and the grid gets *shorter* at three rows (700) than as
dealt (732) before passing its dealt height at five — a visible jump the first
time a player grows a row.

## Spec invariants this had to keep true

- **Nothing in the grid is marked.** The view has no notion of a correct value:
  no member of it, of the cell or of the key names one, `IWorkingOutTurn`
  returns nothing from `SubmitAnswer`, and a test asserts no cell's colour
  changes as digits are typed or when `Check it` is pressed
  (`Grid_MarksNothing_AndHasNoWayToKnowWhatWouldBeCorrect`,
  `CheckIt_ReadsTheAnswerLeftToRight_HandsItToTurnResolution_AndMarksNothing`).
- **Which cells exist is Core's.** The view iterates
  `WorkingOutGrid.For(card, additionRowCount)` and derives only the two rule
  lines and the operator glyphs, both from the row kinds Core reports. Easy and
  hard shapes are asserted to differ only in column count
  (`Grid_ForTheHardShape_IsWiderThanTheEasyOne_AndOnlyBecauseCoresModelSaysSo`).
- **Both carry strips, always, shared not per-row** (open question 1 / #255,
  confirmed rather than redrawn): `WorkingOutGrid.CarryStripCount` is 2 in Core,
  the page records the call, and a test asserts two strips are drawn whatever
  the addition row count.
- **`Check it` is disabled until the answer row has a digit**, using the shared
  Button's own `Disabled` state and opacity — a digit in an addition row or a
  carry box does not enable it (`CheckIt_IsDisabledUntilTheAnswerRowHasADigit`).
- **This dialog cannot be dismissed, and back is inert.** No back handler, no
  least-destructive button nominated, no click handler on the scrim; a test
  presses hardware back and asserts the dialog stays open with every cell
  unchanged.
- **A grown row is indistinguishable from a dealt one** — which is why the
  smaller height applies to the *whole* section, dealt rows included, rather
  than only to the rows the player added.

## How the spec is changing

- **Open question 3.** Old: undecided, and at the cap the answer row was off the
  bottom of the tablet. New: the addition section — every row of it — is
  `GridAdditionRowHeight` (56 px) with `GridSmallDigitSize` (28 px) digits from
  the moment it holds more rows than the card dealt it; everything else keeps
  its size at every count. Better because the problem and the answer stay
  full-size and legible, and the part that shrinks is the scratch paper nobody
  checks.
- **"A grown row has no size constant of its own."** That sentence was true only
  while the question was open; it is now the opposite, and the paragraph says so
  and says what changed.
- **Open question 5's remainder.** Old: the page left "whether removing a row
  the player isn't at is reachable" to whichever issue built turn interaction.
  New: it isn't — only the bottom row goes, only by backspace, and `clear` never
  removes a row. Better because the alternative reachable-from-anywhere reading
  lets a row vanish from under the player's finger mid-sum.
- **`clear`'s "cell block".** Old: undefined beyond the one sentence. New: the
  block is the caret's row. The narrowest reading that satisfies the sentence,
  as the issue asked.
- **Named constants.** 22 rows added: 20 the mockups draw and the table never
  named (cell/carry-box/key outlines and radii, the header band and its three
  items, the card-readout pill, `KeypadTop`, the three key label sizes, the `=`
  glyph), plus `GridAdditionRowHeight` and `GridSmallDigitSize`. No existing
  value was found to be arithmetically wrong: `KeypadWidth` 452 = 3 × 140 +
  2 × 16 checks out, and `GridHeaderTop` 44 + the chip's 96 is exactly the
  140 px header band the page's prose already quoted.

## Deviations and Decisions

- **`GridSmallDigitSize` (28 px) is the one number here not read off a drawing.**
  No committed mockup ever fills a carry box or a grown addition row, so no
  picture fixes the digit size inside a 56 px-tall box. Rather than block the
  screen on a font size, I derived it as the same share of its box that
  `GridDigitSize` (56) is of `GridCellSize` (104) — which lands on the 28 px the
  drawings already use for their smallest glyph — and said so in the table.
  Happy to redraw if you'd rather pick it by eye.
- **The grid is placed by the Anchors rule, not by the mockups' origins.**
  "Centred in the space left over" puts the as-dealt grid ~12 px lower and
  ~14 px left of where the two committed drawings hand-place it (and those two
  are 2 px apart from each other). Centring is what the page states and it is
  the only rule that also works for the grown grid, which has to move up. Noted
  in the spec page.
- **Two checklist boxes are untickable as worded** — the ones asking for "four
  rows for a 1-digit multiplier" and "seven rows for a 2-digit multiplier". #234
  made every card get the same seven rows at the starting count, and #204 ships
  that. The tests assert Core's actual row sequence instead, for both shapes.
- **Carry boxes are drawn with a solid faint outline, not a dashed one.** A
  dashed stroke needs a texture or a custom mesh, and "no external assets" rules
  out the first; geometry, colour and radius match the mockup exactly.
- **The keypad's backspace key uses the mockup's `⌫` glyph.** Worth a look on
  the tablet: if Unity's built-in font has no U+232B it will draw a box, and the
  fix is a word or a drawn shape — not something to guess at from here.
- **`Check it` is not in the shared Dialog's button row.** This page pins it
  under the keypad at full keypad width, so it is parented into the keypad
  column instead. Everything else about it is the shared Button.
- **The answer row's caption in the two committed mockups ("the answer row — the
  only row that counts") is treated as annotation and not built.** The grown
  mockup omits it and the page's Elements list never mentions it.
- **`IWorkingOutTurn` is not wired to a live `Game` in this PR**, and the dialog
  is not instantiated in any scene — the same state #221's dialog is in. The
  seam is there and tested against a stub; wiring the screens together is the
  issue that owns that.
- **The caret advances left after every digit, in every row**, not only the
  answer row, and lands on the same column of the new bottom row when a grown
  row is removed under it. Neither is spelled out in the page; both are recorded
  in Behaviour.
- EditMode tests were written first and pushed unexecuted — no editor here.
  `dotnet test` (190 pass), `check_core_isolation`, `check_assembly_references`,
  `check_geometry_literals`, `run_python_tests` and `mkdocs build --strict` all
  pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_