### PR TITLE
fix(ui): paint the background to the edge of the screen

### DIFF
--- a/Assets/Editor/GameScene.cs
+++ b/Assets/Editor/GameScene.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.EditorTools
 {
@@ -99,7 +100,19 @@ namespace Frogs.EditorTools
             // A camera, so the app renders a screen rather than nothing.
             // Nothing else — what a screen looks like is a wireframe decision,
             // not something this tool gets to invent.
-            new GameObject(CameraName, typeof(Camera));
+            var camera = new GameObject(CameraName, typeof(Camera)).GetComponent<Camera>();
+
+            // Clearing to the screens' own background rather than to Unity's
+            // stock skybox. A new camera defaults to the skybox, and that
+            // gradient is what showed around the game before #290 — so this is
+            // set here as well as in the committed scene, or regenerating the
+            // asset would quietly put the bug back.
+            //
+            // Belt-and-braces: every screen paints this colour to the edge of
+            // the canvas itself. This is what a frame drawn before any of them
+            // has painted looks like.
+            camera.clearFlags = CameraClearFlags.SolidColor;
+            camera.backgroundColor = ScreenColours.Background;
 
             if (!EditorSceneManager.SaveScene(scene, AssetPath))
             {

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -145,8 +145,8 @@ Camera:
   m_GameObject: {fileID: 1117470437}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.92941177, g: 0.94509804, b: 0.93725491, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/Assets/Scripts/Unity/UI/DialogPanel.cs
+++ b/Assets/Scripts/Unity/UI/DialogPanel.cs
@@ -338,10 +338,14 @@ namespace Frogs.Unity.UI
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The whole canvas, not the reference rectangle. The scrim hangs
+            // off this, and "a dialog always dims what is behind it" has to
+            // stay true on a device whose canvas is bigger than 1920 x 1200 —
+            // a scrim that stopped at the reference would leave the screen
+            // underneath undimmed in a strip down each side. The panel itself
+            // is centre-anchored, so it does not move when this grows:
+            // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+            StretchToFill(_rect);
 
             _canvasGroup = GetComponent<CanvasGroup>();
             if (_canvasGroup == null)

--- a/Assets/Scripts/Unity/UI/ScreenColours.cs
+++ b/Assets/Scripts/Unity/UI/ScreenColours.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The colours a whole screen is painted in, as opposed to the colours a
+    /// single component is painted in.
+    ///
+    /// There is one of them today: the background every screen sits on. It is
+    /// declared here rather than on each screen because two different things
+    /// have to agree on it — every view's own background, and the scene
+    /// camera's clear colour — and a hex value copied into seven places is a
+    /// hex value that will be corrected in six.
+    ///
+    /// docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in
+    /// is where the rule lives; this is where the value does.
+    /// </summary>
+    public static class ScreenColours
+    {
+        /// <summary>
+        /// The background every screen is painted on — the mockups' `--bg`,
+        /// which every committed mockup sets on its 1920 x 1200 `.frame`.
+        ///
+        /// It reaches the edge of the screen on any aspect ratio, and the
+        /// scene camera clears to the same value, so a frame drawn before any
+        /// view has painted is this colour rather than whatever the engine
+        /// would otherwise show.
+        /// </summary>
+        public static readonly Color Background = new Color32(0xED, 0xF1, 0xEF, 0xFF);
+    }
+}

--- a/Assets/Scripts/Unity/UI/ScreenColours.cs.meta
+++ b/Assets/Scripts/Unity/UI/ScreenColours.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 422884e0c6d74ae6ae01b6490aaf7d7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/EndGameConfirmView.cs
+++ b/Assets/Scripts/Unity/Views/EndGameConfirmView.cs
@@ -66,11 +66,6 @@ namespace Frogs.Unity.Views
         // - `ButtonDestructiveGap`, `ButtonHeight` and `ButtonMinWidth` are
         //   the shared Button's (shared-components.md#button).
 
-        // The one canvas every screen is measured in —
-        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
-        const float CanvasWidth = 1920f;
-        const float CanvasHeight = 1200f;
-
         const string QuestionLabel = "End the game for everyone?";
         const string EndTheGameLabel = "End the game";
         const string KeepPlayingLabel = "Keep playing";
@@ -134,7 +129,7 @@ namespace Frogs.Unity.Views
         /// </summary>
         public event Action KeepPlayingRequested;
 
-        /// <summary>The view's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The view's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
@@ -358,10 +353,12 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The whole canvas, not the 1920 x 1200 reference rectangle. This
+            // dialog paints no background of its own — what it lays over the
+            // screen is the shared Dialog's scrim, and that has to reach the
+            // edges on a device that is not 16:10. The panel underneath is
+            // centre-anchored, so it does not move.
+            StretchToFill(_rect);
 
             BuildDialog();
             BuildCost();
@@ -474,6 +471,14 @@ namespace Frogs.Unity.Views
             {
                 handler();
             }
+        }
+
+        static void StretchToFill(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
         }
     }
 }

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -13,6 +13,7 @@ using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.Views
 {
@@ -101,12 +102,18 @@ namespace Frogs.Unity.Views
         // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
         // colours: not a geometry constant on any spec page's table, so not
         // declared as a named spec constant.
-        static readonly Color BoardBackgroundColor = new Color32(0xED, 0xF1, 0xEF, 0xFF); // mockup's --bg
+        //
+        // The mockup's `--bg` is the exception. It is the whole screen's
+        // background rather than this screen's chrome, and the scene camera
+        // has to clear to the same value, so it lives on ScreenColours where
+        // both can read it.
         static readonly Color BandColor = new Color32(0xE2, 0xE8, 0xE5, 0xFF); // mockup's header/controls bands
         static readonly Color BandOutlineColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockup's --faint
         static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
 
         RectTransform _rect;
+        RectTransform _contentRect;
+        Image _background;
 
         RectTransform _headerRect;
         Image _headerHairline;
@@ -143,13 +150,33 @@ namespace Frogs.Unity.Views
         /// </summary>
         public event Action SettingsRequested;
 
-        /// <summary>The screen's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The screen's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
             {
                 EnsureInitialized();
                 return _rect;
+            }
+        }
+
+        /// <summary>The paint that reaches every edge of the screen, whatever the device's aspect ratio.</summary>
+        public Image BackgroundImage
+        {
+            get
+            {
+                EnsureInitialized();
+                return _background;
+            }
+        }
+
+        /// <summary>Everything laid out in reference pixels — the 1920 x 1200 reference canvas, centred.</summary>
+        public RectTransform ContentRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _contentRect;
             }
         }
 
