### PR TITLE
fix(build): the emulator profile builds x86_64 with IL2CPP

### DIFF
--- a/.github/scripts/check_release_apks.py
+++ b/.github/scripts/check_release_apks.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """The two release APKs must be the two builds the docs promise.
 
-`release-build` runs Unity twice — ARM64/IL2CPP for the tablet, x86_64/Mono for
-a desktop emulator (docs/engineering/tech-stack.md). Running it twice is not
+`release-build` runs Unity twice — ARM64/IL2CPP for the tablet, x86_64/IL2CPP
+for a desktop emulator (docs/engineering/tech-stack.md). Running it twice is not
 the same as getting two builds: for `v0.1.0` the profile never reached Unity,
 both invocations built the same thing, and the release went out with two
 byte-identical assets under different names (issue #218).
@@ -16,6 +16,11 @@ those ABI names are Android's, not Unity's — `arm64-v8a` and `x86_64` mean the
 same thing in every APK ever built. IL2CPP additionally ships `libil2cpp.so`,
 and a Mono build does not, so the scripting backend is readable from the same
 listing.
+
+Both profiles are IL2CPP: Unity has no Mono for 64-bit Android, so a build that
+comes back without `libil2cpp.so` was built for a pairing Unity silently
+reduces to no architecture at all (issue #282). The ABIs are what tell the two
+profiles apart.
 
 Usage:
     python3 .github/scripts/check_release_apks.py \\
@@ -88,14 +93,19 @@ def problems(device, emulator):
             f"(sha256 {device.digest[:16]}…). Two build profiles cannot "
             f"produce one file, so neither profile reached Unity.")
 
-    found.extend(profile_problems(device, "device", DEVICE_ABI, il2cpp=True))
-    found.extend(profile_problems(emulator, "emulator", EMULATOR_ABI, il2cpp=False))
+    found.extend(profile_problems(device, "device", DEVICE_ABI))
+    found.extend(profile_problems(emulator, "emulator", EMULATOR_ABI))
 
     return found
 
 
-def profile_problems(apk, profile, abi, il2cpp):
-    """Whether one APK is the build its profile asked for."""
+def profile_problems(apk, profile, abi):
+    """Whether one APK is the build its profile asked for.
+
+    Every profile is IL2CPP, so the backend check is the same for both: 64-bit
+    Android has no Mono, and an APK without `libil2cpp.so` was built for a
+    pairing Unity cannot build (#282).
+    """
     found = []
 
     if apk.abis != {abi}:
@@ -104,15 +114,11 @@ def profile_problems(apk, profile, abi, il2cpp):
             f"{apk.name} is the '{profile}' profile, so it must contain {abi} "
             f"and nothing else. It has {listed}.")
 
-    if il2cpp and not apk.il2cpp:
+    if not apk.il2cpp:
         found.append(
             f"{apk.name} is the '{profile}' profile, which is IL2CPP, but it "
-            f"has no {IL2CPP_LIBRARY}.")
-
-    if not il2cpp and apk.il2cpp:
-        found.append(
-            f"{apk.name} is the '{profile}' profile, which is Mono, but it "
-            f"ships {IL2CPP_LIBRARY} — it was built with IL2CPP.")
+            f"has no {IL2CPP_LIBRARY} — it was built with Mono, which Unity "
+            f"cannot build for 64-bit Android.")
 
     return found
 
@@ -128,7 +134,7 @@ def main(argv=None):
     parser.add_argument("--device", required=True,
                         help="the ARM64/IL2CPP APK, for the tablet")
     parser.add_argument("--emulator", required=True,
-                        help="the x86_64/Mono APK, for a desktop emulator")
+                        help="the x86_64/IL2CPP APK, for a desktop emulator")
     arguments = parser.parse_args(argv)
 
     for path in (arguments.device, arguments.emulator):

--- a/.github/scripts/tests/test_check_release_apks.py
+++ b/.github/scripts/tests/test_check_release_apks.py
@@ -1,8 +1,8 @@
 """The two release APKs have to be two different builds.
 
 `release-build` runs Unity twice, once per profile in
-docs/engineering/tech-stack.md: ARM64/IL2CPP for the tablet, x86_64/Mono for a
-desktop emulator. Nothing checked that the two invocations produced anything
+docs/engineering/tech-stack.md: ARM64/IL2CPP for the tablet, x86_64/IL2CPP for
+a desktop emulator. Nothing checked that the two invocations produced anything
 different, and for `v0.1.0` they did not — the profile never reached Unity, so
 both assets were the same ARM64 file under two names. An x86_64 emulator
 refuses to install an ARM64-only APK, so the failure surfaced on someone
@@ -31,6 +31,15 @@ DEVICE_LIBS = [
     "lib/arm64-v8a/libmain.so",
 ]
 EMULATOR_LIBS = [
+    "lib/x86_64/libunity.so",
+    "lib/x86_64/libil2cpp.so",
+    "lib/x86_64/libmain.so",
+]
+
+# What a Mono build looks like — no libil2cpp.so. No profile produces one any
+# more (Unity has no Mono for 64-bit Android, issue #282), which is exactly why
+# an APK shaped like this has to be caught.
+MONO_LIBS = [
     "lib/x86_64/libunity.so",
     "lib/x86_64/libmonobdwgc-2.0.so",
     "lib/x86_64/libmain.so",
@@ -68,7 +77,7 @@ class InspectionTests(ApkFixture):
         self.assertTrue(inspect_apk(self.apk("d.apk", DEVICE_LIBS)).il2cpp)
 
     def test_a_mono_build_has_no_il2cpp(self):
-        self.assertFalse(inspect_apk(self.apk("e.apk", EMULATOR_LIBS)).il2cpp)
+        self.assertFalse(inspect_apk(self.apk("e.apk", MONO_LIBS)).il2cpp)
 
     def test_two_apks_with_the_same_bytes_have_the_same_digest(self):
         first = inspect_apk(self.apk("one.apk", DEVICE_LIBS))
@@ -128,12 +137,15 @@ class ProblemTests(ApkFixture):
         self.assertTrue(any("IL2CPP" in problem for problem in found),
                         f"expected the backend to be named; got {found}")
 
-    def test_an_emulator_apk_built_with_il2cpp_is_caught(self):
+    def test_an_emulator_apk_built_with_mono_is_caught(self):
+        """Both profiles are IL2CPP now: 64-bit Android has no Mono (#282).
+
+        A Mono x86_64 APK cannot be produced by the profile any more, so one
+        arriving here means something has been changed back to a pairing Unity
+        silently reduces to no architecture at all.
+        """
         device = inspect_apk(self.apk("device.apk", DEVICE_LIBS))
-        emulator = inspect_apk(
-            self.apk("emulator.apk",
-                     ["lib/x86_64/libunity.so", "lib/x86_64/libil2cpp.so"],
-                     filler="y"))
+        emulator = inspect_apk(self.apk("emulator.apk", MONO_LIBS, filler="y"))
 
         found = problems(device, emulator)
 

--- a/.github/scripts/tests/test_release_partial_attach.py
+++ b/.github/scripts/tests/test_release_partial_attach.py
@@ -1,0 +1,213 @@
+"""A release must get the APK that did build.
+
+`release-build` builds two APKs, and until now one failure meant the release
+got **neither**: the emulator build failed, the job stopped there, and the
+attach step — three steps further down — never ran. `v0.2.0` was tagged and
+published with no installable asset on it at all, while a perfectly good device
+APK sat in the runner's filesystem until it was deleted (issues #282, #212).
+
+Nothing is gained by throwing that away. A release with one of its two APKs is
+worse than a release with both and better than a release with none, and which
+of the three happened has to be obvious from the run rather than inferred from
+a missing file.
+
+So this asserts the shape that gets that:
+
+- the emulator build may fail without aborting the job, and the device build
+  may not — the device APK *is* the release;
+- a failed emulator build still fails the run, after the attach, so a partial
+  release is never a green one;
+- the two-APK comparison stays strict whenever both APKs exist. It is the gate
+  that caught `v0.1.0` shipping two identical files (#218), and "one of them is
+  missing" is the only reason it may be skipped;
+- a partial attach says so, as a warning and in the job summary.
+
+Regex rather than a YAML parse, and stdlib only, for the same reason as
+`test_build_output_paths.py`: the pipeline suites run on nothing but the Python
+already on the runner.
+
+See docs/engineering/ci-cd.md and issue #282.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+RELEASE_BUILD = WORKFLOWS / "release-build.yml"
+
+DEVICE_STEP = "Build the device APK"
+EMULATOR_STEP = "Build the emulator APK"
+
+CHECK_SCRIPT = "check_release_apks.py"
+
+# The `- ` that opens a list item, capturing its indentation.
+LIST_ITEM = re.compile(r"^(\s*)-\s")
+
+INLINE_COMMENT = re.compile(r"\s+#.*$")
+
+
+def indent_of(line):
+    return len(line) - len(line.lstrip())
+
+
+def steps(text):
+    """Every step in the workflow, as {name: block-of-lines}.
+
+    A step runs from the `- ` that opens it to the next line no more indented
+    than that `- `. Only named steps are returned: a step this suite has an
+    opinion about is one worth naming.
+    """
+    lines = text.splitlines()
+    found = {}
+
+    for index, line in enumerate(lines):
+        match = LIST_ITEM.match(line)
+        if not match:
+            continue
+
+        opening = len(match.group(1))
+        end = index + 1
+        while end < len(lines):
+            following = lines[end]
+            if following.strip() and indent_of(following) <= opening:
+                break
+            end += 1
+
+        block = lines[index:end]
+        name = scalar(block, "name")
+        if name:
+            found[name] = block
+
+    return found
+
+
+def scalar(block, key):
+    """The value of `key: value` in `block`, or None."""
+    pattern = re.compile(rf"^\s*(?:-\s*)?{re.escape(key)}:\s*(.+?)\s*$")
+    for line in block:
+        match = pattern.match(line)
+        if match:
+            return INLINE_COMMENT.sub("", match.group(1)).strip().strip("'\"")
+    return None
+
+
+def body(block):
+    """The step's lines as one string, for asking what its script does."""
+    return "\n".join(block)
+
+
+def uncommented(block):
+    """The same, with whole-line comments dropped.
+
+    A rule explained in a comment is not a rule the run obeys, and every step
+    in this workflow is heavily commented — including with the shapes that used
+    to be wrong.
+    """
+    return "\n".join(line for line in block if not line.lstrip().startswith("#"))
+
+
+class ReleaseBuildTests(unittest.TestCase):
+    def setUp(self):
+        self.text = RELEASE_BUILD.read_text()
+        self.steps = steps(self.text)
+
+    def test_both_builds_are_present_and_named(self):
+        """Guards against every other test here passing on nothing."""
+        self.assertIn(DEVICE_STEP, self.steps)
+        self.assertIn(EMULATOR_STEP, self.steps)
+
+    def test_a_failed_emulator_build_does_not_abort_the_job(self):
+        """The bug: one failure meant the release got neither APK."""
+        self.assertEqual(
+            scalar(self.steps[EMULATOR_STEP], "continue-on-error"), "true",
+            f"{EMULATOR_STEP!r} has no `continue-on-error: true`, so a failure "
+            f"there stops the job before the attach step and the release gets "
+            f"nothing — not even the device APK, which built fine. See #282.")
+
+    def test_a_failed_device_build_still_aborts_the_job(self):
+        """The device APK is the release. There is nothing to attach without it."""
+        self.assertIsNone(
+            scalar(self.steps[DEVICE_STEP], "continue-on-error"),
+            f"{DEVICE_STEP!r} must not continue on error. The device APK is "
+            f"what people install; a release without it is not a release.")
+
+    def test_the_emulator_build_can_be_referred_to_later(self):
+        """`steps.<id>.outcome` is how the run finds out it was partial."""
+        self.assertIsNotNone(
+            scalar(self.steps[EMULATOR_STEP], "id"),
+            f"{EMULATOR_STEP!r} has no `id:`, so nothing downstream can ask "
+            f"whether it failed.")
+
+    def test_a_failed_emulator_build_still_fails_the_run(self):
+        """Attaching what built must not turn a broken build green."""
+        emulator_id = scalar(self.steps[EMULATOR_STEP], "id")
+        outcome = f"steps.{emulator_id}.outcome"
+
+        failing = [
+            name for name, block in self.steps.items()
+            if outcome in uncommented(block) and "exit 1" in uncommented(block)
+        ]
+
+        self.assertTrue(
+            failing,
+            f"No step reads {outcome} and fails on it. A release that got one "
+            f"of its two APKs must still show up as a failed run, or the next "
+            f"person to look sees a green build and a half-filled release.")
+
+    def test_the_two_apk_comparison_is_still_run(self):
+        """#218's gate. Not weakened by any of the above."""
+        checking = [name for name, block in self.steps.items()
+                    if CHECK_SCRIPT in uncommented(block)]
+
+        self.assertTrue(checking, f"Nothing runs {CHECK_SCRIPT} any more.")
+
+        for name in checking:
+            with self.subTest(step=name):
+                script = uncommented(self.steps[name])
+                self.assertIn("--device", script)
+                self.assertIn("--emulator", script)
+
+    def test_the_comparison_is_skipped_only_when_an_apk_is_missing(self):
+        """Both present is the strict case, and it must be tested for.
+
+        A comparison that ran only when someone remembered to ask for it would
+        be no comparison at all — the v0.1.0 pair looked entirely plausible
+        from the outside.
+        """
+        checking = [block for _, block in self.steps.items()
+                    if CHECK_SCRIPT in uncommented(block)]
+
+        for block in checking:
+            script = uncommented(block)
+            with self.subTest(step=scalar(block, "name")):
+                self.assertTrue(
+                    re.search(r'\[\s+-f\s+"?\$\{?device', script)
+                    and re.search(r'\[\s+-f\s+"?\$\{?emulator', script),
+                    "The step running the comparison does not test for both "
+                    "APKs existing. It may only be skipped when one of them "
+                    "genuinely is not there.")
+
+    def test_a_partial_attach_is_never_silent(self):
+        """One APK on a release has to be visible without reading the log."""
+        attaching = [block for name, block in self.steps.items()
+                     if "gh release upload" in uncommented(block)]
+
+        self.assertTrue(attaching, "Nothing attaches anything to the release.")
+
+        for block in attaching:
+            script = uncommented(block)
+            with self.subTest(step=scalar(block, "name")):
+                self.assertIn(
+                    "::warning::", script,
+                    "The attach step raises no warning, so a release that got "
+                    "one APK instead of two looks exactly like one that got "
+                    "both.")
+                self.assertIn(
+                    "GITHUB_STEP_SUMMARY", script,
+                    "The attach step writes no job summary, which is where "
+                    "what a release actually received is read.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -138,8 +138,18 @@ jobs:
       # Its own build path, so the two APKs cannot be confused with each other —
       # they have the same version and differ only in architecture, which is not
       # visible from a filename in a shared directory.
+      #
+      # `continue-on-error`, unlike the device build above: the device APK is
+      # the release, and it has already been built by the time this runs. When
+      # this step failed the job outright, the attach step three steps down
+      # never ran and the release got *nothing* — that is how v0.2.0 was
+      # published with no installable asset while a good device APK sat on the
+      # runner (#282). The run still ends red; see "Report a failed emulator
+      # build" at the bottom of this job.
       - name: Build the emulator APK
+        id: emulator
         if: steps.licence.outputs.present == 'true'
+        continue-on-error: true
         uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5.0.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -158,13 +168,31 @@ jobs:
       # release that should not go out: an ARM64-only APK labelled "emulator"
       # fails at install time on someone else's machine, with no build log
       # anywhere near it. That is what v0.1.0 did (#218).
+      #
+      # Strict whenever both APKs exist, and skipped only when one genuinely
+      # does not. Attaching a single, correctly named device APK is not the
+      # mislabelling this gate protects against; attaching two identical ones
+      # still is.
       - name: Check the two APKs are the two builds
         if: steps.licence.outputs.present == 'true'
         run: |
           set -euo pipefail
-          python3 .github/scripts/check_release_apks.py \
-            --device build/device/Android/multiplying-frogs-${{ steps.stamp.outputs.version }}.apk \
-            --emulator build/emulator/Android/multiplying-frogs-${{ steps.stamp.outputs.version }}-emulator.apk
+          version="${{ steps.stamp.outputs.version }}"
+          device="build/device/Android/multiplying-frogs-$version.apk"
+          emulator="build/emulator/Android/multiplying-frogs-$version-emulator.apk"
+
+          if [ -f "$device" ] && [ -f "$emulator" ]; then
+            python3 .github/scripts/check_release_apks.py \
+              --device "$device" --emulator "$emulator"
+          elif [ -f "$device" ]; then
+            echo "::warning::Only the device APK was built, so there is no pair" \
+                 "to compare. Attaching it on its own — see the emulator build" \
+                 "step for why it is missing."
+          else
+            echo "::error::No device APK at $device. The device build is the" \
+                 "release; there is nothing worth attaching without it."
+            exit 1
+          fi
 
       - name: Attach the APKs to the release
         if: steps.licence.outputs.present == 'true'
@@ -219,6 +247,32 @@ jobs:
           for asset in "${assets[@]}"; do
             echo "- \`$(basename "$asset")\`" >> "$GITHUB_STEP_SUMMARY"
           done
+
+          # A release that got one of its two APKs is a release someone has to
+          # know about. It looks completely normal from the releases page —
+          # there is an asset, it installs, it runs — so the only place the gap
+          # can be stated is here.
+          if [ ${#assets[@]} -lt 2 ]; then
+            echo "::warning::$TAG got ${#assets[@]} of the 2 APKs. The build that" \
+                 "produced nothing is the failed step in this job."
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo "**This release is incomplete**: ${#assets[@]} of the 2 APKs." \
+                 "The other profile's build failed — see the failed step in this" \
+                 "job — so the release is missing it until this workflow is" \
+                 "re-run against \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Last, so everything above has already run: the device APK is attached,
+      # the summary is written, and only then does the job go red. Attaching
+      # what built must not turn a broken build green — a half-filled release
+      # nobody is told about is how the next one gets shipped the same way.
+      - name: Report a failed emulator build
+        if: steps.licence.outputs.present == 'true' && steps.emulator.outcome == 'failure'
+        run: |
+          echo "::error::The emulator APK did not build, so ${{ inputs.tag }} has" \
+               "only its device APK. The device build and the attach both" \
+               "succeeded; this job is red for the emulator build alone."
+          exit 1
 
       - name: Summarise a skip
         if: steps.licence.outputs.present != 'true'

--- a/Assets/Editor/BuildStampPreprocessor.cs
+++ b/Assets/Editor/BuildStampPreprocessor.cs
@@ -92,13 +92,25 @@ namespace Frogs.EditorTools
                     break;
 
                 case "emulator":
-                    // x86_64 and Mono. IL2CPP cross-compiling to x86_64 is slow
-                    // and buys nothing for a smoke test — this profile trades
-                    // fidelity for a build that finishes while you are still
-                    // looking at it.
+                    // x86_64 and IL2CPP. **IL2CPP is not a choice here.** Mono
+                    // compiles at runtime with a JIT, and Unity does not support
+                    // that JIT on 64-bit Android, so x86_64 and ARM64 are both
+                    // IL2CPP-only.
+                    //
+                    // This used to say Mono2x, on the reasoning that IL2CPP
+                    // cross-compiling to x86_64 is slow and buys nothing for a
+                    // smoke test. The speed argument was true and the pairing
+                    // was still impossible: Unity dropped the architecture it
+                    // could not build, left the set empty, and failed the build
+                    // at its prerequisites check with "Target architecture not
+                    // specified" — a message that names neither. That is issue
+                    // #282, and it took the v0.2.0 release's APKs with it.
+                    //
+                    // The emulator is x86_64, so x86_64 is the part that cannot
+                    // move. A slower build is the price.
                     PlayerSettings.Android.targetArchitectures = AndroidArchitecture.X86_64;
                     PlayerSettings.SetScriptingBackend(
-                        NamedBuildTarget.Android, ScriptingImplementation.Mono2x);
+                        NamedBuildTarget.Android, ScriptingImplementation.IL2CPP);
                     break;
 
                 default:
@@ -111,13 +123,33 @@ namespace Frogs.EditorTools
                         + $"It comes from {source}.");
             }
 
-            // Read back rather than echoing the request: this line is how a
-            // build log answers "did the profile actually take", which is the
+            // Read back rather than echoing the request: this is how a build
+            // log answers "did the profile actually take", which is the
             // question #218 left open.
-            Debug.Log(
-                $"Android build profile: {profile} — "
-                + $"{PlayerSettings.Android.targetArchitectures}, "
-                + $"{PlayerSettings.GetScriptingBackend(NamedBuildTarget.Android)}.");
+            var architectures = PlayerSettings.Android.targetArchitectures;
+            var backend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.Android);
+
+            // `None` is the flags enum's empty set, and an empty set is not a
+            // reading Core should have to know Unity's spelling of.
+            var applied = architectures == AndroidArchitecture.None
+                ? string.Empty
+                : architectures.ToString();
+
+            Debug.Log($"Android build profile: {profile} — {architectures}, {backend}.");
+
+            // And then fail on it, rather than only logging it. Reading the
+            // values back was already the right instinct; a log line is only
+            // read once someone is already looking for the failure. Unity's own
+            // complaint arrives much later, from the prerequisites check, and
+            // says "Target architecture not specified" without naming the
+            // profile, the architecture, or the backend that emptied it (#282).
+            var problem = AndroidBuildSupport.AppliedProblem(profile, applied, backend.ToString());
+
+            if (problem != null)
+            {
+                throw new BuildFailedException(
+                    $"The '{profile}' Android build profile did not take. {problem}");
+            }
         }
 
         static void ApplyApplicationIdSuffix()

