### PR TITLE
fix(pipeline): show every issue that needs attention, not only the focus milestone's

### DIFF
--- a/.claude/skills/pipeline-dashboard/SKILL.md
+++ b/.claude/skills/pipeline-dashboard/SKILL.md
@@ -85,10 +85,27 @@ be a stream of meaningless edits.
 
 Settings resolve **override → marker → default**. A `/focus` naming no live
 milestone is rejected rather than stored, because a typo renders a board whose
-every section is empty — indistinguishable from a finished milestone, and the
-most misleading output this script can produce. A malformed `cap` marker falls
-back to 3, because a board that does not render is worse than one with a
-default cap.
+pie and ready queue are empty — indistinguishable from a finished milestone,
+and the most misleading output this script can produce. A malformed `cap`
+marker falls back to 3, because a board that does not render is worse than one
+with a default cap.
+
+## Focus scopes the pie and the ready queue, and nothing else
+
+Those two say *what is being built now*, and the builder builds the focus
+milestone. Intake, Waiting for you, Needs clarification and Parked say
+*somebody has to look at this*, which is true regardless of milestone — so
+they list the whole board, and the **Milestone** column tells the rows apart.
+
+Scoping them to focus hid the work most worth surfacing. An `ai-triage` issue
+has not been triaged, and triage is what assigns the milestone, so a
+focus-scoped Intake is near-empty by construction. `Direct Involvement Needed`
+carries no version and never ships, so it can never be the focus — and a
+focus-scoped "Waiting for you" hides the milestone that exists to say Derek
+has to do something by hand.
+
+An issue with **no pipeline-state label at all** is in no section either way.
+It has not been admitted; `/admit` is what brings it in.
 
 ## Running the tests
 
@@ -96,7 +113,7 @@ default cap.
 python3 .github/scripts/run_python_tests.py pipeline-dashboard
 ```
 
-51 tests. The centrepiece is a golden-snapshot test rendering a fixture board
+66 tests. The centrepiece is a golden-snapshot test rendering a fixture board
 and comparing byte-for-byte against a committed file. A dashboard is a wall of
 generated Markdown, and a whole-board diff is the only review that catches a
 section quietly changing shape.

--- a/.claude/skills/pipeline-dashboard/SKILL.md
+++ b/.claude/skills/pipeline-dashboard/SKILL.md
@@ -104,8 +104,26 @@ carries no version and never ships, so it can never be the focus — and a
 focus-scoped "Waiting for you" hides the milestone that exists to say Derek
 has to do something by hand.
 
-An issue with **no pipeline-state label at all** is in no section either way.
-It has not been admitted; `/admit` is what brings it in.
+## Intake carries two piles
+
+An issue with **no pipeline-state label at all** has not been `/admit`ted, and
+the nightly analysis run keys on `ai-triage` alone — so nothing will happen to
+it until Derek types the command. Leaving it off the board meant it was
+invisible until somebody scrolled the issue list.
+
+Intake lists both, flagged:
+
+| Row | Means | Who moves it |
+| --- | --- | --- |
+| plain | `ai-triage` — the pipeline has it | tonight's analysis run |
+| `🚪 not admitted` | no state label — nothing has it | Derek, with `/admit` |
+
+**Keep the flag on any row that needs it.** The two piles wait on different
+things, and an unflagged Intake means "handled" and "stalled on you" at once.
+
+The `dashboard` issue and any `type:epic` are never listed as unadmitted —
+`/admit` is refused on both, and offering a command that gets refused is worse
+than not offering it.
 
 ## Running the tests
 
@@ -113,7 +131,7 @@ It has not been admitted; `/admit` is what brings it in.
 python3 .github/scripts/run_python_tests.py pipeline-dashboard
 ```
 
-66 tests. The centrepiece is a golden-snapshot test rendering a fixture board
+75 tests. The centrepiece is a golden-snapshot test rendering a fixture board
 and comparing byte-for-byte against a committed file. A dashboard is a wall of
 generated Markdown, and a whole-board diff is the only review that catches a
 section quietly changing shape.

--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -45,9 +45,15 @@ READY = "ready-for-work"
 IN_PROGRESS = "in-progress"
 PARKED = "parked"
 
+DASHBOARD = "dashboard"
+EPIC = "type:epic"
+
 PLANNING_LABELS = {TRIAGE, PENDING, NEEDS_CLARIFICATION}
 ACTIVE_LABELS = {READY, IN_PROGRESS}
 STATE_LABELS = PLANNING_LABELS | ACTIVE_LABELS | {PARKED}