@@ -376,12 +403,17 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The root fills the whole canvas, which on a device that is not
+            // 16:10 is larger than the 1920 x 1200 reference — see
+            // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+            // Only the background hangs off it. Everything that is laid out in
+            // reference pixels hangs off `Content` instead, so the extra space
+            // a wider or taller device gives us is painted and nothing else.
+            StretchToFill(_rect);
 
             BuildBackground();
+            BuildContent();
+
             BuildHeader();
             BuildPond();
             BuildControls();
@@ -390,12 +422,30 @@ namespace Frogs.Unity.Views
         void BuildBackground()
         {
             var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
-            var background = backgroundGO.GetComponent<Image>();
-            background.color = BoardBackgroundColor;
-            background.raycastTarget = false;
-            var backgroundRect = background.rectTransform;
+            _background = backgroundGO.GetComponent<Image>();
+            _background.color = ScreenColours.Background;
+            _background.raycastTarget = false;
+            var backgroundRect = _background.rectTransform;
             backgroundRect.SetParent(_rect, worldPositionStays: false);
+
+            // The canvas, not the reference rectangle: this is the paint that
+            // reaches the edge of the screen whatever shape the screen is.
             StretchToFill(backgroundRect);
+        }
+
+        void BuildContent()
+        {
+            // The reference canvas, centred — exactly the rect the root used
+            // to be, so every child below keeps the anchors, sizes and offsets
+            // it already had and nothing on the board moves by a pixel.
+            var contentGO = new GameObject("Content", typeof(RectTransform));
+            _contentRect = (RectTransform)contentGO.transform;
+            _contentRect.SetParent(_rect, worldPositionStays: false);
+            _contentRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _contentRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _contentRect.pivot = new Vector2(0.5f, 0.5f);
+            _contentRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            _contentRect.anchoredPosition = Vector2.zero;
         }
 
         void BuildHeader()
@@ -408,7 +458,7 @@ namespace Frogs.Unity.Views
             headerImage.raycastTarget = false;
 
             _headerRect = headerImage.rectTransform;
-            _headerRect.SetParent(_rect, worldPositionStays: false);
+            _headerRect.SetParent(_contentRect, worldPositionStays: false);
             _headerRect.anchorMin = new Vector2(0f, 1f);
             _headerRect.anchorMax = new Vector2(1f, 1f);
             _headerRect.pivot = new Vector2(0.5f, 1f);
@@ -498,7 +548,7 @@ namespace Frogs.Unity.Views
             // loses height from here and nothing else.
             var pondGO = new GameObject("Pond", typeof(RectTransform));
             _pondRect = (RectTransform)pondGO.transform;
-            _pondRect.SetParent(_rect, worldPositionStays: false);
+            _pondRect.SetParent(_contentRect, worldPositionStays: false);
             _pondRect.anchorMin = Vector2.zero;
             _pondRect.anchorMax = Vector2.one;
             _pondRect.offsetMin = new Vector2(0f, BoardControlsHeight);
@@ -515,7 +565,7 @@ namespace Frogs.Unity.Views
             controlsImage.raycastTarget = false;
 
             _controlsRect = controlsImage.rectTransform;
-            _controlsRect.SetParent(_rect, worldPositionStays: false);
+            _controlsRect.SetParent(_contentRect, worldPositionStays: false);
             _controlsRect.anchorMin = new Vector2(0f, 0f);
             _controlsRect.anchorMax = new Vector2(1f, 0f);
             _controlsRect.pivot = new Vector2(0.5f, 0f);

--- a/Assets/Scripts/Unity/Views/GameOverScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameOverScreenView.cs
@@ -12,6 +12,7 @@ using CoreScreen = Frogs.Core.Screen;
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.Views
 {
@@ -214,6 +215,8 @@ namespace Frogs.Unity.Views
         }
 
         RectTransform _rect;
+        RectTransform _contentRect;
+        Image _background;
 
         RectTransform _headlineRect;
         Text _headlineText;
@@ -235,13 +238,33 @@ namespace Frogs.Unity.Views
         ScreenRouter _router;
         Func<ulong> _seedFactory = DefaultSeedFactory;
 
-        /// <summary>The screen's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The screen's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
             {
                 EnsureInitialized();
                 return _rect;
+            }
+        }
+
+        /// <summary>The paint that reaches every edge of the screen, whatever the device's aspect ratio.</summary>
+        public Image BackgroundImage
+        {
+            get
+            {
+                EnsureInitialized();
+                return _background;
+            }
+        }
+
+        /// <summary>Everything laid out in reference pixels — the 1920 x 1200 reference canvas, centred.</summary>
+        public RectTransform ContentRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _contentRect;
             }
         }
 
@@ -676,14 +699,50 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The root fills the whole canvas, which on a device that is not
+            // 16:10 is larger than the 1920 x 1200 reference — see
+            // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+            // Only the background hangs off it. Everything laid out in
+            // reference pixels hangs off `Content` instead, so the extra space
+            // a wider or taller device gives us is painted and nothing else.
+            StretchToFill(_rect);
+
+            BuildBackground();
+            BuildContent();
 
             BuildHeadline();
             BuildStandings();
             BuildControls();
