### PR TITLE
feat(ui): the pond reads as water — blue water, brown logs, green lily pads

### DIFF
--- a/Assets/Scripts/Unity/UI/BoardColours.cs
+++ b/Assets/Scripts/Unity/UI/BoardColours.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+
+namespace Frogs.Unity.UI
+{
+    /// <summary>
+    /// The pond's palette — docs/specs/ui/game-board.md § Colours, which is
+    /// the table these values are received from, exactly as
+    /// <see cref="Frogs.Unity.Views.GameBoardScreenView"/> receives that page's
+    /// geometry.
+    ///
+    /// Until issue #291 these colours lived as private fields in two view
+    /// files, annotated "copied verbatim from the committed mockup". That was
+    /// honest and it was still the wrong home: every other number on this
+    /// screen is born on the spec page and received by the code, and a colour
+    /// that only exists in a mockup's CSS and a private field is a colour
+    /// nobody can change on purpose.
+    ///
+    /// They live in one class rather than on the two views because the board's
+    /// shape is still moving. Issue #296 takes the logs off the lane and gives
+    /// them to the pond; a log's colour should not have to move house when its
+    /// drawing does.
+    ///
+    /// **These are not the final palette.** Derek's decision — blue water,
+    /// brown logs, green lily pads — is settled. The exact hues are Connor's
+    /// call, made on the tablet against the committed mockups, and until he
+    /// makes it these carry the proposal drawn there. See the spec page's own
+    /// "Placeholder, or settled?" note, which says the same thing about the
+    /// same values, and <see cref="FrogColours"/>, which carries the identical
+    /// caveat for the four frogs.
+    /// </summary>
+    public static class BoardColours
+    {
+        /// <summary>
+        /// The water — docs/specs/ui/game-board.md § Colours, `PondWater`.
+        ///
+        /// It is the board's background, and it is what the board paints to
+        /// every edge of the device: the pond is not a rectangle inside a page,
+        /// it is the whole screen. That makes it this screen's own colour
+        /// rather than <see cref="ScreenColours.Background"/>, which is what
+        /// every other screen paints and what the camera clears to.
+        /// </summary>
+        public static readonly Color PondWater = new Color32(0x9F, 0xD8, 0xF2, 0xFF);
+
+        /// <summary>The lily pads — `LilyPadGreen`. The seven positions a lane has to itself.</summary>
+        public static readonly Color LilyPadGreen = new Color32(0xCC, 0xEA, 0xAF, 0xFF);
+
+        /// <summary>The lily pad's rim, drawn `TrackOutline` (3 px) thick — `LilyPadEdge`.</summary>
+        public static readonly Color LilyPadEdge = new Color32(0x7F, 0xAE, 0x5E, 0xFF);
+
+        /// <summary>The Start and End logs — `LogBrown`.</summary>
+        public static readonly Color LogBrown = new Color32(0xE2, 0xC7, 0x9C, 0xFF);
+
+        /// <summary>
+        /// The log's rim, drawn `TrackOutline` (3 px) thick — `LogEdge`.
+        ///
+        /// It is doing more work than the lily pad's. A log and the water are
+        /// deliberately close in brightness and far apart in hue, so this rim
+        /// is what makes the log's shape read against the water rather than
+        /// its fill — see the spec page's "keeping the frogs visible".
+        /// </summary>
+        public static readonly Color LogEdge = new Color32(0xA9, 0x7F, 0x4F, 0xFF);
+
+        /// <summary>
+        /// The header and controls bands — `BandFill`.
+        ///
+        /// Unchanged by issue #291, deliberately: it is the pond that Derek
+        /// asked to be water, and whether these two bands still read as a
+        /// frame against blue is game-board.md's open question for Connor.
+        /// </summary>
+        public static readonly Color BandFill = new Color32(0xE2, 0xE8, 0xE5, 0xFF);
+
+        /// <summary>The hairline under `header` and over `controls`, `BoardBandOutline` (3 px) thick — `BandEdge`.</summary>
+        public static readonly Color BandEdge = new Color32(0xB9, 0xC0, 0xBD, 0xFF);
+
+        /// <summary>The board's words — `BoardInk`.</summary>
+        public static readonly Color BoardInk = new Color32(0x1E, 0x24, 0x22, 0xFF);
+
+        /// <summary>
+        /// The frog piece's outline, drawn `FrogPieceOutline` (4 px) thick —
+        /// `PieceEdge`. Black at 35%, so it darkens whatever it is over rather
+        /// than being a fifth colour that has to work against four surfaces.
+        /// </summary>
+        public static readonly Color PieceEdge = new Color(0f, 0f, 0f, 0.35f);
+    }
+}

--- a/Assets/Scripts/Unity/UI/BoardColours.cs.meta
+++ b/Assets/Scripts/Unity/UI/BoardColours.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a32fcd67d1d64b2eb35c8b5d942ccf70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/UI/ScreenColours.cs
+++ b/Assets/Scripts/Unity/UI/ScreenColours.cs
@@ -6,11 +6,11 @@ namespace Frogs.Unity.UI
     /// The colours a whole screen is painted in, as opposed to the colours a
     /// single component is painted in.
     ///
-    /// There is one of them today: the background every screen sits on. It is
-    /// declared here rather than on each screen because two different things
-    /// have to agree on it — every view's own background, and the scene
-    /// camera's clear colour — and a hex value copied into seven places is a
-    /// hex value that will be corrected in six.
+    /// There is one of them today: the app's own background. It is declared
+    /// here rather than on each screen because two different things have to
+    /// agree on it — those views' backgrounds, and the scene camera's clear
+    /// colour — and a hex value copied into seven places is a hex value that
+    /// will be corrected in six.
     ///
     /// docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in
     /// is where the rule lives; this is where the value does.