+
+# What an Intake row says when nobody has `/admit`ted the issue.
+UNADMITTED_FLAG = "🚪 not admitted"
 
 FOCUS_MARKER = re.compile(r"<!--\s*pipeline-focus:\s*(.+?)\s*-->")
 CAP_MARKER = re.compile(r"<!--\s*pipeline-cap:\s*(.+?)\s*-->")
@@ -243,20 +249,56 @@ def _sorted_rows(issues, data):
     )
 
 
-def intake(data: dict) -> list:
-    """Everything waiting for triage, **anywhere on the board.**
+def is_unadmitted(issue) -> bool:
+    """Open, carrying no pipeline-state label, and admissible.
 
-    Deliberately not focus-scoped. `ai-triage` means the issue has not been
-    triaged, and triage is what decides its milestone — so an issue in Intake
-    typically has no milestone at all, and the ones that do are usually
-    somewhere other than the milestone currently being built. Filtering this
-    table by focus would leave it permanently empty while the work it exists
-    to surface piled up out of sight.
+    An issue nobody has `/admit`ted. It is not a triage candidate — the
+    nightly analysis run keys on `ai-triage` alone — so nothing will happen to
+    it until Derek types the command.
 
-    The Milestone column is what keeps that readable: a row reading `—` is an
-    issue nobody has scheduled, which is the point of putting it here.
+    The two exclusions are the two things `/admit` would be refused on, and
+    listing an issue beside a command that gets refused is worse than not
+    listing it. The dashboard is the pipeline's own furniture, and an epic is
+    a container whose children carry the work.
     """
-    return _sorted_rows(_active(data, TRIAGE), data)
+    labels = _labels(issue)
+
+    return (
+        issue.get("state") != "closed"
+        and not (labels & STATE_LABELS)
+        and DASHBOARD not in labels
+        and EPIC not in labels
+    )
+
+
+def intake(data: dict) -> list:
+    """Everything waiting to be looked at, **anywhere on the board.**
+
+    Two piles, and the `🚪 not admitted` flag is what tells them apart:
+
+    - **`ai-triage`** — the pipeline has it. Tonight's analysis run picks it
+      up and nothing is needed from Derek.
+    - **unadmitted** — nothing has it. Only `/admit` moves it.
+
+    They share a table because both answer "what has nobody looked at yet",
+    and a section Derek has to remember to scroll to is a section that stops
+    being read. They carry a flag because the *action* differs, and an Intake
+    row that does not say which pile it is in would mean two things at once.
+
+    Deliberately not focus-scoped, for the reason the two piles exist at all:
+    neither has been triaged, and triage is what decides an issue's milestone,
+    so most rows here have no milestone to filter on. Filtering by focus left
+    this table permanently near-empty while the work it exists to surface
+    piled up out of sight.
+
+    The Milestone column keeps that readable — a row reading `—` is an issue
+    nobody has scheduled, which is the point of putting it here.
+    """
+    # Disjoint by construction: `ai-triage` is itself a state label, so an
+    # issue carrying it is never unadmitted.
+    return _sorted_rows(
+        _active(data, TRIAGE) + [i for i in data.get("issues") or [] if is_unadmitted(i)],
+        data)
 
 
 def pending(data: dict) -> list:
@@ -375,6 +417,11 @@ def render(data: dict, focus_override=None, cap_override=None, as_of=None) -> st
         for issue in issues:
             number = issue["number"]
             title = issue.get("title", "")
+
+            # Inside the star prefix, so the highest-leverage signal still
+            # reads first on a row that carries both.
+            if is_unadmitted(issue):
+                title = f"{UNADMITTED_FLAG} — {title}"
 
             if number in stars:
                 unblocked = ", ".join(f"#{n}" for n in stars[number])

--- a/.claude/skills/pipeline-dashboard/render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/render_dashboard.py
@@ -161,10 +161,15 @@ def ready_queue(data: dict, focus=None) -> list:
 
     `parked` is excluded even when it also carries `ready-for-work`. The
     Parked section is a listing, not a re-admission.
+
+    **This is the one issue table that is focus-scoped**, because it is the
+    one that predicts what the nightly builder will do — and the builder
+    builds the focus milestone. Listing an out-of-focus `ready-for-work` issue
+    here would put work in front of Derek that nothing is going to pick up.
     """
     focus = focus or resolve_focus(data)
 
