### PR TITLE
fix(game): record a frog's finish when it reaches the End log

### DIFF
--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -334,15 +334,39 @@ namespace Frogs.Core
 
         /// <summary>
         /// Moves the phase from <see cref="TurnPhase.Answering"/> to
-        /// <see cref="TurnPhase.ResultShown"/>. Deciding whether the answer
-        /// was right belongs to <c>core-turn-resolution</c> (#210), not this
-        /// type — this only moves the phase along.
+        /// <see cref="TurnPhase.ResultShown"/>, and — if that answer landed
+        /// the active frog on its End log — captures its place in
+        /// <see cref="FinishingOrder"/>.
+        ///
+        /// Deciding whether the answer was right still belongs to
+        /// <c>core-turn-resolution</c> (#210), not this type: this never
+        /// grades anything and never moves a frog. It only notices that a
+        /// frog is home, which is a fact only this type can keep, because
+        /// every finisher ends up on the same
+        /// <see cref="Lane.LaneWinningPosition"/> and position cannot tell
+        /// arrival order apart afterward.
+        ///
+        /// **This is the moment, and it is Core's rather than a caller's, on
+        /// purpose.** <see cref="Lane.Resolve"/> is the only thing that moves
+        /// a frog and it can only be run while the turn is
+        /// <see cref="TurnPhase.Answering"/>; this call is the very next one
+        /// the phase machine will accept. So it is the first moment after a
+        /// move that a caller cannot skip, which makes the recording
+        /// impossible to forget — the way it was forgotten while it lived on
+        /// the shell's to-do list. Recording later, at hand-off, would miss
+        /// the last finisher of all: when the final frog gets home the game
+        /// ends itself and <see cref="CompleteHandOff"/> is never called
+        /// (docs/specs/ui/game-board.md#behaviour).
         /// </summary>
         /// <exception cref="InvalidOperationException">The turn is not answering.</exception>
         public void ShowResult()
         {
             RequirePhase(TurnPhase.Answering);
             _phase = TurnPhase.ResultShown;
+
+            // A no-op unless this turn's answer actually put the active frog
+            // on the End log — see RecordFinish.
+            RecordFinish(ActiveFrog);
         }
 
         /// <summary>

--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs
@@ -72,13 +72,13 @@ namespace Frogs.Unity
         /// <inheritdoc />
         public void CompleteHandOff()
         {
-            // Just the advance. A frog that lands on the End log also needs
-            // its place in the finishing order captured
-            // (<see cref="Game.RecordFinish"/>, #211), and this is a plausible
-            // moment to do it — but recording a finish is not this issue's,
-            // nothing here is tested against it, and a silent extra call to
-            // Core is exactly the kind of thing that goes unnoticed until it
-            // is wrong.
+            // Just the advance, and deliberately nothing else. A frog that
+            // lands on the End log has its place in the finishing order
+            // captured by Core itself, inside Game.ShowResult — the phase
+            // before this one, and the first one after a move that no caller
+            // can skip. The shell does not have to remember to announce an
+            // arrival, and must not: a second announcement from here would be
+            // a duplicate of a fact Core already holds.
             _game.CompleteHandOff();
         }
     }

