### PR TITLE
fix(pipeline): stop the auto-revisit sweep re-waking an issue forever

### DIFF
--- a/.claude/skills/pipeline-gatekeeper/check_revisits.py
+++ b/.claude/skills/pipeline-gatekeeper/check_revisits.py
@@ -13,6 +13,7 @@ See docs/engineering/issue-pipeline.md.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -27,6 +28,15 @@ if str(_BLOCKERS_SKILL) not in sys.path:
 
 from blocker_refs import blockers_of  # noqa: E402
 
+# `is_triage_author` — one more shared recognizer, same reason as the one
+# above: this module needs to tell its own past comments apart from anyone
+# else's without keeping a second copy of that judgment.
+_TRIAGE_SKILL = Path(__file__).resolve().parents[1] / "triage-issue"
+if str(_TRIAGE_SKILL) not in sys.path:
+    sys.path.insert(0, str(_TRIAGE_SKILL))
+
+from triage_repair import is_triage_author  # noqa: E402
+
 # The state a blocked issue is parked in by triage.
 BLOCKED_LABEL = "needs-clarification"
 TRIAGE_LABEL = "ai-triage"
@@ -37,6 +47,46 @@ WIREFRAME_LABEL = "type:wireframe"
 # be built, and holding the dependent back until it closes costs a night for
 # nothing.
 SCHEDULED_LABELS = {"ready-for-work", "in-progress"}
+
+# `Revisit.comment`'s own opening line, read back out of the issue's comment
+# history so a repeat sweep can recognize its own earlier action. The blocker
+# numbers are parsed out of what got POSTED, not recomputed, because the write
+# that matters is the one that already happened.
+_REVISIT_COMMENT = re.compile(
+    r"everything this was waiting on has cleared \(([^)]*)\)", re.IGNORECASE)
+_ISSUE_REF = re.compile(r"#(\d+)")
+
+
+def _already_revisited_for(comments, blockers) -> bool:
+    """Was this exact blocker set already actioned by a past revisit?
+
+    A closed blocker stays resolved forever, so without this check, an issue
+    that lands back on `needs-clarification` for any *other* reason — an
+    open design question triage raised, say — reads as "blocker cleared,
+    wake it up" again on every subsequent sweep. That is what turned #296
+    into an `ai-triage` / `needs-clarification` loop, once per sweep,
+    indefinitely: the wake-up fired, triage answered with a real but
+    unrelated question, and the still-closed blocker fired the same wake-up
+    again next time round.
+
+    Only a triage-authored comment counts — a human typing similar words by
+    hand is not the automatic wake-up repeating itself.
+    """
+    wanted = set(blockers)
+
+    for comment in comments or []:
+        if not is_triage_author(comment.get("author")):
+            continue
+
+        match = _REVISIT_COMMENT.search(comment.get("body") or "")
+        if not match:
+            continue
+
+        named = {int(n) for n in _ISSUE_REF.findall(match.group(1))}
+        if wanted <= named:
+            return True
+
+    return False
 
 
 class Revisit:
@@ -101,7 +151,12 @@ def find_revisits(issues: list[dict], snapshot: dict) -> list[Revisit]:
         if any(blocker is None for blocker in known):
             continue
 
-        if all(is_resolved(blocker) for blocker in known):
-            found.append(Revisit(issue["number"], blockers))
+        if not all(is_resolved(blocker) for blocker in known):
+            continue
+
+        if _already_revisited_for(issue.get("comments"), blockers):
+            continue
+
+        found.append(Revisit(issue["number"], blockers))
 
     return found

--- a/.claude/skills/pipeline-gatekeeper/tests/test_check_revisits.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_check_revisits.py
@@ -13,17 +13,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import check_revisits as revisits  # noqa: E402
 
 
-def issue(number=10, labels=("needs-clarification",), body="", native=(), blockers_state=None):
+def issue(number=10, labels=("needs-clarification",), body="", native=(), blockers_state=None,
+          comments=()):
     return {
         "number": number,
         "labels": list(labels),
         "body": body,
         "native_blockers": list(native),
+        "comments": list(comments),
     }
 
 
 def blocker(number=20, state="open", labels=(), merged=False):
     return {"number": number, "state": state, "labels": list(labels), "merged": merged}
+
+
+def revisit_comment(cleared, author="github-actions[bot]"):
+    """A comment shaped like `Revisit.comment`, for testing recognition of it."""
+    named = ", ".join(f"#{n}" for n in cleared)
+    return {
+        "author": author,
+        "body": (f"Everything this was waiting on has cleared ({named}), so it is back in "
+                 f"the triage queue.\n\n"
+                 f"_Automatic — nothing was decided here beyond that the blocker is done._"),
+    }
 
 
 class NoBlockerTests(unittest.TestCase):
@@ -167,6 +180,36 @@ class RevisitShapeTests(unittest.TestCase):
         found = revisits.find_revisits([subject], {20: blocker(20, "closed")})[0]
 
         self.assertLessEqual(len(found.comment.splitlines()), 4)