+        }
+
+        void BuildBackground()
+        {
+            // The paint that reaches the edge of the screen on any aspect
+            // ratio — the mockups' `--bg`, which every mockup sets on its
+            // 1920 x 1200 frame and which nothing here painted until now.
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            _background = backgroundGO.GetComponent<Image>();
+            _background.color = ScreenColours.Background;
+            _background.raycastTarget = false;
+
+            var backgroundRect = _background.rectTransform;
+            backgroundRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(backgroundRect);
+        }
+
+        void BuildContent()
+        {
+            // The reference canvas, centred — exactly the rect the root used
+            // to be, so every child below keeps the anchors, sizes and offsets
+            // it already had and nothing on this screen moves by a pixel.
+            var contentGO = new GameObject("Content", typeof(RectTransform));
+            _contentRect = (RectTransform)contentGO.transform;
+            _contentRect.SetParent(_rect, worldPositionStays: false);
+            _contentRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _contentRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _contentRect.pivot = new Vector2(0.5f, 0.5f);
+            _contentRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            _contentRect.anchoredPosition = Vector2.zero;
         }
 
         void BuildHeadline()
@@ -702,7 +761,7 @@ namespace Frogs.Unity.Views
             _headlineText.raycastTarget = false;
 
             _headlineRect = _headlineText.rectTransform;
-            _headlineRect.SetParent(_rect, worldPositionStays: false);
+            _headlineRect.SetParent(_contentRect, worldPositionStays: false);
             _headlineRect.anchorMin = new Vector2(0.5f, 1f);
             _headlineRect.anchorMax = new Vector2(0.5f, 1f);
             _headlineRect.pivot = new Vector2(0.5f, 1f);
@@ -717,7 +776,7 @@ namespace Frogs.Unity.Views
             // frog with StandingsRowGap between rows.
             var standingsGO = new GameObject("Standings", typeof(RectTransform));
             _standingsRect = (RectTransform)standingsGO.transform;
-            _standingsRect.SetParent(_rect, worldPositionStays: false);
+            _standingsRect.SetParent(_contentRect, worldPositionStays: false);
             _standingsRect.anchorMin = new Vector2(0.5f, 1f);
             _standingsRect.anchorMax = new Vector2(0.5f, 1f);
             _standingsRect.pivot = new Vector2(0.5f, 1f);
@@ -844,7 +903,7 @@ namespace Frogs.Unity.Views
             // bottom safe-area line.
             var controlsGO = new GameObject("Controls", typeof(RectTransform));
             _controlsRect = (RectTransform)controlsGO.transform;
-            _controlsRect.SetParent(_rect, worldPositionStays: false);
+            _controlsRect.SetParent(_contentRect, worldPositionStays: false);
             StretchToFill(_controlsRect);
 
             _backToTheTitleButton = CreateControlButton("BackToTheTitle", ButtonKind.Secondary, BackToTheTitleLabel);

--- a/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
@@ -13,6 +13,7 @@ using CoreScreen = Frogs.Core.Screen;
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.Views
 {
@@ -215,6 +216,8 @@ namespace Frogs.Unity.Views
         }
 
         RectTransform _rect;
+        RectTransform _contentRect;
+        Image _background;
 
         RectTransform _headerRect;
         Text _headerText;
@@ -235,13 +238,33 @@ namespace Frogs.Unity.Views
         ScreenRouter _router;
         Func<ulong> _seedFactory = DefaultSeedFactory;
 
-        /// <summary>The screen's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The screen's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
             {
                 EnsureInitialized();
                 return _rect;
+            }
+        }
+
+        /// <summary>The paint that reaches every edge of the screen, whatever the device's aspect ratio.</summary>
+        public Image BackgroundImage
+        {
+            get
+            {
+                EnsureInitialized();
+                return _background;
+            }
+        }
+
+        /// <summary>Everything laid out in reference pixels — the 1920 x 1200 reference canvas, centred.</summary>
+        public RectTransform ContentRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _contentRect;
             }
         }
 
@@ -468,15 +491,51 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The root fills the whole canvas, which on a device that is not
+            // 16:10 is larger than the 1920 x 1200 reference — see
+            // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+            // Only the background hangs off it. Everything laid out in
+            // reference pixels hangs off `Content` instead, so the extra space
+            // a wider or taller device gives us is painted and nothing else.
+            StretchToFill(_rect);
+
+            BuildBackground();
+            BuildContent();
 
             BuildHeader();
             BuildSeats();
             BuildHint();
             BuildControls();
+        }
+
+        void BuildBackground()
+        {
+            // The paint that reaches the edge of the screen on any aspect
+            // ratio — the mockups' `--bg`, which every mockup sets on its
+            // 1920 x 1200 frame and which nothing here painted until now.
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            _background = backgroundGO.GetComponent<Image>();
+            _background.color = ScreenColours.Background;
+            _background.raycastTarget = false;
+
+            var backgroundRect = _background.rectTransform;
+            backgroundRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(backgroundRect);
+        }
+
+        void BuildContent()
+        {
+            // The reference canvas, centred — exactly the rect the root used
+            // to be, so every child below keeps the anchors, sizes and offsets
+            // it already had and nothing on this screen moves by a pixel.
+            var contentGO = new GameObject("Content", typeof(RectTransform));
+            _contentRect = (RectTransform)contentGO.transform;
+            _contentRect.SetParent(_rect, worldPositionStays: false);
+            _contentRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _contentRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _contentRect.pivot = new Vector2(0.5f, 0.5f);
+            _contentRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            _contentRect.anchoredPosition = Vector2.zero;
         }
 
         void BuildHeader()
@@ -494,7 +553,7 @@ namespace Frogs.Unity.Views
             _headerText.raycastTarget = false;
 
             _headerRect = _headerText.rectTransform;
-            _headerRect.SetParent(_rect, worldPositionStays: false);
+            _headerRect.SetParent(_contentRect, worldPositionStays: false);
             _headerRect.anchorMin = new Vector2(0.5f, 1f);
             _headerRect.anchorMax = new Vector2(0.5f, 1f);
             _headerRect.pivot = new Vector2(0.5f, 1f);
@@ -514,7 +573,7 @@ namespace Frogs.Unity.Views
 
             var seatsGO = new GameObject("Seats", typeof(RectTransform));
             _seatsRect = (RectTransform)seatsGO.transform;