-    return _sorted_rows(_active(data, focus, READY), data)
+    return _sorted_rows(_active(data, READY, focus), data)
 
 
 def _open_issues(data) -> dict:
@@ -206,15 +211,20 @@ def _is_blocked(issue, data) -> bool:
     return any(blocker in issues for blocker in blockers_of(issue))
 
 
-def _active(data, focus, label):
-    """Open, in focus, carrying `label`, and **not** parked.
+def _active(data, label, focus=None):
+    """Open, carrying `label`, and **not** parked. Board-wide unless scoped.
 
     Parked is excluded from every active queue. The Parked section is a
     listing, not a re-admission — an issue set aside by `/park` must not
     reappear in a table that says "here is what to do next".
+
+    `focus` narrows to one milestone, and **only the ready queue passes it.**
+    See `intake` for why the attention sections do not.
     """
+    issues = data.get("issues") or [] if focus is None else _focus_issues(data, focus)
+
     return [
-        issue for issue in _focus_issues(data, focus)
+        issue for issue in issues
         if issue.get("state") != "closed"
         and label in _labels(issue)
         and PARKED not in _labels(issue)
@@ -233,26 +243,53 @@ def _sorted_rows(issues, data):
     )
 
 
-def intake(data: dict, focus=None) -> list:
-    focus = focus or resolve_focus(data)
-    return _sorted_rows(_active(data, focus, TRIAGE), data)
+def intake(data: dict) -> list:
+    """Everything waiting for triage, **anywhere on the board.**
+
+    Deliberately not focus-scoped. `ai-triage` means the issue has not been
+    triaged, and triage is what decides its milestone — so an issue in Intake
+    typically has no milestone at all, and the ones that do are usually
+    somewhere other than the milestone currently being built. Filtering this
+    table by focus would leave it permanently empty while the work it exists
+    to surface piled up out of sight.
+
+    The Milestone column is what keeps that readable: a row reading `—` is an
+    issue nobody has scheduled, which is the point of putting it here.
+    """
+    return _sorted_rows(_active(data, TRIAGE), data)
 
 
-def pending(data: dict, focus=None) -> list:
-    focus = focus or resolve_focus(data)
-    return _sorted_rows(_active(data, focus, PENDING), data)
+def pending(data: dict) -> list:
+    """Everything waiting on Derek, **anywhere on the board.**
+
+    Board-wide for a blunter reason than Intake: much of this work lives in
+    `Direct Involvement Needed`, a milestone with no version that never ships
+    and therefore can never be the focus. Focus-scoping the one section titled
+    "Waiting for you" would hide exactly the issues that are waiting for him.
+    """
+    return _sorted_rows(_active(data, PENDING), data)
 
 
-def needs_clarification(data: dict, focus=None) -> list:
-    focus = focus or resolve_focus(data)
-    return _sorted_rows(_active(data, focus, NEEDS_CLARIFICATION), data)
+def needs_clarification(data: dict) -> list:
+    """Everything blocked on a question, **anywhere on the board.**
+
+    A question does not stop being unanswered because it is scheduled for a
+    later milestone, and answering it early is often what lets the issue be
+    scheduled at all.
+    """
+    return _sorted_rows(_active(data, NEEDS_CLARIFICATION), data)
 
 
-def parked(data: dict, focus=None) -> list:
-    focus = focus or resolve_focus(data)
+def parked(data: dict) -> list:
+    """Everything set aside, **anywhere on the board.**
+
+    Parked work is listed so it can be found and unparked. An out-of-focus
+    parked issue is the one most in need of that — it is two filters away from
+    anybody noticing it again.
+    """
     return sorted(
         (
-            issue for issue in _focus_issues(data, focus)
+            issue for issue in data.get("issues") or []
             if issue.get("state") != "closed" and PARKED in _labels(issue)
         ),
         key=lambda issue: issue.get("number", 0),
@@ -352,18 +389,22 @@ def render(data: dict, focus_override=None, cap_override=None, as_of=None) -> st
             lines.append(
                 f"| #{number} | {title} | {issue.get('milestone') or '—'} | {blocked} |")
 
+    # Only the ready queue is focus-scoped. The sections below it say
+    # "somebody has to look at this", and an issue does not stop needing to be
+    # looked at by sitting outside the milestone currently being built —
+    # least of all one that has no milestone because nobody has triaged it.
     table(f"## 🔨 Ready queue (cap {cap})", ready_queue(data, focus),
           "Nothing is ready to build.")
-    table("## 📥 Intake", intake(data, focus), "Nothing waiting for triage.")
-    table("## ✋ Waiting for you", pending(data, focus),
+    table("## 📥 Intake", intake(data), "Nothing waiting for triage.")
+    table("## ✋ Waiting for you", pending(data),
           "Nothing waiting for approval.")
-    table("## ❓ Needs clarification", needs_clarification(data, focus),
+    table("## ❓ Needs clarification", needs_clarification(data),
           "Nothing blocked on a question.")
 
     # Read-only: parked work stays visible so it can be found and unparked,
     # but it is deliberately not a queue.
     lines += ["", "## ⏸️ Parked", ""]
-    parked_issues = parked(data, focus)
+    parked_issues = parked(data)
     if parked_issues:
         for issue in parked_issues:
             lines.append(f"- #{issue['number']} {issue.get('title', '')} — `/unpark`")

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
@@ -26,7 +26,9 @@ a hand edit to a rendered section disappears at the next render._
 
 ## 📥 Intake
 
-Nothing waiting for triage.
+| Issue | Title | Milestone | Blocked by |
+| --- | --- | --- | --- |
+| #18 | A later-milestone issue | v0.0.2 | — |
 
 ## ✋ Waiting for you
 

--- a/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
+++ b/.claude/skills/pipeline-dashboard/tests/fixtures/expected_dashboard.md
@@ -28,6 +28,7 @@ a hand edit to a rendered section disappears at the next render._
 
 | Issue | Title | Milestone | Blocked by |
 | --- | --- | --- | --- |
+| #16 | 🚪 not admitted — Nobody has triaged this yet | v0.0.1 | — |
 | #18 | A later-milestone issue | v0.0.2 | — |
 
 ## ✋ Waiting for you

--- a/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
@@ -265,8 +265,9 @@ class SectionTests(unittest.TestCase):
         self.assertIn("Splash screen", rendered)
 
     def test_every_issue_table_has_a_milestone_column(self):
+        """Four tables render on the fixture: ready, intake, pending, clarify."""
         rendered = dash.render(state())
-        self.assertEqual(rendered.count("| Issue | Title | Milestone | Blocked by |"), 3)
+        self.assertEqual(rendered.count("| Issue | Title | Milestone | Blocked by |"), 4)
 
     def test_the_reconcile_section_lists_flag_findings(self):
         data = state()
@@ -309,6 +310,69 @@ class SectionTests(unittest.TestCase):
         self.assertIn("/park", rendered)
 
 
+class AttentionSectionScopeTests(unittest.TestCase):
+    """Intake, Waiting for you, Needs clarification and Parked are board-wide.
+
+    Only the pie and the ready queue are scoped to the focus milestone. The
+    sections that exist to say *somebody has to look at this* are not, because
+    the issues that most need looking at are exactly the ones no milestone has
+    been decided for yet — an `ai-triage` issue has not been triaged, and
+    triage is what assigns the milestone. Scoping Intake to the focus
+    milestone makes it structurally near-empty.
+    """
+
+    def issue(self, number, title, labels, milestone):
+        return {
+            "number": number, "title": title, "state": "open",
+            "labels": labels, "milestone": milestone,
+            "body": "", "native_blockers": []}
+
+    def with_issue(self, *args):
+        data = state()
+        data["issues"].append(self.issue(*args))
+        return data
+
+    def test_intake_lists_an_untriaged_issue_with_no_milestone(self):
+        data = self.with_issue(30, "Nobody has scheduled this", ["ai-triage"], None)
+        self.assertIn(30, [i["number"] for i in dash.intake(data)])
+
+    def test_intake_lists_an_ai_triage_issue_in_another_milestone(self):
+        self.assertIn(18, [i["number"] for i in dash.intake(state())])
+
+    def test_pending_approval_outside_the_focus_milestone_is_listed(self):
+        data = self.with_issue(
+            31, "Derek: add the signing secret", ["pending-approval"],
+            "Direct Involvement Needed")
+        self.assertIn(31, [i["number"] for i in dash.pending(data)])
+
+    def test_needs_clarification_outside_the_focus_milestone_is_listed(self):
+        data = self.with_issue(32, "App icon", ["needs-clarification"], None)
+        self.assertIn(32, [i["number"] for i in dash.needs_clarification(data)])
+
+    def test_parked_outside_the_focus_milestone_is_listed(self):
+        data = self.with_issue(33, "Sound effects", ["parked"], "v0.0.2")
+        self.assertIn(33, [i["number"] for i in dash.parked(data)])
+
+    def test_an_out_of_focus_row_names_its_own_milestone(self):
+        """The Milestone column is what tells these rows apart."""
+        rendered = dash.render(state())
+        self.assertIn("| #18 | A later-milestone issue | v0.0.2 |", rendered)
+
+    def test_a_row_with_no_milestone_renders_an_em_dash(self):
+        data = self.with_issue(30, "Nobody has scheduled this", ["ai-triage"], None)
+        self.assertIn("| #30 | Nobody has scheduled this | — |", dash.render(data))
+
+    def test_the_ready_queue_is_still_focus_scoped(self):
+        """The builder builds the focus milestone. Widening this queue would
+        put work in front of Derek that the nightly builder will not pick up."""
+        data = self.with_issue(34, "A later-milestone build", ["ready-for-work"], "v0.0.2")
+        self.assertNotIn(34, [i["number"] for i in dash.ready_queue(data)])
+
+    def test_the_pie_is_still_focus_scoped(self):
+        data = self.with_issue(35, "Elsewhere", ["ai-triage"], "v0.0.2")
+        self.assertEqual(sum(dash.focus_pie(data).values()), 8)
+
+
 class ParkedExclusionTests(unittest.TestCase):
     def parked_ready(self):
         data = state()
@@ -328,7 +392,7 @@ class ParkedExclusionTests(unittest.TestCase):
             "number": 30, "title": "Parked mid-triage", "state": "open",
             "labels": ["ai-triage", "parked"], "milestone": "v0.0.1",
             "body": "", "native_blockers": []})
-        self.assertEqual(dash.intake(data), [])
+        self.assertNotIn(30, [i["number"] for i in dash.intake(data)])
 
     def test_parked_still_counts_in_the_unplanned_slice(self):
         """The one deliberate exception — otherwise the pie stops adding up."""

--- a/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
+++ b/.claude/skills/pipeline-dashboard/tests/test_render_dashboard.py
@@ -373,6 +373,66 @@ class AttentionSectionScopeTests(unittest.TestCase):
         self.assertEqual(sum(dash.focus_pie(data).values()), 8)
 
 
+class UnadmittedTests(unittest.TestCase):
+    """Intake also carries issues nobody has `/admit`ted, flagged as such.
+
+    They are waiting on a different thing from an `ai-triage` row — the
+    nightly run will never pick them up, only `/admit` moves them — so the
+    flag is what stops one table meaning two things.
+    """
+
+    def with_issue(self, number, title, labels, milestone=None, closed=False):
+        data = state()
+        data["issues"].append({
+            "number": number, "title": title,
+            "state": "closed" if closed else "open",
+            "labels": labels, "milestone": milestone,
+            "body": "", "native_blockers": []})
+        return data
+
+    def numbers(self, data):
+        return [i["number"] for i in dash.intake(data)]
+
+    def test_an_unadmitted_issue_is_listed_in_intake(self):
+        data = self.with_issue(30, "Never admitted", ["type:task"])
+        self.assertIn(30, self.numbers(data))
+
+    def test_an_unadmitted_issue_in_the_focus_milestone_is_listed(self):
+        self.assertIn(16, self.numbers(state()))
+
+    def test_an_unadmitted_row_is_flagged(self):
+        data = self.with_issue(30, "Never admitted", ["type:task"])
+        self.assertIn("🚪 not admitted — Never admitted", dash.render(data))
+
+    def test_an_ai_triage_row_is_not_flagged(self):
+        """The flag has to tell the two piles apart, so it cannot be on both."""
+        self.assertIn("| #18 | A later-milestone issue |", dash.render(state()))
+
+    def test_the_dashboard_issue_is_never_in_intake(self):
+        """The board is the pipeline's furniture, not work for the pipeline."""
+        self.assertNotIn(78, self.numbers(state()))
+
+    def test_an_epic_is_not_in_intake(self):
+        """`/admit` on an epic is refused, so offering it would be a dead end."""
+        data = self.with_issue(31, "The whole pond", ["type:epic"])
+        self.assertNotIn(31, self.numbers(data))
+
+    def test_a_closed_unadmitted_issue_is_not_in_intake(self):
+        data = self.with_issue(32, "Done long ago", ["type:task"], closed=True)
+        self.assertNotIn(32, self.numbers(data))
+
+    def test_a_parked_issue_is_not_treated_as_unadmitted(self):
+        """`parked` is a state label, and a deliberate one."""
+        data = self.with_issue(33, "Set aside", ["parked", "type:task"])
+        self.assertNotIn(33, self.numbers(data))
+
+    def test_the_pie_still_adds_up(self):
+        """Intake widening must not move an issue between slices."""
+        counts = dash.focus_pie(state())
+        self.assertEqual(sum(counts.values()), 8)
+        self.assertEqual(counts["Unplanned"], 2)
+
+
 class ParkedExclusionTests(unittest.TestCase):
     def parked_ready(self):
         data = state()

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -36,7 +36,7 @@ Exactly one state label per open issue.
 
 | State | Meaning | Set by | Leaves when |
 | --- | --- | --- | --- |
