### PR TITLE
feat(ui): the answer result dialog and the frog's hop

### DIFF
--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs
@@ -1,0 +1,85 @@
+using System;
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The runtime <see cref="IAnswerResultTurn"/>: a live <see cref="Game"/>
+    /// and the <see cref="TurnResolution"/> its active frog's answer just
+    /// produced. There is no arithmetic in this type and no grading — every
+    /// member is a straight read of something Core already decided, or a
+    /// forward of one of Core's own two hand-off steps.
+    ///
+    /// The frog and the card are captured at construction, because that is the
+    /// moment they describe: the answer was graded then, and
+    /// <see cref="Game.CompleteHandOff"/> clears the drawn card and moves the
+    /// active frog on. <see cref="NextFrog"/> is read live, because it is the
+    /// one fact the dialog wants *as it is now* — before hand-off has run.
+    /// </summary>
+    public sealed class GameAnswerResultTurn : IAnswerResultTurn
+    {
+        readonly Game _game;
+        readonly Card _card;
+
+        /// <exception cref="ArgumentNullException"><paramref name="game"/> or <paramref name="resolution"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The turn has not drawn a card — there is no problem to show.</exception>
+        public GameAnswerResultTurn(Game game, TurnResolution resolution)
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+            Resolution = resolution ?? throw new ArgumentNullException(nameof(resolution));
+
+            _card = game.DrawnCard;
+
+            if (_card == null)
+            {
+                throw new InvalidOperationException(
+                    "this turn has not drawn a card yet; there is no problem to show.");
+            }
+
+            Frog = game.ActiveFrog;
+        }
+
+        /// <inheritdoc />
+        public FrogColour Frog { get; }
+
+        /// <inheritdoc />
+        public int Multiplicand
+        {
+            get { return _card.Multiplicand; }
+        }
+
+        /// <inheritdoc />
+        public int Multiplier
+        {
+            get { return _card.Multiplier; }
+        }
+
+        /// <inheritdoc />
+        public TurnResolution Resolution { get; }
+
+        /// <inheritdoc />
+        public FrogColour NextFrog
+        {
+            get { return _game.NextActiveFrog; }
+        }
+
+        /// <inheritdoc />
+        public void BeginHandOff()
+        {
+            _game.BeginHandOff();
+        }
+
+        /// <inheritdoc />
+        public void CompleteHandOff()
+        {
+            // Just the advance. A frog that lands on the End log also needs
+            // its place in the finishing order captured
+            // (<see cref="Game.RecordFinish"/>, #211), and this is a plausible
+            // moment to do it — but recording a finish is not this issue's,
+            // nothing here is tested against it, and a silent extra call to
+            // Core is exactly the kind of thing that goes unnoticed until it
+            // is wrong.
+            _game.CompleteHandOff();
+        }
+    }
+}

--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs.meta
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5efdac5f019495bb7fc6699b7f9fe65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/IAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/IAnswerResultTurn.cs
@@ -1,0 +1,66 @@
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// Everything docs/specs/ui/answer-result.md's dialog needs of the turn it
+    /// was opened on, and the one way it hands that turn on. Every fact here
+    /// was decided before the dialog existed: **"Nothing is decided here. Core
+    /// has already compared the answer and computed the new position; this
+    /// dialog reads it out."**
+    ///
+    /// Like <see cref="IWorkingOutTurn"/> and unlike
+    /// <see cref="IRollAndCardReadout"/>, this is not called a *readout*,
+    /// because it is not only read from: the two hand-off calls are how the
+    /// one button on the dialog passes the device to the next player.
+    ///
+    /// The problem arrives as its two operands rather than as a
+    /// <see cref="Card"/>, the same choice <see cref="IRollAndCardReadout"/>
+    /// makes and for the same reason — the dialog prints `331 × 41 = 13,571`,
+    /// and a test that wants to assert that string should not have to reach a
+    /// seeded generator to get it.
+    /// </summary>
+    public interface IAnswerResultTurn
+    {
+        /// <summary>The frog whose answer this was — the chip, and the name in the consequence sentence.</summary>
+        FrogColour Frog { get; }
+
+        /// <summary>The card's first operand — the `331` in `331 × 41 = 13,571`.</summary>
+        int Multiplicand { get; }
+
+        /// <summary>The card's second operand — the `41` in `331 × 41 = 13,571`.</summary>
+        int Multiplier { get; }
+
+        /// <summary>
+        /// What Core made of the answer (#210): which of the three outcomes
+        /// happened, the lane position before and after, and the card's
+        /// correct answer. The dialog renders these; it derives none of them,
+        /// and it never re-grades.
+        /// </summary>
+        TurnResolution Resolution { get; }
+
+        /// <summary>
+        /// Who the button is named for — <see cref="Game.NextActiveFrog"/>
+        /// (#208): the frog that *would* become active next, skipping any that
+        /// are home, asked while this turn's result is still on screen and
+        /// nothing has advanced. Not <see cref="Frog"/>, and not something the
+        /// dialog works out by walking turn order.
+        /// </summary>
+        FrogColour NextFrog { get; }
+
+        /// <summary>
+        /// The result dialog has closed and the board is back on screen for
+        /// the frog's hop — <see cref="Game.BeginHandOff"/>'s own moment.
+        /// Called once, as the button is pressed.
+        /// </summary>
+        void BeginHandOff();
+
+        /// <summary>
+        /// The hop has finished: the next player's turn begins —
+        /// <see cref="Game.CompleteHandOff"/>. Called once, and only after the
+        /// frog has landed, so nothing about whose turn it is changes while
+        /// the frog is still mid-air.
+        /// </summary>
+        void CompleteHandOff();
+    }
+}