-            _seatsRect.SetParent(_rect, worldPositionStays: false);
+            _seatsRect.SetParent(_contentRect, worldPositionStays: false);
             _seatsRect.anchorMin = new Vector2(0.5f, 0.5f);
             _seatsRect.anchorMax = new Vector2(0.5f, 0.5f);
             _seatsRect.pivot = new Vector2(0.5f, 0.5f);
@@ -666,7 +725,7 @@ namespace Frogs.Unity.Views
             _hintText.raycastTarget = false;
 
             _hintRect = _hintText.rectTransform;
-            _hintRect.SetParent(_rect, worldPositionStays: false);
+            _hintRect.SetParent(_contentRect, worldPositionStays: false);
             _hintRect.anchorMin = new Vector2(0.5f, 0.5f);
             _hintRect.anchorMax = new Vector2(0.5f, 0.5f);
             _hintRect.pivot = new Vector2(0.5f, 0.5f);
@@ -680,7 +739,7 @@ namespace Frogs.Unity.Views
             // SafeMargin from their edge, pinned to the bottom safe area.
             var controlsGO = new GameObject("Controls", typeof(RectTransform));
             _controlsRect = (RectTransform)controlsGO.transform;
-            _controlsRect.SetParent(_rect, worldPositionStays: false);
+            _controlsRect.SetParent(_contentRect, worldPositionStays: false);
             StretchToFill(_controlsRect);
 
             _backButton = CreateControlButton("Back", ButtonKind.Secondary, BackLabel);

--- a/Assets/Scripts/Unity/Views/SettingsDialogView.cs
+++ b/Assets/Scripts/Unity/Views/SettingsDialogView.cs
@@ -74,11 +74,6 @@ namespace Frogs.Unity.Views
         // - `VersionLabelSize` is title-screen.md's — the same value doing the
         //   same job, a quiet version readout bottom-left.
 
-        // The one canvas every screen is measured in —
-        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
-        const float CanvasWidth = 1920f;
-        const float CanvasHeight = 1200f;
-
         const string TitleLabel = "Settings";
         const string HowToPlayLabel = "How to play";
         const string EndGameLabel = "End the game";
@@ -125,7 +120,7 @@ namespace Frogs.Unity.Views
         /// </summary>
         public event Action EndGameConfirmRequested;
 
-        /// <summary>The view's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The view's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
@@ -301,10 +296,12 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The whole canvas, not the 1920 x 1200 reference rectangle. This
+            // dialog paints no background of its own — what it lays over the
+            // screen is the shared Dialog's scrim, and that has to reach the
+            // edges on a device that is not 16:10. The panel underneath is
+            // centre-anchored, so it does not move.
+            StretchToFill(_rect);
 
             BuildDialog();
             BuildActions();

--- a/Assets/Scripts/Unity/Views/TitleScreenView.cs
+++ b/Assets/Scripts/Unity/Views/TitleScreenView.cs
@@ -9,6 +9,7 @@ using CoreScreen = Frogs.Core.Screen;
 // or `ButtonKind` in this file always means the shared component's.
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.Views
 {
@@ -72,6 +73,8 @@ namespace Frogs.Unity.Views
         static readonly Color VersionColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' --line
 
         RectTransform _rect;
+        RectTransform _contentRect;
+        Image _background;
 
         RectTransform _backdropRect;
         CanvasGroup _backdropCanvasGroup;
@@ -93,13 +96,33 @@ namespace Frogs.Unity.Views
         ScreenRouter _router;
         ISavedGameQuery _savedGameQuery = new NoSavedGameQuery();
 
-        /// <summary>The screen's own <see cref="RectTransform"/>, sized to the full 1920 x 1200 reference canvas.</summary>
+        /// <summary>The screen's own <see cref="RectTransform"/>, filling the whole canvas — which is the reference canvas or larger.</summary>
         public RectTransform RectTransform
         {
             get
             {
                 EnsureInitialized();
                 return _rect;
+            }
+        }
+
+        /// <summary>The paint that reaches every edge of the screen, whatever the device's aspect ratio.</summary>
+        public Image BackgroundImage
+        {
+            get
+            {
+                EnsureInitialized();
+                return _background;
+            }
+        }
+
+        /// <summary>Everything laid out in reference pixels — the 1920 x 1200 reference canvas, centred.</summary>
+        public RectTransform ContentRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _contentRect;
             }
         }
 
@@ -312,14 +335,56 @@ namespace Frogs.Unity.Views
                 _rect = gameObject.AddComponent<RectTransform>();
             }
 
-            _rect.anchorMin = new Vector2(0.5f, 0.5f);
-            _rect.anchorMax = new Vector2(0.5f, 0.5f);
-            _rect.pivot = new Vector2(0.5f, 0.5f);
-            _rect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            // The root fills the whole canvas, which on a device that is not
+            // 16:10 is larger than the 1920 x 1200 reference — see
+            // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+            // Only the background hangs off it. Everything laid out in
+            // reference pixels hangs off `Content` instead.
+            StretchToFill(_rect);
+
+            BuildBackground();
+            BuildContent();
 
             BuildBackdrop();
             BuildAction();
             BuildFootprint();
+        }
+
+        void BuildBackground()
+        {
+            // The paint that reaches the edge of the screen on any aspect
+            // ratio. It sits *under* the backdrop rather than being part of
+            // it, because the backdrop fades in and this must not: the first
+            // frame of the title screen is this colour, not whatever is
+            // behind the canvas.
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            _background = backgroundGO.GetComponent<Image>();
+            _background.color = ScreenColours.Background;
+            _background.raycastTarget = false;
+
+            var backgroundRect = _background.rectTransform;
+            backgroundRect.SetParent(_rect, worldPositionStays: false);
+            StretchToFill(backgroundRect);
+        }
+
+        void BuildContent()
+        {
+            // The reference canvas, centred — exactly the rect the root used
+            // to be, so every child below keeps the anchors and offsets it
+            // already had and nothing on the title screen moves.
+            //
+            // The splash art is in here rather than on the background, so it
+            // keeps the shape it is drawn at. An illustration stretched to
+            // whatever proportions a device happens to have is the one thing a
+            // 1:1 mockup cannot describe.
+            var contentGO = new GameObject("Content", typeof(RectTransform));
+            _contentRect = (RectTransform)contentGO.transform;
+            _contentRect.SetParent(_rect, worldPositionStays: false);
+            _contentRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _contentRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _contentRect.pivot = new Vector2(0.5f, 0.5f);
+            _contentRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            _contentRect.anchoredPosition = Vector2.zero;
         }
 
         void BuildBackdrop()
