### PR TITLE
fix(gatekeeper): let a gate refusal explain itself instead of crashing

### DIFF
--- a/.claude/skills/issue-blockers/SKILL.md
+++ b/.claude/skills/issue-blockers/SKILL.md
@@ -74,6 +74,10 @@ and native blockers are merged. Every reader in the pipeline imports it — the
 sweep, the queue selector, the reconciler, the dashboard, the comment-event
 snapshot, and `audit` here.
 
+It owns the soft `Depends on: #N` line as well, as `text_depends_on`. That one
+had a single reader — the builder's queue order — until the gatekeeper's
+milestone-order gate became its second.
+
 ```python
 _BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
 if str(_BLOCKERS_SKILL) not in sys.path:

--- a/.claude/skills/issue-blockers/blocker_refs.py
+++ b/.claude/skills/issue-blockers/blocker_refs.py
@@ -39,10 +39,27 @@ import re
 # pass. "This is similar to #42" is not a dependency either.
 TEXT_BLOCKER = re.compile(r"^\s*blocked\s+by\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
 
+# "Depends on: #42", "depends on #42". Soft ordering — it never gates the
+# builder, it only sequences the queue and the approval gates' milestone check.
+# It lives beside the hard pattern because it now has two readers, and two
+# copies of a line-recognizer is exactly how the readers came to disagree about
+# what a body said. See #147.
+TEXT_DEPENDS = re.compile(r"^\s*depends\s+on\s*:?\s*#(\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
 
 def text_blockers(body) -> set[int]:
     """Issue numbers named as blockers in a body — which is the wrong place."""
     return {int(number) for number in TEXT_BLOCKER.findall(body or "")}
+
+
+def text_depends_on(body) -> set[int]:
+    """Issue numbers named as soft ordering hints in a body.
+
+    Not blockers: `Depends on:` says "this goes better afterwards", and reading
+    it as a hard blocker turns a preference into a gate the builder refuses to
+    pass.
+    """
+    return {int(number) for number in TEXT_DEPENDS.findall(body or "")}
 
 
 def union_blockers(body, native) -> list[int]:

--- a/.claude/skills/issue-blockers/tests/test_blocker_refs.py
+++ b/.claude/skills/issue-blockers/tests/test_blocker_refs.py
@@ -43,6 +43,43 @@ class TextBlockers(unittest.TestCase):
         self.assertEqual(set(), blocker_refs.text_blockers(None))
 
 
+class TextDependsOn(unittest.TestCase):
+    """The soft-ordering line lives here for the same reason the hard one does.
+
+    It has two readers now — the builder's queue order and the gatekeeper's
+    milestone-order gate — and two copies of a pattern is how the two disagree
+    about what the body said.
+    """
+
+    def test_a_structured_line_is_a_soft_dependency(self):
+        self.assertEqual({42}, blocker_refs.text_depends_on("Depends on: #42"))
+
+    def test_the_colonless_form_and_case_are_both_accepted(self):
+        self.assertEqual({42}, blocker_refs.text_depends_on("depends on #42"))
+
+    def test_a_blocker_is_not_a_soft_dependency(self):
+        self.assertEqual(set(), blocker_refs.text_depends_on("Blocked by #42"))
+
+    def test_a_mention_in_ordinary_prose_is_not_one(self):
+        self.assertEqual(set(), blocker_refs.text_depends_on("This depends on how #42 goes."))
+
+    def test_no_body_is_no_soft_dependencies(self):
+        self.assertEqual(set(), blocker_refs.text_depends_on(None))
+
+    def test_the_builder_reads_the_shared_pattern(self):
+        """`select_queue` orders by these lines; it must not carry its own copy."""
+        sys.path.insert(0, str(SKILLS / "pipeline-dev"))
+        try:
+            import select_queue
+
+            wider = re.compile(r"^\s*depends[\s-]+on\s*:?\s*#(\d+)\s*$",
+                               re.IGNORECASE | re.MULTILINE)
+            with mock.patch.object(blocker_refs, "TEXT_DEPENDS", wider):
+                self.assertEqual([42], select_queue.depends_on({"body": "Depends-on: #42"}))
+        finally:
+            sys.path.remove(str(SKILLS / "pipeline-dev"))
+
+
 class UnionBlockers(unittest.TestCase):
     def test_text_and_native_are_unioned(self):
         self.assertEqual([20, 21], blocker_refs.union_blockers("Blocked by #20", {21}))
@@ -107,7 +144,9 @@ def _every_reader() -> dict:
                  "comment": {"id": 5, "body": "/approve",
                              "user": {"login": "derekwinters", "type": "User"}}}
         snapshot = fetch_comment_event.build(event, _NoApi(), owner="derekwinters")
-        return snapshot["issue"]["blockers"]
+        # The snapshot carries edges, not numbers — the gates read each one's
+        # milestone. Only the recognizer is under test here.
+        return [edge["number"] for edge in snapshot["issue"]["blockers"]]
 
     return {
         "set_blocker.prose_blockers":

--- a/.claude/skills/pipeline-dev/select_queue.py
+++ b/.claude/skills/pipeline-dev/select_queue.py
@@ -21,15 +21,16 @@ import re
 import sys
 from pathlib import Path
 
-# One recognizer for `Blocked by #N`, and one union of it with the native
-# edges, shared with the skill that documents the format. A copy here that
-# drifted from the sweep's would refuse to build an issue nothing would ever
-# wake, with nothing reporting a reason. See #147.
+# One recognizer for `Blocked by #N` and one for `Depends on: #N`, and one
+# union of the first with the native edges, shared with the skill that
+# documents both formats. A copy here that drifted from the sweep's would
+# refuse to build an issue nothing would ever wake, with nothing reporting a
+# reason. See #147.
 _BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
 if str(_BLOCKERS_SKILL) not in sys.path:
     sys.path.insert(0, str(_BLOCKERS_SKILL))
 