--- a/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
+++ b/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using Frogs.Core;
+using Frogs.Unity.Views;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The shell half of issue #230's acceptance pass. The Core half —
+    /// <c>Tests/Core/ScriptedGameTests.cs</c> — plays whole games from a fixed
+    /// seed and proves every joint of the turn loop fits together. It cannot
+    /// say anything about what reaches the screen, and this is the part that
+    /// can.
+    ///
+    /// **It is deliberately not a walkthrough.** EditMode is an edit-mode
+    /// editor session: no <c>Start</c>, no coroutines, no frames, and
+    /// <c>Time.deltaTime</c> never advances, so a tapped-through sequence of
+    /// screens cannot be observed here and no harness in this repo builds one
+    /// — see docs/engineering/testing.md#the-end-to-end-acceptance-pass. What
+    /// EditMode is actually for is the adapter-shaped checking below: that a
+    /// view builds what Core reported, that a screen renders what Core
+    /// decided, and that the assets the flow depends on are still wired after
+    /// a round trip through Unity's serializer.
+    ///
+    /// The two game-over fixtures are **games that were played**, not
+    /// standings typed out by hand: the same scripted plays the Core tier
+    /// runs, replayed here so the screen is shown a result a real game
+    /// produced.
+    /// </summary>
+    public sealed class EndToEndAcceptanceTests
+    {
+        /// <summary>
+        /// The same named seed the Core-tier scripted games use, so the cards
+        /// dealt here are the cards dealt there.
+        /// </summary>
+        const ulong ScriptedGameSeed = 20260810UL;
+
+        /// <summary>
+        /// A stop on the turn loop, so a play that stops making progress
+        /// fails as a test rather than hanging the editor.
+        /// </summary>
+        const int MaxScriptedTurns = 64;
+
+        /// <summary>Turns played before the deliberate-ending fixture ends its game.</summary>
+        const int TurnsBeforeTheDeliberateEnding = 4;
+
+        // --- The working-out grid, from Core's own grid model ---------------
+
+        /// <summary>
+        /// The one seam Core alone structurally cannot reach: whether the view
+        /// draws the grid Core reported. Asserted against the model rather
+        /// than against expected numbers, for one card of each of the three
+        /// problem shapes ADR-0002 pins — so a view that drew a plausible grid
+        /// of its own devising fails even if the numbers happen to look right.
+        /// </summary>
+        [Test]
+        public void TheWorkingOutGridView_BuildsExactlyTheRowsColumnsAndCells_CoreReportsForEachProblemShape()
+        {
+            foreach (var pile in new[] { Pile.Easy, Pile.Medium, Pile.Hard })
+            {
+                var card = Card.Draw(pile, Rng.FromSeed(ScriptedGameSeed));
+                var model = WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart);
+                var view = CreateGridView(card, pile);
+
+                try
+                {
+                    Assert.That(
+                        view.RowKinds, Is.EqualTo(model.Rows.Select(row => row.Kind).ToArray()),
+                        $"{pile}: the view's rows are not Core's rows");
+
+                    Assert.That(view.Cells.Count, Is.EqualTo(model.Rows.Count), $"{pile}: row count");
+
+                    for (var row = 0; row < model.Rows.Count; row++)
+                    {
+                        Assert.That(
+                            view.Cells[row].Count, Is.EqualTo(model.ColumnCount),
+                            $"{pile}: row {row} is not {model.ColumnCount} columns wide");
+
+                        Assert.That(
+                            view.Cells[row].Select(cell => cell.Kind).ToArray(),
+                            Is.EqualTo(model.Rows[row].Cells.Select(cell => cell.Kind).ToArray()),
+                            $"{pile}: row {row}'s cell kinds are not the ones Core reported");
+                    }
+
+                    Assert.That(
+                        view.Cells.Sum(row => row.Count),
+                        Is.EqualTo(model.Rows.Count * model.ColumnCount),
+                        $"{pile}: total cell count");
+
+                    // The card's own digits, read back off the cells the view
+                    // drew — the round trip from a Core card to what a child
+                    // actually sees printed.
+                    AssertPrintedRowReads(view, GridRowKind.Multiplicand, card.Multiplicand);
+                    AssertPrintedRowReads(view, GridRowKind.Multiplier, card.Multiplier);
+                }
+                finally
+                {
+                    Destroy(view);
+                }
+            }
+        }
+
+        // --- The game-over screen, from games that were actually played -----
+
+        /// <summary>
+        /// docs/specs/ui/game-over.md#behaviour's first route: the last frog
+        /// reaches its End log and the game ends itself. The headline names
+        /// the frog that got home *first*, and its row leads the standings and
+        /// is the only one drawn heavier.
+        /// </summary>
+        [Test]
+        public void TheGameOverScreen_NamesTheWinner_FromAGamePlayedAllTheWayToItsOwnEnding()
+        {
+            var game = PlayUntilEveryFrogIsHome();
+            var view = CreateGameOverView();
+
+            try
+            {
+                // Both frogs are home, so a screen that guessed "the winner is
+                // whoever is home" would have two answers and no way to pick.
+                Assert.That(game.IsOver, Is.True);
+                Assert.That(game.TurnOrder.All(colour => game.LaneFor(colour).IsHome), Is.True);
+
+                view.Show(game);
+
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Green frog wins!"));
+                Assert.That(view.RowCount, Is.EqualTo(game.Standings.Count));
+                Assert.That(view.RowColour(0), Is.EqualTo(FrogColour.Green), "the first finisher leads the standings");
+                Assert.That(view.RowColour(1), Is.EqualTo(FrogColour.Blue));
+                Assert.That(view.RowProgressText(0).text, Is.EqualTo("Home — 8 of 8"));
+                Assert.That(view.RowProgressText(1).text, Is.EqualTo("Home — 8 of 8"));
+
+                Assert.That(
+                    view.RowBorderWidth(0), Is.EqualTo(GameOverScreenView.StandingsWinnerBorder),
+                    "the winner's row is drawn heavier");
+                Assert.That(
+                    view.RowBorderWidth(1), Is.EqualTo(GameOverScreenView.StandingsRowBorder),
+                    "a finisher that did not win is an ordinary row");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// The other headline: the game was ended before anybody got home, so
+        /// there is nobody to name. docs/specs/ui/game-over.md — "announcing a
+        /// winner who did not win is worse than announcing nobody."
+        /// </summary>
+        [Test]
+        public void TheGameOverScreen_ReadsGameOver_FromAGamePlayedAndThenEndedBeforeAnybodyGotHome()
+        {
+            var game = PlayThenEndDeliberatelyWithNobodyHome();
+            var view = CreateGameOverView();
+
+            try
+            {
+                Assert.That(game.IsOver, Is.True);
+                Assert.That(game.Winner, Is.Null);
+
+                view.Show(game);
+
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Game over"));
+                Assert.That(view.RowCount, Is.EqualTo(game.Standings.Count));
+
+                for (var row = 0; row < view.RowCount; row++)
+                {
+                    Assert.That(
+                        view.IsWinnerRow(row), Is.False,
+                        $"row {row} is highlighted as a winner in a game nobody won");
+                    Assert.That(
+                        view.RowBorderWidth(row), Is.EqualTo(GameOverScreenView.StandingsRowBorder),
+                        $"row {row} is drawn as a winner's row in a game nobody won");
+                    Assert.That(view.RowProgressText(row).text, Does.Not.Contain("Home"));
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // --- The assets the flow depends on ---------------------------------
+
+        /// <summary>
+        /// Every scene the build ships is present where the build looks for
+        /// it, and every object in it comes back off disk with all of its
+        /// components still attached.
+        ///
+        /// A component whose script reference did not survive the round trip
+        /// does not throw and does not log: it comes back as a **null entry**
+        /// in the object's component list, and the scene looks fine until the
+        /// thing it was driving quietly does nothing. That silent failure is
+        /// what docs/engineering/unity-serialization.md asks to be guarded,
+        /// and it is what this looks for. <c>GameSceneTests</c> and
+        /// <c>HelloWorldSceneTests</c> pin their own scene's path, ordering
+        /// and camera; this asks a different question, of every registered
+        /// scene at once, so a scene added later is covered without anybody
+        /// remembering to come back here.
+        /// </summary>
+        [Test]
+        public void EverySceneTheBuildShips_IsPresent_AndKeepsEveryComponentThroughARoundTripThroughTheSerializer()
+        {
+            var registered = EditorBuildSettings.scenes.Where(scene => scene.enabled).ToArray();
+
+            Assert.That(
+                registered, Is.Not.Empty,
+                "No scene is registered in build settings at all, so the app has nothing to boot into.");
+
+            foreach (var entry in registered)
+            {
+                Assert.That(
+                    AssetDatabase.LoadAssetAtPath<SceneAsset>(entry.path), Is.Not.Null,
+                    $"{entry.path} is registered in build settings but there is no scene asset there.");
+
+                var scene = EditorSceneManager.OpenScene(entry.path, OpenSceneMode.Additive);
+
+                try
+                {
+                    Assert.That(
+                        scene.GetRootGameObjects(), Is.Not.Empty,
+                        $"{entry.path} opened with nothing in it at all.");
+
+                    foreach (var root in scene.GetRootGameObjects())
+                    {
+                        foreach (var component in root.GetComponentsInChildren<Component>(includeInactive: true))
+                        {
+                            Assert.That(
+                                component, Is.Not.Null,
+                                $"An object under {root.name} in {entry.path} has a component that did not "
+                                + "come back from the serializer. A detached script reads as a missing "
+                                + "script in the inspector and as nothing at all at runtime.");
+                        }
+                    }
+                }
+                finally
+                {
+                    EditorSceneManager.CloseScene(scene, removeScene: true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// **The flow needs no prefab, and this is what says so out loud.**
+        /// Every screen builds its whole hierarchy through the typed Unity API
+        /// the first time it is asked for anything — no committed prefab, no
+        /// imported font, no imported sprite
+        /// (docs/specs/ui/shared-components.md: "no external assets"). A
+        /// screen that quietly started depending on an asset that is not
+        /// committed would come up empty here, in milliseconds, instead of on
+        /// the tablet.
+        /// </summary>
+        [Test]
+        public void EveryScreenInTheFlow_BuildsItsWholeHierarchyItself_SoTheFlowDependsOnNoPrefabAndNoImportedAsset()
+        {
+            AssertScreenBuildsItself<TitleScreenView>(view => view.RectTransform);
+            AssertScreenBuildsItself<GameSetupScreenView>(view => view.RectTransform);
+            AssertScreenBuildsItself<GameBoardScreenView>(view => view.RectTransform);
+            AssertScreenBuildsItself<RollAndCardDialogView>(view => view.RectTransform);
+            AssertScreenBuildsItself<WorkingOutGridView>(view => view.RectTransform);
+            AssertScreenBuildsItself<AnswerResultDialogView>(view => view.RectTransform);
+            AssertScreenBuildsItself<SettingsDialogView>(view => view.RectTransform);
+            AssertScreenBuildsItself<EndGameConfirmView>(view => view.RectTransform);
+            AssertScreenBuildsItself<GameOverScreenView>(view => view.RectTransform);
+        }
+
+        // --- The scripted plays ---------------------------------------------
+
+        // The same two-frog roster and the same seed the Core tier plays, so
+        // the results shown to the screen here are the results asserted there.
+        static FrogColour[] ScriptedRoster()
+        {
+            return new[] { FrogColour.Green, FrogColour.Blue };
+        }
+
+        // Both frogs answer everything right; Green goes first, so Green gets
+        // home first and Blue's finish is what ends the game.
+        static Game PlayUntilEveryFrogIsHome()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+
+            for (var turn = 0; turn < MaxScriptedTurns && !game.IsOver; turn++)
+            {
+                PlayOneTurn(game, answerCorrectly: true);
+            }
+
+            Assert.That(game.IsOver, Is.True, "the scripted game never ended");
+            return game;
+        }
+
+        // Four real turns, both frogs answering right, then the game is ended
+        // from the end-game confirm's route with everybody still swimming.
+        static Game PlayThenEndDeliberatelyWithNobodyHome()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+
+            for (var turn = 0; turn < TurnsBeforeTheDeliberateEnding; turn++)
+            {
+                PlayOneTurn(game, answerCorrectly: true);
+            }
+
+            game.EndGame();
+            return game;
+        }
+
+        // One turn, through the phases docs/specs/ui/game-board.md lists, with
+        // the frog moved by Core's own grading and nothing else. The Core tier
+        // is where each of these joints is asserted; here the play is only a
+        // way of producing a genuine result for the screen to render.
+        static void PlayOneTurn(Game game, bool answerCorrectly)
+        {
+            var frog = game.ActiveFrog;
+
+            game.RollDie();
+            var card = game.DrawnCard;
+            game.BeginAnswering();
+
+            game.LaneFor(frog).Resolve(answerCorrectly ? card.Product : card.Product + 1, card);
+
+            game.ShowResult();
+            game.BeginHandOff();
+
+            if (!game.IsOver)
+            {
+                game.CompleteHandOff();
+            }
+        }
+
+        // --- Helpers ----------------------------------------------------------
+
+        static void AssertPrintedRowReads(WorkingOutGridView view, GridRowKind kind, int operand)
+        {
+            var rowIndex = view.RowKinds.ToList().IndexOf(kind);
+
+            Assert.That(rowIndex, Is.GreaterThanOrEqualTo(0), $"the view drew no {kind} row");
+
+            var printed = view.Cells[rowIndex]
+                .Where(cell => cell.Kind == GridCellKind.Printed)
+                .Select(cell => cell.Content);
+
+            Assert.That(
+                string.Concat(printed), Is.EqualTo(operand.ToString()),
+                $"the {kind} row does not read {operand}");
+        }
+
+        static void AssertScreenBuildsItself<TView>(Func<TView, RectTransform> ownRect)
+            where TView : MonoBehaviour
+        {
+            var host = new GameObject(typeof(TView).Name, typeof(RectTransform));
+
+            try
+            {
+                var view = host.AddComponent<TView>();
+
+                // Asking for the screen's own rect is what forces it to build
+                // itself, on every one of these views. Nothing here depends on
+                // Awake having run, because in an edit-mode session it may not
+                // have.
+                Assert.That(
+                    ownRect(view), Is.Not.Null,
+                    $"{typeof(TView).Name} has no RectTransform of its own after being added.");
+
+                Assert.That(
+                    host.transform.childCount, Is.GreaterThan(0),
+                    $"{typeof(TView).Name} built nothing, so the screen it draws comes from an "
+                    + "asset that is not committed rather than from its own code.");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+
+        static WorkingOutGridView CreateGridView(Card card, Pile pile)
+        {
+            var host = new GameObject(nameof(EndToEndAcceptanceTests), typeof(RectTransform));
+            var view = host.AddComponent<WorkingOutGridView>();
+            view.Initialize(new AcceptanceTurn { Frog = FrogColour.Green, Pile = pile, Card = card });
+            return view;
+        }
+
+        static GameOverScreenView CreateGameOverView()
+        {
+            var host = new GameObject(nameof(EndToEndAcceptanceTests), typeof(RectTransform));
+            return host.AddComponent<GameOverScreenView>();
+        }
+
+        static void Destroy(MonoBehaviour view)
+        {
+            if (view != null)
+            {
+                UnityEngine.Object.DestroyImmediate(view.gameObject);
+            }
+        }
+
+        // The card the grid is opened on, and somewhere for the answer to go.
+        // Nothing here grades anything — the grid never learns whether what it
+        // handed over was right (ADR-0002).
+        sealed class AcceptanceTurn : IWorkingOutTurn
+        {
+            public FrogColour Frog { get; set; }
+
+            public Pile Pile { get; set; }
+
+            public Card Card { get; set; }
+
+            public List<int> Submitted { get; } = new List<int>();
+
+            public void SubmitAnswer(int answer)
+            {
+                Submitted.Add(answer);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs.meta
+++ b/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43395d0a256d4ced9e0aceaeb6a395fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/GameTests.cs
+++ b/Tests/Core/GameTests.cs
@@ -404,6 +404,51 @@ namespace Frogs.Core.Tests
             Assert.That(game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Orange, FrogColour.Blue }));
         }
 
+        // docs/specs/ui/game-over.md#invariants: "the winner is the frog that
+        // reached the End log first." Nothing outside Core ever announced an
+        // arrival — #211 added RecordFinish and left the wiring to a later
+        // issue, #224 declined it as belonging elsewhere, and the result was
+        // that a real game's Winner stayed null however it was played. So the
+        // arrival is recorded by the turn itself: grading can only happen
+        // while the turn is Answering, and ShowResult is the very next call
+        // the phase machine will accept, which makes it the first moment
+        // after a move that Core is guaranteed to be given.
+        [Test]
+        public void AFrogThatReachesItsEndLogOnItsTurn_IsRecordedAsAFinisher_WithoutAnybodyCallingRecordFinish()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var game = new Game(roster, Seed);
+            AdvanceTo(game, FrogColour.Green, Lane.LaneWinningPosition - 1);
+
+            game.RollDie();
+            game.BeginAnswering();
+            game.LaneFor(game.ActiveFrog).Resolve(game.DrawnCard.Product, game.DrawnCard);
+            game.ShowResult();
+
+            Assert.That(game.LaneFor(FrogColour.Green).IsHome, Is.True, "a correct answer on pad 7 lands on the End log");
+            Assert.That(game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Green }));
+            Assert.That(game.Winner, Is.EqualTo(FrogColour.Green));
+        }
+
+        // The other half of the same rule: a turn that did not land a frog
+        // home records nothing, so an arrival cannot be manufactured by
+        // taking turns.
+        [Test]
+        public void ATurnThatDoesNotLandAFrogHome_RecordsNoFinisher()
+        {
+            var roster = new[] { FrogColour.Green, FrogColour.Blue };
+            var game = new Game(roster, Seed);
+
+            game.RollDie();
+            game.BeginAnswering();
+            game.LaneFor(game.ActiveFrog).Resolve(game.DrawnCard.Product, game.DrawnCard);
+            game.ShowResult();
+
+            Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(1));
+            Assert.That(game.FinishingOrder, Is.Empty);
+            Assert.That(game.Winner, Is.Null);
+        }
+
         // docs/specs/ui/game-over.md: "Frogs that did not finish are ranked
         // by how many lily pads they made", and the open question's own
         // wording is the current, still-open-to-change behaviour to build:

--- a/Tests/Core/ScriptedGameTests.cs
+++ b/Tests/Core/ScriptedGameTests.cs
@@ -1,0 +1,538 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// Whole games, played end to end through the real Core types from one
+    /// fixed seed — issue #230, the acceptance pass for the shape-only
+    /// playable proof of concept (#198).
+    ///
+    /// Every other Core fixture proves one piece in isolation: that a lane
+    /// moves a frog correctly, that a roll maps to the right pile, that a
+    /// grid takes the right shape. **None of them proves the pieces fit
+    /// together into a game somebody can play from the first roll to the
+    /// last.** That is the only thing this file is for, and it is why the
+    /// tests here are long and sequential where the rest of the suite is
+    /// short and pointed: the value is in the joints, so the joints are what
+    /// is asserted, in the order a real turn passes through them.
+    ///
+    /// **These games are played, not staged.** Nothing here reaches for
+    /// <see cref="Lane.MoveForward"/> to put a frog where a scenario wants
+    /// it, and nothing hand-builds a <see cref="StandingsRow"/>. A frog gets
+    /// up its lane by answering questions drawn from the game's own seeded
+    /// generator, which is the whole point — a seam that is never called in
+    /// a real sequence is a seam that can be broken without any isolated
+    /// test noticing.
+    ///
+    /// One named seed, shared by all three games, so a failure here is the
+    /// same failure every run — docs/adr/0004-core-owns-the-save-format.md is
+    /// what put a seeded generator in Core, and this is the fixture that
+    /// spends it.
+    /// </summary>
+    public sealed class ScriptedGameTests
+    {
+        /// <summary>
+        /// The one seed every scripted game in this file is built from. Any
+        /// fixed value would do; what matters is that it is fixed and named,
+        /// so the rolls, the cards and therefore every assertion below replay
+        /// identically on an ARM64 device, an x86_64 emulator and
+        /// <c>dotnet test</c> — see <see cref="Rng"/>.
+        /// </summary>
+        const ulong ScriptedGameSeed = 20260810UL;
+
+        /// <summary>
+        /// The floor of a lane. <see cref="Lane"/> keeps its own copy private
+        /// and there is no public name for it, so this is named here rather
+        /// than written as a bare literal at each of the places the Start log
+        /// is the expected answer.
+        /// </summary>
+        const int StartLogPosition = 0;
+
+        /// <summary>
+        /// A stop on the turn loop, so a scripted game that stops making
+        /// progress fails as a test rather than hanging the suite. Comfortably
+        /// above the turns two frogs need — eight correct answers each, plus
+        /// the scripted wrong ones — and never reached by a passing run.
+        /// </summary>
+        const int MaxScriptedTurns = 64;
+
+        // Reads better at the call site than a bare true/false, in a file
+        // whose whole subject is which answers were right.
+        const bool Right = true;
+        const bool Wrong = false;
+
+        // docs/specs/ui/working-out-grid.md: "`331 × 41` needs five digit
+        // columns (`13571`); `68 × 5` needs three (`340`)" — plus the operator
+        // column, in every case. A medium card, 2-digit × 2-digit, tops out at
+        // `9801`: four digit columns.
+        const int EasyColumnCount = 4;
+        const int MediumColumnCount = 5;
+        const int HardColumnCount = 6;
+
+        // The row sequence every card is dealt, at the addition section's
+        // starting size — docs/specs/ui/working-out-grid.md#how-many-columns-and-rows.
+        static GridRowKind[] ExpectedRowKinds()
+        {
+            return new[]
+            {
+                GridRowKind.CarryStrip,
+                GridRowKind.Multiplicand,
+                GridRowKind.Multiplier,
+                GridRowKind.AdditionRow,
+                GridRowKind.AdditionRow,
+                GridRowKind.CarryStrip,
+                GridRowKind.AnswerRow
+            };
+        }
+
+        // Two frogs, in the order docs/specs/ui/game-setup.md hands to Core
+        // when `Start` is tapped: "`Start` begins the game with the chosen
+        // frogs in badge order."
+        static FrogColour[] ScriptedRoster()
+        {
+            return new[] { FrogColour.Green, FrogColour.Blue };
+        }
+
+        /// <summary>
+        /// The whole thing: two frogs, one seed, played turn by turn until
+        /// both are home and the game ends itself — with the winner being the
+        /// frog that got home *first*, not the one whose finish ended the
+        /// game (docs/specs/ui/game-over.md#invariants).
+        /// </summary>
+        [Test]
+        public void AWholeGame_PlayedFromTheFixedSeedUntilEveryFrogIsHome_EndsItself_WithTheFirstFinisherAsTheWinner()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+
+            // --- The roster, and the turn order that follows from it. -------
+            // docs/specs/ui/game-board.md#behaviour: "Entering from game
+            // setup: every frog on its Start log, frog 1 active, `Roll`
+            // enabled."
+            Assert.That(game.TurnOrder, Is.EqualTo(new[] { FrogColour.Green, FrogColour.Blue }));
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Green));
+            Assert.That(game.NextActiveFrog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+            Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(StartLogPosition));
+            Assert.That(game.LaneFor(FrogColour.Blue).Position, Is.EqualTo(StartLogPosition));
+            Assert.That(game.IsOver, Is.False);
+            Assert.That(game.FrogsStillSwimming, Is.EqualTo(2));
+
+            // --- Turn 1: Green, on the Start log, answers wrong. ------------
+            // The floor. docs/specs/reference/index.md — the Start log is a
+            // floor, not a special space: a wrong answer there leaves the frog
+            // where it is rather than pushing it off the bottom of the lane.
+            var greenOnTheFloor = PlayOneTurn(game, Wrong);
+
+            Assert.That(greenOnTheFloor.Frog, Is.EqualTo(FrogColour.Green));
+            Assert.That(greenOnTheFloor.Resolution.Outcome, Is.EqualTo(TurnOutcome.WrongOnStartLog));
+            Assert.That(greenOnTheFloor.Resolution.PositionBefore, Is.EqualTo(StartLogPosition));
+            Assert.That(greenOnTheFloor.Resolution.PositionAfter, Is.EqualTo(StartLogPosition));
+            Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(StartLogPosition));
+
+            // Hand-off ran: the device is the next player's.
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+
+            // --- Turn 2: Blue answers right and hops forward. ---------------
+            var blueHopsForward = PlayOneTurn(game, Right);
+
+            Assert.That(blueHopsForward.Frog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(blueHopsForward.Resolution.Outcome, Is.EqualTo(TurnOutcome.Correct));
+            Assert.That(blueHopsForward.Resolution.PositionBefore, Is.EqualTo(StartLogPosition));
+            Assert.That(blueHopsForward.Resolution.PositionAfter, Is.EqualTo(StartLogPosition + 1));
+            Assert.That(game.LaneFor(FrogColour.Blue).Position, Is.EqualTo(StartLogPosition + 1));
+
+            // --- Turn 3: Green answers right, off the Start log. ------------
+            PlayOneTurn(game, Right);
+            Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(StartLogPosition + 1));
+
+            // --- Turn 4: Blue, above the Start log, answers wrong. ----------
+            // The other wrong outcome: this one really does move the frog.
+            var blueHopsBack = PlayOneTurn(game, Wrong);
+
+            Assert.That(blueHopsBack.Frog, Is.EqualTo(FrogColour.Blue));
+            Assert.That(blueHopsBack.Resolution.Outcome, Is.EqualTo(TurnOutcome.WrongAboveStartLog));
+            Assert.That(blueHopsBack.Resolution.PositionAfter, Is.EqualTo(blueHopsBack.Resolution.PositionBefore - 1));
+            Assert.That(game.LaneFor(FrogColour.Blue).Position, Is.EqualTo(StartLogPosition));
+
+            // --- Everything after: both frogs answer right, to the end. -----
+            var turnsAfterGreenGotHome = new List<FrogColour>();
+
+            while (!game.IsOver)
+            {
+                Assert.That(
+                    turnsAfterGreenGotHome.Count, Is.LessThan(MaxScriptedTurns),
+                    "the scripted game stopped making progress");
+
+                var greenWasAlreadyHome = game.LaneFor(FrogColour.Green).IsHome;
+                var turn = PlayOneTurn(game, Right);
+
+                if (greenWasAlreadyHome)
+                {
+                    turnsAfterGreenGotHome.Add(turn.Frog);
+                }
+            }
+
+            // --- Play continued after the first frog got home. --------------
+            // docs/specs/ui/game-board.md#behaviour: "A frog that reaches the
+            // End log stays there... Play continues — the other frogs keep
+            // taking turns," and "a frog that is home is skipped in turn
+            // order." Both are asserted by the same list: it is not empty, and
+            // Green is not in it.
+            Assert.That(turnsAfterGreenGotHome, Is.Not.Empty, "the other frog must keep taking turns");
+            Assert.That(
+                turnsAfterGreenGotHome, Is.All.EqualTo(FrogColour.Blue),
+                "a frog that is home is skipped in turn order");
+
+            // --- The game ended itself, and named the right winner. ---------
+            // Blue's finish is what ended the game; Green's is what won it.
+            Assert.That(game.IsOver, Is.True);
+            Assert.That(game.LaneFor(FrogColour.Green).IsHome, Is.True);
+            Assert.That(game.LaneFor(FrogColour.Blue).IsHome, Is.True);
+            Assert.That(game.FrogsStillSwimming, Is.EqualTo(0));
+            Assert.That(
+                game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Green, FrogColour.Blue }),
+                "finishing order is the order frogs got home");
+            Assert.That(
+                game.Winner, Is.EqualTo(FrogColour.Green),
+                "the winner is the frog that reached the End log first, not the one whose finish ended the game");
+
+            // --- The standings that come out of it. -------------------------
+            var standings = game.Standings;
+
+            Assert.That(standings.Count, Is.EqualTo(2));
+            Assert.That(standings[0].Colour, Is.EqualTo(FrogColour.Green));
+            Assert.That(standings[0].Place, Is.EqualTo(1));
+            Assert.That(standings[0].Position, Is.EqualTo(Lane.LaneWinningPosition));
+            Assert.That(standings[0].IsHome, Is.True);
+            Assert.That(standings[1].Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(standings[1].Place, Is.EqualTo(2));
+            Assert.That(standings[1].IsHome, Is.True);
+        }
+
+        /// <summary>
+        /// The `Game over` route: ended deliberately before anybody got home.
+        /// docs/specs/ui/game-over.md#behaviour's route table — "`<c>Colour</c>
+        /// frog wins!` if anyone got home, otherwise `Game over`" — and
+        /// docs/specs/ui/end-game-confirm.md, which "stops the game and shows
+        /// the results" rather than resetting anyone.
+        /// </summary>
+        [Test]
+        public void AGameEndedDeliberatelyBeforeAnyFrogIsHome_IsOverAtOnce_KeepsEveryFrogsLilyPads_AndHasNoWinner()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+
+            // Four real turns, both frogs answering right, so each frog has
+            // pads it would mind losing.
+            PlayOneTurn(game, Right);
+            PlayOneTurn(game, Right);
+            PlayOneTurn(game, Right);
+            PlayOneTurn(game, Right);
+
+            var padsBefore = ScriptedRoster().ToDictionary(
+                colour => colour, colour => game.LaneFor(colour).Position);
+
+            Assert.That(game.IsOver, Is.False, "nobody is home, so nothing has ended the game yet");
+            Assert.That(padsBefore.Values, Is.All.GreaterThan(StartLogPosition));
+
+            game.EndGame();
+
+            Assert.That(game.IsOver, Is.True);
+            Assert.That(game.Winner, Is.Null, "announcing a winner who did not win is worse than announcing nobody");
+            Assert.That(game.FinishingOrder, Is.Empty);
+
+            foreach (var colour in ScriptedRoster())
+            {
+                Assert.That(
+                    game.LaneFor(colour).Position, Is.EqualTo(padsBefore[colour]),
+                    $"{colour} lost lily pads to a deliberate ending");
+                Assert.That(game.LaneFor(colour).IsHome, Is.False);
+            }
+
+            var standings = game.Standings;
+
+            Assert.That(standings.Count, Is.EqualTo(2));
+            Assert.That(standings.Select(row => row.IsHome), Is.All.False);
+            Assert.That(
+                standings.Select(row => row.Position),
+                Is.Ordered.Descending,
+                "frogs that did not finish are ranked by how many lily pads they made");
+        }
+
+        /// <summary>
+        /// The other half of that route table, and the branch most likely to
+        /// be got wrong: ended deliberately *after* one frog is home. The
+        /// headline still names a winner, because one frog really did reach
+        /// the End log first.
+        /// </summary>
+        [Test]
+        public void AGameEndedDeliberatelyAfterOneFrogIsHome_NamesThatFrogAsTheWinner()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+
+            // Green answers every question right; Blue answers every question
+            // wrong, so it never leaves the Start log and the game cannot end
+            // itself. Green gets home on its own steam, one correct answer per
+            // turn, exactly as a player would.
+            while (!game.LaneFor(FrogColour.Green).IsHome)
+            {
+                Assert.That(game.IsOver, Is.False, "the game must not end itself with Blue still swimming");
+
+                PlayOneTurn(game, game.ActiveFrog == FrogColour.Green ? Right : Wrong);
+            }
+
+            Assert.That(
+                game.IsOver, Is.False,
+                "one frog home is not the end of a game — the others keep taking turns");
+            Assert.That(game.Winner, Is.EqualTo(FrogColour.Green), "Green is home, so Green got home first");
+            Assert.That(game.LaneFor(FrogColour.Blue).Position, Is.EqualTo(StartLogPosition));
+            Assert.That(game.FrogsStillSwimming, Is.EqualTo(1));
+
+            game.EndGame();
+
+            Assert.That(game.IsOver, Is.True);
+            Assert.That(game.Winner, Is.EqualTo(FrogColour.Green));
+            Assert.That(game.FinishingOrder, Is.EqualTo(new[] { FrogColour.Green }));
+
+            var standings = game.Standings;
+
+            Assert.That(standings[0].Colour, Is.EqualTo(FrogColour.Green));
+            Assert.That(standings[0].Place, Is.EqualTo(1));
+            Assert.That(standings[0].IsHome, Is.True);
+            Assert.That(standings[1].Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(standings[1].Place, Is.EqualTo(2));
+            Assert.That(standings[1].Position, Is.EqualTo(StartLogPosition));
+            Assert.That(standings[1].IsHome, Is.False);
+        }
+
+        /// <summary>
+        /// What the fixed seed buys: the same script played twice deals the
+        /// same rolls and the same cards, in the same order, and ends the same
+        /// way. Without this, a failure above would be a different failure
+        /// every run and worth nothing as evidence.
+        /// </summary>
+        [Test]
+        public void TheSameScriptPlayedTwiceFromTheSameSeed_DealsTheSameRollsAndCards_AndEndsTheSameWay()
+        {
+            var first = PlayEveryFrogHome();
+            var second = PlayEveryFrogHome();
+
+            Assert.That(second.Log.Count, Is.EqualTo(first.Log.Count), "the same script took a different number of turns");
+
+            for (var turn = 0; turn < first.Log.Count; turn++)
+            {
+                Assert.That(second.Log[turn].Frog, Is.EqualTo(first.Log[turn].Frog), $"turn {turn}: frog");
+                Assert.That(second.Log[turn].Face, Is.EqualTo(first.Log[turn].Face), $"turn {turn}: die face");
+                Assert.That(second.Log[turn].Pile, Is.EqualTo(first.Log[turn].Pile), $"turn {turn}: pile");
+                Assert.That(
+                    second.Log[turn].Card.Multiplicand, Is.EqualTo(first.Log[turn].Card.Multiplicand),
+                    $"turn {turn}: multiplicand");
+                Assert.That(
+                    second.Log[turn].Card.Multiplier, Is.EqualTo(first.Log[turn].Card.Multiplier),
+                    $"turn {turn}: multiplier");
+            }
+
+            Assert.That(second.Game.Winner, Is.EqualTo(first.Game.Winner));
+            Assert.That(second.Game.FinishingOrder, Is.EqualTo(first.Game.FinishingOrder));
+        }
+
+        // --- The driver -----------------------------------------------------
+
+        // One turn's worth of what the screens saw, kept so the test that
+        // played it can assert against it afterwards.
+        sealed class PlayedTurn
+        {
+            public PlayedTurn(FrogColour frog, int face, Pile pile, Card card, TurnResolution resolution)
+            {
+                Frog = frog;
+                Face = face;
+                Pile = pile;
+                Card = card;
+                Resolution = resolution;
+            }
+
+            public FrogColour Frog { get; }
+
+            public int Face { get; }
+
+            public Pile Pile { get; }
+
+            public Card Card { get; }
+
+            public TurnResolution Resolution { get; }
+        }
+
+        sealed class PlayedGame
+        {
+            public PlayedGame(Game game, IReadOnlyList<PlayedTurn> log)
+            {
+                Game = game;
+                Log = log;
+            }
+
+            public Game Game { get; }
+
+            public IReadOnlyList<PlayedTurn> Log { get; }
+        }
+
+        /// <summary>
+        /// Plays exactly one turn, through every phase, in the order
+        /// docs/specs/ui/game-board.md#behaviour lists them: "`Roll` → roll
+        /// and card → working-out grid → answer result → back here with the
+        /// frog moved and the turn passed to the next frog in order."
+        ///
+        /// This is the only place in the file a frog moves, and it moves the
+        /// way the shell moves one — <see cref="Lane.Resolve"/> against the
+        /// card the game itself drew. The joints that are the same on every
+        /// turn (the roll picking the pile, the card matching the pile's
+        /// shape, the grid matching the card) are asserted here rather than
+        /// re-asserted by each test, so they are checked on every turn of
+        /// every scripted game rather than on the one turn a test remembered
+        /// to look at.
+        /// </summary>
+        static PlayedTurn PlayOneTurn(Game game, bool answerCorrectly)
+        {
+            var frog = game.ActiveFrog;
+
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+            Assert.That(game.LaneFor(frog).IsHome, Is.False, "a frog that is home is never asked to take a turn");
+
+            // `Roll` — the roll and the card it sends the turn to.
+            game.RollDie();
+
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.RolledAndCardDrawn));
+
+            var roll = game.DrawnRoll;
+            var card = game.DrawnCard;
+
+            AssertTheRollSelectedThePile(roll);
+            AssertTheCardMatchesItsPilesShape(card, roll.Pile);
+
+            // The working-out grid, derived from that card and nothing else.
+            AssertTheGridMatchesTheCard(WorkingOutGrid.For(card, WorkingOutGrid.GridAdditionRowsAtStart), card, roll.Pile);
+
+            game.BeginAnswering();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.Answering));
+
+            // `Check it`: the answer row's digits leave the grid and are
+            // graded against the card. A wrong answer is the true product
+            // missed by one — wrong is wrong, and how wrong is not a fact the
+            // game has any use for.
+            var submitted = answerCorrectly ? card.Product : card.Product + 1;
+            var resolution = game.LaneFor(frog).Resolve(submitted, card);
+
+            Assert.That(resolution.CorrectAnswer, Is.EqualTo(card.Product));
+            Assert.That(game.LaneFor(frog).Position, Is.EqualTo(resolution.PositionAfter));
+
+            // The answer-result dialog, and the hand-off its one button runs.
+            game.ShowResult();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.ResultShown));
+
+            game.BeginHandOff();
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.HandOff));
+
+            // docs/specs/ui/game-board.md#behaviour: "When the last frog gets
+            // home, the game ends itself... A finished game never sits on this
+            // screen waiting to be dismissed." So there is no next player to
+            // hand off to, and asking for one is the mistake this branch
+            // avoids.
+            if (!game.IsOver)
+            {
+                game.CompleteHandOff();
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+                Assert.That(game.LaneFor(game.ActiveFrog).IsHome, Is.False);
+            }
+
+            return new PlayedTurn(frog, roll.Face, roll.Pile, card, resolution);
+        }
+
+        // Both frogs answer everything right, until the game ends itself.
+        static PlayedGame PlayEveryFrogHome()
+        {
+            var game = new Game(ScriptedRoster(), ScriptedGameSeed);
+            var log = new List<PlayedTurn>();
+
+            while (!game.IsOver)
+            {
+                Assert.That(log.Count, Is.LessThan(MaxScriptedTurns), "the scripted game stopped making progress");
+                log.Add(PlayOneTurn(game, Right));
+            }
+
+            return new PlayedGame(game, log);
+        }
+
+        // docs/specs/rules.md — "the roll selects the pile and does nothing
+        // else", and the mapping is fixed: 1 or 2 easy, 3 or 4 medium, 5 or 6
+        // hard.
+        static void AssertTheRollSelectedThePile(Roll roll)
+        {
+            Assert.That(roll.Face, Is.InRange(Roll.MinimumFace, Roll.MaximumFace));
+            Assert.That(roll.Pile, Is.EqualTo(Roll.PileForFace(roll.Face)), $"a face of {roll.Face} chose the wrong pile");
+        }
+
+        // docs/adr/0002-structured-working-out-grid.md pins three shapes and
+        // nothing else about a card: easy is 2-digit × 1-digit, medium
+        // 2-digit × 2-digit, hard 3-digit × 2-digit.
+        static void AssertTheCardMatchesItsPilesShape(Card card, Pile pile)
+        {
+            switch (pile)
+            {
+                case Pile.Easy:
+                    AssertOperandIsInRange(card.Multiplicand, Card.TwoDigitMinimum, Card.TwoDigitMaximum, pile);
+                    AssertOperandIsInRange(card.Multiplier, Card.OneDigitMinimum, Card.OneDigitMaximum, pile);
+                    break;
+
+                case Pile.Medium:
+                    AssertOperandIsInRange(card.Multiplicand, Card.TwoDigitMinimum, Card.TwoDigitMaximum, pile);
+                    AssertOperandIsInRange(card.Multiplier, Card.TwoDigitMinimum, Card.TwoDigitMaximum, pile);
+                    break;
+
+                default:
+                    AssertOperandIsInRange(card.Multiplicand, Card.ThreeDigitMinimum, Card.ThreeDigitMaximum, pile);
+                    AssertOperandIsInRange(card.Multiplier, Card.TwoDigitMinimum, Card.TwoDigitMaximum, pile);
+                    break;
+            }
+        }
+
+        static void AssertOperandIsInRange(int operand, int minimum, int maximum, Pile pile)
+        {
+            Assert.That(operand, Is.InRange(minimum, maximum), $"an operand of {operand} is the wrong shape for the {pile} pile");
+        }
+
+        // docs/specs/ui/working-out-grid.md — the grid's columns are the
+        // largest possible product for the card's *shape* plus an operator
+        // column, and every card is dealt the same row kinds.
+        static void AssertTheGridMatchesTheCard(WorkingOutGrid grid, Card card, Pile pile)
+        {
+            var expectedColumnCount = pile == Pile.Easy
+                ? EasyColumnCount
+                : pile == Pile.Medium ? MediumColumnCount : HardColumnCount;
+
+            Assert.That(grid.ColumnCount, Is.EqualTo(expectedColumnCount), $"the {pile} pile's grid is the wrong width");
+            Assert.That(grid.Rows.Select(row => row.Kind), Is.EqualTo(ExpectedRowKinds()));
+            Assert.That(grid.Rows.Select(row => row.Cells.Count), Is.All.EqualTo(grid.ColumnCount));
+
+            // Exactly one graded row, and it is the last one and it is empty.
+            // ADR-0002: nothing in the grid is marked, and the answer row is
+            // the only row the player is graded on.
+            Assert.That(grid.Rows.Count(row => row.Kind == GridRowKind.AnswerRow), Is.EqualTo(1));
+            Assert.That(grid.Rows[grid.Rows.Count - 1].Kind, Is.EqualTo(GridRowKind.AnswerRow));
+
+            // The card's own digits are the printed ones, right-aligned.
+            AssertPrintedRowReads(grid, GridRowKind.Multiplicand, card.Multiplicand);
+            AssertPrintedRowReads(grid, GridRowKind.Multiplier, card.Multiplier);
+        }
+
+        static void AssertPrintedRowReads(WorkingOutGrid grid, GridRowKind kind, int operand)
+        {
+            var printed = grid.Rows
+                .Single(row => row.Kind == kind).Cells
+                .Where(cell => cell.Kind == GridCellKind.Printed)
+                .Select(cell => cell.Digit.ToString());
+
+            Assert.That(string.Concat(printed), Is.EqualTo(operand.ToString()), $"the {kind} row does not read {operand}");
+        }
+    }
+}

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -125,6 +125,56 @@ The order is always the same:
 If you find yourself starting in a `MonoBehaviour`, stop. The feature will end
 up testable only in an editor, and it will end up untested.
 