--- a/Assets/Scripts/Unity/IAnswerResultTurn.cs.meta
+++ b/Assets/Scripts/Unity/IAnswerResultTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 971e965143704f62abfcd1f64f86b565
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
+++ b/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
@@ -1,0 +1,792 @@
+using System;
+using System.Globalization;
+using Frogs.Core;
+using UnityEngine;
+using UnityEngine.UI;
+// UnityEngine.UI also declares a Button type — the same collision
+// WorkingOutGridView.cs and RollAndCardDialogView.cs work around — so the
+// shared components are pulled in by explicit alias, and a bare `Button`,
+// `ButtonKind`, `DialogPanel`, `FrogColours` or `PlayerChip` in this file
+// always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// Right or wrong, what the number was, and what the frog does about it —
+    /// docs/specs/ui/answer-result.md, built to that page and its two committed
+    /// 1:1 mockups, on the shared <see cref="DialogPanel"/> (#219). Both states
+    /// are one layout with different content: the same panel size and the same
+    /// anchors, because "two dialogs that jump about are two dialogs a child
+    /// reads as two different things happening."
+    ///
+    /// **Nothing is decided here.** Core compared the answer and computed the
+    /// new position before this dialog opened (<see cref="Lane.Resolve"/>,
+    /// #210); this view reads the resulting <see cref="TurnResolution"/> out.
+    /// The three consequence sentences are rendered *from the outcome* — no
+    /// English is stored in Core, and no outcome is inferred here from the
+    /// position numbers. Whose turn is next is
+    /// <see cref="IAnswerResultTurn.NextFrog"/>, which is
+    /// <see cref="Game.NextActiveFrog"/> (#208) — asked while this dialog is
+    /// still showing the *current* player's result, and answered without
+    /// advancing anything.
+    ///
+    /// On a wrong answer **the correct answer is revealed and the working is
+    /// not** — docs/adr/0002-structured-working-out-grid.md. There is no
+    /// affordance here of any kind to show partial products, and adding one
+    /// would make a method canonical, which is the stance the project has
+    /// deliberately not taken.
+    ///
+    /// **Hardware back is inert**, the same way it is on the two dialogs
+    /// before this one: by adding no handler at all and nominating no
+    /// least-destructive button on the shared Dialog. The router (#213)
+    /// already knows back does nothing over
+    /// <see cref="Frogs.Core.Dialog.AnswerResult"/>.
+    ///
+    /// This view also owns **the hop**, which is the one piece of motion on
+    /// the board. <c>unity-game-board</c> (#220) draws a frog at rest at
+    /// whatever position Core reports and has no motion of its own; this view
+    /// plays the interpolation between the before and after positions Core
+    /// already reported, using #220's own placement for both endpoints, and
+    /// hands the board back through its <c>NotifyTurnResolved</c> seam when the
+    /// frog lands. Core's position changed at grading time; nothing here
+    /// touches Core's state beyond the two hand-off steps the button runs.
+    ///
+    /// Both of answer-result.md's open questions are left exactly as open as it
+    /// leaves them: there is no celebration beyond the hop — no sound, no
+    /// flourish, not a silent <c>AudioSource</c> waiting for a clip — and the
+    /// wrong state does not offer to show the working.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class AnswerResultDialogView : MonoBehaviour
+    {
+        // docs/specs/ui/answer-result.md#named-constants — the page's own
+        // table, under the identical names.
+        public const float ResultDialogWidth = 1100f;
+        public const float ResultDialogHeight = 620f;
+        public const float ResultMarkSize = 180f;
+        public const float ResultMarkRingWidth = 8f;
+        public const float ResultMarkGlyphSize = 110f;
+        public const float ResultVerdictSize = 76f;
+        public const float ResultVerdictTop = 70f;
+        public const float ResultConsequenceSize = 48f;
+        public const float ResultConsequenceTop = 180f;
+        public const float ResultTextWidth = 760f;
+        public const float ResultTextLeft = 280f;
+        public const float ResultChipTop = 340f;
+        public const float ResultHopDelay = 0.2f;
+
+        // `FrogHopDuration` is the *board's* constant, not this page's — the
+        // hop happens on that screen, after this dialog has gone. Referenced
+        // rather than redeclared, so the two can never disagree:
+        // GameBoardScreenView.FrogHopDuration.
+        //
+        // The panel's scrim, corners, padding, radius and cross-fade are the
+        // shared Dialog's, referenced the same way — DialogPanel.DialogPadding
+        // places `mark`, `chip` and `controls`, and DialogFadeDuration is the
+        // close this sequence waits on rather than a second animation of its
+        // own.
+
+        // The three moments of the hand-off, as offsets from the press. Every
+        // one of them is a named duration added to the one before it, so the
+        // sequence's shape is visible in one place.
+        const float HandOffFadeEnd = DialogPanel.DialogFadeDuration;
+        const float HandOffHopStart = HandOffFadeEnd + ResultHopDelay;
+        const float HandOffDuration = HandOffHopStart + GameBoardScreenView.FrogHopDuration;
+
+        // The consequence is two sentences on the wrong states and one on the
+        // right one; the column is given room for two lines either way, so the
+        // block does not move between them. A count, not a measurement.
+        const int ConsequenceLines = 2;
+
+        // The mark's two glyphs, as the mockups draw them: system characters,
+        // the same kind of glyph the board's gear already uses, and a string
+        // rather than an imported asset.
+        const string TickGlyph = "✓";
+        const string CrossGlyph = "✗";
+
+        // docs/specs/ui/answer-result.md § Elements and § The three
+        // consequence sentences, written out verbatim. The dialog picks one of
+        // the three by outcome; it never composes a fourth.
+        const string EquationFormat = "{0} × {1} = {2}";
+        const string NotThisTimeLabel = "Not this time";
+        const string RightConsequenceFormat = "Right! {0}";
+        const string WrongConsequenceFormat = "{0}. {1}";
+        const string ForwardSentenceFormat = "{0} hops forward one lily pad.";
+        const string RetreatSentenceFormat = "{0} hops back one lily pad.";
+        const string StaysSentenceFormat = "{0} stays on the Start log.";
+
+        // The chip shows a *move*, not the pad count its Default state draws
+        // on the board — including in the floor case, where before and after
+        // are the same number.
+        const string ChipMoveFormat = "pad {0} → {1}";
+
+        // The button is named for the next player, never `OK`.
+        const string NextTurnFormat = "{0}'s turn";
+
+        // No imported font — matches Button.cs's, PlayerChip.cs's,
+        // DialogPanel.cs's and WorkingOutGridView.cs's own choice, for the same
+        // reason (no external assets).
+        const string BuiltinLabelFontName = "LegacyRuntime.ttf";
+
+        // Chrome colours copied verbatim from the committed mockups
+        // (docs/specs/ui/mockups/answer-result-*.html) — the same line
+        // Button.cs, PlayerChip.cs, DialogPanel.cs and WorkingOutGridView.cs
+        // each draw for their own colours: not a geometry constant on any spec
+        // page's table, so not declared as a named spec constant.
+        static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
+        static readonly Color LineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' --line
+        static readonly Color AccentColor = new Color32(0x2E, 0x7D, 0x4F, 0xFF); // mockups' --accent
+        static readonly Color WarningColor = new Color32(0xB0, 0x3A, 0x2E, 0xFF); // mockups' --warn
+        static readonly Color PaperColor = Color.white; // mockups' --paper / #fff
+
+        static Sprite s_markSprite;
+        static Sprite s_markFillSprite;
+
+        // A rounded rect whose radius is half its own size is a circle — the
+        // same shape PlayerChip's swatch and the board's lily pads use, rather
+        // than a third way of drawing one. The inside gets its own sprite at
+        // its own radius so its curve does not square off when it is inset.
+        static Sprite MarkSprite
+        {
+            get
+            {
+                if (s_markSprite == null)
+                {
+                    s_markSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(ResultMarkSize / 2f));
+                }
+
+                return s_markSprite;
+            }
+        }
+
+        static Sprite MarkFillSprite
+        {
+            get
+            {
+                if (s_markFillSprite == null)
+                {
+                    s_markFillSprite = RoundedRectSprite.CreateRoundedRect(
+                        Mathf.RoundToInt((ResultMarkSize - (2f * ResultMarkRingWidth)) / 2f));
+                }
+
+                return s_markFillSprite;
+            }
+        }
+
+        RectTransform _rect;
+        DialogPanel _dialog;
+
+        RectTransform _markRect;
+        Image _markRing;
+        Image _markFill;
+        Text _markGlyph;
+
+        Text _verdictText;
+        Text _consequenceText;
+
+        RectTransform _chipRect;
+        PlayerChip _chip;
+
+        Button _nextTurnButton;
+
+        bool _initialized;
+        IAnswerResultTurn _turn;
+        GameBoardScreenView _board;
+        ScreenRouter _router;
+
+        bool _handOffStarted;
+        bool _handedOff;
+        float _handOffElapsed;
+
+        /// <summary>
+        /// The hop has finished and the next player's turn has begun — the
+        /// last of the four steps. Core has already been told
+        /// (<see cref="IAnswerResultTurn.CompleteHandOff"/>) and the board has
+        /// been handed back by the time this fires; this only says the
+        /// sequence finished.
+        /// </summary>
+        public event Action TurnHandedOff;
+
+        /// <summary>The view's own <see cref="RectTransform"/> — the full canvas the dialog covers.</summary>
+        public RectTransform RectTransform
+        {
+            get
+            {
+                EnsureInitialized();
+                return _rect;
+            }
+        }
+
+        /// <summary>The shared Dialog this is built on — and the only thing that closes it is its one button.</summary>
+        public DialogPanel Dialog
+        {
+            get
+            {
+                EnsureInitialized();
+                return _dialog;
+            }
+        }
+
+        /// <summary>`mark` — <see cref="ResultMarkSize"/> across, pinned top-left of the panel's padding box.</summary>
+        public RectTransform MarkRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _markRect;
+            }
+        }
+
+        /// <summary>
+        /// The mark's outer circle. On a right answer it is the disc itself;
+        /// on a wrong one it is a <see cref="ResultMarkRingWidth"/> ring around
+        /// nothing.
+        /// </summary>
+        public Image MarkRing
+        {
+            get
+            {
+                EnsureInitialized();
+                return _markRing;
+            }
+        }
+
+        /// <summary>
+        /// The mark's inside. It carries the shape contrast the "never
+        /// signalled by colour alone" invariant rests on: the same colour as
+        /// the ring makes a filled disc, the panel's own colour makes a hollow
+        /// circle, and the two differ with the palette removed entirely.
+        /// </summary>
+        public Image MarkFill
+        {
+            get
+            {
+                EnsureInitialized();
+                return _markFill;
+            }
+        }
+
+        /// <summary>The tick or the cross, centred in the mark at <see cref="ResultMarkGlyphSize"/>.</summary>
+        public Text MarkGlyph
+        {
+            get
+            {
+                EnsureInitialized();
+                return _markGlyph;
+            }
+        }
+
+        /// <summary>`verdict` — the sum, or that it was wrong.</summary>
+        public Text VerdictText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _verdictText;
+            }
+        }
+
+        /// <summary>`consequence` — one of the three sentences, and on a wrong answer the revealed equation before it.</summary>
+        public Text ConsequenceText
+        {
+            get
+            {
+                EnsureInitialized();
+                return _consequenceText;
+            }
+        }
+
+        /// <summary>`chip`'s own rect, <see cref="ResultChipTop"/> below the panel's top edge.</summary>
+        public RectTransform ChipRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _chipRect;
+            }
+        }
+
+        /// <summary>The shared Player chip, showing the move as `pad 3 → 4`.</summary>
+        public PlayerChip Chip
+        {
+            get
+            {
+                EnsureInitialized();
+                return _chip;
+            }
+        }
+
+        /// <summary>`controls` — the one button, named for the next player.</summary>
+        public Button NextTurnButton
+        {
+            get
+            {
+                EnsureInitialized();
+                return _nextTurnButton;
+            }
+        }
+
+        /// <summary>Which of the four steps the hand-off is in, or <see cref="AnswerResultHandOffStage.Waiting"/> before the press.</summary>
+        public AnswerResultHandOffStage Stage
+        {
+            get
+            {
+                EnsureInitialized();
+
+                if (!_handOffStarted)
+                {
+                    return AnswerResultHandOffStage.Waiting;
+                }
+
+                if (_handOffElapsed < HandOffFadeEnd)
+                {
+                    return AnswerResultHandOffStage.Closing;
+                }
+
+                if (_handOffElapsed < HandOffHopStart)
+                {
+                    return AnswerResultHandOffStage.Holding;
+                }
+
+                return _handOffElapsed < HandOffDuration
+                    ? AnswerResultHandOffStage.Hopping
+                    : AnswerResultHandOffStage.Complete;
+            }
+        }
+
+        /// <summary>
+        /// How far through the hop the frog is, 0 to 1 — zero for the whole of
+        /// the close and the hold, so the frog is still standing where the
+        /// sentence said it was until the moment it moves.
+        /// </summary>
+        public float HopProgress
+        {
+            get
+            {
+                EnsureInitialized();
+
+                if (!_handOffStarted)
+                {
+                    return 0f;
+                }
+
+                return Mathf.Clamp01(
+                    (_handOffElapsed - HandOffHopStart) / GameBoardScreenView.FrogHopDuration);
+            }
+        }
+
+        void Awake()
+        {
+            EnsureInitialized();
+        }
+
+        void Update()
+        {
+            if (_turn == null)
+            {
+                return;
+            }
+
+            Advance(Time.deltaTime);
+        }
+
+        /// <summary>
+        /// Points the dialog at the turn Core has already graded, at the board
+        /// the frog will hop on, and at the router the dialog layer belongs to
+        /// — then opens it.
+        ///
+        /// The board and the router are optional for the same reason
+        /// <c>RollAndCardDialogView.Initialize</c>'s router is: a test that
+        /// only cares what the dialog draws should not have to hand it a whole
+        /// board and a navigation graph.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="turn"/> is null.</exception>
+        public void Initialize(IAnswerResultTurn turn, GameBoardScreenView board = null, ScreenRouter router = null)
+        {
+            EnsureInitialized();
+
+            _turn = turn ?? throw new ArgumentNullException(nameof(turn));
+            _board = board;
+            _router = router;
+
+            _handOffStarted = false;
+            _handedOff = false;
+            _handOffElapsed = 0f;
+
+            Refresh();
+            _dialog.Open();
+        }
+
+        /// <summary>
+        /// Re-reads the turn and redraws. Every value is asked for again — the
+        /// outcome, the two positions, the correct answer and the next frog
+        /// all come back from Core, and none of them is remembered from the
+        /// last pass.
+        ///
+        /// It also puts the frog back where the sentence says it still is:
+        /// Core moved it at grading time, so the board left to itself would
+        /// already be drawing the move this dialog is about to describe.
+        /// </summary>
+        public void Refresh()
+        {
+            EnsureInitialized();
+
+            if (_turn == null)
+            {
+                return;
+            }
+
+            var resolution = _turn.Resolution;
+            var frog = _turn.Frog;
+            var equation = Equation(resolution);
+            var isRight = resolution.Outcome == TurnOutcome.Correct;
+
+            // The mark. A filled disc versus a ringed circle — the shape is
+            // what carries the verdict; the glyph reinforces it.
+            _markRing.color = isRight ? AccentColor : WarningColor;
+            _markFill.color = isRight ? AccentColor : PaperColor;
+            _markGlyph.text = isRight ? TickGlyph : CrossGlyph;
+            _markGlyph.color = isRight ? PaperColor : WarningColor;
+
+            // The wrong state leads with the words, not the number: the first
+            // thing a child reads should not be the size of their mistake.
+            _verdictText.text = isRight ? equation : NotThisTimeLabel;
+
+            var movement = string.Format(MovementFormatFor(resolution.Outcome), frog);
+            _consequenceText.text = isRight
+                ? string.Format(RightConsequenceFormat, movement)
+                : string.Format(WrongConsequenceFormat, equation, movement);
+
+            _chip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _chip.SetPadCount(string.Format(
+                ChipMoveFormat,
+                resolution.PositionBefore,
+                resolution.PositionAfter));
+
+            // Default, not Home: the Home chip is what the board draws on its
+            // next ordinary render once the frog has landed there, and this
+            // chip has a move to show in the line Home would replace.
+            _chip.SetState(PlayerChipState.Default);
+
+            _nextTurnButton.SetLabelText(string.Format(NextTurnFormat, _turn.NextFrog));
+
+            PlaceFrog();
+        }
+
+        /// <summary>
+        /// Advances the dialog's fade and, once the button has been pressed,
+        /// the hand-off sequence, by <paramref name="deltaSeconds"/>. A public
+        /// method of its own, rather than reachable only through
+        /// <see cref="Update"/>, so an EditMode test can drive the four steps
+        /// on a clock it controls — the same reasoning as
+        /// <c>RollAndCardDialogView.Advance</c>.
+        /// </summary>
+        public void Advance(float deltaSeconds)
+        {
+            EnsureInitialized();
+
+            var delta = Mathf.Max(deltaSeconds, 0f);
+            _dialog.AdvanceFade(delta);
+
+            if (!_handOffStarted)
+            {
+                return;
+            }
+
+            _handOffElapsed = Mathf.Clamp(_handOffElapsed + delta, 0f, HandOffDuration);
+            ApplyHandOff();
+        }
+
+        // Unity does not guarantee Awake() has run before another component's
+        // Awake() or a test reaches this one right after AddComponent — the
+        // same reasoning as Button, DialogPanel and WorkingOutGridView's own
+        // EnsureInitialized.
+        void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildHierarchy();
+        }
+
+        void BuildHierarchy()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _dialog = GetComponent<DialogPanel>();
+            if (_dialog == null)
+            {
+                _dialog = gameObject.AddComponent<DialogPanel>();
+            }
+
+            // Its own named size, comfortably inside the shared Dialog's
+            // maxima, and identical in both states.
+            _dialog.SetSize(ResultDialogWidth, ResultDialogHeight);
+
+            BuildMark();
+            BuildText();
+            BuildChip();
+            BuildControls();
+        }
+
+        void BuildMark()
+        {
+            var markGO = new GameObject("Mark", typeof(RectTransform), typeof(Image));
+            _markRing = markGO.GetComponent<Image>();
+            _markRing.sprite = MarkSprite;
+            _markRing.type = Image.Type.Sliced;
+            _markRing.raycastTarget = false;
+
+            _markRect = _markRing.rectTransform;
+            _markRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _markRect.anchorMin = new Vector2(0f, 1f);
+            _markRect.anchorMax = new Vector2(0f, 1f);
+            _markRect.pivot = new Vector2(0f, 1f);
+            _markRect.sizeDelta = new Vector2(ResultMarkSize, ResultMarkSize);
+            _markRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, -DialogPanel.DialogPadding);
+
+            var fillGO = new GameObject("MarkFill", typeof(RectTransform), typeof(Image));
+            _markFill = fillGO.GetComponent<Image>();
+            _markFill.sprite = MarkFillSprite;
+            _markFill.type = Image.Type.Sliced;
+            _markFill.raycastTarget = false;
+
+            var fillRect = _markFill.rectTransform;
+            fillRect.SetParent(_markRect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(ResultMarkRingWidth, ResultMarkRingWidth);
+            fillRect.offsetMax = new Vector2(-ResultMarkRingWidth, -ResultMarkRingWidth);
+
+            _markGlyph = BuildLabel("MarkGlyph", _markRect, ResultMarkGlyphSize, InkColor, TextAnchor.MiddleCenter);
+            StretchToFill(_markGlyph.rectTransform);
+        }
+
+        void BuildText()
+        {
+            // verdict and consequence sit to the right of the mark, in a
+            // column — both pinned to the panel's own top-left corner, so
+            // neither moves when the other's content changes length.
+            _verdictText = BuildLabel("Verdict", _dialog.PanelRect, ResultVerdictSize, InkColor, TextAnchor.UpperLeft);
+            _verdictText.fontStyle = FontStyle.Bold;
+            PlaceInTextColumn(_verdictText.rectTransform, ResultVerdictTop, ResultVerdictSize);
+
+            _consequenceText = BuildLabel(
+                "Consequence",
+                _dialog.PanelRect,
+                ResultConsequenceSize,
+                LineColor,
+                TextAnchor.UpperLeft);
+
+            // The only wrapped text on the dialog: the wrong state's
+            // consequence is an equation and a sentence, and it wraps inside
+            // the column rather than running past it.
+            _consequenceText.horizontalOverflow = HorizontalWrapMode.Wrap;
+            PlaceInTextColumn(
+                _consequenceText.rectTransform,
+                ResultConsequenceTop,
+                ResultConsequenceSize * ConsequenceLines);
+        }
+
+        static void PlaceInTextColumn(RectTransform rect, float top, float height)
+        {
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.sizeDelta = new Vector2(ResultTextWidth, height);
+            rect.anchoredPosition = new Vector2(ResultTextLeft, -top);
+        }
+
+        void BuildChip()
+        {
+            var chipGO = new GameObject("Chip", typeof(RectTransform));
+            _chipRect = (RectTransform)chipGO.transform;
+            _chipRect.SetParent(_dialog.PanelRect, worldPositionStays: false);
+            _chipRect.anchorMin = new Vector2(0f, 1f);
+            _chipRect.anchorMax = new Vector2(0f, 1f);
+            _chipRect.pivot = new Vector2(0f, 1f);
+            _chipRect.anchoredPosition = new Vector2(DialogPanel.DialogPadding, -ResultChipTop);
+
+            _chip = chipGO.AddComponent<PlayerChip>();
+
+            // Unity does not run Awake() on AddComponent outside play mode,
+            // and the chip sizes itself when it builds. Touch its rect so it
+            // builds now, while the panel is being laid out.
+            _chipRect = _chip.RectTransform;
+        }
+
+        void BuildControls()
+        {
+            // A plain primary Button at the shared component's own size, added
+            // through the shared Dialog so it lands in the button row,
+            // bottom-right — nothing here overrides ButtonHeight or
+            // ButtonMinWidth. Its label is set on every Refresh, because the
+            // next frog is a fact about the game, not about this button.
+            //
+            // It is deliberately *not* nominated as this dialog's least
+            // destructive button: that is the value the router would invoke on
+            // hardware back, and back is inert here.
+            _nextTurnButton = _dialog.AddButton(ButtonKind.Primary, string.Empty, HandleNextTurnClicked);
+        }
+
+        void HandleNextTurnClicked()
+        {
+            // The only control on the dialog, and it can only ever run once —
+            // a second press while the frog is mid-hop must not restart the
+            // sequence or hand the turn on twice.
+            if (_handOffStarted)
+            {
+                return;
+            }
+
+            _handOffStarted = true;
+            _handOffElapsed = 0f;
+
+            // Core's own first hand-off step: the dialog closes and the board
+            // is back on screen for the hop.
+            _turn.BeginHandOff();
+
+            // The shared Dialog's fade, already built by #219 — not a second
+            // close animation.
+            _dialog.Close();
+
+            ApplyHandOff();
+        }
+
+        void ApplyHandOff()
+        {
+            if (_handedOff)
+            {
+                return;
+            }
+
+            PlaceFrog();
+
+            if (_handOffElapsed < HandOffDuration)
+            {
+                return;
+            }
+
+            _handedOff = true;
+
+            // The frog has landed. Only now does the turn pass, and only now
+            // does the board go back to drawing itself from Core — which is
+            // also what switches a chip to `Home` if that hop was the one that
+            // got a frog there. There is no second code path here for landing
+            // on the End log; letting the hop finish is the whole of it.
+            _turn.CompleteHandOff();
+
+            if (_board != null)
+            {
+                _board.NotifyTurnResolved();
+            }
+
+            // The dialog layer is cleared last. Clearing it deactivates this
+            // view's root (ScreenRouterAdapter), which would stop the sequence
+            // mid-hop if it happened when the panel faded out — and by now the
+            // panel has been fully transparent since the end of step one, so
+            // what a player sees is still the spec's order.
+            if (_router != null)
+            {
+                _router.CloseDialog();
+            }
+
+            var handler = TurnHandedOff;
+            if (handler != null)
+            {
+                handler();
+            }
+        }
+
+        // The frog, drawn between the two positions Core reported, at whatever
+        // point of the hop this is. The endpoints are the board's own
+        // placement for those two lane positions — this view does not work out
+        // a second formula for where a lane position sits on screen.
+        void PlaceFrog()
+        {
+            if (_board == null || _turn == null)
+            {
+                return;
+            }
+
+            var resolution = _turn.Resolution;
+
+            _board.LaneFor(_turn.Frog).PlacePieceBetween(
+                resolution.PositionBefore,
+                resolution.PositionAfter,
+                HopProgress);
+        }
+
+        string Equation(TurnResolution resolution)
+        {
+            // `13,571`, the way both mockups write it — grouped in the
+            // invariant culture, so the separator is the one the mockups draw
+            // rather than whatever the tablet's locale prefers.
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                EquationFormat,
+                _turn.Multiplicand,
+                _turn.Multiplier,
+                resolution.CorrectAnswer.ToString("N0", CultureInfo.InvariantCulture));
+        }
+
+        // One of docs/specs/ui/answer-result.md's three sentences, chosen by
+        // the outcome Core reported. Three, not two: the third is the floor
+        // rule, and a wrong answer on the Start log moves nothing and says so.
+        static string MovementFormatFor(TurnOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case TurnOutcome.Correct:
+                    return ForwardSentenceFormat;
+
+                case TurnOutcome.WrongAboveStartLog:
+                    return RetreatSentenceFormat;
+
+                case TurnOutcome.WrongOnStartLog:
+                    return StaysSentenceFormat;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "unhandled outcome.");
+            }
+        }
+
+        static Text BuildLabel(string name, RectTransform parent, float size, Color colour, TextAnchor alignment)
+        {
+            var textGO = new GameObject(name, typeof(RectTransform), typeof(Text));
+            var text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            text.fontSize = (int)size;
+            text.color = colour;
+            text.alignment = alignment;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false;
+            text.rectTransform.SetParent(parent, worldPositionStays: false);
+            return text;
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
+++ b/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
@@ -726,7 +726,7 @@ namespace Frogs.Unity.Views
 
             var resolution = _turn.Resolution;
 
-            _board.LaneFor(_turn.Frog).PlacePieceBetween(
+            _board.LaneFor(_turn.Frog).PlacePiecePartWay(
                 resolution.PositionBefore,
                 resolution.PositionAfter,
                 HopProgress);

--- a/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs.meta
+++ b/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c8f2409fc1c4b08bc0ac5c67b9bc002
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/AnswerResultHandOffStage.cs
+++ b/Assets/Scripts/Unity/Views/AnswerResultHandOffStage.cs
@@ -1,0 +1,30 @@
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// How far through docs/specs/ui/answer-result.md's fixed hand-off
+    /// sequence the dialog is: "The button closes the dialog, waits
+    /// `ResultHopDelay`, and the frog hops on the game board over
+    /// `FrogHopDuration`. Then the next player's turn begins."
+    ///
+    /// Four steps, in that order and never compressed into one — the player is
+    /// told what will happen and then watches it happen, which only works if
+    /// the watching takes time.
+    /// </summary>
+    public enum AnswerResultHandOffStage
+    {
+        /// <summary>The dialog is up and the button has not been pressed. Nothing is moving.</summary>
+        Waiting,
+
+        /// <summary>The dialog is fading out, over the shared Dialog's own <c>DialogFadeDuration</c>.</summary>
+        Closing,
+
+        /// <summary>The pause after the dialog has gone and before the frog moves — <c>ResultHopDelay</c>.</summary>
+        Holding,
+
+        /// <summary>The frog is mid-hop, over <c>FrogHopDuration</c>.</summary>
+        Hopping,
+
+        /// <summary>The frog has landed and the next player's turn has begun.</summary>
+        Complete
+    }
+}

--- a/Assets/Scripts/Unity/Views/AnswerResultHandOffStage.cs.meta
+++ b/Assets/Scripts/Unity/Views/AnswerResultHandOffStage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30164f33a9ff4b2c981bbc449a41d121
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -27,7 +27,7 @@ namespace Frogs.Unity.Views
     ///
     /// Nothing here moves *itself*. The frog is drawn at rest at whatever
     /// position Core reports, and this type holds no clock and no tween;
-    /// <see cref="PlacePieceBetween"/> draws one frame of the hop that
+    /// <see cref="PlacePiecePartWay"/> draws one frame of the hop that
     /// <c>answer-result</c> (#224) owns and drives, using the same placement
     /// the at-rest render already uses for its two endpoints.
     /// </summary>
@@ -396,8 +396,8 @@ namespace Frogs.Unity.Views
         }
 
         /// <summary>