-| *(none)* | brand new, not yet seen | issue creation | triage picks it up |
+| *(none)* | brand new, not yet admitted | issue creation | `/admit` |
 | `ai-triage` | queued for automated triage | `/admit`, `/propose`, `/revise`, `/unpark` | triage finishes |
 | `pending-approval` | triaged; waiting on a human | triage | `/approve`, `/park` |
 | `needs-clarification` | triage could not proceed without an answer | triage | `/revise <answer>`, `/park`, or the blocker sweep |

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -1206,21 +1206,55 @@ each time.
 `render_dashboard.py` rewrites the dashboard issue from live state. The
 sections, in order:
 
-| Section | Shows |
-| --- | --- |
-| 🎯 Focus | the four-slice pie for the focus milestone |
-| 🔨 Ready queue | `ready-for-work`, headed by the build cap |
-| 📥 Intake | `ai-triage` — waiting to be analyzed |
-| ✋ Waiting for you | `pending-approval` — waiting on Derek |
-| ❓ Needs clarification | blocked on a question |
-| ⏸️ Parked | set aside, listed so it can be found |
-| ⚠️ Reconcile | the sweep's flag findings |
-| 📅 Other milestones | progress elsewhere; finished milestones omitted |
-| 🎮 Commands | the command reference |
+| Section | Shows | Scope |
+| --- | --- | --- |
+| 🎯 Focus | the four-slice pie for the focus milestone | focus |
+| 🔨 Ready queue | `ready-for-work`, headed by the build cap | focus |
+| 📥 Intake | `ai-triage` — waiting to be analyzed | board-wide |
+| ✋ Waiting for you | `pending-approval` — waiting on Derek | board-wide |
+| ❓ Needs clarification | blocked on a question | board-wide |
+| ⏸️ Parked | set aside, listed so it can be found | board-wide |
+| ⚠️ Reconcile | the sweep's flag findings | board-wide |
+| 📅 Other milestones | progress elsewhere; finished milestones omitted | every other |
+| 🎮 Commands | the command reference | — |
 
 Every issue table carries a **Milestone** column, so the milestone is visible
 at every stage rather than only where an issue is being scheduled, and a
 **Blocked by** column linking each hard blocker.