@@ -329,7 +394,7 @@ namespace Frogs.Unity.Views
             // "Neither button animates."
             var backdropGO = new GameObject("Backdrop", typeof(RectTransform), typeof(CanvasGroup));
             _backdropRect = (RectTransform)backdropGO.transform;
-            _backdropRect.SetParent(_rect, worldPositionStays: false);
+            _backdropRect.SetParent(_contentRect, worldPositionStays: false);
             StretchToFill(_backdropRect);
 
             _backdropCanvasGroup = backdropGO.GetComponent<CanvasGroup>();
@@ -378,7 +443,7 @@ namespace Frogs.Unity.Views
             // settled open question 1.
             var actionGO = new GameObject("Action", typeof(RectTransform));
             _actionRect = (RectTransform)actionGO.transform;
-            _actionRect.SetParent(_rect, worldPositionStays: false);
+            _actionRect.SetParent(_contentRect, worldPositionStays: false);
             StretchToFill(_actionRect);
 
             _resumeButton = CreateActionButton("Resume", ButtonKind.Secondary, ResumeLabel);
@@ -412,7 +477,7 @@ namespace Frogs.Unity.Views
             // footprint — version string, bottom-left, small and quiet.
             var footprintGO = new GameObject("Footprint", typeof(RectTransform));
             _footprintRect = (RectTransform)footprintGO.transform;
-            _footprintRect.SetParent(_rect, worldPositionStays: false);
+            _footprintRect.SetParent(_contentRect, worldPositionStays: false);
             StretchToFill(_footprintRect);
 
             var versionGO = new GameObject("Version", typeof(RectTransform), typeof(Text));