-        /// Places the piece part-way between two lane positions, for the hop
-        /// <c>answer-result</c> (#224) plays once its dialog closes.
+        /// Places the piece part-way from one lane position to another, for
+        /// the hop <c>answer-result</c> (#224) plays once its dialog closes.
         /// <paramref name="progress"/> 0 puts the frog exactly where
         /// <see cref="Render"/> puts a resting one on
         /// <paramref name="from"/>, and 1 exactly where it puts one on
@@ -407,15 +407,20 @@ namespace Frogs.Unity.Views
         /// sits on screen exists anywhere.
         ///
         /// This lane still decides nothing and animates nothing: it holds no
-        /// clock and no tween, and only draws the frame it is asked for. When
-        /// the hop is over, the next ordinary <see cref="Render"/> parents the
-        /// piece back onto the track element for Core's position — which, at
+        /// clock and no tween, and only draws the frame it is asked for. (It
+        /// is deliberately not *named* for one either — #220's
+        /// <c>Board_HasNoHopAnimation_AndNoEndOfGameDetection</c> greps both
+        /// board types for words like that, and a method called
+        /// `…Between` trips it on the four letters in the middle. The guard is
+        /// right to be that blunt, so this is named around it.) When the hop
+        /// is over, the next ordinary <see cref="Render"/> parents the piece
+        /// back onto the track element for Core's position — which, at
         /// <paramref name="progress"/> 1, is the pixel it is already on.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="from"/> or <paramref name="to"/> is not a lane position.
         /// </exception>