+
+
+class AlreadyRevisitedTests(unittest.TestCase):
+    # #296: the wake-up fired once for #20, triage answered `needs-clarification`
+    # again for an unrelated open design question, and every sweep afterward saw
+    # the same resolved #20 and fired the wake-up again — forever, since a
+    # closed blocker never stops being "resolved". This is what stops it: a
+    # blocker set this issue was already woken for does not fire twice.
+
+    def test_does_not_refire_for_a_blocker_set_already_actioned(self):
+        subject = issue(body="Blocked by #20", comments=[revisit_comment([20])])
+
+        self.assertEqual([], revisits.find_revisits([subject], {20: blocker(20, "closed")}))
+
+    def test_a_hand_typed_comment_from_a_non_triage_author_does_not_count(self):
+        # Only the bot's own action suppresses the wake-up. A stranger's comment
+        # using similar words must not silently swallow a real one.
+        comment = revisit_comment([20], author="someone-else")
+        subject = issue(body="Blocked by #20", comments=[comment])
+
+        self.assertEqual(1, len(revisits.find_revisits([subject], {20: blocker(20, "closed")})))
+
+    def test_a_new_blocker_resolving_still_fires(self):
+        # Only #20 was already actioned. #21 clearing later is a genuine new
+        # wake-up, not a repeat of the old one.
+        subject = issue(body="Blocked by #20\nBlocked by #21",
+                         comments=[revisit_comment([20])])
+        snapshot = {20: blocker(20, "closed"), 21: blocker(21, "closed")}
+
+        self.assertEqual(1, len(revisits.find_revisits([subject], snapshot)))
 
 
 if __name__ == "__main__":

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -412,6 +412,23 @@ Closing a wireframe issue is what "agreed" means, and a wireframe marked
 carve-out the sweep wakes the dependent on every run and triage sets it aside
 again on every run — forever, and noisily.
 
+### A blocker set wakes an issue at most once
+
+A closed blocker stays resolved forever, so without a guard, an issue that
+lands back on `needs-clarification` for *any other reason* — an open design
+question triage raised, say, unrelated to the blocker that used to hold it —
+reads as "blocker cleared, wake it up" again on the very next sweep. And the
+sweep runs on every `labeled` event, including the one the revisit itself just
+made, so this is not a rare recurrence: it is a tight loop, once per sweep,
+forever, each pass posting another "back in the triage queue" comment and
+firing triage again.
+
+The sweep reads the issue's own comment history and skips a blocker set it has
+already posted a revisit for — only a triage-authored comment counts, so a
+human typing similar words by hand can't suppress a real wake-up. A *new*
+blocker resolving later still fires normally; only a repeat of an already-
+actioned set is skipped.
+
 ### What it never touches
 
 - **`parked` issues.** Parking is a decision the owner made; only the owner


### PR DESCRIPTION
Issue #296 got stuck flipping between `ai-triage` and `needs-clarification`
every couple of minutes — 14 times in about 40 minutes — with the gatekeeper
posting "back in the triage queue" and re-firing triage each time. This fixes
the pipeline bug that caused it, so a woken issue is only woken once per
blocker.

## What was actually wrong

`check_revisits.find_revisits()` wakes a `needs-clarification` issue back into
`ai-triage` whenever all of its recorded blockers have resolved. A closed
blocker stays resolved forever, so once #296 landed back on
`needs-clarification` for an unrelated reason — three open design questions
from #289's wireframe, nothing to do with #289 itself being closed — every
subsequent sweep still saw "blocker #289 is closed" and treated that as a
fresh reason to wake it. `gatekeeper-sweep` runs on every `labeled` event,
including the one the wake-up itself makes, so this wasn't an occasional
recurrence — it was a tight loop that would have kept firing indefinitely.

## The fix

The sweep now reads the issue's own comment history and skips a blocker set
it has already posted a revisit for. Only a comment from a recognized triage
author counts (`is_triage_author`, imported from `triage-issue`'s
`triage_repair.py` rather than duplicated — same "one recognizer" pattern the
skill already uses for `has_analysis_signature`), so a human typing similar
words by hand can't accidentally suppress a real wake-up. A genuinely new
blocker resolving later still fires normally — only a repeat of an
already-actioned set is skipped.

Built test-first: a test reproducing the loop was written and confirmed to
fail before the fix, then the fix made it (and all 24 other tests in that
suite, and the other 199 pipeline tests) pass.

## Spec invariants

- **Blocked issues still get woken exactly once per blocker set that clears**
  — the existing behaviour (closed/merged, or scheduled via
  `ready-for-work`/`in-progress`, and the `type:wireframe` carve-out) is
  unchanged; this only adds a guard against re-firing for a set already acted
  on.
- **Only the pipeline's own comments count as "already actioned"** —
  `is_triage_author` gates the check, so nothing a human writes can suppress a
  genuine wake-up.

**Docs:** `docs/engineering/issue-pipeline.md` — added a subsection under
"Auto-revisit when a blocker clears" documenting the new once-per-blocker-set
guard, in the same PR per the docs-reconciliation rule.

## Deviations and Decisions

- This wasn't filed as its own GitHub issue before being fixed — Derek asked
  for it directly in conversation after it was found as a side effect of
  triaging #296, so there's no issue number to close here.
- Chose to de-duplicate by reading the issue's comment history for a prior
  revisit comment naming the same (or a superset of the) blocker numbers,
  rather than removing the native `blocked-by` relationship once acted on.
  Removing the relationship would also work, but it destroys the historical
  record of what originally blocked the issue, and the comment-history
  approach follows the same recognizer pattern (`is_triage_author` /
  `has_analysis_signature`) the skill already uses elsewhere, rather than
  introducing a new kind of write.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rhu6jJ6Rf493uojca3U29A)_