@@ -18,13 +18,17 @@ namespace Frogs.Unity.UI
     public static class ScreenColours
     {
         /// <summary>
-        /// The background every screen is painted on — the mockups' `--bg`,
-        /// which every committed mockup sets on its 1920 x 1200 `.frame`.
+        /// The app's background — the mockups' `--bg`. The title screen, game
+        /// setup and game over paint it, and the scene camera clears to it, so
+        /// a frame drawn before any view has painted is the game's own colour
+        /// rather than whatever the engine would otherwise show.
         ///
-        /// It reaches the edge of the screen on any aspect ratio, and the
-        /// scene camera clears to the same value, so a frame drawn before any
-        /// view has painted is this colour rather than whatever the engine
-        /// would otherwise show.
+        /// The game board is the exception, and the only one: it paints
+        /// <see cref="BoardColours.PondWater"/> instead, because that screen is
+        /// a pond rather than a page — docs/specs/ui/game-board.md § Colours.
+        /// It paints it to every edge of the device exactly as the others
+        /// paint this, so "nothing behind the canvas is ever visible" is as
+        /// true there as here.
         /// </summary>
         public static readonly Color Background = new Color32(0xED, 0xF1, 0xEF, 0xFF);
     }

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Frogs.Core;
 using UnityEngine;
 using UnityEngine.UI;
+using BoardColours = Frogs.Unity.UI.BoardColours;
 using FrogColours = Frogs.Unity.UI.FrogColours;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
@@ -60,16 +61,12 @@ namespace Frogs.Unity.Views
         // whatever Lane reports; the denominator is Lane.LaneWinningPosition.
         const string PadCountFormat = "{0} of {1}";
 
-        // Chrome colours copied verbatim from the committed mockup
-        // (docs/specs/ui/mockups/game-board.html) — the same line Button.cs,
-        // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
-        // colours: not a geometry constant on any spec page's table, so not
-        // declared as a named spec constant.
-        static readonly Color LilyPadColor = new Color32(0xCF, 0xE0, 0xD2, 0xFF); // mockup's .pad fill
-        static readonly Color LilyPadOutlineColor = new Color32(0x9F, 0xB8, 0xA5, 0xFF); // mockup's .pad border
-        static readonly Color LogColor = new Color32(0xE0, 0xD4, 0xC3, 0xFF); // mockup's .log fill
-        static readonly Color LogOutlineColor = new Color32(0xB9, 0xA7, 0x8E, 0xFF); // mockup's .log border
-        static readonly Color PieceOutlineColor = new Color(0f, 0f, 0f, 0.35f); // mockup's .frog border
+        // The track's colours are docs/specs/ui/game-board.md § Colours,
+        // received by name from BoardColours exactly as the geometry above is
+        // received from that page's constants table. They used to be private
+        // hex values here, copied out of the mockup's CSS; issue #291 gave
+        // them a home on the spec page and this file the same relationship to
+        // them it already had to every other number on this screen.
 
         static Sprite s_logSprite;
         static Sprite s_logFillSprite;
@@ -526,7 +523,7 @@ namespace Frogs.Unity.Views
                 var outline = positionGO.GetComponent<Image>();
                 outline.sprite = isLog ? LogSprite : LilyPadSprite;
                 outline.type = Image.Type.Sliced;
-                outline.color = isLog ? LogOutlineColor : LilyPadOutlineColor;
+                outline.color = isLog ? BoardColours.LogEdge : BoardColours.LilyPadEdge;
                 outline.raycastTarget = false;
 
                 var positionRect = outline.rectTransform;
@@ -541,7 +538,7 @@ namespace Frogs.Unity.Views
                 var fill = fillGO.GetComponent<Image>();
                 fill.sprite = isLog ? LogFillSprite : LilyPadFillSprite;
                 fill.type = Image.Type.Sliced;
-                fill.color = isLog ? LogColor : LilyPadColor;
+                fill.color = isLog ? BoardColours.LogBrown : BoardColours.LilyPadGreen;
                 fill.raycastTarget = false;
 
                 var fillRect = fill.rectTransform;
@@ -568,7 +565,7 @@ namespace Frogs.Unity.Views
             _pieceOutline = pieceGO.GetComponent<Image>();
             _pieceOutline.sprite = PieceSprite;
             _pieceOutline.type = Image.Type.Sliced;
-            _pieceOutline.color = PieceOutlineColor;
+            _pieceOutline.color = BoardColours.PieceEdge;
             _pieceOutline.raycastTarget = false;
 
             _pieceRect = _pieceOutline.rectTransform;

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -8,12 +8,12 @@ using UnityEngine.UI;
 // so these are pulled in by explicit alias rather than a wildcard
 // `using Frogs.Unity.UI;`, and a bare `Button`, `ButtonKind`, `FrogColours`
 // or `PlayerChip` in this file always means the shared component's.