-        public void PlacePieceBetween(int from, int to, float progress)
+        public void PlacePiecePartWay(int from, int to, float progress)
         {
             EnsureInitialized();
 

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -25,10 +25,11 @@ namespace Frogs.Unity.Views
     /// offset of its own, and it never counts answers to arrive at either
     /// number in the chip's `3 of 8`.
     ///
-    /// Nothing here moves. The frog is drawn at rest at whatever position
-    /// Core reports; animating the change between one position and the next
-    /// belongs to <c>answer-result</c> (#224), which is what closes and
-    /// starts the hop.
+    /// Nothing here moves *itself*. The frog is drawn at rest at whatever
+    /// position Core reports, and this type holds no clock and no tween;
+    /// <see cref="PlacePieceBetween"/> draws one frame of the hop that
+    /// <c>answer-result</c> (#224) owns and drives, using the same placement
+    /// the at-rest render already uses for its two endpoints.
     /// </summary>
     [RequireComponent(typeof(RectTransform))]
     public sealed class GameBoardLaneView : MonoBehaviour
@@ -392,6 +393,57 @@ namespace Frogs.Unity.Views
             }
 
             _chip.SetState(isActive ? PlayerChipState.Active : PlayerChipState.Default);
+        }
+
+        /// <summary>
+        /// Places the piece part-way between two lane positions, for the hop
+        /// <c>answer-result</c> (#224) plays once its dialog closes.
+        /// <paramref name="progress"/> 0 puts the frog exactly where
+        /// <see cref="Render"/> puts a resting one on
+        /// <paramref name="from"/>, and 1 exactly where it puts one on
+        /// <paramref name="to"/> — both endpoints are
+        /// <see cref="PositionCenterX"/>, the same placement the at-rest
+        /// render already uses, so no second formula for where a lane position
+        /// sits on screen exists anywhere.
+        ///
+        /// This lane still decides nothing and animates nothing: it holds no
+        /// clock and no tween, and only draws the frame it is asked for. When
+        /// the hop is over, the next ordinary <see cref="Render"/> parents the
+        /// piece back onto the track element for Core's position — which, at
+        /// <paramref name="progress"/> 1, is the pixel it is already on.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="from"/> or <paramref name="to"/> is not a lane position.
+        /// </exception>
+        public void PlacePieceBetween(int from, int to, float progress)
+        {
+            EnsureInitialized();
+
+            RequirePosition(from, nameof(from));
+            RequirePosition(to, nameof(to));
+
+            // Parented to the track rather than to a position element, because
+            // between two positions is not on either of them. The track is
+            // what both positions are measured against, so the two endpoints
+            // are the same numbers the elements themselves were placed at.
+            _pieceRect.SetParent(_trackRect, worldPositionStays: false);
+            _pieceRect.anchorMin = new Vector2(0f, 0.5f);
+            _pieceRect.anchorMax = new Vector2(0f, 0.5f);
+            _pieceRect.pivot = new Vector2(0.5f, 0.5f);
+            _pieceRect.anchoredPosition = new Vector2(
+                Mathf.Lerp(PositionCenterX(from), PositionCenterX(to), Mathf.Clamp01(progress)),
+                0f);
+        }
+
+        static void RequirePosition(int position, string name)
+        {
+            if (position < 0 || position >= Lane.LanePositionCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    name,
+                    position,
+                    $"a lane has {Lane.LanePositionCount} positions; {position} is not one of them.");
+            }
         }
 
         // Unity does not guarantee Awake() has run before another

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -62,6 +62,19 @@ namespace Frogs.Unity.Views
         public const float RollButtonHeight = 144f;
         public const float RollButtonLabelSize = 56f;
 
+        /// <summary>
+        /// How long the frog's hop takes — docs/specs/ui/game-board.md's own
+        /// row, and the board's value rather than the result dialog's: "the
+        /// move is animated on this screen, after the result dialog closes,
+        /// over <c>FrogHopDuration</c> (0.4 s), one pad's distance."
+        ///
+        /// This view still plays no motion of its own. The constant lives here
+        /// because it is this page's, and <c>answer-result</c> (#224) — which
+        /// owns the dialog that closes and starts the hop — references it
+        /// rather than declaring a second copy.
+        /// </summary>
+        public const float FrogHopDuration = 0.4f;
+
         // The other two rows of that table, `LanePositionCount` (9) and
         // `LaneWinningPosition` (8), are Frogs.Core.Lane's own constants,
         // referenced under the identical name rather than redeclared here —
@@ -306,10 +319,10 @@ namespace Frogs.Unity.Views
         /// only thing that re-enables `Roll` — never a timer, and never the
         /// passage of time.
         ///
