### PR TITLE
fix(app): build and show the game at runtime, so the app is not a blank screen

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,21 +149,3 @@ jobs:
           path: artifacts
           if-no-files-found: warn
           retention-days: 14
-
-      # TEMPORARY — #285. Reverted before merge. The artifact is unreachable
-      # from an agent environment and the API serves only the log's tail, so
-      # the failing test's name is printed last and small enough to survive it.
-      - name: TEMPORARY name the failures
-        if: always()
-        run: |
-          python3 - <<'PY'
-          import xml.etree.ElementTree as ET
-          root = ET.parse("artifacts/editmode-results.xml").getroot()
-          for case in root.iter("test-case"):
-              if case.get("result") == "Failed":
-                  print("FAILED:", case.get("fullname"))
-                  for tag in ("message", "stack-trace"):
-                      node = case.find("failure/" + tag)
-                      if node is not None and node.text:
-                          print(tag, ">>", node.text.strip()[:900])
-          PY

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,3 +149,21 @@ jobs:
           path: artifacts
           if-no-files-found: warn
           retention-days: 14
+
+      # TEMPORARY — #285. Reverted before merge. The artifact is unreachable
+      # from an agent environment and the API serves only the log's tail, so
+      # the failing test's name is printed last and small enough to survive it.
+      - name: TEMPORARY name the failures
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("artifacts/editmode-results.xml").getroot()
+          for case in root.iter("test-case"):
+              if case.get("result") == "Failed":
+                  print("FAILED:", case.get("fullname"))
+                  for tag in ("message", "stack-trace"):
+                      node = case.find("failure/" + tag)
+                      if node is not None and node.text:
+                          print(tag, ">>", node.text.strip()[:900])
+          PY