-from blocker_refs import blockers_of  # noqa: E402
+from blocker_refs import blockers_of, text_depends_on  # noqa: E402
 
 READY_LABEL = "ready-for-work"
 PARKED_LABEL = "parked"
@@ -39,12 +40,6 @@ EPIC_LABEL = "type:epic"
 # on purpose: three issues that land beat six that half-land, and the cap is
 # the only thing standing between a quiet night and thirty open PRs.
 DEFAULT_CAP = 3
-
-# Soft ordering. Does not gate the issue — it sequences it. It has no native
-# form and exactly one reader, so unlike the blocker pattern there is nothing
-# here for it to drift from.
-TEXT_DEPENDS = re.compile(r"^\s*depends\s+on\s*:?\s*#(\d+)\s*$",
-                          re.IGNORECASE | re.MULTILINE)
 
 # GitHub's closing keywords. An issue with an open PR that *closes* it is
 # already being worked; one merely referenced by a PR is not.
@@ -60,7 +55,7 @@ def _numbers(pattern, body) -> set:
 
 def depends_on(issue: dict) -> list:
     """Soft ordering hints. Never gates — see `docs/engineering/issue-pipeline.md`."""
-    return sorted(_numbers(TEXT_DEPENDS, issue.get("body")))
+    return sorted(text_depends_on(issue.get("body")))
 
 
 def closed_by_open_pr(issue_number: int, pulls) -> bool:

--- a/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/fetch_comment_event.py
@@ -8,9 +8,18 @@ know what GitHub's JSON looks like.
 The snapshot:
 
     {
-      "issue":   {number, labels, body, milestone, blockers, is_dashboard},
+      "issue":   {number, labels, body, milestone, blockers,
+                  soft_dependencies, is_dashboard},
       "comment": {id, body, author, watermarked}
     }
+
+`blockers` and `soft_dependencies` are **edges**, not issue numbers:
+
+    {"number": 20, "state": "open", "milestone": "v0.1"}
+
+The milestone-order gate reads each edge's own state and milestone to decide
+whether it is scheduled before the issue that waits on it, so a list of numbers
+is not something it can answer with.
 
 Returns **None** when the event should not be acted on at all.
 
@@ -30,7 +39,7 @@ _BLOCKERS_SKILL = Path(__file__).resolve().parents[1] / "issue-blockers"
 if str(_BLOCKERS_SKILL) not in sys.path:
     sys.path.insert(0, str(_BLOCKERS_SKILL))
 