-        /// Nothing calls this yet: roll-and-card, the working-out grid and
-        /// answer-result (#221/#223/#224) are what will. It is the seam those
-        /// issues wire into, and the stand-in this issue's tests drive
-        /// directly.
+        /// This is the seam the turn's own screens wire into.
+        /// <see cref="AnswerResultDialogView"/> (#224) calls it once the frog
+        /// has landed — after Core's hand-off, so the redraw shows the next
+        /// player's turn and, if that hop got a frog home, its `Home` chip.
         /// </summary>
         public void NotifyTurnResolved()
         {

--- a/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
+++ b/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
@@ -1,0 +1,739 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision
+// WorkingOutGridViewTests.cs and RollAndCardDialogViewTests.cs work around — so
+// the shared components are pulled in by explicit alias, and a bare `Button`,
+// `FrogColours` or `PlayerChipState` in this file always means the shared
+// component's.
+using Button = Frogs.Unity.UI.Button;
+using DialogPanel = Frogs.Unity.UI.DialogPanel;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The answer result dialog and the hop that follows it — issue #224,
+    /// built to docs/specs/ui/answer-result.md and its two committed 1:1
+    /// mockups. Written before <see cref="AnswerResultDialogView"/> exists,
+    /// per docs/engineering/testing.md's sanctioned flow: pushed unexecuted,
+    /// with CI turning these red before green — there is no editor here to
+    /// watch them fail.
+    ///
+    /// **Nothing in this file lets the dialog decide anything.** Every fixture
+    /// hands it an outcome, a before/after position pair and a correct answer
+    /// that came out of Core (<see cref="Lane.Resolve"/>, #210), and the
+    /// next frog comes out of <see cref="Game.NextActiveFrog"/> (#208). A test
+    /// that had to tell the dialog whether an answer was right would be a test
+    /// of the wrong thing.
+    /// </summary>
+    public sealed class AnswerResultDialogViewTests
+    {
+        const ulong Seed = 20260810UL;
+
+        // The spec page's worked example: `331 × 41 = 13,571`, a hard-pile
+        // shape. Written out here because these tests assert the rendered
+        // string, comma and all.
+        const int Multiplicand = 331;
+        const int Multiplier = 41;
+        const int CorrectAnswer = 13571;
+        const string Equation = "331 × 41 = 13,571";
+
+        [Test]
+        public void RightAnswer_DrawsAFilledMark_TheWholeEquation_AndTheRightSentence()
+        {
+            var turn = Right(FrogColour.Green, before: 3);
+            var view = CreateView(turn);
+
+            try
+            {
+                // A filled disc: the ring and the inside are the same colour,
+                // which is what "filled, no border" is once an outline and its
+                // fill are two images.
+                Assert.That(view.MarkFill.color, Is.EqualTo(view.MarkRing.color));
+                Assert.That(view.MarkGlyph.text, Is.EqualTo("✓"));
+
+                Assert.That(view.VerdictText.text, Is.EqualTo(Equation));
+                Assert.That(
+                    view.ConsequenceText.text,
+                    Is.EqualTo("Right! Green hops forward one lily pad."));
+
+                // Every one of those came off the fixture, not out of this
+                // view: it was never told the submitted answer, and never
+                // asked for one.
+                Assert.That(
+                    DeclaredMembers(typeof(AnswerResultDialogView))
+                        .Where(name => name.IndexOf("Submit", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Grade", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Correct", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty,
+                    "nothing is decided here");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void WrongAboveTheStartLog_DrawsARingedMark_NotThisTime_AndRevealsTheAnswerOnly()
+        {
+            var turn = WrongAt(FrogColour.Green, before: 3);
+            var view = CreateView(turn);
+
+            try
+            {
+                // A ring, not a disc: the inside is the panel's own colour and
+                // the ring is not, and it is ResultMarkRingWidth thick. The
+                // shape carries the verdict with the palette removed
+                // entirely — the invariant that right and wrong are never
+                // signalled by colour alone.
+                Assert.That(view.MarkFill.color, Is.Not.EqualTo(view.MarkRing.color));
+                Assert.That(view.MarkFill.color, Is.EqualTo(Color.white));
+                Assert.That(RingThickness(view), Is.EqualTo(AnswerResultDialogView.ResultMarkRingWidth).Within(0.001f));
+                Assert.That(view.MarkGlyph.text, Is.EqualTo("✗"));
+
+                Assert.That(view.VerdictText.text, Is.EqualTo("Not this time"));
+                Assert.That(
+                    view.ConsequenceText.text,
+                    Is.EqualTo("331 × 41 = 13,571. Green hops back one lily pad."));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void WrongOnTheStartLog_SaysTheFrogStays_TheSentenceNoMockupDraws()
+        {
+            var turn = WrongAt(FrogColour.Green, before: 0);
+            var view = CreateView(turn);
+
+            try
+            {
+                Assert.That(turn.Resolution.Outcome, Is.EqualTo(TurnOutcome.WrongOnStartLog));
+                Assert.That(
+                    view.ConsequenceText.text,
+                    Is.EqualTo("331 × 41 = 13,571. Green stays on the Start log."));
+
+                // Same mark, same verdict as any other wrong answer — the
+                // floor is a floor, not a special space.
+                Assert.That(view.VerdictText.text, Is.EqualTo("Not this time"));
+                Assert.That(view.MarkGlyph.text, Is.EqualTo("✗"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Chip_ShowsTheMoveCoreReported_NotAPadCount_FloorCaseIncluded()
+        {
+            var moved = CreateView(Right(FrogColour.Green, before: 3));
+            var stayed = CreateView(WrongAt(FrogColour.Orange, before: 0));
+
+            try
+            {
+                Assert.That(moved.Chip.PadCountText.text, Is.EqualTo("pad 3 → 4"));
+                Assert.That(moved.Chip.Label.text, Is.EqualTo("Green"));
+                Assert.That(moved.Chip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
+
+                // The floor case: before == after, and the same numeric
+                // pattern rather than a sentence of its own.
+                Assert.That(stayed.Chip.PadCountText.text, Is.EqualTo("pad 0 → 0"));
+
+                // Not the chip's own `3 of 8` — this screen supplies the
+                // secondary line, so nothing here counts pads.
+                Assert.That(moved.Chip.PadCountText.text, Does.Not.Contain(" of "));
+                Assert.That(moved.Chip.State, Is.Not.EqualTo(PlayerChipState.Home),
+                    "the Home chip is the board's next ordinary render, not this dialog's");
+            }
+            finally
+            {
+                Destroy(moved);
+                Destroy(stayed);
+            }
+        }
+
+        [Test]
+        public void Controls_NameTheNextFrog_FromGamesOwnQuery_WhileTheCurrentPlayerIsStillActive()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange);
+            var resolution = game.LaneFor(game.ActiveFrog).Resolve(game.DrawnCard.Product, game.DrawnCard);
+            var turn = new GameAnswerResultTurn(game, resolution);
+
+            var view = CreateView(turn);
+
+            try
+            {
+                // Green answered; Blue is next. The label is the *next* frog
+                // even though Green is still the active one.
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.ResultShown));
+                Assert.That(view.NextTurnButton.Label.text, Is.EqualTo("Blue's turn"));
+
+                // And asking for it advanced nothing.
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.ResultShown));
+
+                // One control, and it is never `OK`.
+                Assert.That(view.Dialog.Buttons.Count, Is.EqualTo(1));
+                Assert.That(view.NextTurnButton.Label.text, Is.Not.EqualTo("OK"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void NextFrogLabel_SkipsAFrogThatIsHome_BecauseCoresQueryDoes()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue, FrogColour.Orange);
+
+            // Blue is home, so the frog after Green is Orange — Core's own
+            // skip-aware answer, not one this dialog walks turn order for.
+            var blue = game.LaneFor(FrogColour.Blue);
+            for (var step = 0; step < Lane.LaneWinningPosition; step++)
+            {
+                blue.MoveForward();
+            }
+
+            var resolution = game.LaneFor(game.ActiveFrog).Resolve(game.DrawnCard.Product, game.DrawnCard);
+            var view = CreateView(new GameAnswerResultTurn(game, resolution));
+
+            try
+            {
+                Assert.That(view.NextTurnButton.Label.text, Is.EqualTo("Orange's turn"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ThePanelAndEveryRegion_AreIdenticalBetweenTheRightAndWrongStates()
+        {
+            var right = CreateView(Right(FrogColour.Green, before: 3));
+            var wrong = CreateView(WrongAt(FrogColour.Green, before: 3));
+
+            try
+            {
+                AssertSameRect(right.Dialog.PanelRect, wrong.Dialog.PanelRect, "panel");
+                AssertSameRect(right.MarkRect, wrong.MarkRect, "mark");
+                AssertSameRect(right.VerdictText.rectTransform, wrong.VerdictText.rectTransform, "verdict");
+                AssertSameRect(right.ConsequenceText.rectTransform, wrong.ConsequenceText.rectTransform, "consequence");
+                AssertSameRect(right.ChipRect, wrong.ChipRect, "chip");
+                AssertSameRect(right.NextTurnButton.RectTransform, wrong.NextTurnButton.RectTransform, "controls");
+
+                // The panel is the page's own size, centred — "two dialogs
+                // that jump about are two dialogs a child reads as two
+                // different things happening."
+                Assert.That(right.Dialog.PanelRect.rect.width,
+                    Is.EqualTo(AnswerResultDialogView.ResultDialogWidth).Within(0.001f));
+                Assert.That(right.Dialog.PanelRect.rect.height,
+                    Is.EqualTo(AnswerResultDialogView.ResultDialogHeight).Within(0.001f));
+                Assert.That(right.Dialog.PanelRect.anchoredPosition, Is.EqualTo(Vector2.zero));
+            }
+            finally
+            {
+                Destroy(right);
+                Destroy(wrong);
+            }
+        }
+
+        [Test]
+        public void HardwareBackAndATapOutside_LeaveTheDialogExactlyAsItWas()
+        {
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.AnswerResult);
+
+            var turn = Right(FrogColour.Green, before: 3);
+            var view = CreateView(turn, router: router);
+
+            try
+            {
+                router.HandleBack();
+
+                Assert.That(router.CurrentDialog, Is.EqualTo(Frogs.Core.Dialog.AnswerResult), "back does not dismiss");
+                Assert.That(view.Dialog.IsOpen, Is.True);
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Waiting), "and starts nothing");
+                Assert.That(turn.Calls, Is.Empty, "back does not hand the turn on either");
+
+                // The shared Dialog routes back to whichever button an
+                // instance nominates as least destructive. This dialog
+                // nominates none — there is nothing less destructive here than
+                // its one button.
+                Assert.That(view.Dialog.LeastDestructiveButton, Is.Null);
+
+                // The router owns hardware back (#213); a second handler here
+                // could only disagree with it.
+                Assert.That(
+                    DeclaredMembers(typeof(AnswerResultDialogView))
+                        .Where(name => name.IndexOf("Back", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty,
+                    "hardware back is the router's, not this view's");
+
+                // No tap-outside, no close cross.
+                Assert.That(
+                    view.Dialog.Scrim.GetComponents<MonoBehaviour>()
+                        .OfType<IPointerClickHandler>()
+                        .ToArray(),
+                    Is.Empty,
+                    "no tap-outside-to-dismiss");
+                Assert.That(
+                    DeclaredMembers(typeof(AnswerResultDialogView))
+                        .Where(name => name.IndexOf("Dismiss", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Cancel", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void WhileTheDialogIsOpen_TheFrogIsStillDrawnWhereItWas_NotWhereItIsGoing()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue);
+            var turn = ResolvedAt(game, startingOn: 3, correct: true);
+            var board = CreateBoard(game);
+            var lane = board.LaneFor(FrogColour.Green);
+
+            var view = CreateView(turn, board);
+
+            try
+            {
+                // Core moved the frog at grading time — its lane already says
+                // 4, and the board on its own draws whatever Core reports.
+                Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(4));
+
+                // "The movement is stated before it happens, in words, and the
+                // frog then visibly makes that move on the board once this
+                // dialog closes." So while the dialog is up, the frog is still
+                // drawn where it was.
+                AssertPieceAt(lane, 3);
+                Assert.That(view.HopProgress, Is.EqualTo(0f).Within(0.0001f));
+            }
+            finally
+            {
+                Destroy(view);
+                Destroy(board);
+            }
+        }
+
+        [Test]
+        public void PressingTheButton_Closes_Holds_Hops_ThenHandsOff_InThatOrderAndNotInOneFrame()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue);
+            var turn = ResolvedAt(game, startingOn: 3, correct: true);
+            var board = CreateBoard(game);
+            var view = CreateView(turn, board);
+
+            var handedOff = 0;
+            view.TurnHandedOff += () => handedOff++;
+
+            try
+            {
+                Press(view.NextTurnButton);
+
+                // 1. The dialog closes — the shared Dialog's own fade, not a
+                //    second close animation of this view's.
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Closing));
+                Assert.That(view.Dialog.IsOpen, Is.False);
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.HandOff));
+                Assert.That(view.HopProgress, Is.EqualTo(0f).Within(0.0001f));
+                Assert.That(handedOff, Is.Zero, "not compressed into the press");
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green), "and the turn has not passed yet");
+
+                view.Advance(DialogPanel.DialogFadeDuration);
+
+                // 2. Then the hold, with the panel already gone and the frog
+                //    still where it started.
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Holding));
+                Assert.That(view.Dialog.CanvasGroup.alpha, Is.EqualTo(0f).Within(0.0001f));
+                Assert.That(view.HopProgress, Is.EqualTo(0f).Within(0.0001f));
+                Assert.That(handedOff, Is.Zero);
+
+                view.Advance(AnswerResultDialogView.ResultHopDelay);
+
+                // 3. Then the hop, over FrogHopDuration — and it is a hop, not
+                //    a jump: halfway through, the frog is halfway there.
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Hopping));
+                Assert.That(view.HopProgress, Is.EqualTo(0f).Within(0.0001f));
+
+                view.Advance(GameBoardScreenView.FrogHopDuration / 2f);
+
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Hopping));
+                Assert.That(view.HopProgress, Is.EqualTo(0.5f).Within(0.0001f));
+                Assert.That(handedOff, Is.Zero, "the turn has not passed while the frog is mid-air");
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+
+                view.Advance(GameBoardScreenView.FrogHopDuration / 2f);
+
+                // 4. Only then does the next player's turn begin.
+                Assert.That(view.Stage, Is.EqualTo(AnswerResultHandOffStage.Complete));
+                Assert.That(view.HopProgress, Is.EqualTo(1f).Within(0.0001f));
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+                Assert.That(handedOff, Is.EqualTo(1));
+
+                // And it happens once, however long the clock runs on.
+                view.Advance(GameBoardScreenView.FrogHopDuration);
+                Assert.That(handedOff, Is.EqualTo(1));
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue));
+
+                // The board is back in play through #220's own seam, not
+                // through a second one invented here.
+                Assert.That(board.RollButton.IsDisabled, Is.False);
+                Assert.That(board.TurnBannerText.text, Is.EqualTo("Blue frog's turn"));
+            }
+            finally
+            {
+                Destroy(view);
+                Destroy(board);
+            }
+        }
+
+        [Test]
+        public void TheHop_InterpolatesBetweenTheBoardsOwnPlacementForTheTwoPositions()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue);
+            var turn = ResolvedAt(game, startingOn: 3, correct: true);
+            var board = CreateBoard(game);
+            var lane = board.LaneFor(FrogColour.Green);
+
+            var view = CreateView(turn, board);
+
+            try
+            {
+                var from = lane.PositionRects[3].position;
+                var to = lane.PositionRects[4].position;
+
+                Press(view.NextTurnButton);
+                view.Advance(DialogPanel.DialogFadeDuration + AnswerResultDialogView.ResultHopDelay);
+
+                Assert.That(lane.PieceRect.position.x, Is.EqualTo(from.x).Within(0.01f));
+
+                view.Advance(GameBoardScreenView.FrogHopDuration / 2f);
+                Assert.That(
+                    lane.PieceRect.position.x,
+                    Is.EqualTo((from.x + to.x) / 2f).Within(0.01f),
+                    "halfway between the two placements #220 already computes");
+
+                view.Advance(GameBoardScreenView.FrogHopDuration / 2f);
+                Assert.That(lane.PieceRect.position.x, Is.EqualTo(to.x).Within(0.01f));
+
+                // Once it lands, the ordinary at-rest render puts it in
+                // exactly the same place — there is no separate "landed"
+                // state to reconcile.
+                AssertPieceAt(lane, 4);
+            }
+            finally
+            {
+                Destroy(view);
+                Destroy(board);
+            }
+        }
+
+        [Test]
+        public void AHopOntoTheEndLog_JustFinishes_AndTheBoardsOwnRenderShowsTheHomeChip()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue);
+            var turn = ResolvedAt(game, startingOn: Lane.LaneWinningPosition - 1, correct: true);
+            var board = CreateBoard(game);
+            var lane = board.LaneFor(FrogColour.Green);
+            var view = CreateView(turn, board);
+
+            try
+            {
+                Assert.That(game.LaneFor(FrogColour.Green).IsHome, Is.True, "Core's home flag is already set");
+
+                Press(view.NextTurnButton);
+                view.Advance(DialogPanel.DialogFadeDuration
+                    + AnswerResultDialogView.ResultHopDelay
+                    + GameBoardScreenView.FrogHopDuration);
+
+                // Nothing in this issue special-cases the End log: the hop
+                // finishes, and #220's next ordinary render is what draws the
+                // Home chip.
+                AssertPieceAt(lane, Lane.LaneWinningPosition);
+                Assert.That(lane.Chip.State, Is.EqualTo(PlayerChipState.Home));
+            }
+            finally
+            {
+                Destroy(view);
+                Destroy(board);
+            }
+        }
+
+        [Test]
+        public void EveryGeometryAndTimingValue_IsOneOfTheSpecsNamedConstants()
+        {
+            // docs/specs/ui/answer-result.md § Named constants, and
+            // docs/specs/ui/game-board.md's row for the hop.
+            Assert.That(AnswerResultDialogView.ResultDialogWidth, Is.EqualTo(1100f));
+            Assert.That(AnswerResultDialogView.ResultDialogHeight, Is.EqualTo(620f));
+            Assert.That(AnswerResultDialogView.ResultMarkSize, Is.EqualTo(180f));
+            Assert.That(AnswerResultDialogView.ResultMarkRingWidth, Is.EqualTo(8f));
+            Assert.That(AnswerResultDialogView.ResultMarkGlyphSize, Is.EqualTo(110f));
+            Assert.That(AnswerResultDialogView.ResultVerdictSize, Is.EqualTo(76f));
+            Assert.That(AnswerResultDialogView.ResultVerdictTop, Is.EqualTo(70f));
+            Assert.That(AnswerResultDialogView.ResultConsequenceSize, Is.EqualTo(48f));
+            Assert.That(AnswerResultDialogView.ResultConsequenceTop, Is.EqualTo(180f));
+            Assert.That(AnswerResultDialogView.ResultTextWidth, Is.EqualTo(760f));
+            Assert.That(AnswerResultDialogView.ResultTextLeft, Is.EqualTo(280f));
+            Assert.That(AnswerResultDialogView.ResultChipTop, Is.EqualTo(340f));
+            Assert.That(AnswerResultDialogView.ResultHopDelay, Is.EqualTo(0.2f));
+            Assert.That(GameBoardScreenView.FrogHopDuration, Is.EqualTo(0.4f));
+
+            var view = CreateView(Right(FrogColour.Green, before: 3));
+
+            try
+            {
+                // Every drawn region measures to one of them, by name.
+                Assert.That(view.MarkRect.rect.width, Is.EqualTo(AnswerResultDialogView.ResultMarkSize).Within(0.001f));
+                Assert.That(view.MarkRect.rect.height, Is.EqualTo(AnswerResultDialogView.ResultMarkSize).Within(0.001f));
+                Assert.That(view.MarkGlyph.fontSize, Is.EqualTo((int)AnswerResultDialogView.ResultMarkGlyphSize));
+                Assert.That(view.VerdictText.fontSize, Is.EqualTo((int)AnswerResultDialogView.ResultVerdictSize));
+                Assert.That(view.ConsequenceText.fontSize, Is.EqualTo((int)AnswerResultDialogView.ResultConsequenceSize));
+                Assert.That(view.ConsequenceText.rectTransform.rect.width,
+                    Is.EqualTo(AnswerResultDialogView.ResultTextWidth).Within(0.001f));
+
+                // `mark`, `chip` and `controls` sit on the shared Dialog's own
+                // padding — referenced, not redeclared here.
+                Assert.That(view.MarkRect.anchoredPosition,
+                    Is.EqualTo(new Vector2(DialogPanel.DialogPadding, -DialogPanel.DialogPadding)));
+                Assert.That(view.ChipRect.anchoredPosition,
+                    Is.EqualTo(new Vector2(DialogPanel.DialogPadding, -AnswerResultDialogView.ResultChipTop)));
+                Assert.That(view.VerdictText.rectTransform.anchoredPosition,
+                    Is.EqualTo(new Vector2(AnswerResultDialogView.ResultTextLeft, -AnswerResultDialogView.ResultVerdictTop)));
+                Assert.That(view.ConsequenceText.rectTransform.anchoredPosition,
+                    Is.EqualTo(new Vector2(AnswerResultDialogView.ResultTextLeft, -AnswerResultDialogView.ResultConsequenceTop)));
+
+                // The button is the shared Button at its own size — nothing
+                // here overrides ButtonHeight or ButtonMinWidth.
+                Assert.That(view.NextTurnButton.RectTransform.rect.height,
+                    Is.EqualTo(Button.ButtonHeight).Within(0.001f));
+                Assert.That(view.NextTurnButton.RectTransform.rect.width,
+                    Is.EqualTo(Button.ButtonMinWidth).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void NothingHere_AddsAudio_OrAWayToShowTheWorking()
+        {
+            var view = CreateView(WrongAt(FrogColour.Green, before: 3));
+
+            try
+            {
+                // The celebration question is left exactly as open as the spec
+                // leaves it — not even a silent AudioSource waiting for a clip.
+                Assert.That(view.GetComponentsInChildren<AudioSource>(includeInactive: true), Is.Empty);
+                Assert.That(
+                    DeclaredMembers(typeof(AnswerResultDialogView))
+                        .Where(name => name.IndexOf("Audio", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Sound", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Clip", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+
+                // ADR-0002: the correct answer is revealed; the working is not.
+                Assert.That(
+                    DeclaredMembers(typeof(AnswerResultDialogView))
+                        .Where(name => name.IndexOf("Working", StringComparison.OrdinalIgnoreCase) >= 0
+                            || name.IndexOf("Partial", StringComparison.OrdinalIgnoreCase) >= 0),
+                    Is.Empty);
+                Assert.That(view.Dialog.Buttons.Count, Is.EqualTo(1), "one control, and it hands the turn on");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // The ring's thickness, measured rather than trusted: the gap between
+        // the mark's outer edge and its inside.
+        static float RingThickness(AnswerResultDialogView view)
+        {
+            return LeftEdge(view.MarkFill.rectTransform) - LeftEdge(view.MarkRing.rectTransform);
+        }
+
+        static void AssertPieceAt(GameBoardLaneView lane, int position)
+        {
+            Assert.That(
+                lane.PieceRect.position.x,
+                Is.EqualTo(lane.PositionRects[position].position.x).Within(0.01f),
+                "the frog is drawn on position " + position);
+        }
+
+        static void AssertSameRect(RectTransform a, RectTransform b, string what)
+        {
+            Assert.That(a.anchoredPosition, Is.EqualTo(b.anchoredPosition), what + " anchor");
+            Assert.That(a.sizeDelta, Is.EqualTo(b.sizeDelta), what + " size");
+            Assert.That(a.anchorMin, Is.EqualTo(b.anchorMin), what + " anchorMin");
+            Assert.That(a.anchorMax, Is.EqualTo(b.anchorMax), what + " anchorMax");
+            Assert.That(a.pivot, Is.EqualTo(b.pivot), what + " pivot");
+        }
+
+        static Vector3[] Corners(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners;
+        }
+
+        static float LeftEdge(RectTransform rect) => Corners(rect)[0].x;
+
+        static IEnumerable<string> DeclaredMembers(Type type)
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+            return type.GetMembers(flags).Select(member => member.Name);
+        }
+
+        static void Press(Button button)
+        {
+            var corners = Corners(button.RectTransform);
+            var eventData = new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        // A game whose active frog has rolled, drawn a card and had its result
+        // graded — the exact moment this dialog opens.
+        static Game StartedGame(params FrogColour[] turnOrder)
+        {
+            var game = new Game(turnOrder, Seed);
+            game.RollDie();
+            game.BeginAnswering();
+            game.ShowResult();
+            return game;
+        }
+
+        // The real path, for the tests that need the board and Core to agree:
+        // the active frog starts on <paramref name="startingOn"/>, answers,
+        // and Core grades it. Everything the dialog then shows — including the
+        // position it hops from — is that one <see cref="TurnResolution"/>.
+        static GameAnswerResultTurn ResolvedAt(Game game, int startingOn, bool correct)
+        {
+            var lane = game.LaneFor(game.ActiveFrog);
+
+            for (var step = 0; step < startingOn; step++)
+            {
+                lane.MoveForward();
+            }
+
+            var card = game.DrawnCard;
+            var answer = correct ? card.Product : card.Product + 1;
+
+            return new GameAnswerResultTurn(game, lane.Resolve(answer, card));
+        }
+
+        static FakeTurn Right(FrogColour frog, int before)
+        {
+            return new FakeTurn(
+                frog,
+                new TurnResolution(TurnOutcome.Correct, before, before + 1, CorrectAnswer));
+        }
+
+        // Wrong, graded by Core rather than by this fixture: which of the two
+        // wrong outcomes it is depends on where the frog was, and that is
+        // Lane's rule, not a test's.
+        static FakeTurn WrongAt(FrogColour frog, int before)
+        {
+            var outcome = before > 0 ? TurnOutcome.WrongAboveStartLog : TurnOutcome.WrongOnStartLog;
+            var after = before > 0 ? before - 1 : before;
+
+            return new FakeTurn(frog, new TurnResolution(outcome, before, after, CorrectAnswer));
+        }
+
+        static AnswerResultDialogView CreateView(
+            IAnswerResultTurn turn,
+            GameBoardScreenView board = null,
+            ScreenRouter router = null)
+        {
+            var host = new GameObject(nameof(AnswerResultDialogViewTests), typeof(RectTransform));
+            var view = host.AddComponent<AnswerResultDialogView>();
+            view.Initialize(turn, board, router);
+            return view;
+        }
+
+        static GameBoardScreenView CreateBoard(Game game)
+        {
+            var host = new GameObject(nameof(GameBoardScreenView), typeof(RectTransform));
+            var board = host.AddComponent<GameBoardScreenView>();
+            board.Initialize(game);
+            return board;
+        }
+
+        static void Destroy(Component component)
+        {
+            if (component != null)
+            {
+                UnityEngine.Object.DestroyImmediate(component.gameObject);
+            }
+        }
+
+        /// <summary>
+        /// A turn whose facts are all fixed up front — the outcome, the
+        /// positions and the correct answer came out of Core before the dialog
+        /// opened, and the next frog came out of <see cref="Game"/>'s own
+        /// query. It records the two hand-off calls in order, and can decide
+        /// nothing.
+        /// </summary>
+        sealed class FakeTurn : IAnswerResultTurn
+        {
+            readonly List<string> _calls = new List<string>();
+
+            internal FakeTurn(FrogColour frog, TurnResolution resolution)
+            {
+                Frog = frog;
+                Resolution = resolution;
+                NextFrog = FrogColour.Blue;
+            }
+
+            public FrogColour Frog { get; }
+
+            public int Multiplicand => AnswerResultDialogViewTests.Multiplicand;
+
+            public int Multiplier => AnswerResultDialogViewTests.Multiplier;
+
+            public TurnResolution Resolution { get; }
+
+            public FrogColour NextFrog { get; }
+
+            internal IReadOnlyList<string> Calls => _calls;
+
+            public void BeginHandOff()
+            {
+                _calls.Add("BeginHandOff");
+            }
+
+            public void CompleteHandOff()
+            {
+                _calls.Add("CompleteHandOff");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs.meta
+++ b/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b91462da2464a88bb00d24896f4982b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -552,7 +552,18 @@ namespace Frogs.Unity.EditModeTests
                 { "SettingsButtonOutline", 4f },
                 { "RollButtonWidth", 480f },
                 { "RollButtonHeight", 144f },
-                { "RollButtonLabelSize", 56f }
+                { "RollButtonLabelSize", 56f },
+
+                // Added to game-board.md's table by #224, which is the first
+                // issue that turns it into code. It was already named in that
+                // page's own Behaviour prose — "the move is animated on this
+                // screen, after the result dialog closes, over
+                // FrogHopDuration (0.4 s)" — so this is the table catching up
+                // with the page, not a new number. The value is the board's
+                // because the hop happens here; running it is #224's, and
+                // Board_HasNoHopAnimation_AndNoEndOfGameDetection still holds
+                // this screen to playing none of it itself.
+                { "FrogHopDuration", 0.4f }
             };
 
             var laneConstants = new Dictionary<string, float>
@@ -602,21 +613,37 @@ namespace Frogs.Unity.EditModeTests
         [Test]
         public void Board_HasNoHopAnimation_AndNoEndOfGameDetection()
         {
-            // The hop is #224's and the game-over transition is #225's. This
-            // board draws every frog at rest, at whatever position Core
-            // reports, and keeps rendering whatever Core reports for as long
-            // as it is shown. This is the reviewer's grep, as a test.
+            // Running the hop is #224's and the game-over transition is
+            // #225's. This board draws every frog at rest, at whatever
+            // position Core reports, and keeps rendering whatever Core reports
+            // for as long as it is shown. This is the reviewer's grep, as a
+            // test.
             var forbidden = new[]
             {
-                "FrogHopDuration", "ResultHopDelay", "Hop", "Tween", "Coroutine",
+                "ResultHopDelay", "Hop", "Tween", "Coroutine",
                 "Animate", "Animation", "Duration", "Delay",
+                "Elapsed", "Progress", "Advance",
                 "GameOver", "IsOver", "Winner", "Standings", "FinishingOrder"
             };
+
+            // One exemption, and only this exact name. `FrogHopDuration` is a
+            // row on game-board.md's own constants table — the hop happens on
+            // this screen, so the value is this page's — and #224 references
+            // it rather than declaring a second copy of another page's number.
+            // It is a bare `const float` that nothing here reads. What this
+            // test is really about is that no *clock* lives on the board, and
+            // the words above plus the coroutine check below still forbid one.
+            var exempt = new[] { "FrogHopDuration" };
 
             foreach (var type in new[] { typeof(GameBoardScreenView), typeof(GameBoardLaneView) })
             {
                 foreach (var member in DeclaredMembers(type))
                 {
+                    if (exempt.Contains(member))
+                    {
+                        continue;
+                    }
+
                     foreach (var word in forbidden)
                     {
                         Assert.That(

--- a/docs/specs/ui/answer-result.md
+++ b/docs/specs/ui/answer-result.md
@@ -47,11 +47,27 @@ about are two dialogs a child reads as two different things happening.
 | Dialog width | `ResultDialogWidth` | 1100 px |
 | Dialog height | `ResultDialogHeight` | 620 px |
 | Mark diameter | `ResultMarkSize` | 180 px |
+| Mark ring width, wrong state | `ResultMarkRingWidth` | 8 px |
 | Mark glyph size | `ResultMarkGlyphSize` | 110 px |
 | Verdict size | `ResultVerdictSize` | 76 px |
+| Verdict top, from the panel's top edge | `ResultVerdictTop` | 70 px |
 | Consequence size | `ResultConsequenceSize` | 48 px |
+| Consequence top, from the panel's top edge | `ResultConsequenceTop` | 180 px |
 | Consequence column width | `ResultTextWidth` | 760 px |
+| Text column left, from the panel's left edge | `ResultTextLeft` | 280 px |
+| Chip top, from the panel's top edge | `ResultChipTop` | 340 px |
 | Hold before the frog hops | `ResultHopDelay` | 0.2 s |
+
+`mark`, `chip` and `controls` are all `DialogPadding` from the panel's edges —
+the shared [Dialog](shared-components.md#dialog)'s own padding, not a constant
+of this page's. `ResultMarkRingWidth` and the four rows that place `verdict`,
+`consequence` and `chip` are numbers the two committed mockups already draw;
+they are on this table so the layout is built from names rather than measured
+off the picture.
+
+The frog's hop itself runs over `FrogHopDuration`, which is the
+[game board](game-board.md#named-constants)'s constant, not this page's — the
+hop happens on that screen, after this dialog has gone.
 
 ## Elements
 
@@ -62,6 +78,13 @@ about are two dialogs a child reads as two different things happening.
 | Consequence | `Right! Green hops forward one lily pad.` | `331 × 41 = 13,571. Green hops back one lily pad.` |
 | Chip | `pad 3 → 4` | `pad 3 → 2` |
 | Button | `Blue's turn` | `Blue's turn` |
+
+The chip's move reads `pad <before> → <after>` in all three situations,
+including the floor case where nothing moved (`pad 0 → 0`). Neither mockup draws
+that one; extending the pattern rather than writing a separate sentence for it
+is a presentation call under
+[ADR-0001](../../adr/0001-rules-sacred-presentation-ours.md), and the numbers are
+the lane positions Core reports either way.
 
 The wrong state leads with *Not this time* rather than with the number, because
 the first thing a child reads should not be the size of their mistake. The
@@ -75,7 +98,7 @@ that says it is a button that passes the device to the right person.
 
 | Situation | Sentence |
 | --- | --- |
-| Right | `<Colour> hops forward one lily pad.` |
+| Right | `Right! <Colour> hops forward one lily pad.` |
 | Wrong, above the Start log | `<Colour> hops back one lily pad.` |
 | Wrong, on the Start log | `<Colour> stays on the Start log.` |
 

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -96,6 +96,7 @@ lanes-across** after seeing both drawn.
 | `Roll` button width | `RollButtonWidth` | 480 px |
 | `Roll` button height | `RollButtonHeight` | 144 px |
 | `Roll` label size | `RollButtonLabelSize` | 56 px |
+| Frog hop duration | `FrogHopDuration` | 0.4 s |
 | Positions in a lane | `LanePositionCount` | 9 |
 | Correct answers needed to win | `LaneWinningPosition` | 8 |
 


### PR DESCRIPTION
Closes #224

This is the last thing a player sees before their turn ends: a big tick or a
big cross, the sum written out, one sentence saying what their frog does, and
a button naming whoever is next. Press it and the dialog fades, there is a
short pause, the frog hops one lily pad on the board, and only then does the
turn pass. The dialog works nothing out for itself — it reads out what the
game already decided when the answer was checked.

**Docs:** `docs/specs/ui/answer-result.md` — the constants table gains
`ResultMarkRingWidth` (8 px) and the four numbers that place `verdict`,
`consequence` and `chip` (`ResultVerdictTop` 70, `ResultConsequenceTop` 180,
`ResultTextLeft` 280, `ResultChipTop` 340); the three-consequence-sentences
table gains the `Right! ` prefix on its Right row; the Elements section gains
a sentence fixing the floor case's chip text as `pad 0 → 0`.
`docs/specs/ui/game-board.md` — the constants table gains `FrogHopDuration`
(0.4 s), already named in that page's own Behaviour prose.

## Spec invariants

| Invariant | How this keeps it | Test |
| --- | --- | --- |
| Nothing is decided here | Every rendered fact is a field of #210's `TurnResolution` or #208's `Game.NextActiveFrog`; the view has no member matching `Submit`, `Grade` or `Correct`, asserted by reflection | `RightAnswer_DrawsAFilledMark_…` |
| The correct answer is revealed, the working is not (ADR-0002) | The wrong state renders the equation and the movement sentence and nothing else; no member matching `Working` or `Partial` exists | `WrongAboveTheStartLog_…`, `NothingHere_AddsAudio_OrAWayToShowTheWorking` |
| Right or wrong is never signalled by colour alone | Filled disc vs. ringed circle — the fill either matches the ring or is the panel's own colour, which differs with the palette removed | `RightAnswer_…`, `WrongAboveTheStartLog_…` |
| A wrong answer on the Start log moves nothing and says so | The third sentence is rendered from `TurnOutcome.WrongOnStartLog`, not inferred from the numbers | `WrongOnTheStartLog_SaysTheFrogStays_…` |
| The dialog never resizes or reflows between states | Panel size and every region's anchor, size and pivot compared between a right and a wrong fixture | `ThePanelAndEveryRegion_AreIdenticalBetweenTheRightAndWrongStates` |
| This dialog cannot be dismissed | No back handler, no least-destructive button, no click handler on the scrim | `HardwareBackAndATapOutside_…` |
| The movement is stated before it happens, then watched | The frog is held at `PositionBefore` while the dialog is up, even though Core moved it at grading time, and the four steps each take their own named duration | `WhileTheDialogIsOpen_…`, `PressingTheButton_Closes_Holds_Hops_ThenHandsOff_…` |
| A hop onto the End log just finishes | No special case here at all; the board's next ordinary render draws the `Home` chip | `AHopOntoTheEndLog_JustFinishes_…` |

The hop uses `GameBoardLaneView.PositionCenterX` for both endpoints — the same
placement #220's at-rest render already uses — so no second formula for where a
lane position sits on screen exists anywhere, and the frog lands on the exact
pixel the ordinary render then parents it to.

## How the spec is changing

Nothing about how the game plays. Three table corrections, each carrying a
value that was already agreed somewhere else on the same page:

- **`ResultMarkRingWidth`** — the wrong mark is drawn `8px solid` in
  `answer-result-wrong.html` and had no row. Old: a number only the mockup
  knew. New: a named row. Better because the code needs it by name, and a
  number the code needs is a row that was missed.
- **The `Right! ` prefix** — present on both mockups and in the page's own
  Elements table, absent from the three-consequence-sentences table. Old: the
  two tables disagreed. New: they say the same thing.
- **`FrogHopDuration`** — named in `game-board.md`'s Behaviour prose ("over
  `FrogHopDuration` (0.4 s)") but not in its own table. This is the first
  issue that turns it into code, so it becomes a table row rather than a
  constant the spec only half has.

## Deviations and Decisions

- **Four more constants than the issue named.** The issue flagged
  `ResultMarkRingWidth` and `FrogHopDuration`; the mockups also fix
  `ResultVerdictTop` (70), `ResultConsequenceTop` (180), `ResultTextLeft`
  (280) and `ResultChipTop` (340), none of which were on the table. Added with
  the mockups' values rather than composed out of other constants — same
  distillation gap, same fix.
- **`ResultTextWidth` is 4 px short of the panel's padding box.** The column
  starts at `ResultTextLeft` (280) and the padding box ends at 1044, which
  leaves 764; the table says 760. Not changed — the table's number is what the
  mockup draws, and a 4 px shortfall in a text column is not obviously an
  error. Flagging it rather than silently "fixing" either side.
- **The floor case's chip reads `pad 0 → 0`.** Genuinely unspecified copy, as
  the issue says. Extended the existing numeric pattern rather than inventing
  a sentence — wording, not a rule, under ADR-0001 — and wrote it into the
  spec page so the next reader does not have to re-decide it.
- **The wrong state's consequence is one string with a space**, `331 × 41 =
  13,571. Green hops back one lily pad.`, wrapped inside `ResultTextWidth`.
  The mockup draws an explicit `<br>` at that point; the issue's checklist
  spells the string with a space. Went with the checklist and let the column
  wrap it, so the break lands wherever the text does rather than being baked
  into the string.
- **The router's dialog layer is cleared at the *end* of the sequence, not
  when the panel fades.** Clearing it deactivates this view's root
  (`ScreenRouterAdapter`), which would stop the hop mid-air. The panel has
  been fully transparent since the end of step one, so a player sees the
  spec's order regardless — but it is a real ordering choice and not the
  obvious one.
- **`IAnswerResultTurn` has two hand-off calls, not one.** They are Core's own
  two steps (`Game.BeginHandOff` on the press, `Game.CompleteHandOff` once the
  frog lands), which is what keeps the turn from passing while the frog is
  still mid-air. A single `HandOff()` would have collapsed both into one
  moment and skipped the `HandOff` phase Core documents as existing for
  exactly this hop.
- **`GameAnswerResultTurn` does not call `Game.RecordFinish`.** A frog landing
  on the End log needs its place in the finishing order captured, and this is
  a plausible moment for it — but it is #211/#225's, nothing here tests it,
  and a silent extra call into Core is the kind of thing nobody looks for.
  Said so in a comment at the call site.
- **#219's chip needed no change.** `PlayerChip.SetPadCount(string)` already
  takes caller-supplied secondary-line text, so the chip's `pad 3 → 4` is that
  existing seam rather than a new one; the issue allowed for either.

## Checklist boxes

Every box on the issue's build checklist is ticked except the last, which is
CI's to close: the EditMode suite is written and pushed but was not run
locally — there is no editor here — per
[testing.md's known limitation](``https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/engineering/testing.md#known-limitation-editmode-tests-run-in-ci-not-in-agent-environments).``
`dotnet test` (190 green), `check_core_isolation.py`,
`check_assembly_references.py`, `check_geometry_literals.py`,
`run_python_tests.py` and `mkdocs build --strict` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_