### PR TITLE
feat(game-board): one Start log and one End log for the whole pond

### DIFF
--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -14,10 +14,20 @@ namespace Frogs.Unity.Views
     /// <summary>
     /// One frog's lane on the board — docs/specs/ui/game-board.md's `chip`,
     /// `track` and `piece`, built to that page's per-lane constants table.
-    /// The track is the Start log, seven lily pads and the End log, drawn
-    /// left to right (Derek's settled call — see the page's "why the lanes
-    /// run across"); the chip is the shared
-    /// <see cref="PlayerChip"/> (#219) in this lane's gutter.
+    /// The track is this lane's **seven lily pads**, drawn left to right
+    /// (Derek's settled call — see the page's "why the lanes run across"); the
+    /// chip is the shared <see cref="PlayerChip"/> (#219) in this lane's
+    /// gutter.
+    ///
+    /// A lane is still nine positions, and it still holds a rect for every one
+    /// of them. Two of those rects — position 0 and
+    /// <see cref="Lane.LaneWinningPosition"/> — draw nothing at all: they are
+    /// where this lane crosses the Start log and the End log, and those are one
+    /// drawing each for the whole pond, owned by
+    /// <see cref="GameBoardScreenView"/> (#296). A four-frog game draws two
+    /// logs, not eight. What the lane keeps is the *place*, so its piece sits
+    /// on its own lane's centre line on a log it shares with nobody's position
+    /// but its own.
     ///
     /// It reads, and never computes. Where the frog sits and whether it is
     /// home come straight off the <see cref="Lane"/> it is handed on every
@@ -40,9 +50,6 @@ namespace Frogs.Unity.Views
         public const float LilyPadDiameter = 112f;
         public const float FrogPieceDiameter = 88f;
         public const float FrogPieceOutline = 4f;
-        public const float LogWidth = 176f;
-        public const float LogHeight = 120f;
-        public const float LogRadius = 24f;
         public const float TrackOutline = 3f;
         public const float LanePositionGap = 48f;
         public const float LaneGutterWidth = 256f;
@@ -61,6 +68,12 @@ namespace Frogs.Unity.Views
         // whatever Lane reports; the denominator is Lane.LaneWinningPosition.
         const string PadCountFormat = "{0} of {1}";
 
+        // `LogWidth`, `SharedLogHeight` and `LogRadius` are game-board.md's
+        // third table, and they are not this type's either. The logs belong to
+        // the pond, so they are GameBoardScreenView's — referenced here, under
+        // the identical names, because the track's own width arithmetic still
+        // has to reserve the column each log stands in.
+
         // The track's colours are docs/specs/ui/game-board.md § Colours,
         // received by name from BoardColours exactly as the geometry above is
         // received from that page's constants table. They used to be private
@@ -68,8 +81,6 @@ namespace Frogs.Unity.Views
         // them a home on the spec page and this file the same relationship to
         // them it already had to every other number on this screen.
 
-        static Sprite s_logSprite;
-        static Sprite s_logFillSprite;
         static Sprite s_lilyPadSprite;
         static Sprite s_lilyPadFillSprite;
         static Sprite s_pieceSprite;
@@ -80,32 +91,6 @@ namespace Frogs.Unity.Views
         // Each rounded shape gets a sprite generated at its own radius rather
         // than one sprite stretched to two sizes, so the inset one keeps its
         // curve instead of squaring off.