-from blocker_refs import union_blockers  # noqa: E402
+from blocker_refs import text_depends_on, union_blockers  # noqa: E402
 
 DASHBOARD_LABEL = "dashboard"
 WATERMARK = "eyes"
@@ -41,11 +50,12 @@ def _labels(issue: dict) -> list[str]:
 
 
 def _native_blockers(api, issue_number: int) -> set[int]:
-    """Native blocked-by edges, or nothing if the lookup fails.
+    """Native blocked-by edge numbers, or nothing if the lookup fails.
 
     A failed dependency lookup must not lose the whole event: the command is
-    probably `/park`, which does not care. The gates that *do* care see the
-    smaller list and refuse, which is the safe direction.
+    probably `/park`, which does not care. The text blockers are still known,
+    and an edge nobody can read still reaches the gates as unscheduled — see
+    `_edges` — so the refusal, not the approval, is the degraded outcome.
     """
     try:
         edges = api("GET", f"/issues/{issue_number}/dependencies/blocked_by") or []
@@ -53,6 +63,46 @@ def _native_blockers(api, issue_number: int) -> set[int]:
         return set()
 
     return {edge["number"] for edge in edges if isinstance(edge.get("number"), int)}
+
+
+def _edge(issue: dict) -> dict:
+    """One dependency edge, flattened out of GitHub's issue shape."""
+    return {
+        "number": issue.get("number"),
+        "state": issue.get("state") or "open",
+        "milestone": (issue.get("milestone") or {}).get("title"),
+    }
+
+
+def _unreadable(number: int) -> dict:
+    """An edge we know exists but could not read: open, and unscheduled.
+
+    Deliberately the shape that makes the milestone-order gate **refuse**.
+    Approving over a dependency nobody can see is the expensive direction —
+    the issue goes ready, the builder skips it every night because the blocker
+    is still open, and nothing says why. A refusal costs one comment.
+    """
+    return {"number": number, "state": "open", "milestone": None}
+
+
+def _edges(api, numbers) -> list[dict]:
+    """Each issue number as an edge carrying its own state and milestone.
+
+    One read per edge. The dependency endpoint's own payload is not trusted for
+    this: a shape that happens to omit `milestone` today would read as
+    unscheduled and refuse every approval, and that is not a thing to guess at.
+    """
+    edges = []
+
+    for number in sorted(numbers):
+        try:
+            fetched = api("GET", f"/issues/{number}")
+        except Exception:  # noqa: BLE001 - any failure means "unknown"
+            fetched = None
+
+        edges.append(_edge(fetched) if fetched else _unreadable(number))
+
+    return edges
 
 
 def _is_watermarked(api, comment_id: int, bot_login: str) -> bool:
@@ -94,14 +144,20 @@ def build(event: dict, api, owner: str, bot_login: str = "github-actions[bot]") 
 
     labels = _labels(issue)
 
+    blocked_by = union_blockers(issue.get("body"), _native_blockers(api, issue["number"]))
+    # An issue that both blocks and is depended on is one dependency, not two.
+    # It is already the stronger of the pair, so the soft reading adds nothing
+    # but a second mention of it in the refusal.
+    depends_on = text_depends_on(issue.get("body")) - set(blocked_by)
+
     return {
         "issue": {
             "number": issue["number"],
             "labels": labels,
             "body": issue.get("body") or "",
             "milestone": (issue.get("milestone") or {}).get("title"),
-            "blockers": union_blockers(
-                issue.get("body"), _native_blockers(api, issue["number"])),
+            "blockers": _edges(api, blocked_by),
+            "soft_dependencies": _edges(api, depends_on),
             "is_dashboard": DASHBOARD_LABEL in labels,
         },
         "comment": {

--- a/.claude/skills/pipeline-gatekeeper/run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/run_comment_event.py
@@ -119,8 +119,12 @@ def _apply_gates(outcome, issue):
         if verdict is None:
             actions.append(action)
         else:
+            # `Skip` is (code, prose); `Verdict` names the same pair the other
+            # way round. Swapped, the acknowledgement reads "was not applied.
+            # approve-no-milestone" and — worse — `SILENT_SKIPS` gets a
+            # sentence to match against codes like `not-owner`.
             skips.append(parse_commands.Skip(
-                verdict.reason, verdict.detail, action.command))
+                verdict.skip_reason, verdict.reason, action.command))
 
     return actions, skips
 