+using BoardColours = Frogs.Unity.UI.BoardColours;
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
-using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.Views
 {
@@ -97,19 +97,18 @@ namespace Frogs.Unity.Views
         // external assets).
         const string BuiltinLabelFontName = "LegacyRuntime.ttf";
 
-        // Chrome colours copied verbatim from the committed mockup
-        // (docs/specs/ui/mockups/game-board.html) — the same line Button.cs,
-        // PlayerChip.cs and GameSetupScreenView.cs each draw for their own
-        // colours: not a geometry constant on any spec page's table, so not
-        // declared as a named spec constant.
+        // The board's colours are docs/specs/ui/game-board.md § Colours,
+        // received by name from BoardColours exactly as the geometry above is
+        // received from that page's constants table.
         //
-        // The mockup's `--bg` is the exception. It is the whole screen's
-        // background rather than this screen's chrome, and the scene camera
-        // has to clear to the same value, so it lives on ScreenColours where
-        // both can read it.
-        static readonly Color BandColor = new Color32(0xE2, 0xE8, 0xE5, 0xFF); // mockup's header/controls bands
-        static readonly Color BandOutlineColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockup's --faint
-        static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockup's --ink
+        // The one worth reading twice is `PondWater`. Every other screen
+        // paints ScreenColours.Background, which is also what the scene camera
+        // clears to; the board paints its own water instead, to every edge of
+        // the device, because the pond is not a rectangle inside a page — it
+        // is the whole screen. #290's rule still holds: nothing behind the
+        // canvas is ever visible, because this screen's own paint reaches the
+        // edges. What the camera clears to is unchanged, and it is what shows
+        // for the frame before *any* screen has painted.
 
         RectTransform _rect;
         RectTransform _contentRect;
@@ -423,7 +422,7 @@ namespace Frogs.Unity.Views
         {
             var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
             _background = backgroundGO.GetComponent<Image>();
-            _background.color = ScreenColours.Background;
+            _background.color = BoardColours.PondWater;
             _background.raycastTarget = false;
             var backgroundRect = _background.rectTransform;
             backgroundRect.SetParent(_rect, worldPositionStays: false);
@@ -454,7 +453,7 @@ namespace Frogs.Unity.Views
             // shorter screen.
             var headerGO = new GameObject("Header", typeof(RectTransform), typeof(Image));
             var headerImage = headerGO.GetComponent<Image>();
-            headerImage.color = BandColor;
+            headerImage.color = BoardColours.BandFill;
             headerImage.raycastTarget = false;
 
             _headerRect = headerImage.rectTransform;
@@ -480,7 +479,7 @@ namespace Frogs.Unity.Views
             _turnBannerText.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
             _turnBannerText.fontSize = (int)TurnBannerSize;
             _turnBannerText.fontStyle = FontStyle.Bold;
-            _turnBannerText.color = InkColor;
+            _turnBannerText.color = BoardColours.BoardInk;
             _turnBannerText.alignment = TextAnchor.MiddleLeft;
             _turnBannerText.horizontalOverflow = HorizontalWrapMode.Overflow;
             _turnBannerText.verticalOverflow = VerticalWrapMode.Overflow;
@@ -528,7 +527,7 @@ namespace Frogs.Unity.Views
         {
             var hairlineGO = new GameObject(hairlineName, typeof(RectTransform), typeof(Image));
             var hairline = hairlineGO.GetComponent<Image>();
-            hairline.color = BandOutlineColor;
+            hairline.color = BoardColours.BandEdge;
             hairline.raycastTarget = false;
 
             var hairlineRect = hairline.rectTransform;
@@ -561,7 +560,7 @@ namespace Frogs.Unity.Views
             // is the wrong thing to trade away, so this band does not shrink.
             var controlsGO = new GameObject("Controls", typeof(RectTransform), typeof(Image));
             var controlsImage = controlsGO.GetComponent<Image>();
-            controlsImage.color = BandColor;
+            controlsImage.color = BoardColours.BandFill;
             controlsImage.raycastTarget = false;
 
             _controlsRect = controlsImage.rectTransform;

--- a/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
+++ b/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using UnityEngine;
 using Frogs.Core;
 using Frogs.Unity.Views;
+using BoardColours = Frogs.Unity.UI.BoardColours;
 using ScreenColours = Frogs.Unity.UI.ScreenColours;
 
 namespace Frogs.Unity.EditModeTests
@@ -63,11 +64,20 @@ namespace Frogs.Unity.EditModeTests
                 AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "the board's background");
                 AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "the board's content");
 
+                // The board is the one screen that paints something other than
+                // the shared app background: its own water — issue #291,
+                // docs/specs/ui/game-board.md § Colours. What #290 asked of it
+                // is unchanged and asserted above: whatever it paints, it
+                // paints to every edge, so nothing behind the canvas shows.
                 Assert.That(
                     view.BackgroundImage.color,
-                    Is.EqualTo(ScreenColours.Background),
-                    "the background the whole screen is painted in is the shared screen "
-                    + "background, which is also what the camera clears to");
+                    Is.EqualTo(BoardColours.PondWater),
+                    "the board is painted in the water, and the water reaches the edges");
+                Assert.That(
+                    view.BackgroundImage.color,
+                    Is.Not.EqualTo(ScreenColours.Background),
+                    "the fixture, not the assertion — if these two are ever the same value "
+                    + "the test above proves nothing");
 
                 // The layout itself is untouched: the header and the controls
                 // band are full width *of the reference canvas*, not of the