+## The end-to-end acceptance pass
+
+Most tests prove one piece. The **acceptance pass** is the small set that
+proves the pieces fit together into a game somebody can play from the first
+roll to the last, and it is deliberately split across the two tiers by what
+each one can honestly reach.
+
+| Seam | Proved by | Where |
+| --- | --- | --- |
+| The roster and the turn order that follows from it | scripted game | `Tests/Core/ScriptedGameTests.cs` |
+| A roll, and the pile it selects | scripted game | Core |
+| The card that pile deals, and the grid Core derives from it | scripted game | Core |
+| A right answer moving the frog forward | scripted game | Core |
+| A wrong answer moving it back | scripted game | Core |
+| The floor at the Start log | scripted game | Core |
+| A frog reaching its End log, and being recorded as a finisher | scripted game | Core |
+| Play continuing afterwards, with home frogs skipped | scripted game | Core |
+| The game ending itself once every frog is home | scripted game | Core |
+| The winner being the **first** finisher, not the last | scripted game | Core |
+| A game ended deliberately, and the standings it produces | scripted game | Core |
+| The grid **view** drawing the grid Core reported | EditMode | `Assets/Tests/EditMode/EndToEndAcceptanceTests.cs` |
+| The game-over **screen** rendering both headlines | EditMode | same |
+| The scenes the build ships keeping their components | EditMode | same |
+
+Three whole games are played at the Core tier, all from **one named seed**, so
+a failure is the same failure every run: one played until both frogs are home
+and the game ends itself, one ended deliberately with nobody home, and one
+ended deliberately with one frog home. They are *played*, not staged — a frog
+gets up its lane by answering questions the game itself dealt, because a seam
+that is never called in a real sequence is a seam that can break without any
+isolated test noticing. That is not a hypothetical: this pass is what caught
+`Game.RecordFinish` never being called from anywhere but a test, which left
+every real game with no winner.
+
+### What the acceptance pass cannot reach
+
+**There is no harness in this repo for driving the real screens end to end.**
+EditMode is an edit-mode editor session: it opens a scene without running
+`Awake`, `OnEnable` or `Start`, no coroutines run, no frames tick, and
+`Time.deltaTime` never advances. A tapped-through sequence of screens, a screen
+transition, and a timed hop cannot be observed there, and
+[PlayMode tests are not the answer](#no-playmode-tests-no-on-device-testing).
+
+So the shell tier proves the adapter-shaped things EditMode is actually for,
+and nothing pretends otherwise. Writing a real walkthrough needs a lifecycle
+driver — explicit `Initialize()` entry points, or a test driver that pumps the
+lifecycle by hand — that does not exist yet. Until it does, the only place the
+real screens are seen *running* is a build somebody installs and opens, which
+is where Derek and Connor find out whether it is fun.
+
 ## Known limitation: EditMode tests run in CI, not in agent environments
 
 Agent environments have no Unity editor and no licence. **EditMode tests cannot


### PR DESCRIPTION
Closes #230

A whole game now plays from the first roll to the last inside the two-second
test suite: two frogs, one fixed seed, every turn taken the way the screens
take one, until both frogs are home and the game ends itself. Writing that
found a real bug — **nothing in the game ever told Core that a frog had got
home**, so the game-over screen would have announced a flat "Game over" even
when a frog genuinely won, and the standings would have had no finishing order
in them. Core now notices the arrival itself, the moment it happens, so nobody
has to remember to say so.

**Docs:** `docs/engineering/testing.md` — adds "The end-to-end acceptance
pass": a table of which seam is proved at which tier, that the three scripted
games are *played* rather than staged, and that driving the real screens in
sequence is out of reach until a lifecycle driver exists.

## The bug three issues walked past

`Game.RecordFinish(colour)` is what records finishing order, and therefore who
won. Before this PR it was called from **`Tests/Core/GameTests.cs` and
`Assets/Tests/EditMode/GameOverScreenViewTests.cs`, and nowhere else.** No
production path called it, so:

- `Game.Winner` was always `null`
- `Game.FinishingOrder` was always empty
- [game over](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/game-over.md)'s
  headline would have read `Game over` on **both** of its two routes, including
  the one where a frog reached the End log and won
- every standings row would have been ranked by lily pads, with no finisher
  ever placed first

#211 built `RecordFinish` and said the wiring belonged to a later issue. #224
declined it, as belonging to #211/#225. `GameAnswerResultTurn.cs` carried a
comment marking the exact spot and explaining why it was being left. This issue
is the one designed to catch a seam that is never called, and it caught it: a
scripted whole game that ends with a winner cannot pass while this is broken.

### Where the fix went, and why there rather than the shell

**In Core, inside `Game.ShowResult()`** — not in the Unity layer, where the
deferred comment pointed.

`Lane.Resolve` is the only thing that moves a frog, and the phase machine only
lets it run while the turn is `Answering`. `ShowResult` is the very next call
the machine will accept. So it is the **first moment after a move that no
caller can skip**, which makes the recording impossible to forget — the way it
was forgotten while it sat on the shell's to-do list. A future caller that
drives a game some other way gets the finishing order for free.

Two alternatives were considered and rejected:

- **The shell (`GameAnswerResultTurn.CompleteHandOff`)**, as #211 suggested.
  It is forgettable by construction, it is testable only in EditMode, and it is
  in the wrong place twice over: `CompleteHandOff` is **never called for the
  last finisher of all**, because when the final frog gets home the game ends
  itself and there is no next player to hand off to
  ([game board](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/game-board.md#behaviour)).
  The frog whose finish ends the game would never have been recorded.
- **A `Game.SubmitAnswer(answer)` that owns the grading**, collapsing
  `game.LaneFor(frog).Resolve(...)` plus `game.ShowResult()` into one call.
  That is arguably the deeper design — it would make it structurally impossible
  to move a frog without `Game` noticing, rather than merely unavoidable in
  practice. It is also new public API on a "no new behaviour" issue, and it
  changes how every existing caller submits an answer. Not this issue's to
  design; worth its own if the seam is ever reached for again.

`RecordFinish` stays public and stays idempotent, so the existing tests that
call it directly are unaffected.

## Spec invariants this had to keep true

| Invariant | Where it is asserted |
| --- | --- |
| "the winner is the frog that reached the End log first" — not the one whose finish ended the game (game-over.md) | `AWholeGame_...EndsItself_WithTheFirstFinisherAsTheWinner`: Green finishes first, Blue's finish ends the game, `Winner` is Green |
| "finishing order is the order frogs got home" | same test — `FinishingOrder` is `[Green, Blue]` |
| The Start log is a floor, not a special space | `WrongOnStartLog` on turn 1: `PositionBefore == PositionAfter == 0` |
| Play continues after the first frog gets home; a frog that is home is skipped | every turn after Green got home is Blue's, and there is at least one |
| The game ends itself once every frog is home | the loop's exit condition is `game.IsOver`, and nothing calls `EndGame` |
| Ending a game deliberately is not losing it — every frog keeps its lily pads | `AGameEndedDeliberatelyBeforeAnyFrogIsHome_...KeepsEveryFrogsLilyPads_AndHasNoWinner` |
| `Game over` when nobody got home; `<Colour> frog wins!` when somebody did | both Core plays, and both EditMode game-over tests |
| The roll selects the pile and does nothing else; a card matches its pile's shape; the grid is derived from the card | asserted on **every turn of every scripted game**, inside the driver |
| Nothing in the grid is marked (ADR-0002) | the grid is only ever asked for its shape; the answer is graded by `Lane.Resolve` and the grid never learns the verdict |

## How the spec is changing

It is not. No rule in `/docs` moved — the docs gained a description of the
acceptance pass, which is the contract catching up with what this issue found
out rather than the contract changing. The code was treated as the bug: the
specs already said the winner is the first finisher, and the code could not
produce one.

## What was red first

`AFrogThatReachesItsEndLogOnItsTurn_IsRecordedAsAFinisher_WithoutAnybodyCallingRecordFinish`
failed with:

```
Expected is <Frogs.Core.FrogColour[1]>, actual is <List`1[FrogColour]> with 0 elements
Missing:  < Green >
```

The fix was then reverted once, with the scripted games in place, to check they
really do catch it. They do — the whole-game play fails on the same empty
`FinishingOrder`, and the deliberate-ending-with-one-frog-home play fails with
`Expected: Green / But was: null`.

## Verification

- `dotnet test Tests/Core/Frogs.Core.Tests.csproj` — **196 passed**, 0 failed
  (was 190). Four of the new tests are the scripted games; two are the bug's
  own regression tests.
- `check_core_isolation.py`, `check_assembly_references.py`,
  `check_geometry_literals.py`, `run_python_tests.py`, `mkdocs build --strict`
  — all pass.
- EditMode: three new tests in `EndToEndAcceptanceTests.cs`. Watching the
  `EditMode (Unity)` job on this PR; what it showed goes in this thread.

## Deviations and Decisions

- **This PR fixes a broken seam instead of handing it off, which is a
  departure from this issue's own "When a seam turns out to be broken"
  protocol.** That protocol says to open an issue against the slate work that
  owns the piece, add a native blocked-by, and leave the assertion out or
  `[Ignore]`d. It was not followed, for one reason: the seam had already been
  handed off twice (#211 → "a later issue", #224 → "belongs to #211/#225"), and
  a third hand-off would have parked this issue's entire central claim behind a
  queue while leaving `main` with a game that cannot report a winner. The fix
  is nine lines and one comment, in the type the issue already owns. **Flagging
  it because it is exactly the kind of call a reviewer might have made
  differently** — if the preference is a hand-off, the Core change reverts
  cleanly and the two affected assertions are the winner ones.
- **`RecordFinish` is wired in Core rather than in the Unity layer**, against
  #211's own suggestion of the shell. Reasoning in full above; the short version
  is that the shell site would have missed the last finisher entirely.
- **No red step for the three scripted games.** They build no behaviour, so
  there was nothing to make them fail and nothing to write to make them pass —
  a green first run is the success this issue exists to demonstrate. The one
  exception is the bug, which was red first and is quoted above.
- **No composition root was built.** No view in this repo is instantiated
  outside tests, and each screen issue deliberately left that wiring alone. The
  issue does not ask for one, and says out loud that no walkthrough harness
  exists; the end-to-end proof here is at the tier the issue asked for.
  Follow-up #279 is the issue that makes a real walkthrough writable.
- **The EditMode game-over fixtures replay the scripted play rather than
  sharing the Core one.** `Tests/Core` and `Assets/Tests/EditMode` are separate
  assemblies with no shared compilation unit, and giving them one would mean
  either the Core suite compiling something outside `Assets/Scripts/Core`
  (contradicting what `testing.md` says it does) or a new asmdef. The duplicated
  driver is about twenty lines; the games it produces are genuinely played, not
  hand-built standings, which is what the checklist asked for.
- **The scene/prefab EditMode test asserts components survive the serializer,
  not that a screen does.** The flow needs one scene and zero prefabs — every
  view builds itself procedurally, by design. A save-and-reload round trip of a
  *view* would assert nothing real and would probably fail for architectural
  reasons: these views were never designed to be scene-serialized, their sprites
  are created at runtime, and their `EnsureInitialized` guard is not a
  serialized field, so a reloaded view would rebuild its children on top of the
  deserialized ones. So the test asks the question that does have a real answer
  — every registered scene loads with no detached component — plus a separate
  one that every screen in the flow builds its whole hierarchy itself, which is
  what "the flow needs no prefab" actually means.
- **Two follow-ups opened**, as the checklist asks: #279 (`area:ui`, the
  lifecycle driver) and #280 (`area:build`, the emulator-profile PR build).
  Both linked from #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_