--- a/Assets/Scripts/Core/AndroidBuildSupport.cs
+++ b/Assets/Scripts/Core/AndroidBuildSupport.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// Which Android architecture and scripting-backend pairings Unity can
+    /// actually build, and whether the settings a build asked for took.
+    ///
+    /// **Unity has no Mono for 64-bit Android.** The Mono backend compiles at
+    /// runtime, with a JIT, and that JIT is not supported on 64-bit Android —
+    /// so `ARM64` and `x86_64` are IL2CPP-only (Unity Manual, "Mono scripting
+    /// backend" and "IL2CPP Overview").
+    ///
+    /// Asking for the unsupported pairing anyway does not produce an error at
+    /// the point of asking. Unity drops the architecture it cannot build,
+    /// `PlayerSettings.Android.targetArchitectures` is left holding nothing,
+    /// and the build dies much later, at the prerequisites check, saying
+    /// *"Target architecture not specified"* — which names neither the
+    /// architecture nor the backend that caused it. That is how the emulator
+    /// profile (x86_64 + Mono) got as far as a release before anyone saw it:
+    /// issue #282, release v0.2.0.
+    ///
+    /// So the pairing is checked here, in plain C# with no editor in sight, and
+    /// <see cref="AppliedProblem"/> re-checks what the editor really ended up
+    /// with. Strings rather than Unity's enums, because this assembly does not
+    /// reference UnityEngine — the caller in `Assets/Editor` converts.
+    ///
+    /// See docs/engineering/tech-stack.md#two-build-profiles.
+    /// </summary>
+    public static class AndroidBuildSupport
+    {
+        /// <summary>Unity's name for the ahead-of-time backend.</summary>
+        public const string Il2Cpp = "IL2CPP";
+
+        /// <summary>
+        /// The 64-bit Android architectures, spelled as Unity's
+        /// `AndroidArchitecture` members are.
+        /// </summary>
+        static readonly string[] SixtyFourBit = { "ARM64", "X86_64" };
+
+        /// <summary>
+        /// Whether this architecture can only be built with IL2CPP.
+        /// </summary>
+        public static bool RequiresIl2Cpp(string architecture) =>
+            IndexOf(SixtyFourBit, Clean(architecture)) >= 0;
+
+        /// <summary>
+        /// What is wrong with building <paramref name="architectures"/> with
+        /// <paramref name="scriptingBackend"/>, or null if nothing is.
+        ///
+        /// <paramref name="architectures"/> may name several, comma-separated,
+        /// the way a flags enum prints itself: "ARM64, X86_64".
+        /// </summary>
+        public static string PairingProblem(string architectures, string scriptingBackend)
+        {
+            if (IsIl2Cpp(scriptingBackend))
+            {
+                return null;
+            }
+
+            var unsupported = new List<string>();
+
+            foreach (var architecture in Split(architectures))
+            {
+                if (RequiresIl2Cpp(architecture))
+                {
+                    unsupported.Add(architecture);
+                }
+            }
+
+            if (unsupported.Count == 0)
+            {
+                return null;
+            }
+
+            return $"{string.Join(", ", unsupported.ToArray())} is 64-bit Android, "
+                + $"which Unity builds with {Il2Cpp} only — the "
+                + $"{Clean(scriptingBackend)} backend has no 64-bit JIT. Unity "
+                + "does not refuse this pairing; it drops the architecture and "
+                + "then fails the build with \"Target architecture not "
+                + "specified\". See issue #282.";
+        }
+
+        /// <summary>
+        /// What is wrong with the settings a build ended up with, or null.
+        ///
+        /// Called with what the editor reports *after* the profile was applied,
+        /// not with what was asked for. An empty
+        /// <paramref name="architectures"/> means Unity kept none of them,
+        /// which is the failure this whole type exists to name.
+        /// </summary>
+        public static string AppliedProblem(
+            string profile, string architectures, string scriptingBackend)
+        {
+            if (!string.IsNullOrWhiteSpace(architectures))
+            {
+                return PairingProblem(architectures, scriptingBackend);
+            }
+
+            return $"The '{Clean(profile)}' Android build profile left no target "
+                + $"architecture set at all, with the {Clean(scriptingBackend)} "
+                + "scripting backend. Unity silently drops an architecture that "
+                + "backend cannot build, so an empty set here means the profile "
+                + "asked for something impossible. See issue #282.";
+        }
+
+        static bool IsIl2Cpp(string scriptingBackend) =>
+            string.Equals(Clean(scriptingBackend), Il2Cpp, StringComparison.OrdinalIgnoreCase);
+
+        static IEnumerable<string> Split(string architectures)
+        {
+            foreach (var part in (architectures ?? string.Empty).Split(','))
+            {
+                var cleaned = Clean(part);
+
+                if (cleaned.Length > 0)
+                {
+                    yield return cleaned;
+                }
+            }
+        }
+
+        static int IndexOf(string[] names, string value)
+        {
+            for (var index = 0; index < names.Length; index++)
+            {
+                if (string.Equals(names[index], value, StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        static string Clean(string value) => (value ?? string.Empty).Trim();
+    }
+}

--- a/Assets/Scripts/Core/AndroidBuildSupport.cs.meta
+++ b/Assets/Scripts/Core/AndroidBuildSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ac39376257b4984aacfd9c63e5c15e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/AndroidBuildProfileTests.cs
+++ b/Assets/Tests/EditMode/AndroidBuildProfileTests.cs
@@ -1,0 +1,119 @@
+using System;
+using Frogs.EditorTools;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The device/emulator split, applied by the build rather than promised by
+    /// a doc — docs/engineering/tech-stack.md#two-build-profiles.
+    ///
+    /// The emulator profile used to ask for x86_64 with the Mono backend, which
+    /// Unity cannot build: there is no Mono JIT for 64-bit Android, so the
+    /// editor dropped the architecture, kept nothing, and failed the build at
+    /// its prerequisites check with "Target architecture not specified". It
+    /// took the v0.2.0 release's APKs with it (issue #282).
+    ///
+    /// `AndroidBuildSupportTests` in the Core suite covers the rule itself in
+    /// two seconds with no editor. These are the other half: that the profiles
+    /// this project actually ships obey it, read back out of `PlayerSettings`
+    /// after the pre-processor has run.
+    /// </summary>
+    public sealed class AndroidBuildProfileTests
+    {
+        const string ProfileVariable = BuildInputs.AndroidProfileVariable;
+        const string BuildShaVariable = BuildInputs.BuildShaVariable;
+        const string VersionCodeVariable = BuildInputs.VersionCodeVariable;
+
+        string previousProfile;
+        string previousSha;
+        string previousVersionCode;
+
+        [SetUp]
+        public void StampADebugBuildWithoutTouchingGit()
+        {
+            // As in ProjectIdentityTests: the pre-processor stamps a version
+            // before it reaches the profile, and the debug path needs both of
+            // these so nothing shells out to git. The environment rather than
+            // the command line, because a test cannot change the process's
+            // arguments — in CI these ride Unity's command line instead.
+            previousProfile = Environment.GetEnvironmentVariable(ProfileVariable);
+            previousSha = Environment.GetEnvironmentVariable(BuildShaVariable);
+            previousVersionCode = Environment.GetEnvironmentVariable(VersionCodeVariable);
+
+            Environment.SetEnvironmentVariable(BuildShaVariable, "abc1234");
+            Environment.SetEnvironmentVariable(VersionCodeVariable, "1");
+        }
+
+        [TearDown]
+        public void RestoreTheEnvironment()
+        {
+            Environment.SetEnvironmentVariable(ProfileVariable, previousProfile);
+            Environment.SetEnvironmentVariable(BuildShaVariable, previousSha);
+            Environment.SetEnvironmentVariable(VersionCodeVariable, previousVersionCode);
+        }
+
+        [Test]
+        public void TheEmulatorProfileBuildsX86_64WithIl2Cpp()
+        {
+            Environment.SetEnvironmentVariable(ProfileVariable, "emulator");
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            // Sequential rather than Assert.Multiple: the NUnit inside the
+            // Unity Test Framework has none.
+            Assert.That(
+                PlayerSettings.Android.targetArchitectures,
+                Is.EqualTo(AndroidArchitecture.X86_64));
+            Assert.That(
+                PlayerSettings.GetScriptingBackend(NamedBuildTarget.Android),
+                Is.EqualTo(ScriptingImplementation.IL2CPP));
+        }
+
+        [Test]
+        public void TheDeviceProfileBuildsArm64WithIl2Cpp()
+        {
+            Environment.SetEnvironmentVariable(ProfileVariable, "device");
+
+            new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+            Assert.That(
+                PlayerSettings.Android.targetArchitectures,
+                Is.EqualTo(AndroidArchitecture.ARM64));
+            Assert.That(
+                PlayerSettings.GetScriptingBackend(NamedBuildTarget.Android),
+                Is.EqualTo(ScriptingImplementation.IL2CPP));
+        }
+
+        [Test]
+        public void NeitherProfileLeavesTheBuildWithNoArchitectureAtAll()
+        {
+            // The shape of the v0.2.0 failure. An empty set is what Unity is
+            // left holding when a profile asks for something it cannot build,
+            // and the pre-processor now refuses to hand that on to the build.
+            foreach (var profile in new[] { "device", "emulator" })
+            {
+                Environment.SetEnvironmentVariable(ProfileVariable, profile);
+
+                new BuildStampPreprocessor().OnPreprocessBuild(null);
+
+                Assert.That(
+                    PlayerSettings.Android.targetArchitectures,
+                    Is.Not.EqualTo(AndroidArchitecture.None),
+                    $"the '{profile}' profile left no target architecture set");
+            }
+        }
+
+        [Test]
+        public void AProfileNameTheBuildDoesNotKnowFailsRatherThanGuessing()
+        {
+            Environment.SetEnvironmentVariable(ProfileVariable, "tablet");
+
+            Assert.That(
+                () => new BuildStampPreprocessor().OnPreprocessBuild(null),
+                Throws.TypeOf<ArgumentException>());
+        }
+    }
+}

--- a/Assets/Tests/EditMode/AndroidBuildProfileTests.cs.meta
+++ b/Assets/Tests/EditMode/AndroidBuildProfileTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 855a5ecd6f5f44e09b3d7eca090cf680
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Core/AndroidBuildSupportTests.cs
+++ b/Tests/Core/AndroidBuildSupportTests.cs
@@ -1,0 +1,129 @@
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// The rule that broke the v0.2.0 release: Unity has no Mono for 64-bit
+    /// Android, and asking for it anyway produces no error where the asking
+    /// happens — just a build that dies later with "Target architecture not
+    /// specified" (issue #282).
+    ///
+    /// These run without an editor, which is the point: the pairing is checked
+    /// where a two-second test can check it, rather than sixteen minutes into a
+    /// release build.
+    /// </summary>
+    public sealed class AndroidBuildSupportTests
+    {
+        [Test]
+        public void SixtyFourBitArchitecturesCannotBeBuiltWithMono()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("X86_64", "Mono2x"),
+                Does.Contain("IL2CPP"));
+        }
+
+        [Test]
+        public void TheTabletsArchitectureCannotBeBuiltWithMonoEither()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("ARM64", "Mono2x"),
+                Does.Contain("IL2CPP"));
+        }
+
+        [Test]
+        public void TheEmulatorPairingTheProjectNowUsesIsFine()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("X86_64", "IL2CPP"),
+                Is.Null);
+        }
+
+        [Test]
+        public void TheDevicePairingIsFine()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("ARM64", "IL2CPP"),
+                Is.Null);
+        }
+
+        [Test]
+        public void ThirtyTwoBitAndroidStillHasAMonoBackend()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("ARMv7", "Mono2x"),
+                Is.Null);
+        }
+
+        [Test]
+        public void AFlagsEnumPrintsSeveralArchitecturesAtOnceAndEachIsChecked()
+        {
+            var problem = AndroidBuildSupport.PairingProblem("ARMv7, X86_64", "Mono2x");
+
+            Assert.That(problem, Does.Contain("X86_64"));
+            Assert.That(problem, Does.Not.Contain("ARMv7"));
+        }
+
+        [Test]
+        public void TheProblemNamesTheBackendThatCannotBuildIt()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem("X86_64", "Mono2x"),
+                Does.Contain("Mono2x"));
+        }
+
+        [Test]
+        public void OnlyTheAheadOfTimeBackendCanBuildSixtyFourBit()
+        {
+            Assert.That(AndroidBuildSupport.RequiresIl2Cpp("ARM64"), Is.True);
+            Assert.That(AndroidBuildSupport.RequiresIl2Cpp("X86_64"), Is.True);
+            Assert.That(AndroidBuildSupport.RequiresIl2Cpp("ARMv7"), Is.False);
+            Assert.That(AndroidBuildSupport.RequiresIl2Cpp("X86"), Is.False);
+        }
+
+        [Test]
+        public void AnEmptyArchitectureSetIsTheFailureItself()
+        {
+            // What the editor reports back when it has dropped everything the
+            // profile asked for. Unity's own message at this point names
+            // neither the architecture nor the backend.
+            var problem = AndroidBuildSupport.AppliedProblem("emulator", "", "Mono2x");
+
+            Assert.That(problem, Is.Not.Null);
+            Assert.That(problem, Does.Contain("emulator"));
+            Assert.That(problem, Does.Contain("Mono2x"));
+        }
+
+        [Test]
+        public void AnAppliedProfileThatKeptItsArchitectureIsStillPairChecked()
+        {
+            Assert.That(
+                AndroidBuildSupport.AppliedProblem("emulator", "X86_64", "Mono2x"),
+                Does.Contain("IL2CPP"));
+        }
+
+        [Test]
+        public void AnAppliedProfileThatIsWhatItAskedForHasNoProblem()
+        {
+            Assert.That(
+                AndroidBuildSupport.AppliedProblem("emulator", "X86_64", "IL2CPP"),
+                Is.Null);
+        }
+
+        [Test]
+        public void SurroundingWhitespaceDoesNotHideAnUnsupportedPairing()
+        {
+            Assert.That(
+                AndroidBuildSupport.PairingProblem(" X86_64 ", " Mono2x "),
+                Does.Contain("IL2CPP"));
+        }
+
+        [Test]
+        public void NothingAppliedAtAllReadsAsNothingApplied()
+        {
+            Assert.That(
+                AndroidBuildSupport.AppliedProblem("emulator", null, "IL2CPP"),
+                Is.Not.Null);
+        }
+    }
+}