--- a/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
+++ b/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
@@ -1,0 +1,336 @@
+using NUnit.Framework;
+using UnityEngine;
+using Frogs.Core;
+using Frogs.Unity.Views;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// **Nothing behind the canvas is ever visible** — issue #290, and the
+    /// rule docs/specs/ui/shared-components.md now states under
+    /// "The canvas every component is measured in".
+    ///
+    /// Every screen is laid out at the 1920 x 1200 reference, and the
+    /// `CanvasScaler` is set to `Expand`, so on a device that is not 16:10 the
+    /// canvas is *bigger* than that reference in one direction. What fills the
+    /// difference is what these tests are about: the screen's own background,
+    /// reaching the edge, and never the engine's clear.
+    ///
+    /// Two halves, asserted separately on purpose, because a fix that only
+    /// does one of them looks right on the tablet and is wrong everywhere
+    /// else:
+    ///
+    /// - the painted background covers the whole canvas, whatever its shape;
+    /// - the laid-out content is still exactly 1920 x 1200, centred, so the
+    ///   fix cannot pass by stretching the layout instead. Every constant on
+    ///   every spec page means what it meant before.
+    ///
+    /// The canvas used here is bigger in *both* directions than the reference,
+    /// which is not a shape any real device has — it is the shape that makes a
+    /// background that only stretched one way fail here rather than on
+    /// somebody's tablet.
+    /// </summary>
+    public sealed class FullBleedBackgroundTests
+    {
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float ReferenceWidth = 1920f;
+        const float ReferenceHeight = 1200f;
+
+        // A canvas that is not 16:10, larger than the reference in both
+        // directions — what `ScreenMatchMode.Expand` produces on a device
+        // whose aspect ratio is not the one the game is drawn at.
+        const float OversizedCanvasWidth = 2400f;
+        const float OversizedCanvasHeight = 1400f;
+
+        const float Tolerance = 0.001f;
+
+        const ulong AnySeed = 20260812UL;
+
+        [Test]
+        public void GameBoard_PaintsItsBackgroundToEveryEdge_AndLeavesTheBoardAtReferenceSize()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(GameBoardScreenView), typeof(RectTransform))
+                    .AddComponent<GameBoardScreenView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+                view.Initialize(new Game(new[] { FrogColour.Green, FrogColour.Blue }, AnySeed));
+
+                AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "the board's background");
+                AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "the board's content");
+
+                Assert.That(
+                    view.BackgroundImage.color,
+                    Is.EqualTo(ScreenColours.Background),
+                    "the background the whole screen is painted in is the shared screen "
+                    + "background, which is also what the camera clears to");
+
+                // The layout itself is untouched: the header and the controls
+                // band are full width *of the reference canvas*, not of the
+                // device. If either of these reads 2400 the fix stretched the
+                // board instead of the background, and every constant on
+                // docs/specs/ui/game-board.md has quietly stopped meaning what
+                // it says.
+                Assert.That(
+                    view.HeaderRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "the header is still the reference canvas wide, not the device wide");
+                Assert.That(
+                    view.ControlsRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "the controls band is still the reference canvas wide, not the device wide");
+                Assert.That(
+                    view.PondRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "the pond is still the reference canvas wide, so every lane is where "
+                    + "docs/specs/ui/game-board.md puts it");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        [Test]
+        public void TitleScreen_PaintsItsBackgroundToEveryEdge_AndLeavesItsContentAtReferenceSize()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(TitleScreenView), typeof(RectTransform))
+                    .AddComponent<TitleScreenView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+
+                AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "the title screen's background");
+                AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "the title screen's content");
+
+                // The splash art stays at reference size rather than being
+                // stretched to the device. It is a flat placeholder today
+                // (#168 brings the real illustration), and an illustration
+                // stretched to whatever shape the device happens to be is the
+                // one thing a mockup cannot describe.
+                Assert.That(
+                    view.ArtRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "the splash art is still the reference canvas wide, not the device wide");
+                Assert.That(
+                    view.ArtRect.rect.height,
+                    Is.EqualTo(ReferenceHeight).Within(Tolerance),
+                    "the splash art is still the reference canvas tall, not the device tall");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        [Test]
+        public void GameSetup_PaintsItsBackgroundToEveryEdge_AndLeavesItsContentAtReferenceSize()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(GameSetupScreenView), typeof(RectTransform))
+                    .AddComponent<GameSetupScreenView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+
+                AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "game setup's background");
+                AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "game setup's content");
+
+                Assert.That(
+                    view.ControlsRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "Back and Start are still SafeMargin from the reference canvas's edges, "
+                    + "not from the device's");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        [Test]
+        public void GameOver_PaintsItsBackgroundToEveryEdge_AndLeavesItsContentAtReferenceSize()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(GameOverScreenView), typeof(RectTransform))
+                    .AddComponent<GameOverScreenView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+
+                AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "game over's background");
+                AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "game over's content");
+
+                Assert.That(
+                    view.ControlsRect.rect.width,
+                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                    "the controls are still SafeMargin from the reference canvas's edges, "
+                    + "not from the device's");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// A dialog paints no background of its own — what it lays over the
+        /// screen is the shared scrim, "a dimmed copy of the screen
+        /// underneath". That is the thing that has to reach the edges: a scrim
+        /// that stopped at the reference rectangle would leave the screen
+        /// underneath undimmed in a strip down each side, which reads as a
+        /// rendering fault rather than as a dialog.
+        /// </summary>
+        [Test]
+        public void SettingsDialog_DimsTheWholeCanvas_AndLeavesItsPanelWhereItWas()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(SettingsDialogView), typeof(RectTransform))
+                    .AddComponent<SettingsDialogView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+
+                AssertCoversTheWholeCanvas(view.Dialog.Scrim.rectTransform, canvas, "the settings dialog's scrim");
+
+                AssertIsCentredOn(view.Dialog.PanelRect, canvas, "the settings dialog's panel");
+                Assert.That(
+                    view.Dialog.PanelRect.rect.width,
+                    Is.EqualTo(SettingsDialogView.SettingsDialogWidth).Within(Tolerance),
+                    "the panel is still its own specified width, not the device's");
+                Assert.That(
+                    view.Dialog.PanelRect.rect.height,
+                    Is.EqualTo(SettingsDialogView.SettingsDialogHeight).Within(Tolerance),
+                    "the panel is still its own specified height, not the device's");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        [Test]
+        public void EndGameConfirm_DimsTheWholeCanvas_AndLeavesItsPanelWhereItWas()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = new GameObject(nameof(EndGameConfirmView), typeof(RectTransform))
+                    .AddComponent<EndGameConfirmView>();
+                view.transform.SetParent(canvas, worldPositionStays: false);
+
+                AssertCoversTheWholeCanvas(view.Dialog.Scrim.rectTransform, canvas, "the end-game confirm's scrim");
+
+                AssertIsCentredOn(view.Dialog.PanelRect, canvas, "the end-game confirm's panel");
+                Assert.That(
+                    view.Dialog.PanelRect.rect.width,
+                    Is.EqualTo(EndGameConfirmView.ConfirmDialogWidth).Within(Tolerance),
+                    "the panel is still its own specified width, not the device's");
+                Assert.That(
+                    view.Dialog.PanelRect.rect.height,
+                    Is.EqualTo(EndGameConfirmView.ConfirmDialogHeight).Within(Tolerance),
+                    "the panel is still its own specified height, not the device's");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        // --- helpers ---------------------------------------------------------
+
+        // A canvas the shape `ScreenMatchMode.Expand` produces on a device
+        // that is not 16:10 — bigger than the reference, with the view under
+        // it exactly as AppRoot's "Screens" host holds it.
+        static RectTransform OversizedCanvas()
+        {
+            var host = new GameObject("OversizedCanvas", typeof(RectTransform));
+            var rect = (RectTransform)host.transform;
+
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = new Vector2(OversizedCanvasWidth, OversizedCanvasHeight);
+            rect.anchoredPosition = Vector2.zero;
+
+            return rect;
+        }
+
+        static void DestroyCanvas(RectTransform canvas)
+        {
+            UnityEngine.Object.DestroyImmediate(canvas.gameObject);
+        }
+
+        // Measured in world corners rather than in sizes and anchors, so no
+        // anchoring arrangement can satisfy it without actually covering the
+        // canvas.
+        static void AssertCoversTheWholeCanvas(RectTransform rect, RectTransform canvas, string what)
+        {
+            var expected = new Vector3[4];
+            var actual = new Vector3[4];
+
+            canvas.GetWorldCorners(expected);
+            rect.GetWorldCorners(actual);
+
+            for (var corner = 0; corner < expected.Length; corner++)
+            {
+                Assert.That(
+                    actual[corner].x,
+                    Is.EqualTo(expected[corner].x).Within(Tolerance),
+                    $"{what} does not reach the canvas horizontally — corner {corner}. "
+                    + "The strip it leaves is where the engine's own clear shows through.");
+                Assert.That(
+                    actual[corner].y,
+                    Is.EqualTo(expected[corner].y).Within(Tolerance),
+                    $"{what} does not reach the canvas vertically — corner {corner}. "
+                    + "The strip it leaves is where the engine's own clear shows through.");
+            }
+        }
+
+        static void AssertIsTheReferenceCanvasCentred(RectTransform rect, RectTransform canvas, string what)
+        {
+            Assert.That(
+                rect.rect.width,
+                Is.EqualTo(ReferenceWidth).Within(Tolerance),
+                $"{what} is not the reference canvas wide. Everything laid out inside it is "
+                + "positioned in reference pixels, so a different width moves all of it.");
+            Assert.That(
+                rect.rect.height,
+                Is.EqualTo(ReferenceHeight).Within(Tolerance),
+                $"{what} is not the reference canvas tall.");
+
+            AssertIsCentredOn(rect, canvas, what);
+        }
+
+        static void AssertIsCentredOn(RectTransform rect, RectTransform canvas, string what)
+        {
+            Assert.That(
+                CenterOf(rect).x,
+                Is.EqualTo(CenterOf(canvas).x).Within(Tolerance),
+                $"{what} is not centred horizontally on the canvas, so the extra space is "
+                + "all down one side instead of split evenly.");
+            Assert.That(
+                CenterOf(rect).y,
+                Is.EqualTo(CenterOf(canvas).y).Within(Tolerance),
+                $"{what} is not centred vertically on the canvas.");
+        }
+
+        static Vector3 CenterOf(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+
+            return (corners[0] + corners[2]) / 2f;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/FullBleedBackgroundTests.cs.meta
+++ b/Assets/Tests/EditMode/FullBleedBackgroundTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c532394267114a5a85155649c3e2e26a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameSceneTests.cs
+++ b/Assets/Tests/EditMode/GameSceneTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.EditModeTests
 {
@@ -24,6 +25,10 @@ namespace Frogs.Unity.EditModeTests
         // pins it independently — a rename that moves the asset has to fail
         // here rather than quietly agree with itself.
         const string ScenePath = "Assets/Scenes/Game.unity";
+
+        // One 8-bit step is 1/255; a tenth of that is well inside a round trip
+        // through the scene file and nowhere near a different colour.
+        const float ColourTolerance = 0.0004f;
 
         [Test]
         public void TheSceneAssetIsWhereTheBuildLooksForIt()
@@ -93,6 +98,57 @@ namespace Frogs.Unity.EditModeTests
                     "The scene has no camera, so the app renders nothing at all and there "
                     + "is no way to tell a working build from a broken one by looking at "
                     + "it.");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, removeScene: true);