+
+#### Only the pie and the ready queue are focus-scoped
+
+Those two answer *what is being built now*, and the builder builds the focus
+milestone. Listing an out-of-focus `ready-for-work` issue in the queue would
+put work in front of Derek that nothing is going to pick up.
+
+Every other section answers a different question — *what does somebody have to
+look at* — and an issue does not stop needing to be looked at by sitting
+outside the milestone currently being built. Scoping those to focus hides the
+work that most needs surfacing:
+
+- **Intake is the worst case.** `ai-triage` means the issue has *not* been
+  triaged, and triage is what decides its milestone — so an issue waiting for
+  triage usually has no milestone at all. A focus-scoped Intake is
+  structurally near-empty: the section reads "Nothing waiting for triage"
+  precisely because the untriaged pile is growing out of sight.
+- **`Direct Involvement Needed` can never be the focus.** It carries no
+  version and never ships, so a focus-scoped "Waiting for you" hides every
+  issue in the one milestone that exists to say *Derek has to do this by
+  hand* — which is most of them.
+- **A question is not answered by being scheduled late**, and answering it
+  early is often what lets the issue be scheduled at all.
+- **Parked work is listed so it can be found.** An out-of-focus parked issue
+  is the one most in need of that.
+
+The **Milestone** column is what keeps a board-wide table readable: a row
+reading `—` is an issue nobody has scheduled, which is the point of showing
+it. If every table were focus-scoped, that column would be a constant.
+
+**An issue with no pipeline-state label appears in no section**, board-wide
+scope or not. It has not been admitted, and `/admit` is how it enters. Only
+the pie counts them, in its Unplanned slice, and only inside the focus
+milestone — because the pie's job is to add up.
 
 #### Unblocker stars
 

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -1210,7 +1210,7 @@ sections, in order:
 | --- | --- | --- |
 | 🎯 Focus | the four-slice pie for the focus milestone | focus |
 | 🔨 Ready queue | `ready-for-work`, headed by the build cap | focus |