--- a/docs/engineering/ci-cd.md
+++ b/docs/engineering/ci-cd.md
@@ -385,7 +385,7 @@ permanent.
 | Asset | Profile | For |
 | --- | --- | --- |
 | `multiplying-frogs-0.2.0.apk` | ARM64, IL2CPP | the phone |
-| `multiplying-frogs-0.2.0-emulator.apk` | x86_64, Mono | a desktop emulator |
+| `multiplying-frogs-0.2.0-emulator.apk` | x86_64, IL2CPP | a desktop emulator |
 
 They are built into `build/device/` and `build/emulator/` rather than a shared
 directory. The two have the same version and differ only in architecture, which
@@ -447,13 +447,57 @@ table:
 | the two files are not byte-identical | two profiles cannot produce one file |
 | device has `arm64-v8a` and nothing else | the tablet's architecture, alone |
 | emulator has `x86_64` and nothing else | an ARM64 APK will not install on an x86_64 emulator |
-| device ships `libil2cpp.so`, emulator does not | the profile is a backend as well as an architecture |
+| both ship `libil2cpp.so` | 64-bit Android has no Mono, so an APK without it was built for a pairing Unity cannot build ([#282](https://github.com/derekwinters/connor-multiplying-frogs/issues/282)) |
 
 It runs **before** the attach step, so a release that failed it gets no assets
 rather than the wrong ones. That is the right way round: a bad APK attached to
 a tag is a failure that surfaces on someone else's machine, days later, with no
 build log anywhere near it, while a release missing its APKs is a backfill this
 workflow already knows how to do.
+
+It is skipped in exactly one case: when only one of the two APKs exists, so
+there is no pair to compare. Attaching a single, correctly named device APK is
+not the mislabelling this gate protects against; attaching two identical files
+still is, and that stays strict.
+
+#### A failed emulator build does not cost the release its device APK
+
+The emulator build carries `continue-on-error`, and the device build does not.
+Until `v0.2.0` neither did, and the consequence was the worst available
+outcome: the emulator build failed, the job stopped, the attach step three
+steps below never ran, and the release was **published with nothing on it** —
+while a perfectly good device APK sat on the runner until it was deleted
+(#282).
+
+So the job now finishes what it can:
+
+| | |
+| --- | --- |
+| Device build fails | the job stops. The device APK *is* the release. |
+| Emulator build fails | the device APK is still checked and attached |
+| Only one APK attached | a `::warning::` and a line in the job summary saying the release is incomplete |
+| Emulator build failed | the last step re-raises it, so the **run is still red** |
+
+The last row is the one that stops this being a papering-over. Attaching what
+built must not turn a broken build green, because a half-filled release nobody
+is told about is how the next release ships the same way. The run goes red
+*after* the attach, not instead of it.
+
+`.github/scripts/tests/test_release_partial_attach.py` asserts that shape:
+which build may continue on error and which may not, that something downstream
+reads the emulator step's `outcome` and fails on it, that the two-APK
+comparison is still invoked with both APKs, and that a partial attach warns.
+
+#### Backfilling a release that missed its APKs
+
+`workflow_dispatch` takes the tag as an **input**, and the checkout uses it:
+the build is of the source at that tag, exactly as released. The *workflow
+file* is a different matter — Actions runs the version of it that lives at the
+ref the dispatch was made against. So dispatching from `main` with
+`tag: v0.2.0` builds v0.2.0's source using today's workflow, which is what
+makes a backfill able to rescue a release whose failure was in the workflow
+rather than in the code. A fix that lives in the source at `main` does **not**
+reach a backfill of an older tag; only the next release gets it.
 
 Both are **attached to the GitHub release** rather than left as workflow
 artifacts, so the tag and the thing you install are one object. A release whose

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -60,7 +60,7 @@ around, because that is what kids play on.
 | --- | --- |
 | Primary target | Android tablets, ARM64 (`arm64-v8a`) |
 | Also runs on | Android phones |
-| Scripting backend | IL2CPP for device builds |
+| Scripting backend | IL2CPP — 64-bit Android has no other option |
 | Minimum API level | 24 (Android 7.0) |
 | Orientation | Landscape only (both ways up) |
 | Reference resolution | 1920 × 1200 (16:10) |
@@ -88,16 +88,46 @@ designed against one agreed canvas instead of each being guessed at separately.
 phone. This is what the release build produces, and what an RC build has to
 prove works.
 
-**Emulator build** — x86_64, Mono. IL2CPP cross-compiling to x86_64 is slow and
-buys nothing for a smoke test, so the emulator profile trades fidelity for a
-build that finishes while you are still looking at it. Use it for "does the app
-launch and show the right screen", never for judging performance or for anything
-shipped.
+**Emulator build** — x86_64, IL2CPP, for trying the game on a desktop emulator.
+Use it for "does the app launch and show the right screen", never for judging
+performance or for anything shipped.
 
 CI builds both: the device profile is what the release ships, and an
 emulator-targeted asset is attached alongside it so the release can be tried on
 a desktop without rebuilding. A bug that reproduces only under the emulator is a
 bug in the profile until proven otherwise.
+
+#### Both profiles are IL2CPP, and that is not a preference
+
+This page used to specify **x86_64 with Mono** for the emulator, on the
+reasoning that IL2CPP cross-compiling to x86_64 is slow and buys nothing for a
+smoke test. The reasoning about speed was right. The pairing was impossible.
+
+**Unity has no Mono for 64-bit Android.** The Mono backend compiles at runtime
+with a JIT, and that JIT is not supported on 64-bit Android, so `ARM64` and
+`x86_64` are both IL2CPP-only (Unity Manual: *Mono scripting backend*, *IL2CPP
+Overview*). Mono remains available for the 32-bit architectures, which this
+project does not build.
+
+Asking for it anyway fails in the worst possible way: nothing objects at the
+point of asking. Unity drops the architecture it cannot build, leaves
+`targetArchitectures` holding nothing, and the build dies much later with
+*"Target architecture not specified"* — a message that names neither the
+architecture nor the backend. That is what happened to the `v0.2.0` release
+(#282), the first time the emulator profile had ever actually reached a build.
+
+The emulator is x86_64, so x86_64 is the part that could not move. A slower
+emulator build is the price, and two guards keep the pairing from drifting
+back:
+
+- **`Frogs.Core.AndroidBuildSupport`** knows which architectures are 64-bit and
+  refuses to pair them with anything but IL2CPP. `BuildStampPreprocessor` reads
+  the settings back out of `PlayerSettings` after applying a profile and fails
+  the build — loudly, naming the profile — if the architecture set came back
+  empty or the pairing is one Unity cannot build. It is plain C#, so the rule is
+  covered by the two-second Core suite rather than by a release.
+- **`.github/scripts/check_release_apks.py`** opens both APKs before either is
+  attached and requires `libil2cpp.so` in each.
 
 ### The settings above are applied by the build, not stored in the repo
 


### PR DESCRIPTION
Closes #282

The emulator APK asked Unity for something Unity cannot do — an x86_64 build using the Mono scripting backend — and Unity's way of saying so was to quietly build nothing and then complain, much later, that no architecture had been chosen. The emulator profile now uses IL2CPP, the build stops with a message that actually names the problem if a profile ever fails to take again, and a release that only manages to build one of its two APKs now gets that one attached instead of getting nothing at all.

**Docs:** `docs/engineering/tech-stack.md` — the emulator profile is x86_64 + **IL2CPP**, not x86_64 + Mono, with a new subsection saying why the backend is not a preference (64-bit Android has no Mono). `docs/engineering/ci-cd.md` — the release asset table and the two-APK check table follow the backend change; two new subsections describe what happens when only one APK builds, and what a `workflow_dispatch` backfill can and cannot fix.

## Spec invariants

| Rule kept true | The test that asserts it |
| --- | --- |
| The two release assets are two different builds, never one file twice (#218) | `test_check_release_apks.py` — the byte-identical, ABI and backend cases; the comparison still runs, strict, whenever both APKs exist |
| The device APK is the release; a release without it is not a release | `test_release_partial_attach.py::test_a_failed_device_build_still_aborts_the_job` |
| An unrecognised profile name fails the build rather than guessing an architecture | `AndroidBuildProfileTests::AProfileNameTheBuildDoesNotKnowFailsRatherThanGuessing` (EditMode) |
| A build that asked for a profile must not proceed with no architecture set | `AndroidBuildSupportTests::AnEmptyArchitectureSetIsTheFailureItself` (Core), and `NeitherProfileLeavesTheBuildWithNoArchitectureAtAll` (EditMode) |
| Core stays engine-free — the new rule is plain C# | `check_core_isolation.py` |

## How the spec is changing

**Old rule** (`tech-stack.md`): the emulator profile is *x86_64, Mono* — "IL2CPP cross-compiling to x86_64 is slow and buys nothing for a smoke test, so the emulator profile trades fidelity for a build that finishes while you are still looking at it."

**New rule**: the emulator profile is *x86_64, IL2CPP*, and both profiles are IL2CPP because 64-bit Android has no other option.

**Why**: the old rule's reasoning about build speed was correct, and the pairing was still impossible. Unity's Mono backend compiles at runtime with a JIT, and that JIT is not supported on 64-bit Android, so ARM64 and x86_64 are IL2CPP-only (Unity Manual: *Mono scripting backend*, *IL2CPP Overview*). Derek verified this against Unity's documentation before this change; our own builds corroborate it — the `device` profile (ARM64 + IL2CPP) builds, the `emulator` profile (x86_64 + Mono2x) came back with an empty architecture set. Since the emulator *is* x86_64, the backend was the part that had to move. A slower emulator build is the price of one that exists.

A second, smaller move: the release job used to treat "either APK failed" as "attach neither". It now treats the device APK as the release and the emulator APK as an extra — a failed emulator build no longer takes the good APK down with it, but it does still turn the run red, after the attach.

## Deviations and Decisions

- **The two-APK comparison is skipped in exactly one case** — when only one of the two APKs exists, so there is no pair to compare. It stays strict whenever both are present, which is the case #218 was about. The alternative, running it against a missing file, only ever produces "no APK at …", which the attach step says better.
- **A failed emulator build still fails the job, in a step after the attach.** `continue-on-error` on its own would have made a half-filled release a green run. Attaching first and failing last gets both: the release keeps what built, and the run is visibly red.
- **The pairing rule went into `Frogs.Core` (`AndroidBuildSupport`) rather than into the editor script**, so the rule that caused this is covered by the two-second Core suite instead of only by a sixteen-minute release build. The editor script converts Unity's enums to strings at the boundary; Core references no UnityEngine type.
- **`profile_problems()` in `check_release_apks.py` lost its `il2cpp` parameter.** Both profiles are IL2CPP now, so the "this profile is Mono and must not ship libil2cpp.so" branch was unreachable code that would have read as a live rule.
- **Not done: confirming a green `release-build` run** (issue checklist, box 5). It needs a release, or a dispatch against a tag built from this code, and neither exists yet.
- **Not done: rescuing v0.2.0 from within this PR.** `release-build` checks out `ref: inputs.tag`, so a backfill rebuilds v0.2.0's source, which still has the Mono profile — the emulator build will fail there again. The workflow half of this PR is what lets that run attach the device APK anyway, and it applies to a backfill because Actions runs the workflow file from the ref the dispatch is made against. **That means dispatching from `main` with `tag: v0.2.0`** — dispatching against the `v0.2.0` tag itself would run the old workflow file and abort exactly as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_