+            }
+        }
+
+        /// <summary>
+        /// The camera clears to the screens' own background, not to Unity's
+        /// stock skybox — issue #290, where that skybox's blue-to-brown
+        /// gradient was what showed around a letterboxed game.
+        ///
+        /// This is belt-and-braces on top of every screen painting its
+        /// background to the edge of the canvas: it is what a frame drawn
+        /// before any view has painted looks like. It is asserted here, on the
+        /// committed asset, because the asset is what ships — the editor tool
+        /// that produced it agrees, but a build reads the `.unity` file.
+        /// </summary>
+        [Test]
+        public void TheCameraClearsToTheScreenBackground_NotToUnitysDefaultSkybox()
+        {
+            var scene = EditorSceneManager.OpenScene(ScenePath, OpenSceneMode.Additive);
+
+            try
+            {
+                var camera = scene.GetRootGameObjects()
+                    .Select(root => root.GetComponent<Camera>())
+                    .FirstOrDefault(found => found != null);
+
+                Assert.That(camera, Is.Not.Null, "the scene has no camera to assert about");
+
+                Assert.That(
+                    camera.clearFlags,
+                    Is.EqualTo(CameraClearFlags.SolidColor),
+                    "The camera still clears to the skybox. Anything the canvas has not "
+                    + "painted — a strip at the edge on a device that is not 16:10, or the "
+                    + "very first frame — shows Unity's stock sky gradient, which is not "
+                    + "anything this game drew.");
+
+                // Component-wise and with a tolerance: the colour makes a
+                // round trip through the scene's own float serialization, so
+                // an exact struct comparison would be asserting the format
+                // rather than the colour.
+                Assert.That(camera.backgroundColor.r, Is.EqualTo(ScreenColours.Background.r).Within(ColourTolerance));
+                Assert.That(camera.backgroundColor.g, Is.EqualTo(ScreenColours.Background.g).Within(ColourTolerance));
+                Assert.That(camera.backgroundColor.b, Is.EqualTo(ScreenColours.Background.b).Within(ColourTolerance));
+                Assert.That(
+                    camera.backgroundColor.a,
+                    Is.EqualTo(1f).Within(ColourTolerance),
+                    "a transparent clear colour clears to nothing, which is the bug this "
+                    + "is here to stop rather than a version of the fix");
             }
             finally
             {

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -69,6 +69,38 @@ designed against — see
 `CanvasScaler` is set to that same reference resolution, so a constant written
 here is the constant the code sets, with no conversion in between.
 
+### What fills a screen that is not 16:10
+
+The target tablet is 1920 × 1200 exactly, but the game runs on whatever screen
+it is opened on, and the `CanvasScaler` is set to **expand** — the canvas is
+never smaller than the reference in either direction, so nothing drawn at
+1920 × 1200 is ever cropped off an edge. The cost of that choice is that on any
+other aspect ratio the canvas is *larger* than the reference in one direction,
+and something has to fill the difference.
+
+**Invariant:** the screen's background reaches all four edges of the screen, on
+every aspect ratio.
+
+**Invariant:** everything laid out is laid out in the 1920 × 1200 reference
+canvas, centred on the screen. The extra space a wider or taller device gives
+us is margin, not layout — every constant on every screen page keeps meaning
+exactly what it says.
+
+**Invariant:** the extra space is background and nothing else. No element
+appears there, and no element grows into it. An element that only exists on
+some devices is an element nobody can review against a mockup, and every mockup
+in this repo is drawn at exactly one size.
+
+**Invariant:** nothing behind the canvas is ever visible. The scene camera
+clears to the same background colour rather than to the engine's default sky,
+so even a frame drawn before any screen has painted is the game's own colour.
+
+That background colour is the mockups' `--bg`, `#EDF1EF` — the colour every
+committed mockup paints its 1920 × 1200 frame. A dialog is the one screen that
+paints no background of its own: what it lays over the screen underneath is the
+[scrim](#dialog), and the scrim reaches the edges for the same reason and by
+the same rule.
+
 ### Why the numbers look big
 
 `MinTouchTarget` is 96 px, which is roughly double what a UI guideline for


### PR DESCRIPTION
Closes #290

The game sat in a box in the middle of the tablet with a blue-to-brown gradient
down both sides — Unity's stock sky, not anything we drew. Every screen was
building itself into a rectangle of exactly 1920 × 1200, and on a screen that
is not 16:10 the canvas is bigger than that, so the leftover strip was
genuinely unpainted. Now each screen paints its background right out to the
edge, and the camera clears to that same colour instead of the sky, so there is
nothing left for a gradient to show through. Nothing on any screen moved: the
board, the buttons and the frogs are in exactly the pixel they were in before.

**Docs:** `docs/specs/ui/shared-components.md` — the canvas section had nothing
to say about a screen that is not 16:10, which is why six screens could each be
built to a fixed box without contradicting anything written down. It now states
four invariants for that case: the background reaches all four edges; the
layout stays at 1920 × 1200 and centred; the extra space is background and
nothing else; and nothing behind the canvas is ever visible.

## Spec invariants

| Rule this had to keep true | Test that asserts it |
| --- | --- |
| Every number on every screen page is in pixels at the 1920 × 1200 reference — so nothing may move or resize | `FullBleedBackgroundTests` — every screen's `Content` rect is exactly 1920 × 1200 and centred on an oversized canvas, and the header, pond and controls bands each still measure the reference width, not the device's |
| The board's own geometry (`docs/specs/ui/game-board.md`) | The existing `GameBoardScreenViewTests` assertions on header/lane/controls widths are untouched and still pass — those bands moved one level down the hierarchy onto a rect that is the same size and in the same place as the one they used to hang off |
| "A dialog always dims what is behind it" (`shared-components.md#dialog`) | `FullBleedBackgroundTests` — the settings dialog's and the end-game confirm's scrims cover the whole oversized canvas, while their panels stay at their own specified size, centred |
| The splash art is drawn at 1920 × 1200 (`title-screen.md`) | `FullBleedBackgroundTests` — the art rect is still reference-sized on an oversized canvas, so the real illustration in #168 will not arrive stretched to whatever shape a device happens to be |
| `ScreenMatchMode.Expand` stays — nothing designed at the reference is ever cropped | Untouched; `AppRoot.cs` is not in this diff |

## How the spec is changing

- **Old rule:** every number is in pixels at the 1920 × 1200 reference, and the
  `CanvasScaler` matches. Silent on what fills a screen of any other shape.
- **New rule:** the same, plus — the background reaches all four edges on every
  aspect ratio; everything laid out stays at 1920 × 1200, centred; the extra
  space is background and nothing else; and nothing behind the canvas is ever
  visible, because the camera clears to the same colour.
- **Why it is better:** the gap was not a detail nobody had got to. It was the
  whole bug. Six screens were each built to a fixed box, each defensibly,
  because the page said what size things are and never said what happens to the
  rest of the screen. Writing the answer down is what stops the seventh screen
  being built the same way.

## What changed, in shape

Each screen's root now fills the canvas and carries the background. A new
centred `Content` rect, exactly the size the root used to be, carries
everything else — so every child keeps the anchors, offsets and sizes it
already had, and the layout cannot move. Dialogs paint no background of their
own, so for them the shared `DialogPanel`'s root is what stretches, and the
scrim reaches the edges.

## Deviations and Decisions

- **The shared `DialogPanel` changed too, though the issue named six views.**
  Two of those six are dialogs, and their scrim lives on `DialogPanel` rather
  than on the view — stretching only the view roots would have left their
  scrims stopping at the reference rectangle, and the fix for those two would
  have been a no-op. Fixing it there also fixes the roll-and-card, working-out
  and answer-result dialogs for free, since they share the same panel.
- **The two dialog views got no `Content` rect**, unlike the approved plan's
  "split each of the six views' root into an outer rect and an inner `Content`
  rect". Nothing is parented to their roots except the `DialogPanel` itself,
  and putting that inside a reference-sized `Content` is precisely what would
  keep the scrim letterboxed. Their panel is centre-anchored and fixed-size, so
  it does not move without one.
- **Game setup, game over and the title screen gained a background element they
  did not have.** They painted nothing at all before — on those screens the
  gradient was the *entire* background, not a strip. The colour is not a new
  choice: it is `--bg`, `#EDF1EF`, which every committed mockup already paints
  on its 1920 × 1200 frame. Judged a restyle rather than structure under
  `ui-design-process.md`'s test — the mockups are still accurate pictures of
  these screens afterwards, and rather more accurate than they were.
- **`#EDF1EF` moved to a new shared `ScreenColours.Background`.** Two things
  have to agree on it now — every view's background and the scene camera's
  clear colour — and a hex copied into seven places is a hex that gets
  corrected in six. Same shape as the existing `FrogColours`.
- **The scene's YAML was edited by hand**, for two fields: `m_ClearFlags` and
  `m_BackGroundColor`. `CLAUDE.md` rule 6 says not to guess at Unity
  serialization, so this is not left to a guess — `GameSceneTests` opens the
  committed scene in CI and asserts the camera's `clearFlags` and colour
  through the typed API, which fails if the YAML is wrong. `Assets/Editor/GameScene.cs`
  now sets the same two values when it creates the scene, so regenerating the
  asset cannot quietly restore the skybox.
- **The issue's open question is not answered by this PR.** "Does anything land
  in the extra space, or is it just more background?" was answered in the
  approved triage plan — background and nothing else, since an element that
  exists only on some devices cannot be reviewed against a mockup — and that
  answer is what is written into the docs here.
- **The last checklist box is not ticked.** It asks for a screenshot from a
  non-16:10 viewport, which needs an editor or a device; there is neither in an
  agent environment. #299 is open in `Direct Involvement Needed` with exactly
  what to look at. Nothing is blocked on it — both halves of the fix are
  asserted in CI — it is the confirmation that what the tests assert is what
  the eye sees.

## Checked locally

`check_core_isolation.py`, `check_geometry_literals.py`,
`check_assembly_references.py`, `run_python_tests.py` and
`mkdocs build --strict` all pass. `dotnet` is not installed in this environment
and the proxy blocks its installer, so the Core suite runs in CI rather than
here — nothing in this diff touches Core, and the isolation check says so. The
EditMode tests were written but not executed locally, for the usual reason:
there is no editor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2TZkYRwNZ5xD7iqMtgYgD)_