--- a/.claude/skills/pipeline-gatekeeper/tests/test_fetch_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_fetch_comment_event.py
@@ -1,5 +1,6 @@
 """Tests for the per-issue snapshot builder."""
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -21,16 +22,36 @@ def payload(body="/approve", author="derekwinters", bot=False, is_pr=False, numb
     }
 
 
+ONE_ISSUE = re.compile(r"^/issues/(\d+)$")
+
+
+def an_issue(number, milestone="v0.1", state="open"):
+    """One issue in GitHub's own shape — milestone nested, not flattened."""
+    return {"number": number, "state": state,
+            "milestone": {"title": milestone} if milestone else None}
+
+
 class FakeApi:
-    def __init__(self, blocked_by=(), reactions=()):
+    def __init__(self, blocked_by=(), reactions=(), issues=None):
         self.blocked_by = list(blocked_by)
         self.reactions = list(reactions)
+        # Every issue a dependency edge can point at, by number. Anything not
+        # here reads back as unreadable.
+        self.issues = dict(issues or {})
+        self.paths = []
 
     def __call__(self, method, path, payload=None):
+        self.paths.append(path)
+
         if "dependencies/blocked_by" in path:
             return self.blocked_by
         if "reactions" in path:
             return self.reactions
+
+        match = ONE_ISSUE.match(path)
+        if match:
+            return self.issues.get(int(match.group(1)), {})
+
         return {}
 
 
@@ -69,11 +90,56 @@ class SnapshotTests(unittest.TestCase):
         self.assertEqual(555, snapshot["comment"]["id"])
 
     def test_blockers_union_text_and_native(self):
-        api = FakeApi(blocked_by=[{"number": 21}])
+        api = FakeApi(blocked_by=[{"number": 21}],
+                      issues={20: an_issue(20), 21: an_issue(21)})
 
         snapshot = self.snapshot(api=api)
 
-        self.assertEqual([20, 21], sorted(snapshot["issue"]["blockers"]))
+        self.assertEqual([20, 21], [edge["number"] for edge in snapshot["issue"]["blockers"]])
+
+    def test_a_blocker_is_an_edge_the_gates_can_read(self):
+        """Not a bare number.
+
+        The milestone-order gate reads each edge's own state and milestone, so
+        a list of issue numbers is not something it can answer with — it threw
+        `AttributeError` on the first `/approve` that had a blocker at all.
+        """
+        api = FakeApi(issues={20: an_issue(20, milestone="v0.2", state="closed")})
+
+        edge = self.snapshot(api=api)["issue"]["blockers"][0]
+
+        self.assertEqual(
+            {"number": 20, "state": "closed", "milestone": "v0.2"}, edge)
+
+    def test_a_soft_dependency_is_an_edge_too(self):
+        """`Depends on:` is gated on ordering the same way a blocker is."""
+        event = payload()
+        event["issue"]["body"] = "Depends on: #30"
+        api = FakeApi(issues={30: an_issue(30, milestone="v0.2")})
+
+        snapshot = fetcher.build(event, api, owner="derekwinters")
+
+        self.assertEqual([{"number": 30, "state": "open", "milestone": "v0.2"}],
+                         snapshot["issue"]["soft_dependencies"])
+
+    def test_a_depends_on_line_is_not_a_blocker(self):
+        event = payload()
+        event["issue"]["body"] = "Depends on: #30"
+
+        snapshot = fetcher.build(event, FakeApi(issues={30: an_issue(30)}),
+                                 owner="derekwinters")
+
+        self.assertEqual([], snapshot["issue"]["blockers"])
+
+    def test_an_issue_that_both_blocks_and_is_depended_on_is_named_once(self):
+        event = payload()
+        event["issue"]["body"] = "Blocked by #20\n\nDepends on: #20"
+
+        snapshot = fetcher.build(event, FakeApi(issues={20: an_issue(20)}),
+                                 owner="derekwinters")
+
+        self.assertEqual([20], [edge["number"] for edge in snapshot["issue"]["blockers"]])
+        self.assertEqual([], snapshot["issue"]["soft_dependencies"])
 
     def test_the_watermark_is_read_from_the_comment_s_reactions(self):
         api = FakeApi(reactions=[{"content": "eyes", "user": {"login": "github-actions[bot]"}}])