-        static Sprite LogSprite
-        {
-            get
-            {
-                if (s_logSprite == null)
-                {
-                    s_logSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LogRadius));
-                }
-
-                return s_logSprite;
-            }
-        }
-
-        static Sprite LogFillSprite
-        {
-            get
-            {
-                if (s_logFillSprite == null)
-                {
-                    s_logFillSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LogRadius - TrackOutline));
-                }
-
-                return s_logFillSprite;
-            }
-        }
-
         static Sprite LilyPadSprite
         {
             get
@@ -165,15 +150,17 @@ namespace Frogs.Unity.Views
 
         /// <summary>
         /// The track's width, fixed by its nine positions rather than by the
-        /// space available — game-board.md's Anchors section. Two logs, seven
-        /// lily pads and eight gaps: the page's own arithmetic, written out
-        /// rather than trusted as the literal 1520.
+        /// space available — game-board.md's Anchors section. Two log columns,
+        /// seven lily pads and eight gaps: the page's own arithmetic, written
+        /// out rather than trusted as the literal 1520. Sharing the logs did
+        /// not disturb it, because a shared log stands in the same column its
+        /// per-lane predecessor did.
         /// </summary>
         public static float TrackWidth
         {
             get
             {
-                return (2f * LogWidth)
+                return (2f * GameBoardScreenView.LogWidth)
                     + ((Lane.LanePositionCount - 2) * LilyPadDiameter)
                     + ((Lane.LanePositionCount - 1) * LanePositionGap);
             }
@@ -181,22 +168,22 @@ namespace Frogs.Unity.Views
 
         /// <summary>
         /// The centre of one track position, measured from the track's left
-        /// edge. The Start log at index 0, seven lily pads, the End log at
-        /// <see cref="Lane.LaneWinningPosition"/>.
+        /// edge. The Start log's column at index 0, seven lily pads, the End
+        /// log's column at <see cref="Lane.LaneWinningPosition"/>.
         /// </summary>
         public static float PositionCenterX(int position)
         {
             if (position <= 0)
             {
-                return LogWidth / 2f;
+                return GameBoardScreenView.LogWidth / 2f;
             }
 
             if (position >= Lane.LaneWinningPosition)
             {
-                return TrackWidth - (LogWidth / 2f);
+                return TrackWidth - (GameBoardScreenView.LogWidth / 2f);
             }
 
-            return LogWidth
+            return GameBoardScreenView.LogWidth
                 + LanePositionGap
                 + ((position - 1) * (LilyPadDiameter + LanePositionGap))
                 + (LilyPadDiameter / 2f);
@@ -206,8 +193,8 @@ namespace Frogs.Unity.Views
         PlayerChip _chip;
         RectTransform _trackRect;
         readonly List<RectTransform> _positionRects = new List<RectTransform>();
-        readonly List<Image> _positionImages = new List<Image>();
-        readonly List<Image> _positionOutlines = new List<Image>();
+        readonly List<Image> _lilyPadFills = new List<Image>();
+        readonly List<Image> _lilyPadOutlines = new List<Image>();
         RectTransform _pieceRect;
         Image _pieceOutline;
         Image _piece;
@@ -256,7 +243,12 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>The nine track positions, Start log first, End log last.</summary>
+        /// <summary>
+        /// The nine track positions, indexed by <see cref="Lane.Position"/>.
+        /// The first and last draw nothing — they are where this lane crosses
+        /// the pond's two shared logs — and the seven between them are this
+        /// lane's own lily pads.
+        /// </summary>
         public IReadOnlyList<RectTransform> PositionRects
         {
             get
@@ -267,30 +259,31 @@ namespace Frogs.Unity.Views
         }
 
         /// <summary>
-        /// The nine positions' fills. Every lily pad is drawn identically —
-        /// "the pad a frog is on is drawn no differently from the others; the
-        /// frog on it is the marker."
+        /// The seven lily pads' fills — positions 1 to 7, in order, and the
+        /// whole of what this lane draws for itself. Every one is drawn
+        /// identically: "the pad a frog is on is drawn no differently from the
+        /// others; the frog on it is the marker."
         /// </summary>
-        public IReadOnlyList<Image> PositionImages
+        public IReadOnlyList<Image> LilyPadFills
         {
             get
             {
                 EnsureInitialized();
-                return _positionImages;
+                return _lilyPadFills;
             }
         }
 
         /// <summary>
-        /// The nine positions' outlines — <see cref="TrackOutline"/> thick,
-        /// drawn inside each element's own bounds so the track's width is
-        /// exactly the sum the spec's arithmetic gives.
+        /// The seven lily pads' outlines — <see cref="TrackOutline"/> thick,
+        /// drawn inside each pad's own bounds so the track's width is exactly
+        /// the sum the spec's arithmetic gives.
         /// </summary>
-        public IReadOnlyList<Image> PositionOutlines
+        public IReadOnlyList<Image> LilyPadOutlines
         {
             get
             {
                 EnsureInitialized();
-                return _positionOutlines;
+                return _lilyPadOutlines;
             }
         }
 
@@ -498,60 +491,84 @@ namespace Frogs.Unity.Views
         void BuildTrack()
         {
             // track — pinned to the right, its width fixed by its nine
-            // positions rather than by the space available.
+            // positions rather than by the space available. It is the lane's
+            // full height now that both of its ends are drawn by the pond: the
+            // rects standing in the two shared logs' columns are as tall as
+            // the lane, because the log they mark a place on runs past this
+            // lane in both directions.
             var trackGO = new GameObject("Track", typeof(RectTransform));
             _trackRect = (RectTransform)trackGO.transform;
             _trackRect.SetParent(_rect, worldPositionStays: false);
             _trackRect.anchorMin = new Vector2(1f, 0.5f);
             _trackRect.anchorMax = new Vector2(1f, 0.5f);
             _trackRect.pivot = new Vector2(1f, 0.5f);
-            _trackRect.sizeDelta = new Vector2(TrackWidth, LogHeight);
+            _trackRect.sizeDelta = new Vector2(TrackWidth, LaneHeight);
             _trackRect.anchoredPosition = Vector2.zero;
 
             for (var position = 0; position < Lane.LanePositionCount; position++)
             {
-                var isLog = position == 0 || position == Lane.LaneWinningPosition;
-                var size = isLog
-                    ? new Vector2(LogWidth, LogHeight)
-                    : new Vector2(LilyPadDiameter, LilyPadDiameter);
+                var onSharedLog = position == 0 || position == Lane.LaneWinningPosition;
 
-                var positionName = position == 0
-                    ? "StartLog"
-                    : position == Lane.LaneWinningPosition ? "EndLog" : "LilyPad" + position;
+                var positionRect = onSharedLog
+                    ? BuildSharedLogPosition(position)
+                    : BuildLilyPad(position);
 
-                var positionGO = new GameObject(positionName, typeof(RectTransform), typeof(Image));
-                var outline = positionGO.GetComponent<Image>();
-                outline.sprite = isLog ? LogSprite : LilyPadSprite;
-                outline.type = Image.Type.Sliced;
-                outline.color = isLog ? BoardColours.LogEdge : BoardColours.LilyPadEdge;
-                outline.raycastTarget = false;
-
-                var positionRect = outline.rectTransform;
                 positionRect.SetParent(_trackRect, worldPositionStays: false);
                 positionRect.anchorMin = new Vector2(0f, 0.5f);
                 positionRect.anchorMax = new Vector2(0f, 0.5f);
                 positionRect.pivot = new Vector2(0.5f, 0.5f);
-                positionRect.sizeDelta = size;
                 positionRect.anchoredPosition = new Vector2(PositionCenterX(position), 0f);
 
-                var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
-                var fill = fillGO.GetComponent<Image>();
-                fill.sprite = isLog ? LogFillSprite : LilyPadFillSprite;
-                fill.type = Image.Type.Sliced;
-                fill.color = isLog ? BoardColours.LogBrown : BoardColours.LilyPadGreen;
-                fill.raycastTarget = false;
-
-                var fillRect = fill.rectTransform;
-                fillRect.SetParent(positionRect, worldPositionStays: false);
-                fillRect.anchorMin = Vector2.zero;
-                fillRect.anchorMax = Vector2.one;
-                fillRect.offsetMin = new Vector2(TrackOutline, TrackOutline);
-                fillRect.offsetMax = new Vector2(-TrackOutline, -TrackOutline);
-
                 _positionRects.Add(positionRect);
-                _positionOutlines.Add(outline);
-                _positionImages.Add(fill);
             }
+        }
+
+        // Where this lane crosses one of the pond's two shared logs. It draws
+        // nothing — the log is one drawing for the whole board, and
+        // GameBoardScreenView owns it — and exists so the piece has this
+        // lane's own place on that log to sit at: the log's column, on this
+        // lane's centre line.
+        RectTransform BuildSharedLogPosition(int position)
+        {
+            var positionName = position == 0 ? "StartPosition" : "EndPosition";
+
+            var positionGO = new GameObject(positionName, typeof(RectTransform));
+            var positionRect = (RectTransform)positionGO.transform;
+            positionRect.sizeDelta = new Vector2(GameBoardScreenView.LogWidth, LaneHeight);
+
+            return positionRect;
+        }
+
+        RectTransform BuildLilyPad(int position)
+        {
+            var padGO = new GameObject("LilyPad" + position, typeof(RectTransform), typeof(Image));
+            var outline = padGO.GetComponent<Image>();
+            outline.sprite = LilyPadSprite;
+            outline.type = Image.Type.Sliced;
+            outline.color = BoardColours.LilyPadEdge;
+            outline.raycastTarget = false;
+
+            var padRect = outline.rectTransform;
+            padRect.sizeDelta = new Vector2(LilyPadDiameter, LilyPadDiameter);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            var fill = fillGO.GetComponent<Image>();
+            fill.sprite = LilyPadFillSprite;
+            fill.type = Image.Type.Sliced;
+            fill.color = BoardColours.LilyPadGreen;
+            fill.raycastTarget = false;
+
+            var fillRect = fill.rectTransform;
+            fillRect.SetParent(padRect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(TrackOutline, TrackOutline);
+            fillRect.offsetMax = new Vector2(-TrackOutline, -TrackOutline);
+
+            _lilyPadOutlines.Add(outline);
+            _lilyPadFills.Add(fill);
+
+            return padRect;
         }
 
         void BuildPiece()

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -14,6 +14,7 @@ using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
+using RoundedRectSprite = Frogs.Unity.UI.RoundedRectSprite;
 
 namespace Frogs.Unity.Views
 {
@@ -22,8 +23,16 @@ namespace Frogs.Unity.Views
     /// committed 1:1 mockup. Three horizontal bands filling the full height
     /// with no gaps: <c>header</c> (whose turn it is, and the gear),
     /// <c>pond</c> (one <see cref="GameBoardLaneView"/> per frog in the game,
-    /// stacked and vertically centred), and <c>controls</c> (the oversized
-    /// `Roll`).
+    /// stacked and vertically centred, plus the two logs they share), and
+    /// <c>controls</c> (the oversized `Roll`).
+    ///
+    /// **The logs are the pond's, not a lane's.** There is one Start log and
+    /// one End log on the board however many frogs are playing, each spanning
+    /// the whole pond band, and every frog's position 0 and position 8 are on
+    /// them (#296). That is a shared *drawing*, not a shared position: each
+    /// frog sits on its own lane's centre line, which is what keeps "frogs
+    /// never share a lane and never interact" true in the picture as well as
+    /// in the state.
     ///
     /// **It reads Core; it never computes.** Whose turn it is comes from
     /// <see cref="Game.ActiveFrog"/>, and where every frog sits comes from
@@ -42,7 +51,7 @@ namespace Frogs.Unity.Views
     ///   got home and moving off this screen is <c>unity-game-over</c> (#225),
     ///   gated on <c>core-game-end</c> (#211).
     ///
-    /// Both of game-board.md's open questions are left exactly as open as it
+    /// game-board.md's remaining open questions are left exactly as open as it
     /// leaves them: only the lanes in play are drawn, and nothing anywhere
     /// reports the last roll.
     /// </summary>
@@ -62,6 +71,31 @@ namespace Frogs.Unity.Views
         public const float RollButtonWidth = 480f;
         public const float RollButtonHeight = 144f;
         public const float RollButtonLabelSize = 56f;
+
+        // docs/specs/ui/game-board.md#named-constants — the two shared logs'
+        // own table. They are the pond's, not a lane's: there is one Start log
+        // and one End log for the whole board however many frogs are playing,
+        // and every frog's position 0 and position 8 are on them (#296).
+        public const float LogWidth = 176f;
+        public const float LogRadius = 24f;
+
+        /// <summary>
+        /// How tall a shared log is: the pond band's own height, so the log
+        /// fills the band edge to edge with the two hairlines.
+        ///
+        /// It is **the same 896 px at two, three and four frogs**. That is
+        /// Derek's answer, on #296, to the question game-board.md left open —
+        /// the log spans the full pond rather than only the lanes in play — so
+        /// this is one number rather than the `LaneCount x LaneHeight`
+        /// expression the mockup proposed. `LogHeight` (120 px) is gone rather
+        /// than renamed: it was the height of a log sized to sit inside one
+        /// 184 px lane, and there is no such thing on this board any more.
+        ///
+        /// Written as the band's arithmetic rather than as 896 so that if the
+        /// header or the controls band ever changes height, the logs follow
+        /// without anybody having to remember to move them.
+        /// </summary>
+        public const float SharedLogHeight = CanvasHeight - BoardHeaderHeight - BoardControlsHeight;
 
         /// <summary>
         /// How long the frog's hop takes — docs/specs/ui/game-board.md's own
@@ -121,6 +155,10 @@ namespace Frogs.Unity.Views
         GameBoardSettingsButton _settingsButton;
 
         RectTransform _pondRect;
+        Image _startLogOutline;
+        Image _startLogFill;
+        Image _endLogOutline;
+        Image _endLogFill;
         readonly List<GameBoardLaneView> _lanes = new List<GameBoardLaneView>();
         readonly Dictionary<FrogColour, GameBoardLaneView> _lanesByColour = new Dictionary<FrogColour, GameBoardLaneView>();
 
@@ -130,6 +168,41 @@ namespace Frogs.Unity.Views
 
         bool _initialized;
         Game _game;
+
+        static Sprite s_logSprite;
+        static Sprite s_logFillSprite;
+
+        // The log's rim and its fill are two images, the inner one inset by
+        // TrackOutline — the same two-image shape every outlined element on
+        // this screen uses. Each gets a sprite generated at its own radius
+        // rather than one sprite stretched to two sizes, so the inset one
+        // keeps its curve instead of squaring off.
+        static Sprite LogSprite
+        {
+            get
+            {
+                if (s_logSprite == null)
+                {
+                    s_logSprite = RoundedRectSprite.CreateRoundedRect(Mathf.RoundToInt(LogRadius));
+                }
+
+                return s_logSprite;
+            }
+        }
+
+        static Sprite LogFillSprite
+        {
+            get
+            {
+                if (s_logFillSprite == null)
+                {
+                    s_logFillSprite = RoundedRectSprite.CreateRoundedRect(
+                        Mathf.RoundToInt(LogRadius - GameBoardLaneView.TrackOutline));
+                }
+
+                return s_logFillSprite;
+            }
+        }
 
         /// <summary>
         /// `Roll` was pressed. The board disables `Roll` before raising this
@@ -246,6 +319,53 @@ namespace Frogs.Unity.Views
             {
                 EnsureInitialized();
                 return _pondRect;
+            }
+        }
+
+        /// <summary>
+        /// `start-log` — **one** log down the left of the pond, position 0 of
+        /// every lane at once. This is its rim; <see cref="StartLogFill"/> is
+        /// the wood inside it.
+        /// </summary>
+        public Image StartLogOutline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _startLogOutline;
+            }
+        }
+
+        /// <summary>The Start log's fill, inset by `TrackOutline`.</summary>
+        public Image StartLogFill
+        {
+            get
+            {
+                EnsureInitialized();
+                return _startLogFill;
+            }
+        }
+
+        /// <summary>
+        /// `end-log` — **one** log down the right of the pond, position 8 of
+        /// every lane at once, and the winning space.
+        /// </summary>
+        public Image EndLogOutline
+        {
+            get
+            {
+                EnsureInitialized();
+                return _endLogOutline;
+            }
+        }
+
+        /// <summary>The End log's fill, inset by `TrackOutline`.</summary>
+        public Image EndLogFill
+        {
+            get
+            {
+                EnsureInitialized();
+                return _endLogFill;
             }
         }
 
@@ -552,6 +672,64 @@ namespace Frogs.Unity.Views
             _pondRect.anchorMax = Vector2.one;
             _pondRect.offsetMin = new Vector2(0f, BoardControlsHeight);
             _pondRect.offsetMax = new Vector2(0f, -BoardHeaderHeight);
+
+            // The two logs the lanes share. One Start log down the left and
+            // one End log down the right, whatever the frog count — they are
+            // parts of the pond, not parts of a lane, which is the whole of
+            // #296. They are built here, before BuildLanes runs, so every
+            // frog is drawn on top of the log it is standing on rather than
+            // under it.
+            //
+            // The Start log stands in the same column every lane's track
+            // starts in: past the safe margin, the chip gutter and the gap
+            // after it. The End log is pinned to the right of the safe area,
+            // where every lane's track ends. Neither is placed by a number of
+            // its own.
+            _startLogOutline = BuildSharedLog(
+                "StartLog",
+                0f,
+                SafeMargin + GameBoardLaneView.LaneGutterWidth + GameBoardLaneView.LaneGutterGap,
+                out _startLogFill);
+
+            _endLogOutline = BuildSharedLog("EndLog", 1f, -SafeMargin, out _endLogFill);
+        }
+
+        // One shared log — LogWidth across, SharedLogHeight tall, vertically
+        // centred on the pond and so on the lane stack the pond centres too.
+        // Every lane's centre line crosses it, which is what lets a frog on a
+        // log still sit on its own lane's line.
+        Image BuildSharedLog(string logName, float edge, float offsetX, out Image fill)
+        {
+            var logGO = new GameObject(logName, typeof(RectTransform), typeof(Image));
+            var outline = logGO.GetComponent<Image>();
+            outline.sprite = LogSprite;
+            outline.type = Image.Type.Sliced;
+            outline.color = BoardColours.LogEdge;
+            outline.raycastTarget = false;
+
+            var logRect = outline.rectTransform;
+            logRect.SetParent(_pondRect, worldPositionStays: false);
+            logRect.anchorMin = new Vector2(edge, 0.5f);
+            logRect.anchorMax = new Vector2(edge, 0.5f);
+            logRect.pivot = new Vector2(edge, 0.5f);
+            logRect.sizeDelta = new Vector2(LogWidth, SharedLogHeight);
+            logRect.anchoredPosition = new Vector2(offsetX, 0f);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            fill = fillGO.GetComponent<Image>();
+            fill.sprite = LogFillSprite;
+            fill.type = Image.Type.Sliced;
+            fill.color = BoardColours.LogBrown;
+            fill.raycastTarget = false;
+
+            var fillRect = fill.rectTransform;
+            fillRect.SetParent(logRect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(GameBoardLaneView.TrackOutline, GameBoardLaneView.TrackOutline);
+            fillRect.offsetMax = new Vector2(-GameBoardLaneView.TrackOutline, -GameBoardLaneView.TrackOutline);
+
+            return outline;
         }
 
         void BuildControls()

--- a/Assets/Tests/EditMode/GameBoardColoursTests.cs
+++ b/Assets/Tests/EditMode/GameBoardColoursTests.cs
@@ -83,16 +83,21 @@ namespace Frogs.Unity.EditModeTests
             {
                 foreach (var lane in view.Lanes)
                 {
-                    // The seven lily pads — positions 1 to 7. Position 0 and
-                    // position 8 are the logs.
-                    for (var position = 1; position < Lane.LaneWinningPosition; position++)
+                    // The seven lily pads — positions 1 to 7, and the whole of
+                    // what a lane draws for itself. Position 0 and position 8
+                    // are on the two logs the pond shares (#296).
+                    Assert.That(lane.LilyPadFills.Count, Is.EqualTo(Lane.LanePositionCount - 2));
+
+                    for (var index = 0; index < lane.LilyPadFills.Count; index++)
                     {
+                        var position = index + 1;
+
                         Assert.That(
-                            lane.PositionImages[position].color,
+                            lane.LilyPadFills[index].color,
                             Is.EqualTo(LilyPadGreen),
                             $"{lane.Colour}'s lily pad at position {position} is `LilyPadGreen`");
                         Assert.That(
-                            lane.PositionOutlines[position].color,
+                            lane.LilyPadOutlines[index].color,
                             Is.EqualTo(LilyPadEdge),
                             $"{lane.Colour}'s lily pad at position {position} has the `LilyPadEdge` rim");
                     }
@@ -111,21 +116,26 @@ namespace Frogs.Unity.EditModeTests
 
             try
             {
-                foreach (var lane in view.Lanes)
+                // Two logs for the whole pond, not a pair per lane (#296), so
+                // this walks the board rather than every lane on it.
+                var logs = new Dictionary<string, KeyValuePair<Image, Image>>
                 {
-                    foreach (var position in new[] { 0, Lane.LaneWinningPosition })
-                    {
-                        Assert.That(
-                            lane.PositionImages[position].color,
-                            Is.EqualTo(LogBrown),
-                            $"the log at position {position} is `LogBrown`");
-                        Assert.That(
-                            lane.PositionOutlines[position].color,
-                            Is.EqualTo(LogEdge),
-                            $"the log at position {position} has the `LogEdge` rim, which is what "
-                            + "separates a log from the water it floats on — the two are close in "
-                            + "brightness on purpose and far apart in hue");
-                    }
+                    { "Start", new KeyValuePair<Image, Image>(view.StartLogFill, view.StartLogOutline) },
+                    { "End", new KeyValuePair<Image, Image>(view.EndLogFill, view.EndLogOutline) },
+                };
+
+                foreach (var log in logs)
+                {
+                    Assert.That(
+                        log.Value.Key.color,
+                        Is.EqualTo(LogBrown),
+                        $"the {log.Key} log is `LogBrown`");
+                    Assert.That(
+                        log.Value.Value.color,
+                        Is.EqualTo(LogEdge),
+                        $"the {log.Key} log has the `LogEdge` rim, which is what "
+                        + "separates a log from the water it floats on — the two are close in "
+                        + "brightness on purpose and far apart in hue");
                 }
             }
             finally

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -356,14 +356,22 @@ namespace Frogs.Unity.EditModeTests
                 // The rim that separates a log from the water it floats on is
                 // drawn inside the log's own bounds, as every outline on this
                 // screen is.
-                foreach (var fill in new[] { view.StartLogFill, view.EndLogFill })
+                var logs = new[]
                 {
-                    Assert.That(fill.rectTransform.parent.name, Is.AnyOf("StartLog", "EndLog"));
+                    new KeyValuePair<Image, Image>(view.StartLogOutline, view.StartLogFill),
+                    new KeyValuePair<Image, Image>(view.EndLogOutline, view.EndLogFill),
+                };
+
+                foreach (var log in logs)
+                {
+                    var fill = log.Value.rectTransform;
+
+                    Assert.That(fill.parent, Is.SameAs(log.Key.transform), "the fill sits inside its own log");
                     Assert.That(
-                        fill.rectTransform.offsetMin,
+                        fill.offsetMin,
                         Is.EqualTo(new Vector2(GameBoardLaneView.TrackOutline, GameBoardLaneView.TrackOutline)));
                     Assert.That(
-                        fill.rectTransform.offsetMax,
+                        fill.offsetMax,
                         Is.EqualTo(new Vector2(-GameBoardLaneView.TrackOutline, -GameBoardLaneView.TrackOutline)));
                 }
             }

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -15,6 +15,7 @@ using Frogs.Unity.Views;
 using Button = Frogs.Unity.UI.Button;
 using ButtonKind = Frogs.Unity.UI.ButtonKind;
 using FrogColours = Frogs.Unity.UI.FrogColours;
+using Image = UnityEngine.UI.Image;
 using PlayerChip = Frogs.Unity.UI.PlayerChip;
 using PlayerChipState = Frogs.Unity.UI.PlayerChipState;
 
@@ -157,7 +158,7 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
-        public void Track_IsStartLogSevenLilyPadsAndEndLog_AndTheLaneArithmeticLandsOn1920()
+        public void Track_IsSevenLilyPadsBetweenTheTwoSharedLogColumns_AndTheLaneArithmeticLandsOn1920()
         {
             var view = CreateView(TwoFrogGame());
 
@@ -168,11 +169,24 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(positions.Count, Is.EqualTo(Lane.LanePositionCount));
 
-                var logSize = new Vector2(GameBoardLaneView.LogWidth, GameBoardLaneView.LogHeight);
+                // A lane is still nine positions. Seven of them are its own
+                // lily pads; the two on the ends are where this lane crosses a
+                // log the whole pond shares, so the lane holds a rect there
+                // for its piece to sit on and draws no log of its own.
+                var logColumn = new Vector2(GameBoardScreenView.LogWidth, GameBoardLaneView.LaneHeight);
                 var padSize = new Vector2(GameBoardLaneView.LilyPadDiameter, GameBoardLaneView.LilyPadDiameter);
 
-                Assert.That(positions[0].sizeDelta, Is.EqualTo(logSize), "Start log");
-                Assert.That(positions[Lane.LaneWinningPosition].sizeDelta, Is.EqualTo(logSize), "End log");
+                Assert.That(positions[0].sizeDelta, Is.EqualTo(logColumn), "the Start log's column");
+                Assert.That(positions[Lane.LaneWinningPosition].sizeDelta, Is.EqualTo(logColumn), "the End log's column");
+
+                Assert.That(
+                    positions[0].GetComponent<Image>(),
+                    Is.Null,
+                    "position 0 draws nothing: the Start log under it belongs to the pond");
+                Assert.That(
+                    positions[Lane.LaneWinningPosition].GetComponent<Image>(),
+                    Is.Null,
+                    "position 8 draws nothing: the End log under it belongs to the pond");
 
                 for (var index = 1; index < Lane.LaneWinningPosition; index++)
                 {
@@ -195,7 +209,7 @@ namespace Frogs.Unity.EditModeTests
                 // rather than trusted: two logs, seven pads and eight gaps is
                 // 1520 px of track; plus the chip gutter, one gutter gap and
                 // two safe margins, 1920 px on the nose.
-                var expectedTrackWidth = (2f * GameBoardLaneView.LogWidth)
+                var expectedTrackWidth = (2f * GameBoardScreenView.LogWidth)
                     + ((Lane.LanePositionCount - 2) * GameBoardLaneView.LilyPadDiameter)
                     + ((Lane.LanePositionCount - 1) * GameBoardLaneView.LanePositionGap);
 
@@ -217,18 +231,28 @@ namespace Frogs.Unity.EditModeTests
                 Assert.That(lane.Chip.RectTransform.pivot.x, Is.EqualTo(0f).Within(0.001f));
                 Assert.That(lane.Chip.RectTransform.rect.width, Is.EqualTo(GameBoardLaneView.LaneGutterWidth).Within(0.001f));
 
+                // The lane draws seven things and no more — the logs are the
+                // pond's now, so there is no eighth or ninth element here to
+                // walk.
+                Assert.That(
+                    lane.LilyPadFills.Count,
+                    Is.EqualTo(Lane.LanePositionCount - 2),
+                    "seven lily pads — everything else on this lane's track is somebody else's drawing");
+                Assert.That(lane.LilyPadOutlines.Count, Is.EqualTo(Lane.LanePositionCount - 2));
+
                 // Outlines are drawn inside each element's own bounds, so
                 // they cost the 1520 px track nothing.
-                for (var index = 0; index < positions.Count; index++)
+                for (var index = 0; index < lane.LilyPadFills.Count; index++)
                 {
-                    var fill = lane.PositionImages[index].rectTransform;
+                    var position = index + 1;
+                    var fill = lane.LilyPadFills[index].rectTransform;
 
-                    Assert.That(lane.PositionOutlines[index].rectTransform, Is.SameAs(positions[index]));
-                    Assert.That(fill.parent, Is.SameAs(positions[index].transform));
+                    Assert.That(lane.LilyPadOutlines[index].rectTransform, Is.SameAs(positions[position]));
+                    Assert.That(fill.parent, Is.SameAs(positions[position].transform));
                     Assert.That(
                         fill.offsetMin,
                         Is.EqualTo(new Vector2(GameBoardLaneView.TrackOutline, GameBoardLaneView.TrackOutline)),
-                        $"position {index}'s fill is inset by TrackOutline");
+                        $"position {position}'s fill is inset by TrackOutline");
                     Assert.That(
                         fill.offsetMax,
                         Is.EqualTo(new Vector2(-GameBoardLaneView.TrackOutline, -GameBoardLaneView.TrackOutline)));
@@ -238,6 +262,168 @@ namespace Frogs.Unity.EditModeTests
                     lane.Piece.rectTransform.offsetMin,
                     Is.EqualTo(new Vector2(GameBoardLaneView.FrogPieceOutline, GameBoardLaneView.FrogPieceOutline)),
                     "the piece's fill is inset by FrogPieceOutline, so the piece is still FrogPieceDiameter across");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// The whole of #296, in one count: the board draws **two** logs,
+        /// however many frogs are playing. It used to draw a pair inside every
+        /// lane, so a four-frog game drew eight.
+        /// </summary>
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void Pond_DrawsOneStartLogAndOneEndLogForTheWholeBoard_NotOnePairPerLane(int frogCount)
+        {
+            var view = CreateView(new Game(AllColours.Take(frogCount).ToArray(), AnySeed));
+
+            try
+            {
+                var logs = view
+                    .GetComponentsInChildren<Transform>(true)
+                    .Select(transform => transform.name)
+                    .Where(name => name == "StartLog" || name == "EndLog")
+                    .ToArray();
+
+                Assert.That(
+                    logs.Length,
+                    Is.EqualTo(2),
+                    $"a {frogCount}-frog game draws two logs, not {2 * frogCount}");
+                Assert.That(logs, Is.Unique, "one Start log and one End log, not two of either");
+
+                // They belong to the pond, not to a lane — which is the reason
+                // there are two of them rather than two per frog.
+                Assert.That(view.StartLogOutline.transform.parent, Is.SameAs(view.PondRect.transform));
+                Assert.That(view.EndLogOutline.transform.parent, Is.SameAs(view.PondRect.transform));
+
+                // And they are drawn before the lanes are, so every frog sits
+                // on top of the log rather than under it.
+                foreach (var lane in view.Lanes)
+                {
+                    Assert.That(
+                        lane.RectTransform.GetSiblingIndex(),
+                        Is.GreaterThan(view.StartLogOutline.rectTransform.GetSiblingIndex()),
+                        "the lanes, and so the frogs, are drawn over the logs");
+                    Assert.That(
+                        lane.RectTransform.GetSiblingIndex(),
+                        Is.GreaterThan(view.EndLogOutline.rectTransform.GetSiblingIndex()));
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// Derek's answer to game-board.md's first open question, on #296: the
+        /// log spans the **full pond**, not the lanes in play. So its height is
+        /// one number rather than three, and it is the same at two frogs as at
+        /// four — which is the visible difference from the mockup's proposal.
+        /// </summary>
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void SharedLogs_FillThePondBand_AndAreTheSameHeightAtEveryFrogCount(int frogCount)
+        {
+            var view = CreateView(new Game(AllColours.Take(frogCount).ToArray(), AnySeed));
+
+            try
+            {
+                var expected = new Vector2(GameBoardScreenView.LogWidth, GameBoardScreenView.SharedLogHeight);
+
+                Assert.That(view.StartLogOutline.rectTransform.sizeDelta, Is.EqualTo(expected));
+                Assert.That(view.EndLogOutline.rectTransform.sizeDelta, Is.EqualTo(expected));
+
+                Assert.That(
+                    GameBoardScreenView.SharedLogHeight,
+                    Is.EqualTo(view.PondRect.rect.height).Within(0.001f),
+                    "the log fills the pond band, edge to edge with the two hairlines");
+                Assert.That(
+                    GameBoardScreenView.SharedLogHeight,
+                    Is.Not.EqualTo(frogCount * GameBoardLaneView.LaneHeight).Within(0.001f),
+                    "full pond, not LaneCount x LaneHeight — the option Derek chose over the mockup's");
+
+                // Vertically centred on the pond, so it is centred on the lane
+                // stack the pond centres too.
+                Assert.That(view.StartLogOutline.rectTransform.anchoredPosition.y, Is.EqualTo(0f).Within(0.001f));
+                Assert.That(view.EndLogOutline.rectTransform.anchoredPosition.y, Is.EqualTo(0f).Within(0.001f));
+
+                // The rim that separates a log from the water it floats on is
+                // drawn inside the log's own bounds, as every outline on this
+                // screen is.
+                foreach (var fill in new[] { view.StartLogFill, view.EndLogFill })
+                {
+                    Assert.That(fill.rectTransform.parent.name, Is.AnyOf("StartLog", "EndLog"));
+                    Assert.That(
+                        fill.rectTransform.offsetMin,
+                        Is.EqualTo(new Vector2(GameBoardLaneView.TrackOutline, GameBoardLaneView.TrackOutline)));
+                    Assert.That(
+                        fill.rectTransform.offsetMax,
+                        Is.EqualTo(new Vector2(-GameBoardLaneView.TrackOutline, -GameBoardLaneView.TrackOutline)));
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        /// <summary>
+        /// The invariant the sharing could have broken, drawn rather than
+        /// asserted in prose: two frogs on the Start log are not sharing a
+        /// space. Each is on position 0 *of its own lane*, on its own lane's
+        /// centre line — and that line crosses the shared log, which is what
+        /// makes it a log they are both standing on.
+        /// </summary>
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        public void FrogOnASharedLog_SitsOnItsOwnLanesCentreLine_OverTheLogThePondShares(int frogCount)
+        {
+            var roster = AllColours.Take(frogCount).ToArray();
+            var game = new Game(roster, AnySeed);
+
+            // Every frog starts on the Start log; sending the last one home
+            // puts a frog on each of the two shared logs at once.
+            var homeFrog = roster[roster.Length - 1];
+            MoveTo(game, homeFrog, Lane.LaneWinningPosition);
+
+            var view = CreateView(game);
+
+            try
+            {
+                foreach (var colour in roster)
+                {
+                    var lane = view.LaneFor(colour);
+                    var log = colour == homeFrog ? view.EndLogOutline : view.StartLogOutline;
+
+                    Assert.That(
+                        CenterX(lane.PieceRect),
+                        Is.EqualTo(CenterX(log.rectTransform)).Within(0.001f),
+                        $"{colour} is in the shared log's column");
+                    Assert.That(
+                        CenterY(lane.PieceRect),
+                        Is.EqualTo(CenterY(lane.RectTransform)).Within(0.001f),
+                        $"{colour} sits on its own lane's centre line, not clustered with the others");
+
+                    var corners = new Vector3[4];
+                    log.rectTransform.GetWorldCorners(corners);
+
+                    Assert.That(
+                        CenterY(lane.PieceRect),
+                        Is.InRange(corners[0].y, corners[1].y),
+                        $"{colour}'s lane centre line crosses the shared log");
+                }
+
+                // Distinct lines, not one: the frogs are on the same drawing
+                // and visibly not in the same place.
+                var lines = view.Lanes.Select(lane => CenterY(lane.PieceRect)).ToArray();
+                Assert.That(lines, Is.Unique, "one line per lane");
             }
             finally
             {
@@ -537,7 +723,7 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
-        public void EveryGeometryValue_IsANamedConstantFromGameBoardsTwoTables()
+        public void EveryGeometryValue_IsANamedConstantFromGameBoardsThreeTables()
         {
             var boardConstants = new Dictionary<string, float>
             {
@@ -563,7 +749,19 @@ namespace Frogs.Unity.EditModeTests
                 // because the hop happens here; running it is #224's, and
                 // Board_HasNoHopAnimation_AndNoEndOfGameDetection still holds
                 // this screen to playing none of it itself.
-                { "FrogHopDuration", 0.4f }
+                { "FrogHopDuration", 0.4f },
+
+                // game-board.md's third table — the two shared logs. They
+                // belong to the pond rather than to a lane (#296), so their
+                // constants live with the pond's, and `LogHeight` (120 px) is
+                // gone rather than renamed: it was the height of a log sized
+                // to sit inside one 184 px lane, and there is no such thing on
+                // this board any more. `SharedLogHeight` is a flat 896 px, the
+                // pond band's own height — Derek's answer to that page's first
+                // open question, on #296 — not `LaneCount x LaneHeight`.
+                { "LogWidth", 176f },
+                { "SharedLogHeight", 896f },
+                { "LogRadius", 24f }
             };
 
             var laneConstants = new Dictionary<string, float>
@@ -572,9 +770,6 @@ namespace Frogs.Unity.EditModeTests
                 { "LilyPadDiameter", 112f },
                 { "FrogPieceDiameter", 88f },
                 { "FrogPieceOutline", 4f },
-                { "LogWidth", 176f },
-                { "LogHeight", 120f },
-                { "LogRadius", 24f },
                 { "TrackOutline", 3f },
                 { "LanePositionGap", 48f },
                 { "LaneGutterWidth", 256f },
@@ -590,8 +785,18 @@ namespace Frogs.Unity.EditModeTests
             // restyle its corner and its label without moving the pond's logs
             // or its gear. Asserted as equal-today so a future divergence is
             // a visible, deliberate edit here rather than a silent drift.
-            Assert.That(GameBoardLaneView.LogRadius, Is.EqualTo(Button.ButtonRadius));
+            Assert.That(GameBoardScreenView.LogRadius, Is.EqualTo(Button.ButtonRadius));
             Assert.That(GameBoardScreenView.SettingsGlyphSize, Is.EqualTo(Button.ButtonLabelSize));
+
+            // SharedLogHeight is the pond band's own height, not a number
+            // typed in beside it — the log fills the band, so if the header or
+            // the controls band ever changes, the log follows without anybody
+            // remembering to.
+            Assert.That(
+                GameBoardScreenView.SharedLogHeight,
+                Is.EqualTo(CanvasHeight
+                    - GameBoardScreenView.BoardHeaderHeight
+                    - GameBoardScreenView.BoardControlsHeight).Within(0.001f));
 
             // The remaining two of game-board.md's constants are Lane's own,
             // reused under the same name rather than redeclared here.
@@ -703,10 +908,13 @@ namespace Frogs.Unity.EditModeTests
                 var lane = view.LaneFor(FrogColour.Green);
                 Assert.That(lane.Piece.sprite, Is.Not.Null);
                 Assert.That(lane.PieceOutline.sprite, Is.Not.Null);
-                Assert.That(lane.PositionImages[0].sprite, Is.Not.Null);
-                Assert.That(lane.PositionImages[1].sprite, Is.Not.Null);
-                Assert.That(lane.PositionOutlines[0].sprite, Is.Not.Null);
-                Assert.That(lane.PositionOutlines[1].sprite, Is.Not.Null);
+                Assert.That(lane.LilyPadFills[0].sprite, Is.Not.Null);
+                Assert.That(lane.LilyPadOutlines[0].sprite, Is.Not.Null);
+
+                Assert.That(view.StartLogFill.sprite, Is.Not.Null);
+                Assert.That(view.StartLogOutline.sprite, Is.Not.Null);
+                Assert.That(view.EndLogFill.sprite, Is.Not.Null);
+                Assert.That(view.EndLogOutline.sprite, Is.Not.Null);
             }
             finally
             {
@@ -781,6 +989,13 @@ namespace Frogs.Unity.EditModeTests
             var corners = new Vector3[4];
             rect.GetWorldCorners(corners);
             return (corners[0].x + corners[2].x) / 2f;
+        }
+
+        static float CenterY(RectTransform rect)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return (corners[0].y + corners[2].y) / 2f;
         }
 
         static GameBoardScreenView CreateView(Game game)

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -41,9 +41,9 @@ The pond, in turn, is:
 
 | Part | Job |
 | --- | --- |
-| `start-log` | **One** log down the left of the pond, spanning every lane in play. It is position 0 of all of them |
+| `start-log` | **One** log down the left of the pond, spanning the whole pond band. It is position 0 of every lane |
 | `lane` × 2–4 | One per frog in the game, stacked |
-| `end-log` | **One** log down the right of the pond, spanning every lane in play. It is position 8 of all of them |
+| `end-log` | **One** log down the right of the pond, spanning the whole pond band. It is position 8 of every lane |
 
 A lane, in turn, is:
 
@@ -77,11 +77,14 @@ available:
   from each other, and from the End log.
 - `end-log` — pinned to the **right** edge of the safe area.
 
-Both logs are `SharedLogHeight` tall and vertically centred on the stack of
-lanes, so every lane's centre line crosses both of them and a frog on a log
-still sits on its own lane's line. A shorter screen loses height from `pond` and
-nothing else; the header and the controls do not shrink, because a smaller
-`Roll` button is the wrong thing to trade away.
+Both logs are `SharedLogHeight` tall, which is the height of the `pond` band
+itself: they fill it, edge to edge with the two hairlines, whether two frogs are
+playing or four. Every lane's centre line therefore crosses both of them, and a
+frog on a log still sits on its own lane's line. A shorter screen loses height
+from `pond` and nothing else — and the logs lose it with the band, because they
+are the band's height rather than a number typed in beside it. The header and
+the controls do not shrink, because a smaller `Roll` button is the wrong thing
+to trade away.
 
 ## Why the lanes run across
 
@@ -140,8 +143,9 @@ logs once for the whole pond does not change that count: a lane is still nine
 positions, and two of them are now drawn on something the lane shares.
 
 `LaneCount` is the only quantity on this page that is not fixed at design time.
-It is here because the shared logs are the first element whose size depends on
-it.
+It sizes the lane stack — `LaneCount × LaneHeight`, centred in the pond — and
+nothing else. In particular it does **not** size the logs: they fill the pond
+band whatever it is.
 
 The lane:
 
@@ -161,26 +165,26 @@ The two shared logs. They belong to the pond, so they are their own table:
 | Element | Constant | Value |
 | --- | --- | --- |
 | Log width | `LogWidth` | 176 px |
-| Log height | `SharedLogHeight` | `LaneCount × LaneHeight` |
+| Log height | `SharedLogHeight` | 896 px — `1200 − BoardHeaderHeight − BoardControlsHeight` |
 | Log corner radius | `LogRadius` | 24 px |
 
 `LogHeight` (120 px) is **gone**, not renamed to something with the same
 meaning. It was the height of a log sized to sit inside one 184 px lane, and
-there is no such thing on this board any more. `SharedLogHeight` is derived
-because a log that spans the lanes in play cannot have one value:
+there is no such thing on this board any more.
 
-| `LaneCount` | `SharedLogHeight` |
-| --- | --- |
-| 2 | 368 px |
-| 3 | 552 px |
-| 4 | 736 px |
+`SharedLogHeight` is **one number, not an expression**: the log spans the full
+pond, so it is 896 px at two frogs, at three, and at four. That is Derek's
+answer, on
+[issue #296](https://github.com/derekwinters/connor-multiplying-frogs/issues/296),
+to the question this page used to leave open — "log spans full lane space
+regardless of player count" — and it is the option the mockup did *not*
+originally draw. A two-frog game gets a full-height log with open water above
+and below its two lanes, and the board's ends do not change size when a player
+joins or leaves.
 
-There is no lane gap term in that expression because there is no lane gap:
-lanes stack flush, `LaneHeight` to `LaneHeight`. If a gap between lanes is ever
-introduced, `SharedLogHeight` gains a `(LaneCount − 1) × LaneGap` term with it.
-
-**Which lanes the log spans is [open question 1](#open-questions)** — this
-expression is the proposal drawn in the mockup, not a settled number.
+It is written as the band's own arithmetic rather than as the bare 896 because
+the log **is** the band: if `BoardHeaderHeight` or `BoardControlsHeight` ever
+moves, the logs move with it and nobody has to remember them.
 
 That horizontal arithmetic is exact and worth keeping exact, and sharing the
 logs does not disturb it, because a shared log stands in the same column its
@@ -190,9 +194,9 @@ per-lane predecessor did: two logs at 176, seven pads at 112 and eight gaps at
 the others has to move with it.
 
 Vertically, the pond band is `1200 − BoardHeaderHeight − BoardControlsHeight` =
-896 px. Four lanes at 184 px is 736 px, centred with 80 px of water above and
-below, so the tallest `SharedLogHeight` the expression can produce fits the
-pond with 160 px to spare.
+896 px, which is `SharedLogHeight` — the logs fill it exactly. Four lanes at
+184 px is 736 px, centred with 80 px of water above and below, so at four frogs
+the logs stand 80 px proud of the lane stack at each end; at two frogs, 264 px.
 
 Every outline is drawn **inside** the element's own bounds, so `TrackOutline`,
 `FrogPieceOutline`, `SettingsButtonOutline` and `BoardBandOutline` cost the
@@ -326,8 +330,8 @@ change harder to judge. Whether they now read as a frame or as leftovers is
   has to itself. The pad a frog is on is drawn no differently from the others;
   the frog on it is the marker.
 - **Start log × 1, End log × 1** — one of each for the whole board, however many
-  frogs are playing, each spanning every lane in play. They are the ends of
-  every lane at once. The Start log is a real position a frog occupies, and a
+  frogs are playing, each filling the pond band top to bottom. They are the ends
+  of every lane at once. The Start log is a real position a frog occupies, and a
   wrong answer there leaves the frog where it is; see
   [the Start log is a floor](../reference/index.md#the-start-log-is-a-floor-not-a-special-space).
   Two to four frogs sit on the Start log at the beginning of every game and
@@ -386,11 +390,12 @@ against — Green and Pink on lily pads, Orange on the Start log, Blue home on
 the End log — so [the contrast question](#keeping-the-frogs-visible) is
 visible in the picture rather than only asserted in a table.
 
-It draws the proposal on all three open questions below: the logs span the four
-lanes in play and no further, each frog sits on its own lane's centre line, and
-the corner and outline are the `LogRadius` and `TrackOutline` they always were.
-Those are drawn so there is something to react to, not because they are
-decided.
+It draws the three questions #289 left open as Derek answered them on #296: the
+logs fill the pond band top to bottom rather than stopping at the lanes in play,
+each frog sits on its own lane's centre line, and the corner and outline are the
+`LogRadius` and `TrackOutline` they always were. Only the first of the three
+moved — the mockup originally drew a 736 px log spanning the four lanes, and was
+redrawn to 896 px when the answer arrived.
 
 The rejected lanes-up variant is not committed. It was drawn, compared, and
 decided against; keeping a mockup of a layout nobody is building is how a
@@ -419,21 +424,9 @@ decided against; keeping a mockup of a layout nobody is building is how a
 - **Does the board show what the last player rolled?** Currently no: the die
   appears in [roll and card](roll-and-card.md) and is gone. A persistent
   "last roll" readout is an element and would need adding here.
-- **Does a shared log span only the lanes in play, or the full pond?** The
-  mockup draws the first — `SharedLogHeight` is `LaneCount × LaneHeight`, so a
-  two-frog game gets a 368 px log with open water above and below it. The
-  alternative is a log of a fixed 896 px, the full height of the pond, which
-  puts a lot of wood beside empty water in a two-frog game but never changes
-  size. Both are drawable and neither is wrong; which reads better on the tablet
-  is a look-at-it call. **This one decides the `SharedLogHeight` expression** —
-  the full-pond answer replaces it with a constant 896 px.
-- **Where does a frog sit on a shared log?** The mockup keeps each piece on its
-  own lane's centre line, so the log is shared but the positions visibly are
-  not. The alternative — clustering the pieces together on the log, the way real
-  frogs would sit on a real log — looks better and reads worse, because it is
-  the one drawing on this screen that could suggest frogs interact. Worth
-  drawing if Connor wants it.
-- **Does the log keep its corner radius and its outline?** `LogRadius` (24 px)
-  and `TrackOutline` (3 px) were chosen for a 176 × 120 log. The mockup keeps
-  both on a log up to six times taller, where the same corner is a much smaller
-  fraction of the shape. It may look right; it may want a bigger radius.
+The three questions #289 left open about the shared logs are **settled**, by
+Derek on
+[issue #296](https://github.com/derekwinters/connor-multiplying-frogs/issues/296),
+and are recorded above rather than here: the log spans the full pond whatever
+the player count, a frog on a log sits on its own lane's centre line, and the
+log keeps `LogRadius` and `TrackOutline` as they are.

--- a/docs/specs/ui/mockups/game-board-paler-water.html
+++ b/docs/specs/ui/mockups/game-board-paler-water.html
@@ -28,10 +28,11 @@
   play — not one pair per lane. Count them: there are two logs on this canvas,
   whatever the lane count.
 
-  This drawing takes a position on the spec page's three open questions so
-  there is something to react to. None of the three is settled:
-    1. The logs span only the four lanes in play (SharedLogHeight =
-       LaneCount x LaneHeight = 736 px), not the full 896 px pond.
+  The three questions #289 left open about the logs are settled, by Derek on
+  issue #296, and this draws the answers:
+    1. The logs span the FULL POND (SharedLogHeight = 896 px), not the lanes in
+       play. Same height at two frogs as at four. This drawing used to show the
+       736 px lanes-in-play proposal; #296 chose the other one.
     2. Each frog sits on its own lane's centre line, so the log is shared and
        the positions plainly are not.
     3. LogRadius (24 px) and TrackOutline (3 px) are unchanged from the old
@@ -41,8 +42,9 @@
     48 margin + 256 chip + 48 gap
       + 176 log + 48 + (7 x 112 + 6 x 48) + 48 + 176 log
       + 48 margin = 1920.
-  Vertical: pond is 1200 - 128 - 176 = 896; four lanes at 184 = 736, centred,
-  so the lane stack and both logs run from y=208 to y=944.
+  Vertical: pond is 1200 - 128 - 176 = 896, and both logs fill it, y=128 to
+  y=1024. Four lanes at 184 = 736, centred in that band, so the lane stack runs
+  from y=208 to y=944 with the logs standing 80 px proud at each end.
 -->
 <html lang="en">
 <head>
@@ -89,7 +91,7 @@
   .sw{width:64px;height:64px;border-radius:50%;flex:none}
   .pad{width:112px;height:112px;border-radius:50%;background:var(--pad);border:3px solid var(--pad-edge);flex:none;position:relative}
   /* One per pond, not one per lane. Width is LogWidth (176); height is
-     SharedLogHeight (LaneCount x LaneHeight), set inline. */
+     SharedLogHeight (896, the whole pond band), set inline. */
   .log{position:absolute;width:176px;border-radius:24px;background:var(--log);border:3px solid var(--log-edge);
        display:flex;align-items:center;justify-content:center;font-size:22px;color:#8A6A3F}
   .frog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:88px;height:88px;border-radius:50%;
@@ -121,16 +123,16 @@
     <div class="abs gear" style="right:48px;top:16px">⚙</div>
 
     <!-- THE SHARED START LOG — one for the whole pond, position 0 of all four
-         lanes. Orange sits on it, on lane 3's centre line (y=668, i.e. 460
-         down the log). -->
-    <div class="log" style="left:352px;top:208px;height:736px">Start<span class="frog"
-         style="background:var(--orange);top:460px"></span></div>
+         lanes, filling the pond band top to bottom. Orange sits on it, on
+         lane 3's centre line (y=668, i.e. 540 down the log). -->
+    <div class="log" style="left:352px;top:128px;height:896px">Start<span class="frog"
+         style="background:var(--orange);top:540px"></span></div>
 
     <!-- THE SHARED END LOG — one for the whole pond, position 8 of all four
          lanes and the winning space. Blue is home on it, on lane 2's centre
-         line (y=484, i.e. 276 down the log). -->
-    <div class="log" style="left:1696px;top:208px;height:736px">End<span class="frog"
-         style="background:var(--blue);top:276px"></span></div>
+         line (y=484, i.e. 356 down the log). -->
+    <div class="log" style="left:1696px;top:128px;height:896px">End<span class="frog"
+         style="background:var(--blue);top:356px"></span></div>
 
     <!-- The lanes. A lane is now its chip and its own seven lily pads; both
          ends of it are drawn once, above. -->

--- a/docs/specs/ui/mockups/game-board.html
+++ b/docs/specs/ui/mockups/game-board.html
@@ -27,10 +27,11 @@
   play — not one pair per lane. Count them: there are two logs on this canvas,
   whatever the lane count.
 
-  This drawing takes a position on the spec page's three open questions so
-  there is something to react to. None of the three is settled:
-    1. The logs span only the four lanes in play (SharedLogHeight =
-       LaneCount x LaneHeight = 736 px), not the full 896 px pond.
+  The three questions #289 left open about the logs are settled, by Derek on
+  issue #296, and this draws the answers:
+    1. The logs span the FULL POND (SharedLogHeight = 896 px), not the lanes in
+       play. Same height at two frogs as at four. This drawing used to show the
+       736 px lanes-in-play proposal; #296 chose the other one.
     2. Each frog sits on its own lane's centre line, so the log is shared and
        the positions plainly are not.
     3. LogRadius (24 px) and TrackOutline (3 px) are unchanged from the old
@@ -40,8 +41,9 @@
     48 margin + 256 chip + 48 gap
       + 176 log + 48 + (7 x 112 + 6 x 48) + 48 + 176 log
       + 48 margin = 1920.
-  Vertical: pond is 1200 - 128 - 176 = 896; four lanes at 184 = 736, centred,
-  so the lane stack and both logs run from y=208 to y=944.
+  Vertical: pond is 1200 - 128 - 176 = 896, and both logs fill it, y=128 to
+  y=1024. Four lanes at 184 = 736, centred in that band, so the lane stack runs
+  from y=208 to y=944 with the logs standing 80 px proud at each end.
 -->
 <html lang="en">
 <head>
@@ -88,7 +90,7 @@
   .sw{width:64px;height:64px;border-radius:50%;flex:none}
   .pad{width:112px;height:112px;border-radius:50%;background:var(--pad);border:3px solid var(--pad-edge);flex:none;position:relative}
   /* One per pond, not one per lane. Width is LogWidth (176); height is
-     SharedLogHeight (LaneCount x LaneHeight), set inline. */
+     SharedLogHeight (896, the whole pond band), set inline. */
   .log{position:absolute;width:176px;border-radius:24px;background:var(--log);border:3px solid var(--log-edge);
        display:flex;align-items:center;justify-content:center;font-size:22px;color:#8A6A3F}
   .frog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:88px;height:88px;border-radius:50%;
@@ -120,16 +122,16 @@
     <div class="abs gear" style="right:48px;top:16px">⚙</div>
 
     <!-- THE SHARED START LOG — one for the whole pond, position 0 of all four
-         lanes. Orange sits on it, on lane 3's centre line (y=668, i.e. 460
-         down the log). -->
-    <div class="log" style="left:352px;top:208px;height:736px">Start<span class="frog"
-         style="background:var(--orange);top:460px"></span></div>
+         lanes, filling the pond band top to bottom. Orange sits on it, on
+         lane 3's centre line (y=668, i.e. 540 down the log). -->
+    <div class="log" style="left:352px;top:128px;height:896px">Start<span class="frog"
+         style="background:var(--orange);top:540px"></span></div>
 
     <!-- THE SHARED END LOG — one for the whole pond, position 8 of all four
          lanes and the winning space. Blue is home on it, on lane 2's centre
-         line (y=484, i.e. 276 down the log). -->
-    <div class="log" style="left:1696px;top:208px;height:736px">End<span class="frog"
-         style="background:var(--blue);top:276px"></span></div>
+         line (y=484, i.e. 356 down the log). -->
+    <div class="log" style="left:1696px;top:128px;height:896px">End<span class="frog"
+         style="background:var(--blue);top:356px"></span></div>
 
     <!-- The lanes. A lane is now its chip and its own seven lily pads; both
          ends of it are drawn once, above. -->


### PR DESCRIPTION
Closes #296

The pond used to have a Start log and an End log inside *every* lane, so a
four-frog game drew eight logs. It now draws two: one long log down the left
and one down the right, running the full height of the pond, and every frog
starts on the left one and finishes on the right one. Count them on the screen
and there are two, whether two frogs are playing or four.

The logs are the same size at every player count — a two-frog game gets the
same tall logs, with open water above and below its two lanes. That is the
answer Derek gave on the issue ("log spans full lane space regardless of player
count"), and it is not what the mockup had drawn, so the mockup was redrawn to
match. Each frog still sits on its own line across the log, so two frogs on the
Start log are plainly in two different places.

**Docs:** `docs/specs/ui/game-board.md` — `SharedLogHeight` is now a flat 896 px
(the pond band's own height) instead of the `LaneCount × LaneHeight` expression;
`LogWidth`, `SharedLogHeight` and `LogRadius` are stated as the pond's constants
rather than a lane's; the three open questions #289 left about the shared logs
are resolved and removed; the Anchors, Regions, Elements and Mockup sections say
"fills the pond band" where they said "spans every lane in play".
`docs/specs/ui/mockups/game-board.html` and
`docs/specs/ui/mockups/game-board-paler-water.html` — both logs redrawn from
736 px to 896 px, the two frogs on them moved to keep their own lanes' centre
lines, and the header comment now records the three answers instead of three
proposals.

## Spec invariants this had to keep true

| Invariant | How it is kept | Test |
| --- | --- | --- |
| The Start and End log are **one drawing over separate positions** — two frogs on the Start log are not sharing a space | Each lane keeps its own position-0 and position-8 rect, on its own centre line; only the drawing is shared | `FrogOnASharedLog_SitsOnItsOwnLanesCentreLine_OverTheLogThePondShares`, at 2, 3 and 4 frogs — it asserts one line per lane, and that each line crosses the log |
| Frogs never share a lane and never interact | Nothing in Core moved. A lane's piece is still parented onto its own lane's rect | Same test, plus the untouched `FrogPiece_SitsOnTheTrackElementCoreReports_…` |
| A lane is nine positions and `LaneWinningPosition` is 8 | `Lane.LanePositionCount` and `Lane.LaneWinningPosition` are untouched and still the only source of both | `Track_IsSevenLilyPadsBetweenTheTwoSharedLogColumns_…` asserts nine position rects; `ChipPadCount_…` still reads `3 of 8` |
| The horizontal arithmetic sums to 1920 px on the nose | A shared log stands in exactly the column its per-lane predecessor did, so `TrackWidth` is unchanged | Same test's `laneWidth == 1920` assertion, unchanged |
| The hop is one pad's distance over `FrogHopDuration` | `PositionCenterX` and `LanePositionGap` are untouched; only what is *drawn* under the two end positions changed | `AnswerResultDialogViewTests.TheHop_InterpolatesBetweenTheBoardsOwnPlacementForTheTwoPositions`, unchanged and still passing |
| The board plays no motion and owns no clock | No new member on either board type contains a hop, tween, or timing word | `Board_HasNoHopAnimation_AndNoEndOfGameDetection`, unchanged |
| Every geometry value is a named constant | `SharedLogHeight` is derived from the two band heights, not typed in as 896 | `EveryGeometryValue_IsANamedConstantFromGameBoardsThreeTables` asserts both the value and the derivation |

## How the spec is changing

**Old rule:** `SharedLogHeight` is `LaneCount × LaneHeight` — 368 / 552 / 736 px
at two, three and four frogs — and the log spans only the lanes in play. The
page said outright that this was "the proposal drawn in the mockup, not a
settled number".

**New rule:** `SharedLogHeight` is a flat **896 px**, the pond band's own height
(`1200 − BoardHeaderHeight − BoardControlsHeight`). The logs fill the band edge
to edge with the two hairlines, identically at every player count.

Why the new one is better: it is what Derek chose when asked directly, which is
the whole reason the question was left open rather than guessed at. It also
removes a size that changes when a player joins — the board's two ends now stay
put — and it ties the log to a band rather than to a count, so a future change
to the header or the controls height moves the logs with it instead of leaving
them short.

Two smaller contract moves came with it:

- `LogWidth`, `SharedLogHeight` and `LogRadius` are now **the pond's**
  constants, not a lane's, because that is what the spec's own third table says
  they are. `LogHeight` (120 px) is gone rather than renamed: it was the height
  of a log sized to sit inside one 184 px lane, and no such thing exists on this
  board now.
- `LaneCount`'s job on the page shrank. It sizes the lane stack and nothing
  else; the sentence claiming the shared logs were the first element to depend
  on it is no longer true and was removed.

## Deviations and Decisions

- **The lane still holds a rect for positions 0 and 8, drawing nothing.** The
  alternative was for the lane to have seven positions and for the board to
  compute the two log placements itself. Rejected: the hop, the at-rest render
  and `AnswerResultDialogViewTests` all place the piece by parenting it onto
  `PositionRects[position]`, and collapsing the list to seven would have meant a
  second way of saying where a frog is. A place-holding rect keeps one.
- **`PositionImages` / `PositionOutlines` are renamed `LilyPadFills` /
  `LilyPadOutlines`, and are seven long, not nine.** They used to be indexed by
  lane position; they are now indexed 0–6 for positions 1–7. Renaming rather
  than silently shortening is deliberate — a nine-long list that quietly became
  seven-long would have kept compiling at every call site and been wrong at two
  of them.
- **The track rect is now `LaneHeight` tall, not `LogHeight` tall.** It had been
  sized to the tallest thing in it; the tallest things in it are now the two
  place-holding rects, which are the lane's own height because the log they mark
  runs past the lane in both directions.
- **The logs are built in `BuildPond`, before `BuildLanes`.** That is what puts
  the frogs on top of the wood rather than under it, and it is asserted rather
  than left to sibling order happening to work out.
- **Nobody watched these tests fail.** The `test:` commit is genuinely first in
  the history and genuinely does not compile against `main` — it names
  `GameBoardScreenView.LogWidth`, `SharedLogHeight`, `StartLogOutline` and
  `LilyPadFills`, none of which existed — but both commits went up in one push,
  so CI only ever ran them against the finished change. What backs the
  assertions instead is that they state numbers `main` provably did not hold: a
  log height of 896 where `main` had 120, and two log objects at four frogs
  where `main` built eight.
- **The Core suite was not run.** `dotnet` is not installed in this environment.
  Nothing in this PR is under `Assets/Scripts/Core` — Core is untouched, per
  [ADR-0001](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/adr/0001-rules-sacred-presentation-ours.md),
  since this is all presentation. `check_core_isolation.py`,
  `check_geometry_literals.py`, `check_assembly_references.py`,
  `run_python_tests.py` and `mkdocs build --strict` all pass here.

## The checklist box I cannot tick

- [ ] **A screenshot of the built screen next to the mockup.** Untickable here:
  it needs a Unity Editor session or an APK on a real tablet, and this
  environment has an editor, a device and a browser in exactly none of those
  cases. #301 is already the issue that photographs the built board next to the
  mockup, and I have added a note there that the log layout is now part of what
  that photo has to show.

Everything else on the issue's checklist is done. One honesty note to match: the
redrawn mockups were verified by parsing and arithmetic, not by looking — both
files still hold exactly two logs, twenty-eight lily pads, four frogs and five
chips, the logs are `top:128px;height:896px`, the two frogs on them land on
y=668 and y=484 (lanes 3 and 2's centre lines), and the pair remain identical
apart from `--water`, the title and the comment. That proves the drawing is
intact; it does not prove it looks right, which is #301's job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7kzywjz6SXkcaHFGJqqVo)_