-| 📥 Intake | `ai-triage` — waiting to be analyzed | board-wide |
+| 📥 Intake | `ai-triage` — waiting to be analyzed, plus unadmitted work | board-wide |
 | ✋ Waiting for you | `pending-approval` — waiting on Derek | board-wide |
 | ❓ Needs clarification | blocked on a question | board-wide |
 | ⏸️ Parked | set aside, listed so it can be found | board-wide |
@@ -1251,10 +1251,35 @@ The **Milestone** column is what keeps a board-wide table readable: a row
 reading `—` is an issue nobody has scheduled, which is the point of showing
 it. If every table were focus-scoped, that column would be a constant.
 
-**An issue with no pipeline-state label appears in no section**, board-wide
-scope or not. It has not been admitted, and `/admit` is how it enters. Only
-the pie counts them, in its Unplanned slice, and only inside the focus
-milestone — because the pie's job is to add up.
+#### Intake carries two piles, and flags which is which
+
+An issue with **no pipeline-state label at all** has not been `/admit`ted, and
+the nightly analysis run will never pick it up — [its entry condition is
+`ai-triage` and nothing else](#analysis--find-what-needs-triage). Left off the
+board entirely, such an issue is invisible until somebody happens to scroll
+the issue list, which on this repo meant seven of twenty-one open issues.
+
+So Intake lists both, and marks the difference:
+
+| Row | Means | Who moves it |
+| --- | --- | --- |
+| plain | `ai-triage` — the pipeline has it | tonight's analysis run |
+| `🚪 not admitted` | no state label — nothing has it | Derek, with `/admit` |
+
+The flag is not decoration. The two piles are waiting on different things, and
+an Intake row that did not say which pile it was in would make the section
+mean two contradictory things — "handled" and "stalled on you" — at a glance,
+which is the only way this section gets read.
+
+**Two issues are never listed as unadmitted**: the `dashboard` issue, which is
+the pipeline's own furniture, and any `type:epic`, which is a container whose
+children carry the work. The epic case is exactly what
+[`epic-excluded` refuses](#where-each-command-is-refused), and listing an
+issue beside a command that gets refused is worse than not listing it.
+
+Unadmitted issues stay in the pie's **Unplanned** slice, and only inside the
+focus milestone — the pie's job is to add up, and widening Intake does not
+move an issue between slices.
 
 #### Unblocker stars
 


### PR DESCRIPTION
The dashboard was showing 4 issues out of 21. Every section was filtered down to the milestone we're currently building, so anything outside v0.3 vanished from the board — including things that were waiting on you. Now the board shows all of them, and each row says which milestone it belongs to.

Two sections were broken in a way that could never have fixed itself. **Intake** lists issues waiting to be looked at by the triage agent — but being triaged is *how* an issue gets a milestone, so filtering Intake by milestone meant it could only show work that had already been done. It said "Nothing waiting for triage" while three issues sat waiting. **Waiting for you** lists things only you can do, and most of those live in `Direct Involvement Needed` — a milestone with no version number, which can never be the one in focus. So the section named after you hid the issues that were yours.

Seven more issues were in a different hole: nobody had ever run `/admit` on them, so they had no state label, and no section listed those at all. They now appear in Intake marked `🚪 not admitted`, because they're waiting on a different thing from the rest of that table — you, rather than tonight's run.

## Spec invariants

- **The focus pie still adds up.** Four slices, every focus-milestone issue in exactly one, summing to the milestone's issue count. Widening Intake moves nothing between slices — an unadmitted issue was already Unplanned. Pinned by a test asserting both the total and the Unplanned count.
- **Parked is listed, never queued.** `parked` is a state label, so a parked issue is never mistaken for unadmitted, and it stays excluded from every active queue. Existing tests unchanged.
- **The ready queue still predicts the builder.** `select_queue.py` requires the focus milestone; so does the queue. A guard test asserts an out-of-focus `ready-for-work` issue stays out — widening this one would put work in front of you that nothing picks up.
- **Rendering is still byte-stable and still writes one issue body.** The golden snapshot passes; no new I/O.
- **`/admit` still means something.** The analysis run's entry condition is untouched — unadmitted issues are *displayed*, not triaged.

## How the spec is changing

**Was:** the docs listed the board's sections without stating any scope, and the code scoped all of them to the focus milestone.

**Now:** the docs state the scope of each section, and only two are focus-scoped — the pie and the ready queue, the two that answer *what is being built now*. Everything else answers *what does somebody have to look at*, which doesn't stop being true because an issue is scheduled elsewhere.

I treated `/docs` as authoritative. It scopes only the pie, and its line about the **Milestone** column making the milestone "visible at every stage rather than only where an issue is being scheduled" only makes sense if those tables aren't focus-scoped — in a focus-scoped table that column is a constant.

**Also changed:** Intake now holds two piles instead of one, distinguished by a flag rather than by being separate sections. The flag is load-bearing: `ai-triage` rows are handled and need nothing from you; `🚪 not admitted` rows are stalled until you type `/admit`.

**Also corrected:** the states table said an issue with no state label leaves that state when "triage picks it up". It doesn't — `select_triage.py` keys on `ai-triage` alone, as the Analysis section says two hundred lines further down. The table was the more prominent of the two and the wrong one, and is the likely origin of this bug.

**Docs:** `docs/engineering/issue-pipeline.md` — the dashboard section table gains a Scope column and states why only the pie and ready queue are focus-scoped; a new subsection specifies Intake's two piles, the `🚪 not admitted` flag, and the `dashboard`/`type:epic` exclusions; the `*(none)*` state row now says `/admit`. `.claude/skills/pipeline-dashboard/SKILL.md` — the same two rules, and a corrected claim that a bad `/focus` empties "every section".

## Testing

Strict TDD throughout, in two rounds. Round one: 7 scope tests written first, all 7 red for the right reason, with the 2 guard tests (ready queue and pie stay focus-scoped) green from the start as intended. Round two: 9 unadmitted tests, 3 red, with the 5 guards (dashboard, epic, closed, parked, pie total) green from the start.

75 dashboard tests pass, 16 new. The golden board diff was reviewed line by line at each round — one section and one row respectively. All 12 Python suites, `check_core_isolation.py`, and `mkdocs build --strict` pass. Verified against live repo state with the real `fetch_state.py`.

## Deviations and Decisions

- **Folded unadmitted issues into Intake with a flag, rather than giving them their own section.** I recommended a separate section — Intake currently maps one-to-one onto what tonight's analysis run will pick up, and mixing in issues it will never touch costs that property. You chose the flagged single table; noting the tradeoff, not relitigating it.
- **Excluded the `dashboard` issue and `type:epic` from the unadmitted pile.** Not in the brief. `/admit` is refused on both, and a row offering a command that bounces is worse than no row. Without the first guard the dashboard would have listed itself.
- **Un-scoped Parked as well**, though nothing is currently parked so it changes no output today. It's the same fault, and "listed so it can be found" is the section's stated purpose — an out-of-focus parked issue is the one most in need of finding.
- **Kept the existing sort** (unblockers first, then issue number) rather than grouping admitted before unadmitted. Every other table sorts that way, and the flag already distinguishes the rows.
- **Fixed the `*(none)*` states-table row** in this PR rather than as a follow-up. It contradicts the Analysis section, and leaving the sentence that caused this bug in place while fixing the bug seemed the wrong call.
- **Set the milestone on #292 to v0.3 myself.** Normally triage's job or yours via `/milestone`. The fix was already built and the issue would otherwise have rendered as `🚪 not admitted` with no milestone — noise for something already done. Move it if you'd rather.
- **Labelled #292 `in-progress`** rather than leaving it unlabelled, since an agent was building it and a PR exists. That's what the states table says the label means.
- **Four `type:question` issues now sit in Intake offering `/admit`** — #181, #250, #252, #287. They want an answer from you or Connor, not triage. That's a data question rather than a rendering one, so I left them alone; `/park` or an answer would clear them.

Closes #292

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDNQNFKdBJGKfdWh7w7bYb)_