--- a/Assets/Scripts/Unity/AppRoot.cs
+++ b/Assets/Scripts/Unity/AppRoot.cs
@@ -1,0 +1,715 @@
+using System;
+using Frogs.Core;
+using Frogs.Unity.Views;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using CoreScreen = Frogs.Core.Screen;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The one thing that puts a screen on screen — issue #285.
+    ///
+    /// Every screen and dialog in the v0.2 proof of concept was built and
+    /// tested before this existed, and none of them was ever constructed
+    /// outside a test, so the installed app cleared the camera to its
+    /// background colour and stopped. This type is the seam between "the game
+    /// is built" and "the game runs": it makes the canvas, makes the views,
+    /// hands each one the router and the <see cref="Game"/> it reads, and
+    /// connects the events they already raise to the calls they already
+    /// expect.
+    ///
+    /// **It decides nothing about the game.** There is no rule here: no
+    /// grading, no movement, no turn order, no wording. Every branch below is
+    /// either "which view is shown next" — which #213's <see cref="ScreenRouter"/>
+    /// owns and this only reacts to — or a phase call Core's own
+    /// <see cref="TurnPhase"/> machine requires in that order.
+    ///
+    /// **There is no scene edit, and deliberately so.** The entry point is
+    /// <see cref="BootTheApp"/>, a <c>[RuntimeInitializeOnLoadMethod]</c> hook
+    /// that does nothing but call <see cref="Create"/>.
+    /// <c>Assets/Scenes/Game.unity</c> stays exactly what #209 committed — one
+    /// camera, no MonoBehaviour — because a component reference in a scene is a
+    /// GUID that turns into a silent *Missing Script* if a <c>.meta</c> drifts,
+    /// and because hand-authoring scene YAML is what
+    /// docs/engineering/unity-serialization.md exists to forbid. Nothing on
+    /// this type is serialized: it is built at runtime, saved into no asset,
+    /// and every field below is deliberately not a <c>[SerializeField]</c>.
+    ///
+    /// **Every view is asked to build itself here, up front.** Unity does not
+    /// run <c>Awake</c> on a child of an inactive object, and eight of the nine
+    /// roots are inactive at boot, so each view's own <c>EnsureInitialized</c>
+    /// guard is prodded through its public surface rather than left to
+    /// lifecycle timing — the same reasoning the views themselves record.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    [RequireComponent(typeof(Canvas))]
+    [RequireComponent(typeof(CanvasScaler))]
+    [RequireComponent(typeof(GraphicRaycaster))]
+    public sealed class AppRoot : MonoBehaviour
+    {
+        /// <summary>
+        /// The canvas every screen and every shared component is measured in —
+        /// docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in
+        /// and docs/engineering/tech-stack.md#target-platform. The
+        /// <see cref="CanvasScaler"/> is set to exactly this, so a constant on
+        /// a spec page is the constant the code lays out with.
+        /// </summary>
+        public const float ReferenceWidth = 1920f;
+
+        /// <summary>The other half of the reference resolution: 1920 x 1200, 16:10, landscape.</summary>
+        public const float ReferenceHeight = 1200f;
+
+        /// <summary>What the running app's one root object is called in the hierarchy.</summary>
+        public const string AppRootObjectName = "Multiplying Frogs";
+
+        const string EventSystemObjectName = "EventSystem";
+        const string ScreensObjectName = "Screens";
+
+        RectTransform _rect;
+        Canvas _canvas;
+        CanvasScaler _scaler;
+        EventSystem _eventSystem;
+        ScreenRouterAdapter _screens;
+        ScreenRouter _router;
+
+        TitleScreenView _titleScreen;
+        GameSetupScreenView _gameSetup;
+        GameBoardScreenView _board;
+        GameOverScreenView _gameOver;
+        RollAndCardDialogView _rollAndCard;
+        WorkingOutGridView _workingOutGrid;
+        AnswerResultDialogView _answerResult;
+        SettingsDialogView _settings;
+        EndGameConfirmView _endGameConfirm;
+
+        Game _game;
+        GameWorkingOutTurn _turn;
+
+        CoreScreen _shownScreen;
+        Dialog? _shownDialog;
+
+        bool _initialized;
+
+        /// <summary>The Core router every screen navigates through.</summary>
+        public ScreenRouter Router
+        {
+            get
+            {
+                Initialize();
+                return _router;
+            }
+        }
+
+        /// <summary>The one canvas, in screen-space overlay.</summary>
+        public Canvas Canvas
+        {
+            get
+            {
+                Initialize();
+                return _canvas;
+            }
+        }
+
+        /// <summary>The scaler holding the 1920 x 1200 reference resolution.</summary>
+        public CanvasScaler CanvasScaler
+        {
+            get
+            {
+                Initialize();
+                return _scaler;
+            }
+        }
+
+        /// <summary>The event system, without which no tap reaches any button.</summary>
+        public EventSystem EventSystem
+        {
+            get
+            {
+                Initialize();
+                return _eventSystem;
+            }
+        }
+
+        /// <summary>The [title screen](docs/specs/ui/title-screen.md) — the screen the app opens on.</summary>
+        public TitleScreenView TitleScreen
+        {
+            get
+            {
+                Initialize();
+                return _titleScreen;
+            }
+        }
+
+        /// <summary>[Game setup](docs/specs/ui/game-setup.md).</summary>
+        public GameSetupScreenView GameSetup
+        {
+            get
+            {
+                Initialize();
+                return _gameSetup;
+            }
+        }
+
+        /// <summary>[The game board](docs/specs/ui/game-board.md).</summary>
+        public GameBoardScreenView Board
+        {
+            get
+            {
+                Initialize();
+                return _board;
+            }
+        }
+
+        /// <summary>[Game over](docs/specs/ui/game-over.md).</summary>
+        public GameOverScreenView GameOver
+        {
+            get
+            {
+                Initialize();
+                return _gameOver;
+            }
+        }
+
+        /// <summary>[Roll and card](docs/specs/ui/roll-and-card.md).</summary>
+        public RollAndCardDialogView RollAndCard
+        {
+            get
+            {
+                Initialize();
+                return _rollAndCard;
+            }
+        }
+
+        /// <summary>[The working-out grid](docs/specs/ui/working-out-grid.md).</summary>
+        public WorkingOutGridView WorkingOutGrid
+        {
+            get
+            {
+                Initialize();
+                return _workingOutGrid;
+            }
+        }
+
+        /// <summary>[Answer result](docs/specs/ui/answer-result.md).</summary>
+        public AnswerResultDialogView AnswerResult
+        {
+            get
+            {
+                Initialize();
+                return _answerResult;
+            }
+        }
+
+        /// <summary>[The settings dialog](docs/specs/ui/settings-dialog.md).</summary>
+        public SettingsDialogView Settings
+        {
+            get
+            {
+                Initialize();
+                return _settings;
+            }
+        }
+
+        /// <summary>[The end-game confirm](docs/specs/ui/end-game-confirm.md).</summary>
+        public EndGameConfirmView EndGameConfirm
+        {
+            get
+            {
+                Initialize();
+                return _endGameConfirm;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Game"/> this session is playing, or null before the
+        /// first one is started. One instance is held for as long as it is
+        /// being played, so the board, every dialog and the standings all read
+        /// the same game rather than each asking a different copy.
+        /// </summary>
+        public Game CurrentGame
+        {
+            get { return _game; }
+        }
+
+        /// <summary>
+        /// Builds the whole running app and returns its root. The app's one
+        /// object: the canvas, the event system, the router's screen roots, and
+        /// a view under each of them.
+        /// </summary>
+        public static AppRoot Create()
+        {
+            // The canvas parts are named at construction rather than left to
+            // [RequireComponent], so the Transform is replaced by a
+            // RectTransform the same explicit way every view in this assembly
+            // does it.
+            var host = new GameObject(
+                AppRootObjectName,
+                typeof(RectTransform),
+                typeof(Canvas),
+                typeof(CanvasScaler),
+                typeof(GraphicRaycaster));
+
+            var root = host.AddComponent<AppRoot>();
+
+            // Awake has already run this in a player; in an edit-mode session
+            // it has not run at all. The guard inside makes the second call
+            // free either way.
+            root.Initialize();
+
+            return root;
+        }
+
+        /// <summary>
+        /// Where a brand-new <see cref="Game"/>'s seed comes from. Defaults to
+        /// the source <c>GameSetupScreenView</c> and <c>GameOverScreenView</c>
+        /// each default to — the Unity layer is where real-world entropy enters
+        /// the system, and <c>Frogs.Core</c> still never reads a clock. Handing
+        /// in a fixed source is how a test gets the same deal twice.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="seedFactory"/> is null.</exception>
+        public void UseSeed(Func<ulong> seedFactory)
+        {
+            Initialize();
+
+            if (seedFactory == null)
+            {
+                throw new ArgumentNullException(nameof(seedFactory));
+            }
+
+            // Both screens that start a game read it, and both take it the same
+            // way — see GameSetupScreenView.Initialize.
+            _gameSetup.Initialize(_router, seedFactory);
+            _gameOver.Initialize(_router, seedFactory);
+        }
+
+        /// <summary>
+        /// The root <c>GameObject</c> a screen's view lives under — active only
+        /// while that screen is current.
+        /// </summary>
+        public GameObject RootFor(CoreScreen screen)
+        {
+            Initialize();
+            return _screens.RootFor(screen);
+        }
+
+        /// <summary>The root <c>GameObject</c> a dialog's view lives under.</summary>
+        public GameObject RootFor(Dialog dialog)
+        {
+            Initialize();
+            return _screens.RootFor(dialog);
+        }
+
+        /// <summary>
+        /// What the hardware back key does, for every screen and every dialog:
+        /// #213's back-button table, run by the router adapter. A public method
+        /// of its own so an EditMode test can press back without simulating a
+        /// key.
+        /// </summary>
+        public void HandleBackButton()
+        {
+            Initialize();
+            _screens.HandleBackButton();
+        }
+
+        /// <summary>
+        /// Builds and wires everything. Idempotent, and every public entry
+        /// point above funnels through it, for the reason every view in this
+        /// assembly records: Unity does not guarantee <c>Awake</c> has run
+        /// before something else reaches this component, and in an edit-mode
+        /// session it never runs at all.
+        /// </summary>
+        public void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+
+            BuildCanvas();
+            BuildEventSystem();
+            BuildScreenRoots();
+            BuildViews();
+            Wire();
+        }
+
+        void Awake()
+        {
+            Initialize();
+        }
+
+        void Update()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            AdvanceCurrentDialogsFade(Time.deltaTime);
+        }
+
+        // The app's entry point, and the whole of it. Everything it could
+        // usefully say is in Initialize, which an EditMode test can call;
+        // a lifecycle hook is not testable without a player, so nothing lives
+        // in here that would benefit from being.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        static void BootTheApp()
+        {
+            Create();
+        }
+
+        // --- Building ----------------------------------------------------------
+
+        void BuildCanvas()
+        {
+            _rect = GetComponent<RectTransform>();
+            if (_rect == null)
+            {
+                _rect = gameObject.AddComponent<RectTransform>();
+            }
+
+            _canvas = GetComponent<Canvas>();
+            if (_canvas == null)
+            {
+                _canvas = gameObject.AddComponent<Canvas>();
+            }
+
+            // Overlay, so the canvas needs no camera of its own and draws over
+            // whatever the scene's camera cleared to.
+            _canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            _scaler = GetComponent<CanvasScaler>();
+            if (_scaler == null)
+            {
+                _scaler = gameObject.AddComponent<CanvasScaler>();
+            }
+
+            _scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            _scaler.referenceResolution = new Vector2(ReferenceWidth, ReferenceHeight);
+
+            // Expand: the canvas is never smaller than the reference in either
+            // direction, so nothing designed at 1920 x 1200 is ever cropped off
+            // the edge of a device that is not exactly 16:10. On the target
+            // tablet, which is, every match mode gives the same result — this
+            // one is chosen for what it does everywhere else.
+            _scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.Expand;
+
+            if (GetComponent<GraphicRaycaster>() == null)
+            {
+                gameObject.AddComponent<GraphicRaycaster>();
+            }
+        }
+
+        void BuildEventSystem()
+        {
+            var host = new GameObject(
+                EventSystemObjectName,
+                typeof(EventSystem),
+                typeof(StandaloneInputModule));
+
+            host.transform.SetParent(transform, worldPositionStays: false);
+
+            // StandaloneInputModule is the module for the legacy input manager,
+            // which is the one this project uses: Packages/manifest.json has no
+            // com.unity.inputsystem, and ScreenRouterAdapter reads hardware back
+            // through UnityEngine.Input.
+            _eventSystem = host.GetComponent<EventSystem>();
+        }
+
+        void BuildScreenRoots()
+        {
+            var host = new GameObject(ScreensObjectName, typeof(RectTransform));
+            var rect = (RectTransform)host.transform;
+
+            rect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(rect);
+
+            _screens = host.AddComponent<ScreenRouterAdapter>();
+            _router = _screens.Router;
+
+            _shownScreen = _router.CurrentScreen;
+            _shownDialog = _router.CurrentDialog;
+        }
+
+        void BuildViews()
+        {
+            _titleScreen = AddView<TitleScreenView>(RootFor(CoreScreen.TitleScreen));
+            _gameSetup = AddView<GameSetupScreenView>(RootFor(CoreScreen.GameSetup));
+            _board = AddView<GameBoardScreenView>(RootFor(CoreScreen.GameBoard));
+            _gameOver = AddView<GameOverScreenView>(RootFor(CoreScreen.GameOver));
+
+            _rollAndCard = AddView<RollAndCardDialogView>(RootFor(Dialog.RollAndCard));
+            _workingOutGrid = AddView<WorkingOutGridView>(RootFor(Dialog.WorkingOutGrid));
+            _answerResult = AddView<AnswerResultDialogView>(RootFor(Dialog.AnswerResult));
+            _settings = AddView<SettingsDialogView>(RootFor(Dialog.Settings));
+            _endGameConfirm = AddView<EndGameConfirmView>(RootFor(Dialog.EndGameConfirm));
+
+            // Ask each one to build itself now, rather than at whatever moment
+            // its root first becomes active. Every view exposes its own
+            // RectTransform through its EnsureInitialized guard, which is the
+            // published way to say "build".
+            PrimeView(_titleScreen.RectTransform);
+            PrimeView(_gameSetup.RectTransform);
+            PrimeView(_board.RectTransform);
+            PrimeView(_gameOver.RectTransform);
+            PrimeView(_rollAndCard.RectTransform);
+            PrimeView(_workingOutGrid.RectTransform);
+            PrimeView(_answerResult.RectTransform);
+            PrimeView(_settings.RectTransform);
+            PrimeView(_endGameConfirm.RectTransform);
+        }
+
+        static TView AddView<TView>(GameObject root) where TView : MonoBehaviour
+        {
+            var host = new GameObject(typeof(TView).Name, typeof(RectTransform));
+            var rect = (RectTransform)host.transform;
+
+            rect.SetParent(root.transform, worldPositionStays: false);
+            rect.anchoredPosition = Vector2.zero;
+
+            return host.AddComponent<TView>();
+        }
+
+        // Reading a view's own rect is what makes it build; there is nothing to
+        // do with the answer.
+        static void PrimeView(RectTransform rect)
+        {
+            if (rect == null)
+            {
+                throw new InvalidOperationException(
+                    "a screen was added but has no RectTransform of its own, so it never built itself.");
+            }
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        // --- Wiring --------------------------------------------------------------
+
+        void Wire()
+        {
+            _titleScreen.Initialize(_router, new NoSavedGameQuery());
+            _gameSetup.Initialize(_router);
+            _gameOver.Initialize(_router);
+
+            // The gear, and only the gear. The board raises SettingsRequested
+            // from its own hardware-back handler too, and ScreenRouterAdapter
+            // already runs the back-button table for the same key press — so
+            // driving the dialog from both would open and immediately close it,
+            // in whichever order Unity happened to run the two Updates.
+            // docs/specs/ui/game-board.md's rule is honoured once, by the
+            // router.
+            _board.SettingsButton.Clicked += OpenSettings;
+            _board.RollPressed += StartTurn;
+
+            _rollAndCard.SolveItPressed += OpenWorkingOutGrid;
+            _workingOutGrid.AnswerSubmitted += ShowAnswerResult;
+            _answerResult.TurnHandedOff += HandOffFinished;
+
+            _settings.CloseRequested += CloseDialog;
+            _settings.EndGameConfirmRequested += OpenEndGameConfirm;
+
+            _endGameConfirm.GameEnded += ShowGameOver;
+            _endGameConfirm.KeepPlayingRequested += CloseDialog;
+
+            _router.StateChanged += RouterStateChanged;
+        }
+
+        // --- Reacting to the router ----------------------------------------------
+
+        void RouterStateChanged()
+        {
+            var screen = _router.CurrentScreen;
+            if (screen != _shownScreen)
+            {
+                _shownScreen = screen;
+                EnterScreen(screen);
+            }
+
+            var dialog = _router.CurrentDialog;
+            if (dialog != _shownDialog)
+            {
+                _shownDialog = dialog;
+
+                if (dialog.HasValue)
+                {
+                    EnterDialog(dialog.Value);
+                }
+            }
+        }
+
+        void EnterScreen(CoreScreen screen)
+        {
+            switch (screen)
+            {
+                case CoreScreen.GameSetup:
+                    // docs/specs/ui/game-setup.md#behaviour: "Entering: seats
+                    // all empty, every time."
+                    _gameSetup.ResetToEmptySeats();
+                    break;
+
+                case CoreScreen.GameBoard:
+                    AdoptNewlyStartedGame();
+                    break;
+            }
+        }
+
+        void EnterDialog(Dialog dialog)
+        {
+            switch (dialog)
+            {
+                // These two are opened by the router — from the gear, from
+                // `End the game`, or from hardware back — rather than by a
+                // handler that also has something to hand them, so this is
+                // where their panels are told to open.
+                case Dialog.Settings:
+                    _settings.Open();
+                    break;
+
+                case Dialog.EndGameConfirm:
+                    _endGameConfirm.Open();
+                    break;
+            }
+        }
+
+        // `Start` on game setup and `Play again` on game over each construct a
+        // Game and then navigate here. Whichever of them holds one this session
+        // has not adopted yet is the game that was just started.
+        void AdoptNewlyStartedGame()
+        {
+            var started = NewlyStartedGame();
+
+            if (started == null)
+            {
+                return;
+            }
+
+            _game = started;
+            _board.Initialize(_game);
+            _endGameConfirm.Initialize(_game);
+        }
+
+        Game NewlyStartedGame()
+        {
+            if (_gameSetup.StartedGame != null && !ReferenceEquals(_gameSetup.StartedGame, _game))
+            {
+                return _gameSetup.StartedGame;
+            }
+
+            if (_gameOver.StartedGame != null && !ReferenceEquals(_gameOver.StartedGame, _game))
+            {
+                return _gameOver.StartedGame;
+            }
+
+            return null;
+        }
+
+        // --- The turn ------------------------------------------------------------
+
+        // `Roll` — the only way to start a turn. Core draws the roll and the
+        // card; the dialog is pointed at what it drew and then shown.
+        void StartTurn()
+        {
+            _game.RollDie();
+
+            _rollAndCard.Initialize(new GameRollAndCardReadout(_game), _router);
+            _router.OpenDialog(Dialog.RollAndCard);
+        }
+
+        // `Solve it`. The dialog has already asked the router for the grid by
+        // the time this runs, so the grid is pointed at the turn in the same
+        // frame it becomes current.
+        void OpenWorkingOutGrid()
+        {
+            _game.BeginAnswering();
+
+            _turn = new GameWorkingOutTurn(_game);
+            _workingOutGrid.Initialize(_turn, _router);
+        }
+
+        // `Check it`. The submitted answer has already gone out through the
+        // grid's one seam and been graded by Core by the time this fires —
+        // which is why the number it carries is not used here; the dialog is
+        // pointed at Core's verdict, at the board the frog will hop on, and at
+        // the router it closes itself through.
+        void ShowAnswerResult(int submittedAnswer)
+        {
+            _answerResult.Initialize(new GameAnswerResultTurn(_game, _turn.Resolution), _board, _router);
+        }
+
+        // The frog has landed and the next player's turn has begun. The only
+        // thing left is the ending docs/specs/ui/game-board.md describes: "When
+        // the last frog gets home, the game ends itself... with no input from
+        // anybody."
+        void HandOffFinished()
+        {
+            if (_game.IsOver)
+            {
+                ShowGameOver();
+            }
+        }
+
+        // --- Settings, and the two ways a game ends -------------------------------
+
+        void OpenSettings()
+        {
+            _router.OpenDialog(Dialog.Settings);
+        }
+
+        void OpenEndGameConfirm()
+        {
+            _router.OpenDialog(Dialog.EndGameConfirm);
+        }
+
+        void CloseDialog()
+        {
+            _router.CloseDialog();
+        }
+
+        void ShowGameOver()
+        {
+            _gameOver.Show(_game);
+            _router.GameHasEnded();
+        }
+
+        // --- The clock ------------------------------------------------------------
+
+        // Three of the five dialogs have no Update of their own, so their
+        // shared Dialog's cross-fade in has nothing advancing it and they would
+        // open at zero opacity and stay there. The other two run their own
+        // entering and hand-off sequences from their own Update and must not be
+        // advanced twice.
+        void AdvanceCurrentDialogsFade(float deltaSeconds)
+        {
+            var dialog = _router.CurrentDialog;
+
+            if (!dialog.HasValue)
+            {
+                return;
+            }
+
+            switch (dialog.Value)
+            {
+                case Dialog.WorkingOutGrid:
+                    _workingOutGrid.Dialog.AdvanceFade(deltaSeconds);
+                    break;
+
+                case Dialog.Settings:
+                    _settings.Dialog.AdvanceFade(deltaSeconds);
+                    break;
+
+                case Dialog.EndGameConfirm:
+                    _endGameConfirm.Dialog.AdvanceFade(deltaSeconds);
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/AppRoot.cs.meta
+++ b/Assets/Scripts/Unity/AppRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a9afce2511a44e99cdaa8a8db4b8176
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs
@@ -15,6 +15,9 @@ namespace Frogs.Unity
     /// <see cref="Game.CompleteHandOff"/> clears the drawn card and moves the
     /// active frog on. <see cref="NextFrog"/> is read live, because it is the
     /// one fact the dialog wants *as it is now* — before hand-off has run.
+    ///
+    /// Two of its members are guarded for the last turn of a completed game,
+    /// and they sit next to each other below with one comment over both.
     /// </summary>
     public sealed class GameAnswerResultTurn : IAnswerResultTurn
     {
@@ -57,10 +60,25 @@ namespace Frogs.Unity
         /// <inheritdoc />
         public TurnResolution Resolution { get; }
 
+        // --- The turn whose hop got the last frog home ------------------------
+        //
+        // Both members below are guarded for the same one turn in a game, and
+        // they are kept together so the next person finds both.
+        //
+        // docs/specs/ui/game-board.md#behaviour: "When the last frog gets home,
+        // the game ends itself. The hop finishes, and game over follows with no
+        // input from anybody." From the moment that answer is graded there is
+        // no next player — not to name on the button, and not to pass the
+        // device to — and Core says so by throwing from both
+        // Game.NextActiveFrog and Game.CompleteHandOff. The dialog asks each of
+        // them once on every turn, including this one, so the shell answers
+        // "there is nobody" rather than letting Core's exception reach a child
+        // on the winning move.
+
         /// <inheritdoc />
-        public FrogColour NextFrog
+        public FrogColour? NextFrog
         {
-            get { return _game.NextActiveFrog; }
+            get { return _game.IsOver ? (FrogColour?)null : _game.NextActiveFrog; }
         }
 
         /// <inheritdoc />
@@ -72,13 +90,8 @@ namespace Frogs.Unity
         /// <inheritdoc />
         public void CompleteHandOff()
         {
-            // Nothing at all when that hop was the one that got the last frog
-            // home. docs/specs/ui/game-board.md#behaviour: "When the last frog
-            // gets home, the game ends itself. The hop finishes, and game over
-            // follows with no input from anybody." There is no next player to
-            // pass to, and Game.CompleteHandOff says so by throwing — so the
-            // step the spec says does not happen is the step not taken, rather
-            // than one taken and caught.
+            // The step the spec says does not happen is the step not taken,
+            // rather than one taken and caught.
             if (_game.IsOver)
             {
                 return;

--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs
@@ -72,8 +72,20 @@ namespace Frogs.Unity
         /// <inheritdoc />
         public void CompleteHandOff()
         {
-            // Just the advance, and deliberately nothing else. A frog that
-            // lands on the End log has its place in the finishing order
+            // Nothing at all when that hop was the one that got the last frog
+            // home. docs/specs/ui/game-board.md#behaviour: "When the last frog
+            // gets home, the game ends itself. The hop finishes, and game over
+            // follows with no input from anybody." There is no next player to
+            // pass to, and Game.CompleteHandOff says so by throwing — so the
+            // step the spec says does not happen is the step not taken, rather
+            // than one taken and caught.
+            if (_game.IsOver)
+            {
+                return;
+            }
+
+            // Otherwise just the advance, and deliberately nothing else. A frog
+            // that lands on the End log has its place in the finishing order
             // captured by Core itself, inside Game.ShowResult — the phase
             // before this one, and the first one after a move that no caller
             // can skip. The shell does not have to remember to announce an

--- a/Assets/Scripts/Unity/GameWorkingOutTurn.cs
+++ b/Assets/Scripts/Unity/GameWorkingOutTurn.cs
@@ -1,0 +1,84 @@
+using System;
+using Frogs.Core;
+
+namespace Frogs.Unity
+{
+    /// <summary>
+    /// The runtime <see cref="IWorkingOutTurn"/>: the turn a live
+    /// <see cref="Game"/> has already rolled and drawn a card for, and the one
+    /// place the answer that comes back out of the grid goes.
+    ///
+    /// The frog, the pile and the card are captured at construction, because
+    /// that is the moment they describe — the grid is opened on one turn's card
+    /// and stays on it until the answer is handed over. Nothing here formats
+    /// anything, and nothing here grades: <see cref="SubmitAnswer"/> hands the
+    /// number to <see cref="Lane.Resolve"/>, which is Core's grader (#210), and
+    /// keeps the <see cref="TurnResolution"/> it produced so the answer-result
+    /// dialog can be shown Core's verdict rather than a second opinion.
+    ///
+    /// It also takes the phase step Core requires immediately afterwards.
+    /// <see cref="Game.ShowResult"/> documents why that is not optional and why
+    /// it belongs to whoever called <see cref="Lane.Resolve"/>: it is "the first
+    /// moment after a move that a caller cannot skip", and it is where a frog
+    /// landing on its End log has its place in the finishing order captured.
+    /// Splitting the two apart is how that recording gets forgotten.
+    /// </summary>
+    public sealed class GameWorkingOutTurn : IWorkingOutTurn
+    {
+        readonly Game _game;
+        readonly Card _card;
+
+        /// <exception cref="ArgumentNullException"><paramref name="game"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The turn has not rolled and drawn a card yet.</exception>
+        public GameWorkingOutTurn(Game game)
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+
+            var roll = game.DrawnRoll;
+
+            if (roll == null)
+            {
+                throw new InvalidOperationException(
+                    "this turn has not rolled yet; there is no pile to work from.");
+            }
+
+            _card = game.DrawnCard;
+
+            if (_card == null)
+            {
+                throw new InvalidOperationException(
+                    "this turn has not drawn a card yet; there is no problem to work.");
+            }
+
+            Frog = game.ActiveFrog;
+            Pile = roll.Pile;
+        }
+
+        /// <inheritdoc />
+        public FrogColour Frog { get; }
+
+        /// <inheritdoc />
+        public Pile Pile { get; }
+
+        /// <inheritdoc />
+        public Card Card
+        {
+            get { return _card; }
+        }
+
+        /// <summary>
+        /// What Core made of the answer this turn submitted, or null before
+        /// <see cref="SubmitAnswer"/> has run. The one fact the answer-result
+        /// dialog is built from — read from here rather than re-derived, so
+        /// nothing outside <see cref="Lane.Resolve"/> ever grades anything.
+        /// </summary>
+        public TurnResolution Resolution { get; private set; }
+
+        /// <inheritdoc />
+        public void SubmitAnswer(int answer)
+        {
+            Resolution = _game.LaneFor(Frog).Resolve(answer, _card);
+            _game.ShowResult();
+        }
+    }
+}

--- a/Assets/Scripts/Unity/GameWorkingOutTurn.cs.meta
+++ b/Assets/Scripts/Unity/GameWorkingOutTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2e795eeb6df464caa4a40a18621b04a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/IAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/IAnswerResultTurn.cs
@@ -45,8 +45,16 @@ namespace Frogs.Unity
         /// are home, asked while this turn's result is still on screen and
         /// nothing has advanced. Not <see cref="Frog"/>, and not something the
         /// dialog works out by walking turn order.
+        ///
+        /// **Null on exactly one turn in a game:** the one whose hop got the
+        /// last frog home. docs/specs/ui/game-board.md#behaviour — "When the
+        /// last frog gets home, the game ends itself" — so there is no next
+        /// player to name, and <see cref="Game.NextActiveFrog"/> says so by
+        /// throwing. Nullable rather than throwing here, because the dialog
+        /// asks this question on every turn including that one, and a fact the
+        /// caller is expected to handle is a value, not an exception.
         /// </summary>
-        FrogColour NextFrog { get; }
+        FrogColour? NextFrog { get; }
 
         /// <summary>
         /// The result dialog has closed and the board is back on screen for

--- a/Assets/Scripts/Unity/ScreenRouterAdapter.cs
+++ b/Assets/Scripts/Unity/ScreenRouterAdapter.cs
@@ -10,13 +10,20 @@ namespace Frogs.Unity
     /// The thin shell around <see cref="ScreenRouter"/> — issue #213. It owns
     /// the router's engine-facing surface and nothing about navigation logic:
     /// it wires the hardware back key (Android back / <c>Escape</c>) to
-    /// <see cref="ScreenRouter.HandleBack"/>, and activates the one empty
-    /// root <c>GameObject</c> per <see cref="Frogs.Core.Screen"/> and
+    /// <see cref="ScreenRouter.HandleBack"/>, and activates the one root
+    /// <c>GameObject</c> per <see cref="Frogs.Core.Screen"/> and
     /// <see cref="Dialog"/> that matches the router's current state.
     ///
-    /// It draws nothing — no marker, no text, no shapes. What a root looks
-    /// like is a later, wireframed issue; this type only decides which root
-    /// is active.
+    /// It draws nothing — no marker, no text, no shapes. A root is an empty
+    /// canvas-filling <c>RectTransform</c> and nothing else; what goes under
+    /// one is <c>AppRoot</c>'s to decide (#285), and this type only decides
+    /// which root is active.
+    ///
+    /// It is also the only thing that reads the hardware back key for the
+    /// whole app. <c>GameBoardScreenView</c> raises its own
+    /// <c>SettingsRequested</c> from the same key press, and if anything acted
+    /// on both, one press would run the back-button table twice — see
+    /// <c>AppRoot.Wire</c>.
     /// </summary>
     public sealed class ScreenRouterAdapter : MonoBehaviour
     {
@@ -117,10 +124,23 @@ namespace Frogs.Unity
             RefreshActiveRoots();
         }
 
+        // A root is a UI root: it is what a screen or a dialog is parented to,
+        // so it is a RectTransform filling whatever it is under, and a screen
+        // laid out inside it is laid out against the canvas rather than
+        // against a point. A plain Transform here would leave every child
+        // RectTransform anchored to a rect that does not exist — which draws
+        // nothing and reports nothing.
         GameObject CreateRoot(string name)
         {
-            var root = new GameObject(name);
-            root.transform.SetParent(transform, worldPositionStays: false);
+            var root = new GameObject(name, typeof(RectTransform));
+            var rect = (RectTransform)root.transform;
+
+            rect.SetParent(transform, worldPositionStays: false);
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
             root.SetActive(false);
             return root;
         }

--- a/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
+++ b/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
@@ -35,7 +35,10 @@ namespace Frogs.Unity.Views
     /// <see cref="IAnswerResultTurn.NextFrog"/>, which is
     /// <see cref="Game.NextActiveFrog"/> (#208) — asked while this dialog is
     /// still showing the *current* player's result, and answered without
-    /// advancing anything.
+    /// advancing anything. On the one turn that has no next player — the hop
+    /// that got the last frog home — the button falls back to
+    /// <see cref="NoNextPlayerLabel"/>, whose wording is still Connor's to
+    /// settle (#287).
     ///
     /// On a wrong answer **the correct answer is revealed and the working is
     /// not** — docs/adr/0002-structured-working-out-grid.md. There is no
@@ -129,6 +132,20 @@ namespace Frogs.Unity.Views
 
         // The button is named for the next player, never `OK`.
         const string NextTurnFormat = "{0}'s turn";
+
+        /// <summary>
+        /// What the one button reads on the one turn that has no next player —
+        /// the hop that got the last frog home.
+        ///
+        /// **This wording is not Connor's yet.** answer-result.md says the
+        /// button is "named for the next player" and says nothing about the
+        /// turn where there is not one, so this is a placeholder that keeps the
+        /// dialog working rather than a decision: it borrows game-over.md's own
+        /// words for the screen the button now leads to. Issue #287 asks Connor
+        /// what it should say, and this constant is the only thing that has to
+        /// change when he answers.
+        /// </summary>
+        public const string NoNextPlayerLabel = "Game over";
 
         // No imported font — matches Button.cs's, PlayerChip.cs's,
         // DialogPanel.cs's and WorkingOutGridView.cs's own choice, for the same
@@ -475,7 +492,12 @@ namespace Frogs.Unity.Views
             // chip has a move to show in the line Home would replace.
             _chip.SetState(PlayerChipState.Default);
 
-            _nextTurnButton.SetLabelText(string.Format(NextTurnFormat, _turn.NextFrog));
+            // Null on the hop that got the last frog home, and only then —
+            // see IAnswerResultTurn.NextFrog and NoNextPlayerLabel.
+            var next = _turn.NextFrog;
+            _nextTurnButton.SetLabelText(next.HasValue
+                ? string.Format(NextTurnFormat, next.Value)
+                : NoNextPlayerLabel);
 
             PlaceFrog();
         }

--- a/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
+++ b/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
@@ -223,6 +223,54 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
+        public void NextFrogLabel_NamesNobody_OnTheHopThatGotTheLastFrogHome()
+        {
+            var game = StartedGame(FrogColour.Green, FrogColour.Blue);
+
+            // Blue is already home and Green's answer is about to put it there
+            // too, so by the time this dialog opens there is no next player at
+            // all — the one turn in a game where there is not one.
+            var blue = game.LaneFor(FrogColour.Blue);
+            var green = game.LaneFor(FrogColour.Green);
+
+            for (var step = 0; step < Lane.LaneWinningPosition; step++)
+            {
+                blue.MoveForward();
+                if (step < Lane.LaneWinningPosition - 1)
+                {
+                    green.MoveForward();
+                }
+            }
+
+            var resolution = green.Resolve(game.DrawnCard.Product, game.DrawnCard);
+
+            Assert.That(game.IsOver, Is.True, "the scripted position did not end the game");
+
+            var view = CreateView(new GameAnswerResultTurn(game, resolution));
+
+            try
+            {
+                // Before the guard this threw out of Refresh, from Core's own
+                // "there is no next frog to advance to" — on the winning move
+                // of every completed game.
+                Assert.That(
+                    view.NextTurnButton.Label.text,
+                    Is.EqualTo(AnswerResultDialogView.NoNextPlayerLabel));
+
+                foreach (var colour in game.TurnOrder)
+                {
+                    Assert.That(
+                        view.NextTurnButton.Label.text, Does.Not.Contain(colour.ToString()),
+                        "the button names a player on a turn that has none");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
         public void ThePanelAndEveryRegion_AreIdenticalBetweenTheRightAndWrongStates()
         {
             var right = CreateView(Right(FrogColour.Green, before: 3));
@@ -721,7 +769,7 @@ namespace Frogs.Unity.EditModeTests
 
             public TurnResolution Resolution { get; }
 
-            public FrogColour NextFrog { get; }
+            public FrogColour? NextFrog { get; }
 
             internal IReadOnlyList<string> Calls => _calls;
 

--- a/Assets/Tests/EditMode/AppRootTests.cs
+++ b/Assets/Tests/EditMode/AppRootTests.cs
@@ -1,0 +1,589 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+using CoreScreen = Frogs.Core.Screen;
+using Button = Frogs.Unity.UI.Button;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The composition root — issue #285. Every screen in the POC was built and
+    /// unit-tested before this existed, and none of them was ever constructed
+    /// outside a test, so the built app showed the camera's clear colour and
+    /// nothing else.
+    ///
+    /// **What EditMode can and cannot say about that.** It cannot run the
+    /// player: no <c>Awake</c> on <c>AddComponent</c>, no <c>Start</c>, no
+    /// frames, and <c>Time.deltaTime</c> never advances — which is why
+    /// <see cref="AppRoot"/> keeps its <c>[RuntimeInitializeOnLoadMethod]</c>
+    /// hook down to one call into <see cref="AppRoot.Initialize"/>, and why
+    /// every entering sequence in the flow is advanced through a public method
+    /// rather than only from an <c>Update</c>. This suite drives those entry
+    /// points directly, so what it asserts is the wiring — which screen is on,
+    /// which view is under which root, and whether a tap reaches Core — and
+    /// never anything about rendering.
+    ///
+    /// The taps are the shared components' own pointer handlers, called the way
+    /// <c>GameBoardScreenViewTests</c> and <c>WorkingOutGridViewTests</c> call
+    /// them. Nothing here reaches past a view's public surface: if a press
+    /// stops reaching Core, it fails here the way it would fail in a hand.
+    /// </summary>
+    public sealed class AppRootTests
+    {
+        // A named seed, so a run is the same run twice. Nothing below asserts a
+        // particular card — the answers typed are read back off Core — but a
+        // failure that only happens for one deal should be reproducible.
+        const ulong Seed = 20260811UL;
+
+        // Long enough to run any entering or hand-off sequence in the flow
+        // straight to its end, on a clock this suite controls.
+        const float LongEnough = 10f;
+
+        // A stop on the turn loop, so a game that stops making progress fails
+        // as a test rather than hanging the editor.
+        const int MaxTurns = 64;
+
+        [Test]
+        public void TheAppOpensOnTheTitleScreen_WithResumeHidden()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.TitleScreen),
+                    "the app boots into the title screen, not a blue rectangle");
+                Assert.That(root.Router.CurrentDialog, Is.Null, "nothing is layered over it");
+
+                Assert.That(ActiveScreenRoots(root), Is.EqualTo(new[] { CoreScreen.TitleScreen }));
+
+                Assert.That(root.TitleScreen.NewButton.gameObject.activeSelf, Is.True);
+                Assert.That(root.TitleScreen.ResumeButton.gameObject.activeSelf, Is.False,
+                    "there is no save system, so RESUME is not laid out at all");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void TheCanvasIsTheOneEveryScreenIsMeasuredIn_AndTapsCanReachIt()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                Assert.That(root.Canvas.renderMode, Is.EqualTo(RenderMode.ScreenSpaceOverlay));
+                Assert.That(root.CanvasScaler.uiScaleMode, Is.EqualTo(CanvasScaler.ScaleMode.ScaleWithScreenSize));
+                Assert.That(
+                    root.CanvasScaler.referenceResolution,
+                    Is.EqualTo(new Vector2(AppRoot.ReferenceWidth, AppRoot.ReferenceHeight)),
+                    "docs/specs/ui/shared-components.md — the canvas every component is measured in");
+
+                Assert.That(root.GetComponent<GraphicRaycaster>(), Is.Not.Null,
+                    "without a raycaster no tap ever reaches a button");
+                Assert.That(root.EventSystem, Is.Not.Null);
+                Assert.That(
+                    root.EventSystem.GetComponent<BaseInputModule>(), Is.Not.Null,
+                    "an EventSystem with no input module delivers nothing");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void EveryScreenAndEveryDialog_HasItsViewUnderTheRoutersOwnRoot()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                AssertViewUnder<TitleScreenView>(root.RootFor(CoreScreen.TitleScreen));
+                AssertViewUnder<GameSetupScreenView>(root.RootFor(CoreScreen.GameSetup));
+                AssertViewUnder<GameBoardScreenView>(root.RootFor(CoreScreen.GameBoard));
+                AssertViewUnder<GameOverScreenView>(root.RootFor(CoreScreen.GameOver));
+
+                AssertViewUnder<RollAndCardDialogView>(root.RootFor(Dialog.RollAndCard));
+                AssertViewUnder<WorkingOutGridView>(root.RootFor(Dialog.WorkingOutGrid));
+                AssertViewUnder<AnswerResultDialogView>(root.RootFor(Dialog.AnswerResult));
+                AssertViewUnder<SettingsDialogView>(root.RootFor(Dialog.Settings));
+                AssertViewUnder<EndGameConfirmView>(root.RootFor(Dialog.EndGameConfirm));
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void EveryScreenAndDialogRoot_FillsTheCanvas_SoAScreenIsNotLaidOutAgainstNothing()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                foreach (CoreScreen screen in Enum.GetValues(typeof(CoreScreen)))
+                {
+                    AssertFillsItsParent(root.RootFor(screen), screen.ToString());
+                }
+
+                foreach (Dialog dialog in Enum.GetValues(typeof(Dialog)))
+                {
+                    AssertFillsItsParent(root.RootFor(dialog), dialog.ToString());
+                }
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void TappingNew_ReachesGameSetup_WithEverySeatEmpty()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                // A stale line-up must not be sitting there —
+                // docs/specs/ui/game-setup.md#behaviour: "Entering: seats all
+                // empty, every time."
+                TapSeat(root.GameSetup, FrogColour.Pink);
+                Assert.That(root.GameSetup.IsSeatChosen(FrogColour.Pink), Is.True);
+
+                Tap(root.TitleScreen.NewButton);
+
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameSetup));
+                Assert.That(ActiveScreenRoots(root), Is.EqualTo(new[] { CoreScreen.GameSetup }));
+                Assert.That(root.GameSetup.ChosenOrder, Is.Empty);
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void TappingStart_ReachesTheBoard_ShowingTheGameThoseSeatsStarted()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameBoard));
+                Assert.That(root.CurrentGame, Is.Not.Null, "the board is showing a game");
+                Assert.That(
+                    root.CurrentGame, Is.SameAs(root.GameSetup.StartedGame),
+                    "the board reads the game Start created, not one of its own");
+                Assert.That(
+                    root.CurrentGame.TurnOrder, Is.EqualTo(new[] { FrogColour.Green, FrogColour.Blue }),
+                    "turn order is the order the seats were tapped");
+                Assert.That(root.Board.Lanes.Count, Is.EqualTo(2), "one lane per frog, and no placeholder");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void AWholeTurn_CanBeTappedThrough_AndTheFrogMovesAndTheTurnPasses()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+                var game = root.CurrentGame;
+
+                // Roll -> roll and card.
+                Tap(root.Board.RollButton);
+
+                Assert.That(root.Router.CurrentDialog, Is.EqualTo(Dialog.RollAndCard));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.RolledAndCardDrawn), "Core rolled, not the dialog");
+                Assert.That(
+                    root.RollAndCard.MultiplicandText.text, Is.EqualTo(game.DrawnCard.Multiplicand.ToString()),
+                    "the dialog is reading the card Core drew");
+                Assert.That(root.Board.RollButton.IsDisabled, Is.True, "a double-tap cannot roll twice");
+
+                // Solve it -> the working-out grid, on that same card.
+                var card = game.DrawnCard;
+                Tap(root.RollAndCard.SolveItButton);
+
+                Assert.That(root.Router.CurrentDialog, Is.EqualTo(Dialog.WorkingOutGrid));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.Answering));
+                Assert.That(
+                    root.WorkingOutGrid.CardReadoutText.text, Does.Contain(card.Multiplicand.ToString()),
+                    "the grid opened on the card the dialog showed");
+
+                // Check it -> the answer result, with Core's own verdict.
+                TypeAnswer(root.WorkingOutGrid, card.Product);
+                Tap(root.WorkingOutGrid.CheckItButton);
+
+                Assert.That(root.Router.CurrentDialog, Is.EqualTo(Dialog.AnswerResult));
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.ResultShown));
+                Assert.That(game.LaneFor(FrogColour.Green).Position, Is.EqualTo(1), "a right answer is one lily pad");
+
+                // Next turn -> the hop, then the board with the turn passed.
+                Tap(root.AnswerResult.NextTurnButton);
+                root.AnswerResult.Advance(LongEnough);
+
+                Assert.That(root.Router.CurrentDialog, Is.Null, "the dialog layer is clear again");
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameBoard));
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue), "the device has passed on");
+                Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+                Assert.That(root.Board.RollButton.IsDisabled, Is.False, "the next player can roll");
+                Assert.That(
+                    root.Board.TurnBannerText.text, Does.Contain(FrogColour.Blue.ToString()),
+                    "the board redrew for whoever is next");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void AWrongAnswer_IsGradedByCore_AndTheTurnStillPasses()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+                var game = root.CurrentGame;
+
+                Tap(root.Board.RollButton);
+                var card = game.DrawnCard;
+                Tap(root.RollAndCard.SolveItButton);
+
+                // Wrong by one, which on the Start log costs nothing —
+                // docs/specs/reference: the Start log is a floor.
+                TypeAnswer(root.WorkingOutGrid, card.Product + 1);
+                Tap(root.WorkingOutGrid.CheckItButton);
+
+                Assert.That(game.LaneFor(FrogColour.Green).Position, Is.Zero);
+
+                Tap(root.AnswerResult.NextTurnButton);
+                root.AnswerResult.Advance(LongEnough);
+
+                Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue));
+                Assert.That(root.Router.CurrentDialog, Is.Null);
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void PlayingEveryFrogHome_EndsTheGameItself_AndShowsTheStandings()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+                var game = root.CurrentGame;
+
+                for (var turn = 0; turn < MaxTurns && !game.IsOver; turn++)
+                {
+                    PlayOneTurnCorrectly(root, game);
+                }
+
+                Assert.That(game.IsOver, Is.True, "the game never ended");
+
+                // docs/specs/ui/game-board.md#behaviour: "When the last frog
+                // gets home, the game ends itself... with no input from
+                // anybody. A finished game never sits on this screen waiting
+                // to be dismissed."
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameOver));
+                Assert.That(root.Router.CurrentDialog, Is.Null);
+                Assert.That(root.GameOver.HeadlineText.text, Is.EqualTo("Green frog wins!"),
+                    "Green rolled first, so Green got home first");
+                Assert.That(root.GameOver.RowCount, Is.EqualTo(game.Standings.Count));
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void TheGearOpensSettings_AndEndingTheGameThroughItsConfirm_ReachesGameOver()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+
+                TapSettings(root.Board);
+                Assert.That(root.Router.CurrentDialog, Is.EqualTo(Dialog.Settings));
+                Assert.That(root.Settings.Dialog.IsOpen, Is.True, "the settings panel was actually opened");
+
+                Tap(root.Settings.EndGameButton);
+                Assert.That(root.Router.CurrentDialog, Is.EqualTo(Dialog.EndGameConfirm),
+                    "`End the game` opens the confirm and ends nothing");
+                Assert.That(root.CurrentGame.IsOver, Is.False);
+                Assert.That(root.EndGameConfirm.Dialog.IsOpen, Is.True);
+
+                Tap(root.EndGameConfirm.EndTheGameButton);
+
+                Assert.That(root.CurrentGame.IsOver, Is.True);
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameOver));
+                Assert.That(root.Router.CurrentDialog, Is.Null);
+                Assert.That(ActiveScreenRoots(root), Is.EqualTo(new[] { CoreScreen.GameOver }));
+                Assert.That(
+                    root.GameOver.RowCount, Is.EqualTo(root.CurrentGame.Standings.Count),
+                    "the standings screen was shown the game that ended");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void KeepPlaying_ReturnsToExactlyTheBoardThatWasThere()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+
+                TapSettings(root.Board);
+                Tap(root.Settings.EndGameButton);
+                Tap(root.EndGameConfirm.KeepPlayingButton);
+
+                Assert.That(root.Router.CurrentDialog, Is.Null);
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameBoard));
+                Assert.That(root.CurrentGame.IsOver, Is.False, "Keep playing never ends a game");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void PlayAgain_StartsAFreshGameForTheSameRoster_AndTheBoardShowsThatOne()
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+                var first = root.CurrentGame;
+
+                TapSettings(root.Board);
+                Tap(root.Settings.EndGameButton);
+                Tap(root.EndGameConfirm.EndTheGameButton);
+
+                Tap(root.GameOver.PlayAgainButton);
+
+                Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameBoard));
+                Assert.That(root.CurrentGame, Is.Not.SameAs(first), "a new game, not the ended one");
+                Assert.That(root.CurrentGame, Is.SameAs(root.GameOver.StartedGame));
+                Assert.That(root.CurrentGame.TurnOrder, Is.EqualTo(first.TurnOrder), "the same frogs, no re-tapping");
+                Assert.That(root.CurrentGame.IsOver, Is.False);
+                Assert.That(
+                    root.CurrentGame.LaneFor(FrogColour.Green).Position, Is.Zero,
+                    "everyone back on their Start log");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        [Test]
+        public void HardwareBackOnTheBoard_OpensSettingsOnce_WhicheverOfItsTwoHandlersRunsFirst()
+        {
+            // One press of Android back reaches two Update methods:
+            // ScreenRouterAdapter's, which runs the whole back-button table,
+            // and GameBoardScreenView's, which raises its own
+            // SettingsRequested. Unity does not define which runs first, so if
+            // the composition root drove the dialog from both, one press would
+            // open and immediately close the settings dialog on some builds
+            // and not others.
+            AssertBackOpensSettingsOnce(adapterFirst: true);
+            AssertBackOpensSettingsOnce(adapterFirst: false);
+        }
+
+        static void AssertBackOpensSettingsOnce(bool adapterFirst)
+        {
+            var root = CreateRoot();
+
+            try
+            {
+                StartAGame(root);
+
+                if (adapterFirst)
+                {
+                    root.HandleBackButton();
+                    root.Board.HandleHardwareBack();
+                }
+                else
+                {
+                    root.Board.HandleHardwareBack();
+                    root.HandleBackButton();
+                }
+
+                Assert.That(
+                    root.Router.CurrentDialog, Is.EqualTo(Dialog.Settings),
+                    $"adapterFirst: {adapterFirst} — hardware back opens the settings dialog, exactly once");
+                Assert.That(
+                    root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameBoard),
+                    "it does not quit, and it never quits without the confirm");
+            }
+            finally
+            {
+                Destroy(root);
+            }
+        }
+
+        // --- Driving the app ---------------------------------------------------
+
+        static AppRoot CreateRoot()
+        {
+            var root = AppRoot.Create();
+            root.UseSeed(() => Seed);
+            return root;
+        }
+
+        static void StartAGame(AppRoot root)
+        {
+            Tap(root.TitleScreen.NewButton);
+            TapSeat(root.GameSetup, FrogColour.Green);
+            TapSeat(root.GameSetup, FrogColour.Blue);
+            Tap(root.GameSetup.StartButton);
+        }
+
+        // One turn, answered right, through the same four taps a player makes.
+        static void PlayOneTurnCorrectly(AppRoot root, Game game)
+        {
+            Tap(root.Board.RollButton);
+            var card = game.DrawnCard;
+
+            Tap(root.RollAndCard.SolveItButton);
+
+            TypeAnswer(root.WorkingOutGrid, card.Product);
+            Tap(root.WorkingOutGrid.CheckItButton);
+
+            Tap(root.AnswerResult.NextTurnButton);
+            root.AnswerResult.Advance(LongEnough);
+        }
+
+        static void TypeAnswer(WorkingOutGridView view, int answer)
+        {
+            // The caret starts on the rightmost answer cell and walks left, so
+            // an answer is typed units first — the way it is written.
+            var digits = answer.ToString();
+
+            for (var index = digits.Length - 1; index >= 0; index--)
+            {
+                var digit = digits[index] - '0';
+                Tap(view.Keys.Single(key => key.Kind == KeypadKeyKind.Digit && key.Digit == digit));
+            }
+
+            Assert.That(view.AnswerText, Is.EqualTo(digits), "the answer row spells out what was typed");
+        }
+
+        static void Tap(Button button)
+        {
+            var eventData = EventDataAt(button.RectTransform);
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static void Tap(WorkingOutKeypadKey key)
+        {
+            key.OnPointerClick(new PointerEventData(null));
+        }
+
+        static void TapSeat(GameSetupScreenView view, FrogColour colour)
+        {
+            var target = view.SeatTapTargetFor(colour);
+            var eventData = EventDataAt(target.RectTransform);
+
+            target.OnPointerDown(eventData);
+            target.OnPointerUp(eventData);
+        }
+
+        static void TapSettings(GameBoardScreenView view)
+        {
+            var target = view.SettingsButton;
+            var eventData = EventDataAt(target.RectTransform);
+
+            target.OnPointerDown(eventData);
+            target.OnPointerUp(eventData);
+        }
+
+        static PointerEventData EventDataAt(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+
+            return new PointerEventData(null)
+            {
+                position = (Vector2)(corners[0] + corners[2]) / 2f
+            };
+        }
+
+        // --- Assertions ---------------------------------------------------------
+
+        static CoreScreen[] ActiveScreenRoots(AppRoot root)
+        {
+            return ((CoreScreen[])Enum.GetValues(typeof(CoreScreen)))
+                .Where(screen => root.RootFor(screen).activeSelf)
+                .ToArray();
+        }
+
+        static void AssertViewUnder<TView>(GameObject root) where TView : MonoBehaviour
+        {
+            var found = root.GetComponentsInChildren<TView>(includeInactive: true);
+
+            Assert.That(
+                found.Length, Is.EqualTo(1),
+                $"{root.name} should hold exactly one {typeof(TView).Name}; nothing else puts one on screen.");
+
+            Assert.That(
+                found[0].transform.childCount, Is.GreaterThan(0),
+                $"{typeof(TView).Name} was added but never asked to build itself, so its root is empty.");
+        }
+
+        static void AssertFillsItsParent(GameObject root, string name)
+        {
+            var rect = root.GetComponent<RectTransform>();
+
+            Assert.That(
+                rect, Is.Not.Null,
+                $"{name}'s root has no RectTransform, so a screen parented to it is laid out against nothing.");
+
+            Assert.That(rect.anchorMin, Is.EqualTo(Vector2.zero), name);
+            Assert.That(rect.anchorMax, Is.EqualTo(Vector2.one), name);
+            Assert.That(rect.offsetMin, Is.EqualTo(Vector2.zero), name);
+            Assert.That(rect.offsetMax, Is.EqualTo(Vector2.zero), name);
+        }
+
+        static void Destroy(AppRoot root)
+        {
+            if (root != null)
+            {
+                UnityEngine.Object.DestroyImmediate(root.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/AppRootTests.cs.meta
+++ b/Assets/Tests/EditMode/AppRootTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c01df286ec54645938769a721b582da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs
+++ b/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs
@@ -64,6 +64,44 @@ namespace Frogs.Unity.EditModeTests
                 "the last hand-off is left uncompleted, because there is nobody to hand off to");
         }
 
+        [Test]
+        public void NextFrog_IsNobody_WhenThatHopGotTheLastFrogHome_RatherThanThrowing()
+        {
+            var game = new Game(Roster, Seed);
+
+            // One frog short of the ending, so the turn built below is the one
+            // whose answer gets the last frog home.
+            foreach (var colour in Roster)
+            {
+                var lane = game.LaneFor(colour);
+                var steps = colour == game.ActiveFrog
+                    ? Lane.LaneWinningPosition - 1
+                    : Lane.LaneWinningPosition;
+
+                for (var step = 0; step < steps; step++)
+                {
+                    lane.MoveForward();
+                }
+            }
+
+            game.RollDie();
+            var card = game.DrawnCard;
+            game.BeginAnswering();
+
+            var resolution = game.LaneFor(game.ActiveFrog).Resolve(card.Product, card);
+            game.ShowResult();
+
+            Assert.That(game.IsOver, Is.True, "the scripted position did not end the game");
+
+            var turn = new GameAnswerResultTurn(game, resolution);
+
+            // Game.NextActiveFrog throws here, and the answer-result dialog
+            // reads this on every turn to name its one button — so before this
+            // was guarded, the winning move of every completed game threw
+            // instead of showing a result.
+            Assert.That(turn.NextFrog, Is.Null, "there is no next player once every frog is home");
+        }
+
         // One turn through the phases a played turn moves through, ending with
         // the two steps GameAnswerResultTurn owns.
         static void PlayOneTurnRight(Game game)

--- a/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs
+++ b/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The runtime <c>IAnswerResultTurn</c>'s two hand-off steps, and the one
+    /// turn in a game where the second of them must not run.
+    ///
+    /// Everything else this type does is a straight read of something Core
+    /// already decided, and <c>AnswerResultDialogViewTests</c> asserts those
+    /// reads through the dialog that makes them. What is here is the pair of
+    /// calls the `Next turn` button runs, because
+    /// docs/specs/ui/game-board.md#behaviour makes the last one conditional and
+    /// nothing had ever reached that turn outside a Core-only test.
+    /// </summary>
+    public sealed class GameAnswerResultTurnTests
+    {
+        static readonly FrogColour[] Roster = { FrogColour.Green, FrogColour.Blue };
+
+        // The same named seed the Core-tier scripted games use.
+        const ulong Seed = 20260810UL;
+
+        // A stop on the turn loop, so a play that stops making progress fails
+        // as a test rather than hanging the editor.
+        const int MaxTurns = 64;
+
+        [Test]
+        public void CompleteHandOff_PassesTheDevice_WhileSomebodyIsStillSwimming()
+        {
+            var game = new Game(Roster, Seed);
+
+            PlayOneTurnRight(game);
+
+            Assert.That(game.ActiveFrog, Is.EqualTo(FrogColour.Blue), "the turn passed to the next frog in order");
+            Assert.That(game.Phase, Is.EqualTo(TurnPhase.WaitingToRoll));
+        }
+
+        [Test]
+        public void CompleteHandOff_DoesNothingAtAll_WhenThatHopGotTheLastFrogHome()
+        {
+            var game = new Game(Roster, Seed);
+
+            // Every answer right, so the game plays itself out to the ending
+            // docs/specs/ui/game-board.md describes: "When the last frog gets
+            // home, the game ends itself. The hop finishes, and game over
+            // follows with no input from anybody."
+            //
+            // There is no next frog to advance to at that point, and
+            // Game.CompleteHandOff says so by throwing. Before this was
+            // guarded, the very last `Next turn` in every completed game threw
+            // inside the answer-result dialog's hand-off — the one turn no
+            // EditMode test had ever reached.
+            for (var turn = 0; turn < MaxTurns && !game.IsOver; turn++)
+            {
+                PlayOneTurnRight(game);
+            }
+
+            Assert.That(game.IsOver, Is.True, "the scripted game never ended");
+            Assert.That(game.TurnOrder.All(colour => game.LaneFor(colour).IsHome), Is.True);
+            Assert.That(
+                game.Phase, Is.EqualTo(TurnPhase.HandOff),
+                "the last hand-off is left uncompleted, because there is nobody to hand off to");
+        }
+
+        // One turn through the phases a played turn moves through, ending with
+        // the two steps GameAnswerResultTurn owns.
+        static void PlayOneTurnRight(Game game)
+        {
+            game.RollDie();
+
+            var card = game.DrawnCard;
+            game.BeginAnswering();
+
+            var resolution = game.LaneFor(game.ActiveFrog).Resolve(card.Product, card);
+            game.ShowResult();
+
+            var turn = new GameAnswerResultTurn(game, resolution);
+            turn.BeginHandOff();
+            turn.CompleteHandOff();
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs.meta
+++ b/Assets/Tests/EditMode/GameAnswerResultTurnTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad2fa544056f4f9e80084d4e99087b0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -369,9 +369,8 @@ implementation PR.
 
 `Assets/Editor/GameScene.cs` creates `Assets/Scenes/Game.unity` the same way —
 `EditorSceneManager`, not hand-authored YAML — with a camera and nothing else.
-No probe, no layout: what a screen shows still goes through the wireframe loop
-first, and the screen router that puts content into this scene is its own,
-later issue.
+No probe, no layout, and **no MonoBehaviour at all**: what puts a screen on
+screen is code, not a component dropped into the scene (below).
 
 `Game.unity` is **first** in `ProjectSettings/EditorBuildSettings.asset` —
 index 0, which is the entry Unity boots into. `HelloWorld.unity` stays in the
@@ -380,6 +379,38 @@ tests still pass unchanged, because they assert presence and `enabled`, never
 position. Registering `Game.unity` by appending it, the way a first pass at
 this might do it, would leave the built APK opening into the blank Hello World
 scene forever — the ordering is the whole point, not an incidental detail.
+
+### What puts a screen on screen: a code-only entry point
+
+The scene stays empty. `Frogs.Unity.AppRoot` is the composition root, and it is
+reached from a `[RuntimeInitializeOnLoadMethod]` hook that does nothing but call
+`AppRoot.Create()`. It builds, in this order:
+
+1. the one `Canvas`, in screen-space overlay, with a `CanvasScaler` at the
+   **1920 × 1200** reference resolution every spec page is measured against;
+2. an `EventSystem` and a `StandaloneInputModule`, without which no tap reaches
+   any button;
+3. `ScreenRouterAdapter`, whose one root per `Screen` and per `Dialog` is a
+   `RectTransform` filling the canvas;
+4. one view under each of those roots, each asked to build itself immediately
+   rather than when its root first becomes active.
+
+**Why not a bootstrap component in the scene**, which is the obvious way to do
+this: a component reference in a `.unity` file is a GUID, and a GUID that drifts
+from its `.meta` comes back as a *Missing Script* that throws nothing and logs
+nothing. Adding one would also mean regenerating and re-extracting the scene the
+way #209 had to, since there is no editor in an agent environment. A code-only
+entry point has no GUID to lose and leaves `Game.unity` exactly what was
+committed and CI verified.
+
+**Nothing on `AppRoot` is serialized.** It is constructed at runtime and saved
+into no asset, so every field on it is deliberately a plain field rather than a
+`[SerializeField]` — see [Unity serialization](unity-serialization.md).
+
+The app opens on the [title screen](../specs/ui/title-screen.md), and from there
+every screen the POC has is reachable by tapping. `AppRoot` holds one
+`Frogs.Core.Game` for as long as it is being played, so the board, every dialog
+and the standings all read the same game.
 
 ### Naming
 

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -148,6 +148,10 @@ each one can honestly reach.
 | The grid **view** drawing the grid Core reported | EditMode | `Assets/Tests/EditMode/EndToEndAcceptanceTests.cs` |
 | The game-over **screen** rendering both headlines | EditMode | same |
 | The scenes the build ships keeping their components | EditMode | same |
+| The app building its canvas and opening on the title screen | EditMode | `Assets/Tests/EditMode/AppRootTests.cs` |
+| A whole turn tapped through, board back to board | EditMode | same |
+| A game played until every frog is home reaching game over | EditMode | same |
+| A game ended from the settings dialog's confirm reaching it too | EditMode | same |
 
 Three whole games are played at the Core tier, all from **one named seed**, so
 a failure is the same failure every run: one played until both frogs are home
@@ -159,21 +163,31 @@ isolated test noticing. That is not a hypothetical: this pass is what caught
 `Game.RecordFinish` never being called from anywhere but a test, which left
 every real game with no winner.
 
-### What the acceptance pass cannot reach
+### How the shell tier drives a walkthrough without a player
 
-**There is no harness in this repo for driving the real screens end to end.**
 EditMode is an edit-mode editor session: it opens a scene without running
 `Awake`, `OnEnable` or `Start`, no coroutines run, no frames tick, and
-`Time.deltaTime` never advances. A tapped-through sequence of screens, a screen
-transition, and a timed hop cannot be observed there, and
-[PlayMode tests are not the answer](#no-playmode-tests-no-on-device-testing).
+`Time.deltaTime` never advances. `Frogs.Unity` is written so that none of that
+is required. Every view builds itself behind its own `EnsureInitialized` guard
+rather than in `Awake`, every entering animation and the hop are advanced
+through a public `Advance`/`AdvanceFade` method rather than only from an
+`Update`, and the whole app is built by `AppRoot.Initialize()`, which the
+runtime entry point does nothing but call.
 
-So the shell tier proves the adapter-shaped things EditMode is actually for,
-and nothing pretends otherwise. Writing a real walkthrough needs a lifecycle
-driver — explicit `Initialize()` entry points, or a test driver that pumps the
-lifecycle by hand — that does not exist yet. Until it does, the only place the
-real screens are seen *running* is a build somebody installs and opens, which
-is where Derek and Connor find out whether it is fun.
+That is exactly the lifecycle driver a real walkthrough needs, so
+`AppRootTests` is one: it builds the app, taps the shared components' own
+pointer handlers, and turns the clock by hand. What it proves is that a press
+reaches Core and the right screen comes up next — the wiring, screen to screen,
+from the title screen to game over.
+
+**It still is not a device.** Nothing there renders, so nothing there can say a
+layout is readable, a tap target is reachable by a finger, or a hop looks like
+a hop. Taps are delivered by calling a handler, not by a raycast through a
+`GraphicRaycaster`, so a button covered by something else still passes. And
+[PlayMode tests are not the answer](#no-playmode-tests-no-on-device-testing) to
+any of that. The only place the real screens are seen *running* is a build
+somebody installs and opens, which is where Derek and Connor find out whether
+it is fun.
 
 ## Known limitation: EditMode tests run in CI, not in agent environments
 

--- a/docs/specs/ui/answer-result.md
+++ b/docs/specs/ui/answer-result.md
@@ -126,6 +126,15 @@ off-by-one.
 
 ## Open questions
 
+- **What does the button say when there is no next player?** On the hop that
+  gets the *last* frog home, the game ends itself
+  ([game board](game-board.md)) and there is nobody to hand the device to — so
+  the rule above, "named for the next player", has no answer for that one turn.
+  The button is still pressed: it is what closes the dialog and starts the hop.
+  It currently reads `Game over`, borrowed from
+  [game over](game-over.md)'s own words for the screen it now leads to, as a
+  placeholder rather than a decision. Connor's to settle — asked in
+  [#287](https://github.com/derekwinters/connor-multiplying-frogs/issues/287).
 - **Does a right answer get any celebration beyond the hop?** Audio is
   [parked](../future-ideas.md), and a "correct" chime is the most likely parked
   item to be promoted. If it is, this is the screen it plays on.


### PR DESCRIPTION
Closes #285

The app now opens on the title screen instead of a flat blue rectangle, and the
whole game can be played from there: `NEW`, pick two to four frogs, `Start`,
roll, solve, and on through every turn to the standings. Nothing about how any
screen looks has changed — every one of them was already built and tested, and
this is the piece that was missing: something to make them, put them on a
canvas, and connect them to each other and to the game.

**Docs:** `docs/specs/ui/answer-result.md` — a new open question: what the one button says on the turn that wins the game, where the page's "named for the next player" rule has no answer. `docs/engineering/tech-stack.md` — a new *What puts a screen on screen*
section: the app starts from a code-only `[RuntimeInitializeOnLoadMethod]` entry
point rather than a component in the scene, and `Game.unity` stays camera-only;
the stale line saying "the screen router that puts content into this scene is
its own, later issue" is gone. `docs/engineering/testing.md` — the acceptance
pass's *"there is no harness in this repo for driving the real screens end to
end"* is no longer true, so that section now says what an EditMode walkthrough
can reach and, more carefully, what it still cannot.

## Which approach, and why

**`[RuntimeInitializeOnLoadMethod]`, no scene edit.** `Assets/Scenes/Game.unity`
is byte-for-byte what #209 committed. Nothing in the wiring wanted a scene
object: the canvas, the event system and every view are made in code anyway, so
a bootstrap component would only have added a GUID that can drift into a silent
*Missing Script*, plus the CI `-executeMethod`-and-extract-the-bytes dance.
`AppRoot.Create()` is the whole entry point; the hook does nothing but call it.

## Spec invariants this had to keep true

| Rule | Where it is asserted |
| --- | --- |
| The app opens on the title screen, `RESUME` hidden — no save system (`title-screen.md`) | `TheAppOpensOnTheTitleScreen_WithResumeHidden` |
| Every screen is measured at 1920 × 1200, and the `CanvasScaler` is set to it (`shared-components.md`, ADR-0005) | `TheCanvasIsTheOneEveryScreenIsMeasuredIn_AndTapsCanReachIt` |
| Entering game setup: seats all empty, every time (`game-setup.md`) | `TappingNew_ReachesGameSetup_WithEverySeatEmpty` |
| Turn order is the order the seats were tapped (`game-setup.md`) | `TappingStart_ReachesTheBoard_ShowingTheGameThoseSeatsStarted` |
| `Roll` is disabled from the moment it is pressed until the turn resolves (`game-board.md`) | `AWholeTurn_CanBeTappedThrough_...` |
| A right answer is one lily pad; the Start log is a floor (`rules.md`, reference) | `AWholeTurn_...`, `AWrongAnswer_IsGradedByCore_...` |
| When the last frog gets home the game ends itself, with no input from anybody (`game-board.md`) | `PlayingEveryFrogHome_EndsTheGameItself_AndShowsTheStandings` |
| Hardware back on the board opens settings and never quits (`game-board.md`) | `HardwareBackOnTheBoard_OpensSettingsOnce_...` |
| `End the game` ends nothing until the confirm; back and `Keep playing` never end a game (`settings-dialog.md`, `end-game-confirm.md`) | `TheGearOpensSettings_...`, `KeepPlaying_ReturnsToExactlyTheBoardThatWasThere` |
| `Play again` reuses the ended game's roster and skips setup (`game-over.md`) | `PlayAgain_StartsAFreshGameForTheSameRoster_...` |

No spec page's constants or layout moved, and no game rule is decided in the new
code: every branch in `AppRoot` is either "which view comes up next", which
`ScreenRouter` already owns, or a phase call Core's own `TurnPhase` machine
requires in that order.

## What I did and did not verify

- **Verified locally:** Core suite (209 passing, untouched — this needed no Core
  change), `check_core_isolation.py`, `check_assembly_references.py`,
  `check_geometry_literals.py`, `run_python_tests.py`, `mkdocs build --strict`.
- **Written but not run locally:** the EditMode tests — no editor here. Watching
  CI, and the `Debug APK` job in particular, since that is the build actually
  compiling this.
- **Not verified by anybody yet:** what it looks like. Nothing in EditMode
  renders, and taps in the tests are handler calls rather than raycasts, so
  "does it read well in a child's hands" is still a question only an installed
  APK answers. If a screen looks wrong now that it is finally on glass, that is
  a new issue against that screen, not a fix here.

## Deviations and Decisions

- **`GameAnswerResultTurn` is guarded on the turn that wins the game, in two
  places.** That hop is the one turn with no next player, and Core says so by
  throwing from *both* `Game.CompleteHandOff` (there is nobody to pass to) and
  `Game.NextActiveFrog` (there is nobody to name the button for). The dialog
  calls each once on every turn, so **every** completed game crashed on its
  winning move — the second of the two only showed up when the EditMode
  walkthrough played a whole game through the real screens for the first time.
  `CompleteHandOff` now returns early and `NextFrog` is `FrogColour?`, answering
  null. Both sit together under one comment. `game-board.md` already says that
  hand-off does not happen ("the game ends itself... with no input from
  anybody"), so the guards implement a stated rule rather than inventing one.
  `GameAnswerResultTurnTests` covers each directly, because a failure buried in
  a 16-turn walkthrough is hard to read in a CI log.
- **The answer-result button reads a placeholder on that turn, and the wording
  is Connor's — [#287](https://github.com/derekwinters/connor-multiplying-frogs/issues/287).**
  The button still has to say something: it is what closes the dialog and starts
  the winning hop. `answer-result.md` says it is "named for the next player" and
  says nothing about the turn where there is not one, so I did not decide it. It
  currently reads `Game over`, borrowed from `game-over.md`'s own words for the
  screen it now leads to — chosen to invent no new wording, not because it is
  the right thing to read after winning. Recorded as an open question on
  `answer-result.md` and isolated to one constant,
  `AnswerResultDialogView.NoNextPlayerLabel`. Shipped rather than parked because
  the alternative is an app that crashes on every completed game.
- **`ScreenRouterAdapter`'s screen and dialog roots are now canvas-filling
  `RectTransform`s** instead of bare `GameObject`s. A `RectTransform` child of a
  plain `Transform` is anchored to a rect that does not exist, and every screen
  is a `RectTransform`. #213's own tests are unchanged and still pass on their
  own terms; they only ever asserted which root is active.
- **The gear opens the settings dialog; hardware back is left entirely to the
  router.** One press of Android back reaches two `Update` methods —
  `ScreenRouterAdapter`'s, which runs the whole back-button table, and
  `GameBoardScreenView`'s, which raises `SettingsRequested`. Acting on both would
  open and immediately close the dialog, in whichever order Unity happened to run
  them. So the composition root subscribes to the gear's own `Clicked` and leaves
  `SettingsRequested` unsubscribed. Both orderings are asserted.
- **`AppRoot` gives three dialogs a clock.** The working-out grid, settings and
  end-game confirm have no `Update` of their own, so their shared `DialogPanel`
  fade-in had nothing advancing it and they would have opened at zero opacity and
  stayed there. The root advances whichever of those three is current. The other
  two dialogs run their own sequences and must not be advanced twice.
- **Closing a dialog is instant, not a 0.15 s fade out.** Clearing the dialog
  layer deactivates the view's root immediately, so the shared `Dialog`'s close
  cross-fade is never seen. That is how #221 and #223 already behave and is not
  changed here; making it honest needs a deferred deactivate, which is its own
  small issue if anyone minds.
- **`CanvasScaler.screenMatchMode` is `Expand`.** No spec page names one. On the
  target 16:10 tablet every mode is identical; `Expand` is the one where nothing
  designed at 1920 × 1200 is cropped on a device that is not exactly that.
- **`AppRoot.UseSeed` exists so a test can pin the deal.** It is the same seam
  `GameSetupScreenView.Initialize` and `GameOverScreenView.Initialize` already
  expose, hoisted to the one place that now owns both.
- **Not in scope, and not done:** save/resume (so `RESUME` stays hidden and
  unwired), PlayMode tests, and #279's general test driver.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vovypbju1TCKBT81QPEj3t)_

---
_Generated by [Claude Code](https://claude.ai/code)_