@@ -118,16 +184,35 @@ class ToleranceTests(unittest.TestCase):
         self.assertIsNone(fetcher.build({"issue": {"number": 1}}, FakeApi(), owner="d"))
 
     def test_a_failing_blockers_fetch_does_not_lose_the_snapshot(self):
-        # A command should still be honoured when the dependency lookup fails;
-        # the gates that need blockers see an empty list and say so.
+        # A command should still be honoured when the dependency lookup fails.
+        # The text blockers are still known, and the gates still read them.
         def explode(method, path, payload=None):
             if "dependencies" in path:
+                raise RuntimeError("the API is down")
+            if ONE_ISSUE.match(path):
+                return an_issue(20)
+            return []
+
+        snapshot = fetcher.build(payload(), explode, owner="derekwinters")
+
+        self.assertEqual([20], [edge["number"] for edge in snapshot["issue"]["blockers"]])
+
+    def test_an_edge_nobody_can_read_counts_as_unscheduled(self):
+        """Open and with no milestone, so the gates refuse rather than approve.
+
+        Approving over a dependency nobody can see is the expensive direction:
+        the issue goes ready, the builder skips it every night, and nothing
+        says why. A refusal costs one comment.
+        """
+        def explode(method, path, payload=None):
+            if path == "/issues/20":
                 raise RuntimeError("the API is down")
             return []
 
         snapshot = fetcher.build(payload(), explode, owner="derekwinters")
 
-        self.assertEqual([20], snapshot["issue"]["blockers"])
+        self.assertEqual([{"number": 20, "state": "open", "milestone": None}],
+                         snapshot["issue"]["blockers"])
 
 
 if __name__ == "__main__":