--- a/Assets/Tests/EditMode/GameBoardColoursTests.cs
+++ b/Assets/Tests/EditMode/GameBoardColoursTests.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UI;
+using Frogs.Core;
+using Frogs.Unity.Views;
+using BoardColours = Frogs.Unity.UI.BoardColours;
+using FrogColours = Frogs.Unity.UI.FrogColours;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// The pond reads as water — issue #291, and
+    /// docs/specs/ui/game-board.md § Colours, which is where the board's
+    /// colours now live. Written before the change, per
+    /// docs/engineering/testing.md's sanctioned flow: pushed unexecuted, with
+    /// CI turning them red against the old pale values before green — there is
+    /// no editor here to watch them fail in.
+    ///
+    /// The hex values are written out **as literals** rather than read from
+    /// <see cref="BoardColours"/>. A test that asserts a constant equals itself
+    /// is a test that passes whatever the constant is changed to; these are
+    /// game-board.md's table, copied here by hand, so a colour cannot be
+    /// changed in the code without the spec's own value being changed with it.
+    ///
+    /// The last test is the odd one out and deliberately so. It asserts the
+    /// acceptance criterion the issue set — every frog stays clearly separable
+    /// from everything it can sit on — as arithmetic rather than as a hex
+    /// value, so a future repaint of the pond, or the real frog palette
+    /// arriving, cannot quietly land a green frog on a green lily pad.
+    /// </summary>
+    public sealed class GameBoardColoursTests
+    {
+        const ulong AnySeed = 20260812UL;
+
+        // docs/specs/ui/game-board.md § Colours — the page's own table,
+        // copied by hand rather than read from the code under test.
+        static readonly Color PondWater = new Color32(0x9F, 0xD8, 0xF2, 0xFF);
+        static readonly Color LilyPadGreen = new Color32(0xCC, 0xEA, 0xAF, 0xFF);
+        static readonly Color LilyPadEdge = new Color32(0x7F, 0xAE, 0x5E, 0xFF);
+        static readonly Color LogBrown = new Color32(0xE2, 0xC7, 0x9C, 0xFF);
+        static readonly Color LogEdge = new Color32(0xA9, 0x7F, 0x4F, 0xFF);
+        static readonly Color BandFill = new Color32(0xE2, 0xE8, 0xE5, 0xFF);
+
+        // The bar the spec page sets for "clearly separable", and the reason
+        // this issue could change the board's fills at all —
+        // docs/specs/ui/game-board.md#keeping-the-frogs-visible.
+        const float MinimumContrastRatio = 1.9f;
+        const float MinimumColourDistance = 30f;
+
+        [Test]
+        public void TheBoardIsPaintedInPondWater()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                Assert.That(
+                    view.BackgroundImage.color,
+                    Is.EqualTo(PondWater),
+                    "the board's background is the water — game-board.md's `PondWater`. "
+                    + "It is this screen's own colour, not the app background the other "
+                    + "screens paint, and it is what reaches every edge of the device.");
+
+                Assert.That(
+                    BoardColours.PondWater,
+                    Is.EqualTo(PondWater),
+                    "the named constant carries the spec page's value");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryLilyPadIsGreen()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                foreach (var lane in view.Lanes)
+                {
+                    // The seven lily pads — positions 1 to 7. Position 0 and
+                    // position 8 are the logs.
+                    for (var position = 1; position < Lane.LaneWinningPosition; position++)
+                    {
+                        Assert.That(
+                            lane.PositionImages[position].color,
+                            Is.EqualTo(LilyPadGreen),
+                            $"{lane.Colour}'s lily pad at position {position} is `LilyPadGreen`");
+                        Assert.That(
+                            lane.PositionOutlines[position].color,
+                            Is.EqualTo(LilyPadEdge),
+                            $"{lane.Colour}'s lily pad at position {position} has the `LilyPadEdge` rim");
+                    }
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void BothLogsAreBrown()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                foreach (var lane in view.Lanes)
+                {
+                    foreach (var position in new[] { 0, Lane.LaneWinningPosition })
+                    {
+                        Assert.That(
+                            lane.PositionImages[position].color,
+                            Is.EqualTo(LogBrown),
+                            $"the log at position {position} is `LogBrown`");
+                        Assert.That(
+                            lane.PositionOutlines[position].color,
+                            Is.EqualTo(LogEdge),
+                            $"the log at position {position} has the `LogEdge` rim, which is what "
+                            + "separates a log from the water it floats on — the two are close in "
+                            + "brightness on purpose and far apart in hue");
+                    }
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// game-board.md's open question 2, asserted rather than assumed: the
+        /// header and controls bands were **deliberately left** the pale
+        /// grey-green they were chosen as, and this issue did not repaint
+        /// them on its way past. If they are ever changed, it is because
+        /// Connor looked at the blue board and said so — and this test is the
+        /// thing that has to be edited to do it.
+        /// </summary>
+        [Test]
+        public void TheHeaderAndControlsBandsAreLeftExactlyAsTheyWere()
+        {
+            var view = CreateView(TwoFrogGame());
+
+            try
+            {
+                Assert.That(
+                    view.HeaderRect.GetComponent<Image>().color,
+                    Is.EqualTo(BandFill),
+                    "the header band is unchanged by this issue");
+                Assert.That(
+                    view.ControlsRect.GetComponent<Image>().color,
+                    Is.EqualTo(BandFill),
+                    "the controls band is unchanged by this issue");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// The acceptance criterion, as arithmetic. Every one of the four frog
+        /// colours against every surface a frog can sit on: the water, a lily
+        /// pad, and a log.
+        ///
+        /// Two measures, because either one alone can be fooled. Luminance
+        /// contrast catches two colours of different hue and identical
+        /// brightness — which is what a colour-blind player, or anyone in
+        /// bright sunlight, is left with. CIE L*a*b* distance catches two
+        /// colours of the same brightness that a contrast ratio calls fine
+        /// but nobody could name apart.
+        ///
+        /// The 4 px `FrogPieceOutline` is separation on top of this, not
+        /// instead of it.
+        /// </summary>
+        [Test]
+        public void EveryFrogStaysSeparableFromEverythingItCanSitOn()
+        {
+            var surfaces = new Dictionary<string, Color>
+            {
+                { "the water", PondWater },
+                { "a lily pad", LilyPadGreen },
+                { "a log", LogBrown },
+            };
+
+            foreach (FrogColour frog in Enum.GetValues(typeof(FrogColour)))
+            {
+                foreach (var surface in surfaces)
+                {
+                    var piece = FrogColours.For(frog);
+
+                    Assert.That(
+                        ContrastRatio(piece, surface.Value),
+                        Is.GreaterThanOrEqualTo(MinimumContrastRatio),
+                        $"the {frog} frog is too close in brightness to {surface.Key}. "
+                        + "Fix the surface, not the frog — the frog colours are the art "
+                        + "decision this issue does not get to move.");
+
+                    Assert.That(
+                        ColourDistance(piece, surface.Value),
+                        Is.GreaterThanOrEqualTo(MinimumColourDistance),
+                        $"the {frog} frog is too close in colour to {surface.Key}. "
+                        + "Fix the surface, not the frog.");
+                }
+            }
+        }
+
+        // --- the two measures ------------------------------------------------
+
+        // WCAG's relative luminance contrast, (L1 + 0.05) / (L2 + 0.05).
+        static float ContrastRatio(Color a, Color b)
+        {
+            var first = RelativeLuminance(a);
+            var second = RelativeLuminance(b);
+
+            var lighter = Mathf.Max(first, second);
+            var darker = Mathf.Min(first, second);
+
+            return (lighter + 0.05f) / (darker + 0.05f);
+        }
+
+        static float RelativeLuminance(Color colour)
+        {
+            return (0.2126f * ToLinear(colour.r))
+                + (0.7152f * ToLinear(colour.g))
+                + (0.0722f * ToLinear(colour.b));
+        }
+
+        static float ToLinear(float channel)
+        {
+            return channel <= 0.04045f
+                ? channel / 12.92f
+                : Mathf.Pow((channel + 0.055f) / 1.055f, 2.4f);
+        }
+
+        // Straight-line distance in CIE L*a*b* (ΔE*ab). Roughly: 2.3 is the
+        // smallest difference anyone can see, and 30 is two colours nobody
+        // would call shades of one another.
+        static float ColourDistance(Color a, Color b)
+        {
+            var first = ToLab(a);
+            var second = ToLab(b);
+
+            var dl = first.x - second.x;
+            var da = first.y - second.y;
+            var db = first.z - second.z;
+
+            return Mathf.Sqrt((dl * dl) + (da * da) + (db * db));
+        }
+
+        static Vector3 ToLab(Color colour)
+        {
+            var r = ToLinear(colour.r);
+            var g = ToLinear(colour.g);
+            var b = ToLinear(colour.b);
+
+            // sRGB to CIE XYZ, D65.
+            var x = ((0.4124564f * r) + (0.3575761f * g) + (0.1804375f * b)) / 0.95047f;
+            var y = (0.2126729f * r) + (0.7151522f * g) + (0.0721750f * b);
+            var z = ((0.0193339f * r) + (0.1191920f * g) + (0.9503041f * b)) / 1.08883f;
+
+            var fx = LabF(x);
+            var fy = LabF(y);
+            var fz = LabF(z);
+
+            return new Vector3(
+                (116f * fy) - 16f,
+                500f * (fx - fy),
+                200f * (fy - fz));
+        }
+
+        static float LabF(float t)
+        {
+            const float Epsilon = 216f / 24389f;
+
+            return t > Epsilon
+                ? Mathf.Pow(t, 1f / 3f)
+                : ((841f / 108f) * t) + (4f / 29f);
+        }
+
+        // --- fixtures --------------------------------------------------------
+
+        static Game TwoFrogGame()
+        {
+            return new Game(new[] { FrogColour.Green, FrogColour.Blue }, AnySeed);
+        }
+
+        static GameBoardScreenView CreateView(Game game)
+        {
+            var host = new GameObject(nameof(GameBoardColoursTests), typeof(RectTransform));
+            var view = host.AddComponent<GameBoardScreenView>();
+            view.Initialize(game);
+            return view;
+        }
+
+        static void Destroy(GameBoardScreenView view)
+        {
+            UnityEngine.Object.DestroyImmediate(view.gameObject);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameBoardColoursTests.cs.meta
+++ b/Assets/Tests/EditMode/GameBoardColoursTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d02572ee8d4430c9dd03bcb5a30e01b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -205,6 +205,109 @@ and `ButtonLabelSize` also 44 px — and neither is that constant. The Button's
 corner and label are the Button's to restyle; the pond's logs and its gear are
 not, and they must not move when it does.
 
+## Colours
+
+The board is a pond. **Blue water, brown logs, green lily pads** — Derek's
+decision, in his words, on
+[issue #291](https://github.com/derekwinters/connor-multiplying-frogs/issues/291).
+
+| Element | Constant | Value |
+| --- | --- | --- |
+| The water — the pond, and the whole screen behind it | `PondWater` | `#9FD8F2` |
+| Lily pad | `LilyPadGreen` | `#CCEAAF` |
+| Lily pad rim | `LilyPadEdge` | `#7FAE5E` |
+| Log | `LogBrown` | `#E2C79C` |
+| Log rim | `LogEdge` | `#A97F4F` |
+| Header and controls bands | `BandFill` | `#E2E8E5` |
+| Band hairline | `BandEdge` | `#B9C0BD` |
+| The board's words | `BoardInk` | `#1E2422` |
+| Frog piece outline | `PieceEdge` | black at 35% |
+
+The four frog colours are not here. They are one table for the whole game, on
+[shared components](shared-components.md#frog-colours), because a frog is the
+same frog on every screen.
+
+`TrackOutline` (3 px), `BoardBandOutline` (3 px) and `FrogPieceOutline` (4 px)
+in the tables above are **widths**; the `…Edge` rows here are the colours drawn
+at those widths.
+
+### Placeholder, or settled?
+
+**Settled:** the water is blue, the logs are brown, the lily pads are green.
+That is a decision, not a proposal, and nothing should quietly walk it back.
+
+**Not settled:** which blue, which brown, which green. The exact hues are a
+taste call and they are Connor's — see
+[the open questions](#open-questions). The values in the table are the proposal
+drawn in the mockups, and they are what the code carries until he has looked at
+the board on the tablet. They are honest placeholders in exactly the sense the
+[frog colours](shared-components.md#frog-colours) are, and for the same reason.
+
+### The water is the whole screen
+
+`PondWater` is not the pond band's fill. It is what this screen paints to all
+four edges of the device, on any aspect ratio — the header and controls bands
+are drawn on top of it, and so is everything else.
+
+That makes the board the one screen that does not paint the app's own
+background. Every other screen paints `#EDF1EF`, and so does the scene camera,
+which is what shows for the frame before any screen has painted at all. The
+rule from
+[the canvas every component is measured in](shared-components.md#what-fills-a-screen-that-is-not-1610)
+is unchanged and still holds here: nothing behind the canvas is ever visible,
+because this screen's own paint reaches the edges.
+
+### Keeping the frogs visible
+
+A blue pond behind a blue frog, and a green lily pad under a green frog, is the
+thing this change could have broken. The frog pieces are drawn **on top of**
+these fills, and two of the four are `FrogGreen` and `FrogBlue`.
+
+So the fills are chosen against a bar, and the bar is part of the spec:
+
+> **Every frog colour stays clearly separable from every surface it can sit
+> on** — the water, a lily pad, and a log. Separable means a luminance contrast
+> of at least **1.9 : 1** *and* a CIE L\*a\*b\* distance (ΔE\*ab) of at least
+> **30**.
+
+Two measures, because either alone can be fooled. Contrast catches two colours
+of different hue and identical brightness, which is all a colour-blind player —
+or anyone holding the tablet in sunlight — has left. ΔE catches two colours a
+contrast ratio calls fine and nobody could name apart. The 4 px `PieceEdge`
+outline is separation on top of this, never instead of it.
+
+What the table's values measure, as *contrast : 1 / ΔE*:
+
+| | The water | A lily pad | A log |
+| --- | --- | --- | --- |
+| `FrogGreen` | 2.61 / 60.4 | 3.07 / **40.8** | 2.48 / 50.7 |
+| `FrogBlue` | 3.47 / 46.8 | 4.08 / 83.0 | 3.29 / 75.5 |
+| `FrogOrange` | 2.13 / 87.9 | 2.51 / 65.8 | **2.02** / 46.0 |
+| `FrogPink` | 2.91 / 73.8 | 3.42 / 89.5 | 2.76 / 67.6 |
+
+Every pair clears the bar. The two tightest are the two the change was always
+going to squeeze: the green frog on a green lily pad (ΔE 40.8, on a bar of 30)
+and the orange frog on a brown log (contrast 2.02 : 1, on a bar of 1.9). If a
+future repaint cannot clear the bar, **the surface moves, not the frog** — the
+frog colours are an `area:art` decision that this page does not own.
+
+One number in that palette is deliberately low and is not about frogs: the log
+and the water are almost the same brightness (1.05 : 1) and a long way apart in
+hue (ΔE 46.3). What makes a log read as a log floating on water is its
+`LogEdge` rim, which is 2.33 : 1 against the water. That is what `TrackOutline`
+is for.
+
+### The bands are unchanged, deliberately
+
+`BandFill` and `BandEdge` are the pale grey-green they have always been. They
+were chosen to sit against a pale board and they now sit against blue water,
+where they are a soft frame rather than a crisp one — ΔE 23 from the water.
+
+They were left alone on purpose rather than overlooked: Derek's words were
+about the pond, and repainting the chrome on the way past would have made the
+change harder to judge. Whether they now read as a frame or as leftovers is
+[the second open question](#open-questions), and it is a look-at-it call.
+
 ## Elements
 
 - **Turn banner** — `Green frog's turn`, left of the header, with that frog's
@@ -262,11 +365,26 @@ not, and they must not move when it does.
 
 ## Mockup
 
-[`mockups/game-board.html`](mockups/game-board.html)
+[`mockups/game-board.html`](mockups/game-board.html) — and, until Connor has
+picked the water, [`mockups/game-board-paler-water.html`](mockups/game-board-paler-water.html)
+beside it.
+
+The two files differ in **one value**: `PondWater`. `game-board.html` draws the
+proposal in the table above, `#9FD8F2`; the second draws `#B5E3F7`, the same
+blue with more light in it. Everything else on the two canvases is identical to
+the pixel. Open both on the tablet, one after the other, and say which is the
+pond — comparing two pictures is a much easier conversation than critiquing
+one, and the losing file is deleted when the answer arrives, the way
+`title-screen-resume-primary.html` was.
 
 Drawn in the state that exercises every case at once: four frogs, one home on
 the End log, one still on its Start log, two mid-lane, Green to roll — and
 **exactly two logs on the whole screen**, which is the thing to look at.
+
+Every one of the four frogs is drawn on something it has to be legible
+against — Green and Pink on lily pads, Orange on the Start log, Blue home on
+the End log — so [the contrast question](#keeping-the-frogs-visible) is
+visible in the picture rather than only asserted in a table.
 
 It draws the proposal on all three open questions below: the logs span the four
 lanes in play and no further, each frog sits on its own lane's centre line, and
@@ -280,6 +398,20 @@ decided against; keeping a mockup of a layout nobody is building is how a
 
 ## Open questions
 
+- **Which blue is the water?** Blue is settled; this blue is not. Two are drawn
+  — `#9FD8F2` in `game-board.html` and the paler `#B5E3F7` beside it — and
+  Connor picks, on the tablet, at 1:1. Both clear
+  [the separability bar](#keeping-the-frogs-visible), so either can be taken as
+  it stands; a third blue of his own choosing has to be measured against that
+  bar before it lands. The same is true of `LogBrown` and `LilyPadGreen`, which
+  are drawn once each rather than twice — say if either is wrong and it gets
+  the same treatment.
+- **Do the header and controls bands change?** They are `BandFill`, the pale
+  grey-green chosen to sit against a pale board, and this change
+  [deliberately left them alone](#the-bands-are-unchanged-deliberately). Against
+  blue water they either read as a clean frame or as leftovers from the old
+  look, and that is a thing to see rather than to argue about. If they should
+  change, this is where it gets decided.
 - **Do the unused lanes show?** The classroom board always has eight lanes,
   whoever is playing. The mockups draw only the lanes in play, because empty
   lanes on a screen this size cost the ones in play their height. Presentation,

--- a/docs/specs/ui/mockups/game-board-paler-water.html
+++ b/docs/specs/ui/mockups/game-board-paler-water.html
@@ -8,10 +8,11 @@
   the colours: game-board.md now has a Colours table, and --water, --pad,
   --pad-edge, --log and --log-edge below are its rows.
 
-  THE POND IS WATER. Blue water, brown logs, green lily pads — Derek's call on
-  issue #291. Blue is settled; WHICH blue is Connor's, and there are two files:
-  this one draws PondWater #9FD8F2, and game-board-paler-water.html draws
-  #B5E3F7. They differ in that one value and in nothing else. Open both.
+  THE PALER WATER. This file exists to be compared with game-board.html and for
+  no other reason. It draws PondWater as #B5E3F7 — the same blue as that file's
+  #9FD8F2 with more light in it — and every other pixel on the canvas is
+  identical. Open both on the tablet, one after the other, and say which one is
+  the pond. Whichever loses gets deleted.
 
   Every frog is drawn on something it has to be legible against — Green and
   Pink on lily pads, Orange on the Start log, Blue home on the End log — so the
@@ -46,15 +47,15 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Multiplying Frogs — Game board</title>
+<title>Multiplying Frogs — Game board, paler water</title>
 <style>
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
     --accent:#2E7D4F; --warn:#B03A2E;
     --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
     /* game-board.md's Colours table. The one line that differs between this
-       file and game-board-paler-water.html is --water. */
-    --water:#9FD8F2;
+       file and game-board.html is --water. */
+    --water:#B5E3F7;
     --pad:#CCEAAF; --pad-edge:#7FAE5E;
     --log:#E2C79C; --log-edge:#A97F4F;
     --band:#E2E8E5;

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -14,6 +14,7 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Title screen | [`title-screen.html`](title-screen.html) | [Title screen](../title-screen.md) |
 | Game setup | [`game-setup.html`](game-setup.html) | [Game setup](../game-setup.md) |
 | Game board | [`game-board.html`](game-board.html) | [Game board](../game-board.md) |
+| Game board, paler water | [`game-board-paler-water.html`](game-board-paler-water.html) | [Game board](../game-board.md) |
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
 | Working-out grid, `331 × 41` | [`working-out-grid-331x41.html`](working-out-grid-331x41.html) | [Working-out grid](../working-out-grid.md) |
 | Working-out grid, `68 × 5` | [`working-out-grid-68x5.html`](working-out-grid-68x5.html) | [Working-out grid](../working-out-grid.md) |
@@ -40,6 +41,13 @@ Derek settled the question — smaller cells for the addition rows only — so t
 file now draws the answer instead: the same six rows at
 `GridAdditionRowHeight`, fitting with 16 px to spare.
 
+The game board's pair is the live one, and it is the second kind: a real
+choice, drawn twice. `game-board.html` and `game-board-paler-water.html` are
+the same canvas differing in exactly one value — the water's blue. Connor picks
+one on the tablet, the spec page takes the answer, and the losing file is
+deleted. Until then, an edit to the board's layout has to be made in **both**
+files, which is the cost of the pair and the reason it does not stay open long.
+
 The title screen used to have a pair too — `title-screen.html` and
 `title-screen-resume-primary.html`, differing in exactly which of `RESUME` and
 `NEW` was primary, per the wireframe loop's own advice that where there is a
@@ -53,12 +61,20 @@ deleted, per [issue #216](https://github.com/derekwinters/connor-multiplying-fro
 Each row arrives with its screen's `Wireframe:` issue. See
 [UI design process](../../../engineering/ui-design-process.md).
 
-### Colour in these mockups is a placeholder
+### Colour in these mockups is mostly a placeholder
 
 The four frog colours exist so the frogs can be told apart in a picture, and the
 single green accent marks the primary action. Neither is a palette decision —
 that is an `area:art` call and it lands with the frog sprites. See
 [frog colours](../shared-components.md#frog-colours).
+
+The game board is the first exception. Its water, logs and lily pads are a
+decision Derek made — a pond is blue, its logs brown, its lily pads green — and
+they are written down as
+[a constants table on the spec page](../game-board.md#colours), the same as
+every dimension on that screen. The mockup receives them from there rather than
+being the place they live. The exact hues are still Connor's to settle, which
+is what the pair of board files is for.
 
 ## What a mockup is, and is not
 

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -91,15 +91,22 @@ appears there, and no element grows into it. An element that only exists on
 some devices is an element nobody can review against a mockup, and every mockup
 in this repo is drawn at exactly one size.
 
-**Invariant:** nothing behind the canvas is ever visible. The scene camera
-clears to the same background colour rather than to the engine's default sky,
-so even a frame drawn before any screen has painted is the game's own colour.
+**Invariant:** nothing behind the canvas is ever visible. Whatever a screen
+paints, it paints to all four edges, and the scene camera clears to the app's
+background rather than to the engine's default sky — so even a frame drawn
+before any screen has painted is the game's own colour.
 
-That background colour is the mockups' `--bg`, `#EDF1EF` — the colour every
-committed mockup paints its 1920 × 1200 frame. A dialog is the one screen that
-paints no background of its own: what it lays over the screen underneath is the
-[scrim](#dialog), and the scrim reaches the edges for the same reason and by
-the same rule.
+The app's background is the mockups' `--bg`, `#EDF1EF`. The title screen, game
+setup and game over paint it, and it is what the camera clears to.
+
+**The game board is the exception, and the only one.** It paints
+[`PondWater`](game-board.md#colours) instead, to the same four edges by the same
+rule, because that screen is a pond rather than a page. A screen may have a
+background of its own; what it may not do is leave any of the screen unpainted.
+
+A dialog is the one screen that paints no background at all: what it lays over
+the screen underneath is the [scrim](#dialog), and the scrim reaches the edges
+for the same reason and by the same rule.
 
 ### Why the numbers look big
 


### PR DESCRIPTION
Closes #291

The board looked like paper. It now looks like a pond: the water is blue, the
logs are brown, the lily pads are green — Derek's words, and his call. The
colours also get a proper home. They used to live as hex values hidden in two
code files, copied out of the mockup; they are now a table on the game board's
spec page, the same as every measurement on that screen, and the code reads them
from there by name.

All four frogs were checked against the water, a lily pad and a log. Every one
of them stays clearly visible, and no frog's colour was changed to make that
true. Nobody has *looked* at the result yet, though — see the last section.

**Docs:** `docs/specs/ui/game-board.md` — new `## Colours` section: the
constants table, whether each value is settled or a placeholder, the
separability bar and the measured numbers, and why the header and controls
bands were deliberately left alone. Two new open questions (which blue; do the
bands change). `docs/specs/ui/shared-components.md` — the app background is no
longer "the colour every screen paints": the board paints its own water, to the
same four edges, by the same rule. `docs/specs/ui/mockups/game-board.html` —
repainted. `docs/specs/ui/mockups/game-board-paler-water.html` — new, the same
canvas with one different value. `docs/specs/ui/mockups/index.md` — the pair,
and colour in mockups is now *mostly* a placeholder.

## Spec invariants this had to keep true

| Invariant | How it is kept | Test |
| --- | --- | --- |
| Nothing behind the canvas is ever visible (shared-components) | The board still paints a background over the whole canvas — it is just a different colour now | `FullBleedBackgroundTests.GameBoard_PaintsItsBackgroundToEveryEdge_…`, which now asserts the water *and* asserts it differs from the app background, so the test cannot pass vacuously |
| Everything is laid out in the 1920 × 1200 reference, centred | Nothing moved. This change sets fills and touches no rect | Same test's header/controls/pond width assertions, unchanged |
| The pad a frog is on is drawn no differently from the others | All seven pads take one colour; the frog is still the only marker | `GameBoardColoursTests.EveryLilyPadIsGreen` walks every pad in every lane |
| The frog colours are an `area:art` decision this page does not own (shared-components) | Not one of the four was touched; the surfaces moved instead | `EveryFrogStaysSeparableFromEverythingItCanSitOn`, whose failure message says "fix the surface, not the frog" |
| A lane is nine positions, two of them logs (#289) | Untouched — this PR sets colours on the elements #289's layout already defines | Existing board tests |

## How the spec is changing

**Old rule** (shared-components): *the* background colour is `#EDF1EF`, the
colour every committed mockup paints its frame, and the scene camera clears to
it.

**New rule:** whatever a screen paints, it paints to all four edges — and the
game board paints `PondWater` rather than the app background, because that
screen is a pond rather than a page. The camera still clears to the app
background, which is what shows for the frame before *any* screen has painted.

Why the new one is better: the old sentence made "the background" and "the
board's background" the same fact, which was true right up until the pond
became blue. The invariant that actually matters — no unpainted screen, ever —
never depended on the two being equal, and it is now stated in the form that
survives a second screen wanting its own colour. #290's fix is intact: the
board's water reaches every edge on any aspect ratio, which is the assertion
that catches a regression, and it is still asserted.

**New rule** (game-board.md): the board's colours are named constants on the
spec page. "Blue water, brown logs, green lily pads" is settled; the exact hues
are Connor's and are marked as placeholders in the same words
`shared-components.md` uses for the frog colours.

## Keeping the background and the camera in step

The three places `#EDF1EF` lives — `ScreenColours.Background`, the camera in
`Assets/Scenes/Game.unity`, and `Assets/Editor/GameScene.cs` — are all
**unchanged, deliberately**, and that is the answer rather than an omission.

The board no longer paints that colour, so it is not the board's to move. It is
still the title screen's, game setup's and game over's, and it is still what the
camera clears to; those three screens and the camera therefore remain in
agreement with each other, which is the thing `ScreenColours` exists to
guarantee. Repainting the camera water-blue would have put the *other* three
screens out of step and flashed blue behind the title screen.

What stops the pale clear showing behind a blue board is that the board's own
water covers the whole canvas on every aspect ratio — the same mechanism #290
built, asserted by the same test. `ScreenColours`' own doc comment now names the
board as the one exception so the next reader does not have to work it out.

## Deviations and Decisions

- **Nobody watched these tests fail.** There is no editor here, and both commits
  went up in one push, so CI only ever ran the EditMode tests against the
  finished change — the red step happened in neither place. What backs the
  claim instead is what the tests assert: literal hex values (`#9FD8F2`,
  `#CCEAAF`, `#E2C79C`) that are provably not the values on `main`
  (`#EDF1EF`, `#CFE0D2`, `#E0D4C3`), plus an added
  `Is.Not.EqualTo(ScreenColours.Background)` that was false before this change.
  Weaker than watching it go red, and worth knowing when weighing the tests.
- **The Core suite was not run.** `dotnet` is not installed in this environment
  and the proxy blocks its installer, so the one suite that is never allowed to
  be skipped was skipped here. Nothing in this PR is in `Assets/Scripts/Core`,
  and CI's `Core (NUnit)` job is green.
- **The colours live in a new `BoardColours` class, not on the two views.** The
  issue asked for the views' hard-coded fields to be replaced by the spec's
  named constants and did not say where the constants should sit. The obvious
  alternative — `public static readonly` fields on `GameBoardScreenView` and
  `GameBoardLaneView`, mirroring how those two split the geometry — was
  rejected because #296 is about to move the logs off the lane and onto the
  pond, and the log's colour would have had to move house with its drawing. One
  class next to `FrogColours` and `ScreenColours` costs nothing and does not
  care where the log is drawn.
- **"Clearly separable" is now a number, and I chose the number.** The issue set
  the criterion but not a threshold, and a criterion nobody can check is a
  criterion that decays. The bar (contrast ≥ 1.9 : 1 **and** ΔE\*ab ≥ 30) is on
  the spec page, justified there, and asserted in a test. Worth a reviewer's
  eye: it is calibrated so the board *as it is today* would also pass (today's
  worst pair is 2.26 / 50.8), which is what makes it a real bar rather than one
  drawn around the answer I wanted.
- **The two water candidates are two mockup files, not two swatches in one.**
  `ui-design-process.md` says "where there's a real choice, propose *two*
  mockups", and `title-screen-resume-primary.html` is the precedent. The cost
  is a duplicated 170-line file until Connor picks; `mockups/index.md` says so
  and says the loser gets deleted. A swatch strip would have been cheaper and
  would not have answered the actual question, which is what a whole blue board
  feels like at 1:1.
- **The header and controls bands were left alone**, per the issue's own
  recommendation. Recorded as an open question on the spec page with the number
  attached (ΔE 23 from the water — a soft frame rather than a crisp one), and
  pinned by a test, so a future PR cannot repaint them by accident on its way
  past.
- **Open question 3 — do the other screens follow? — is untouched**, as the
  issue says it should be. The board now looks like a different game from its
  own menus, on purpose and temporarily. Worth an issue once somebody has seen
  it; I have not opened one, because what to do about it depends on what it
  looks like.
- **#301 opened in `Direct Involvement Needed`** — Connor picks the blue on the
  tablet, and the built board gets photographed next to the mockup.

## The checklist box I cannot tick

- [ ] **Screenshot of the built board in the PR, next to the mockup.**
  Untickable here. It needs a Unity Editor session or an APK on a real tablet,
  and this environment has neither an editor, a device, nor a browser. #301 is
  the issue that does it, with the steps written out.

Everything else on the issue's checklist is done, and one more honesty note:
**nobody has seen the mockups.** With no browser, the redraw was verified by
parsing and arithmetic — the DOM still holds exactly two logs, twenty-eight lily
pads, four frogs and five chips; every CSS variable used is defined and none is
unused; the two files are byte-identical apart from the water, the title and the
comment. That proves the drawing is intact. It does not prove it looks nice.

`mkdocs build --strict`, `check_core_isolation.py`, `check_geometry_literals.py`,
`check_assembly_references.py` and `run_python_tests.py` all pass here, and all
seven CI checks — including `EditMode (Unity)` and `Debug APK` — are green.