--- a/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
+++ b/.claude/skills/pipeline-gatekeeper/tests/test_run_comment_event.py
@@ -4,6 +4,7 @@ The API is injected as a callable, so the ordering decisions — which are the
 part that can actually be wrong — are asserted without a network call.
 """
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -14,14 +15,19 @@ import run_comment_event as runner  # noqa: E402
 
 OWNER = "derekwinters"
 
+ONE_ISSUE = re.compile(r"^/issues/(\d+)$")
+
 
 class RecordingApi:
     """Records every call, answers the reads the runner makes."""
 
-    def __init__(self, reactions=None, dependencies=None):
+    def __init__(self, reactions=None, dependencies=None, issues=None):
         self.calls = []
         self._reactions = reactions or []
         self._dependencies = dependencies or []
+        # The issues a dependency edge might point at, by number, in GitHub's
+        # own shape — the snapshot reads each one to learn its milestone.
+        self._issues = dict(issues or {})
 
     def __call__(self, method, path, body=None):
         self.calls.append((method, path, body))
@@ -30,6 +36,11 @@ class RecordingApi:
             return self._reactions
         if path.endswith("/blocked_by"):
             return self._dependencies
+
+        match = ONE_ISSUE.match(path)
+        if match and method == "GET":
+            return self._issues.get(int(match.group(1)), {})
+
         return {}
 
     def methods_on(self, fragment):
@@ -41,13 +52,13 @@ class RecordingApi:
 
 
 def event(body="/approve", author=OWNER, labels=("pending-approval",),
-          milestone="v0.0.1", number=10, is_dashboard=False):
+          milestone="v0.0.1", number=10, is_dashboard=False, issue_body=""):
     return {
         "issue": {
             "number": number,
             "labels": [{"name": name} for name in labels]
                       + ([{"name": "dashboard"}] if is_dashboard else []),
-            "body": "",
+            "body": issue_body,
             "milestone": {"title": milestone} if milestone else None,
         },
         "comment": {"id": 999, "body": body, "user": {"login": author, "type": "User"}},
@@ -145,6 +156,91 @@ class WatermarkTests(unittest.TestCase):
             {"content": "eyes", "user": {"login": "github-actions[bot]"}}])
         result = runner.run(event(), api, owner=OWNER, rerender=lambda **kw: None)
         self.assertFalse(result.applied)
+
+
+class GateRefusalTests(unittest.TestCase):
+    """A refused command must come back as an explanation, not an exception.
+
+    The two refusal tests above it come from the *parser* — not-owner and
+    already-watermarked — and never reach a gate. Nothing exercised a gate
+    through the runner, so two separate shape mismatches on this path went
+    unnoticed until the workflow started failing on Derek's `/approve`:
+    the snapshot hands the gates bare issue numbers where they read edges,
+    and the refusal was assembled from a `Verdict` field that does not exist.
+    """
+
+    def refuse(self, api=None, **kwargs):
+        api = api or RecordingApi()
+        result = runner.run(event(**kwargs), api, owner=OWNER, rerender=lambda **kw: None)
+        return api, result
+
+    def posted(self, api):
+        return "\n".join(
+            (body or {}).get("body", "")
+            for method, path, body in api.writes if path.endswith("/comments"))
+
+    def test_an_approve_with_no_milestone_is_explained(self):
+        api, result = self.refuse(milestone=None)
+
+        self.assertFalse(result.applied)
+        self.assertIn("milestone", self.posted(api))
+
+    def test_a_blocker_in_a_later_milestone_is_explained(self):
+        """The failure in the run: the gate read `20` where it expected an edge."""
+        api = RecordingApi(
+            issues={20: {"number": 20, "state": "open", "milestone": {"title": "v0.1"}}})
+
+        api, result = self.refuse(api=api, issue_body="Blocked by #20", milestone="v0.0.1")
+
+        self.assertFalse(result.applied)
+        self.assertIn("#20", self.posted(api))
+
+    def test_a_soft_dependency_in_a_later_milestone_is_explained(self):
+        api = RecordingApi(
+            issues={30: {"number": 30, "state": "open", "milestone": {"title": "v0.1"}}})
+
+        api, result = self.refuse(api=api, issue_body="Depends on: #30", milestone="v0.0.1")
+
+        self.assertIn("#30", self.posted(api))
+
+    def test_a_blocker_in_an_earlier_milestone_still_approves(self):
+        api = RecordingApi(
+            issues={20: {"number": 20, "state": "open", "milestone": {"title": "v0.0.1"}}})
+
+        api, result = self.refuse(api=api, issue_body="Blocked by #20", milestone="v0.1")
+
+        self.assertTrue(result.applied)
+
+    def test_a_closed_blocker_constrains_nothing(self):
+        api = RecordingApi(
+            issues={20: {"number": 20, "state": "closed", "milestone": {"title": "v0.1"}}})
+
+        api, result = self.refuse(api=api, issue_body="Blocked by #20", milestone="v0.0.1")
+
+        self.assertTrue(result.applied)
+
+    def test_a_refusal_changes_no_labels(self):
+        api, _ = self.refuse(milestone=None)
+
+        self.assertEqual([], [p for m, p, _ in api.writes if p.endswith("/labels")])
+
+    def test_a_refusal_is_watermarked(self):
+        """Or the sweep reconsiders it forever, re-posting the same refusal."""
+        api, _ = self.refuse(milestone=None)
+
+        self.assertIn("POST", api.methods_on("/reactions"))
+
+    def test_the_refusal_carries_the_gate_s_prose_not_its_skip_code(self):
+        """`Skip(reason, detail)` is a code and prose, in that order.
+
+        `Verdict` names the same pair the other way round, and swapping them
+        posts an acknowledgement reading "was not applied. approve-no-milestone"
+        — and, worse, hands `SILENT_SKIPS` a sentence to match against codes.
+        """
+        api, _ = self.refuse(milestone=None)
+
+        self.assertNotIn("approve-no-milestone", self.posted(api))
+        self.assertIn("`/milestone <title>`", self.posted(api))
 
 
 class ResultingLabelsTests(unittest.TestCase):

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -181,20 +181,48 @@ it up next time.
 
 ### The snapshot
 
-`fetch_comment_event.py` turns the raw webhook payload into what the parser
-reads: the issue's number, labels, body, milestone, blockers (text ∪ native),
-whether it is the dashboard, and the comment itself. All the payload-shape
-guesswork lives there so the parser never has to know what GitHub's JSON looks
-like.
+`fetch_comment_event.py` turns the raw webhook payload into what the parser and
+the gates read: the issue's number, labels, body, milestone, blockers
+(text ∪ native), its soft `Depends on:` dependencies, whether it is the
+dashboard, and the comment itself. All the payload-shape guesswork lives there
+so the parser never has to know what GitHub's JSON looks like.
 
-It returns nothing at all for a comment on a pull request or from a bot —
-defence in depth, since the workflow filters those too, but a snapshot the
+#### A dependency is an edge, not a number
+
+`blockers` and `soft_dependencies` are lists of **edges**:
+
+```json
+{"number": 20, "state": "open", "milestone": "v0.1"}
+```
+
+Not `[20]`. The [milestone-order gate](#gate-2-milestone-order) is a comparison
+between two milestones, so it needs the blocker's own milestone and its own
+state — a list of issue numbers is not something it can answer with. The
+snapshot reads each edge's issue to fill them in, one request per edge, rather
+than trusting the dependency endpoint's payload to carry a `milestone` field:
+a shape that quietly omitted it would read as unscheduled and refuse every
+approval, and that is not a thing to guess at.
+
+An issue that is both a blocker and a `Depends on:` is one edge, the hard one.
+It is already the stronger of the two, and listing it twice only names it twice
+in the refusal.
+
+#### A partial payload is tolerated; an unreadable edge is not approved over
+
+The builder returns nothing at all for a comment on a pull request or from a
+bot — defence in depth, since the workflow filters those too, but a snapshot the
 parser *could* act on is one it eventually will.
 
-It also tolerates a partial payload rather than throwing. A failed
-dependency lookup in particular does not lose the event: the command is
-probably `/park`, which does not care, and the gates that *do* care see a
-smaller blocker list and refuse — which is the safe direction.
+It also tolerates a partial payload rather than throwing. A failed **dependency
+lookup** does not lose the event: the command is probably `/park`, which does
+not care, and the `Blocked by #N` lines in the body are still read.
+
+An edge whose **issue** cannot be read is a different case, and it is kept
+rather than dropped — as open, with no milestone, which is exactly the shape the
+order gate refuses on. Approving over a dependency nobody can see is the
+expensive direction: the issue goes ready, the builder skips it every night
+because the blocker is still open, and nothing says why. A refusal costs one
+comment.
 
 ## Replaying the comments the webhook lost
 
@@ -384,6 +412,11 @@ dashboard, the comment-event snapshot, and `audit`.
 `issue-blockers` owns them because it is the skill that documents the format —
 the same "the side that writes the format owns the recognizer" rule that put
 `has_analysis_signature` in `triage-issue`.
+
+The soft `Depends on: #42` line lives there too, as `text_depends_on`. It was a
+single-reader pattern sitting in `select_queue.py` right up until the approval
+gates became its second reader, and a second copy would have let the queue and
+the gate disagree about what the same body said.
 
 The pattern used to be written out in each reader, and the drift is silent in
 the worst way: the queue selector reads a line as a blocker and refuses to


### PR DESCRIPTION
When you comment `/approve` on an issue that isn't ready to be approved — no
milestone, or waiting on something scheduled for later — the gatekeeper is
supposed to reply saying so and change nothing. It has never actually managed
that: every refusal crashed the workflow instead, so the comment just sat there
looking like a dropped webhook. This makes the refusal arrive as a comment, the
way it was always meant to.

Two separate mistakes were in the way, both on the same path, and both in a
seam where each side had tests and neither matched the other.

**The snapshot was handing the gates issue numbers where they read edges.**
`fetch_comment_event` built `blockers` as `[20]`. The milestone-order gate is a
comparison between two milestones, so it needs the blocker's own milestone and
state, and it threw `AttributeError: 'int' object has no attribute 'get'` on the
first `/approve` that had a blocker at all — [the run that prompted
this](https://github.com/derekwinters/connor-multiplying-frogs/actions/runs/31638247734).
The snapshot now carries `{number, state, milestone}` per edge, and carries the
soft `Depends on:` dependencies too, which the gate has always been documented
to order against and had never once been given.

**The refusal was assembled from a field that does not exist** — `verdict.detail`
— which is #196 as filed. `Skip` is (code, prose) and `Verdict` names the same
pair the other way round.

## Spec invariants

- *For every open blocker edge A → B, `order(A) ≥ order(B)`, and B must be
  scheduled* — now actually enforceable, since the gate can finally see B's
  milestone. Covered end to end through the runner: a later-milestone blocker
  refuses, an earlier one approves, a closed one constrains nothing.
- *A refusal leaves the issue completely untouched* — asserted directly: no
  label write happens on a refused command.
- *A refused comment is watermarked* — asserted, or the sweep reconsiders it
  every run and re-posts the same refusal forever.
- *A gate refusal is spoken, a not-owner skip is silent* — the code/prose order
  is what `SILENT_SKIPS` matches on, so this is the invariant the swapped
  arguments were quietly breaking.
- *One recognizer per format* — `test_blocker_refs` widens the shared pattern
  and checks every reader sees it; `Depends on:` now has that test too.

## How the spec is changing

The docs described the snapshot as carrying "blockers (text ∪ native)" without
saying in what shape, which is precisely the ambiguity the two sides fell into.
`docs/engineering/issue-pipeline.md` now states that a dependency in the
snapshot is an edge, not a number, and why.

One rule genuinely changes. The old text said a failed dependency lookup left
"a smaller blocker list", and called that "the safe direction" — but a smaller
list is one the gate *passes*, so the degraded outcome was silently approving
over a dependency nobody could read. The new rule: an edge whose issue cannot be
read is kept, as open and unscheduled, so the gate refuses. Approving is the
expensive direction — the issue goes ready, the builder skips it every night
because the blocker is still open, and nothing says why. A refusal costs one
comment. (A failed lookup still never loses the event; that part is unchanged.)

**Docs:** `docs/engineering/issue-pipeline.md` — the snapshot's dependencies are
edges (`{number, state, milestone}`), not issue numbers; an unreadable edge is
kept as unscheduled and refused on rather than dropped; `text_depends_on` joins
the shared recognizers. `.claude/skills/issue-blockers/SKILL.md` — that skill now
owns the `Depends on: #N` pattern as well.

## Deviations and Decisions

- **Fixed two defects, not one.** #196 names the `verdict.detail` crash; the
  run Derek pointed at is the `int`/edge crash, which is upstream of it and hits
  first. They are the same defect from the reader's side — a gate refusal has
  never once reached him — and fixing either alone leaves `/approve` broken.
- **Wired up soft dependencies while I was there**, which is more than the crash
  strictly needed. The gate reads `soft_dependencies` and is tested for it, the
  docs specify it, and nothing had ever put it on the snapshot — so fixing the
  shape without it would have meant defining the contract and leaving half of it
  dead in the same PR.
- **Moved `Depends on:` into `blocker_refs.py`** rather than adding a second
  copy in the gatekeeper. Its own comment said it was safe to keep local because
  it had exactly one reader; this PR gives it a second. `select_queue` imports
  it now and is covered by the shared widening test.
- **One extra API read per dependency edge**, rather than trusting the
  `dependencies/blocked_by` payload to carry a `milestone` field. If that shape
  ever omitted it, every blocked issue would read as unscheduled and every
  approval would be refused — a guess with a bad failure mode, and issues have
  0–2 blockers.
- **Not fixed here:** `/milestone` computes `plan.milestone` and nothing ever
  writes it, so the command appears to be a no-op — and it is the command this
  PR's refusals point Derek at. Filed as #308 rather than folded in.
- Derek asked for this bug directly, so it skipped the focus-milestone queue —
  CLAUDE.md says an explicit instruction wins, and to say so here.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEWJhL5S8pKB5BKoyJk1Nv