### PR TITLE
docs(ui): wireframe editable player names on game setup

### DIFF
--- a/docs/specs/product-scope.md
+++ b/docs/specs/product-scope.md
@@ -165,16 +165,27 @@ long version and the reasoning; the part that constrains the product is short:
 | Audience | Connor first, kids like him second |
 | Session length | 15–45 minutes, from the classroom rules card |
 | Players | 2–4 in v1, sharing one device, pass-and-play |
-| Reading and typing | No player ever types anything but digits |
+| Reading and typing | Digits to answer with, and a player's own name. Nothing else |
 
-That last row is a real product constraint rather than a UI preference. Players
-are identified by frog colour, exactly as the cardboard pieces are, and the only
-keyboard in the game is the
-[digit keypad](ui/working-out-grid.md) for entering an answer — because asking
-four children to each type a name buys a soft keyboard, a misspelling, an
-editing flow, and, reliably, somebody typing something rude about somebody else.
-The reasoning is on
-[the player chip](ui/shared-components.md#player-chip).
+That last row is a real product constraint rather than a UI preference, and it
+is narrower than it looks. There are exactly two keyboards in the game, both
+drawn by the game rather than by Android: the
+[digit keypad](ui/working-out-grid.md) for entering an answer, and the
+[letter keyboard on game setup](ui/game-setup.md#the-keyboard) for naming a
+frog. Nowhere else does a player type, and nothing a player types goes anywhere
+— there is no network, no account, and nothing is kept once the game ends.
+
+**The row used to read "No player ever types anything but digits."** Derek
+reversed it in
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310):
+frogs are named by their players now, starting from the colour name. The
+argument the old rule rested on — that asking four children to each type a name
+buys a soft keyboard, a misspelling, an editing flow, and, reliably, somebody
+typing something rude about somebody else — is kept in full on
+[the player chip](ui/shared-components.md#why-there-is-now-typing), along with
+why each of those costs was accepted. The short version: three of the four are
+the feature, and the fourth is contained by the game being offline and
+forgetting everything.
 
 **The 2–4 cap is a v1 scope fact, not a rule of the classroom game** — the rules
 card says 2–8, and the change is Derek's, recorded in

--- a/docs/specs/ui/answer-result.md
+++ b/docs/specs/ui/answer-result.md
@@ -98,13 +98,19 @@ that says it is a button that passes the device to the right person.
 
 | Situation | Sentence |
 | --- | --- |
-| Right | `Right! <Colour> hops forward one lily pad.` |
-| Wrong, above the Start log | `<Colour> hops back one lily pad.` |
-| Wrong, on the Start log | `<Colour> stays on the Start log.` |
+| Right | `Right! <Name> hops forward one lily pad.` |
+| Wrong, above the Start log | `<Name> hops back one lily pad.` |
+| Wrong, on the Start log | `<Name> stays on the Start log.` |
 
 Three, not two. The third is the floor rule, and writing it as its own sentence
 is how the layout proves it was thought about rather than left as an
 off-by-one.
+
+`<Name>` is the frog's name, with nothing appended: `Green` for a frog still on
+its default, `Connor` for one renamed on [game setup](game-setup.md). These
+sentences already read the bare colour name rather than `Green frog`, so only
+the placeholder's name changed here — see
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310).
 
 ## Behaviour
 

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -314,9 +314,21 @@ change harder to judge. Whether they now read as a frame or as leftovers is
 
 ## Elements
 
-- **Turn banner** — `Green frog's turn`, left of the header, with that frog's
+- **Turn banner** — `Green's turn`, left of the header, with that frog's
   [player chip](shared-components.md#player-chip) in its active state. The
-  wording is the frog's colour name, because frogs have no other name.
+  wording is the frog's **name and nothing else** — `Green's turn` for a frog
+  still on its default, `Connor's turn` for one that has been renamed on
+  [game setup](game-setup.md).
+
+    It used to read `Green frog's turn`, and the reason given was that frogs
+    have no other name. They do now, so the justification went with the word:
+    `Connor frog's turn` is not a sentence anybody would write. Rather than
+    compose the banner one way for a default name and another way for a typed
+    one — a rule with an edge case in it, living in a format string — nothing
+    appends anything to a name, ever. The cost is that an un-renamed frog's
+    banner loses a word, which is
+    [#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310)
+    question 4, settled by Derek.
 - **Settings button** — top right, `SettingsButtonSize` square, a gear. Opens
   the [settings dialog](settings-dialog.md). Available on any turn, at any
   time, including while it is not your turn — it is the way out of a game and

--- a/docs/specs/ui/game-over.md
+++ b/docs/specs/ui/game-over.md
@@ -21,7 +21,7 @@ resume the game that just ended.
 
 | Region | Job |
 | --- | --- |
-| `headline` | `Blue frog wins!` |
+| `headline` | `Blue wins!` |
 | `standings` | One row per frog, in finishing order |
 | `controls` | `Back to the title` and `Play again` |
 
@@ -68,16 +68,30 @@ and is not the number this readout means.
 
 ## Elements
 
-- **Headline** — `<Colour> frog wins!` when a frog reached the End log. If the
-  game was ended before anybody got home, it reads `Game over` instead, because
-  announcing a winner who did not win is worse than announcing nobody.
-- **Standings row × 2–4** — place number, frog swatch, colour name, and how far
+- **Headline** — `<Name> wins!` when a frog reached the End log — the frog's
+  name and nothing appended to it, so `Blue wins!` for a frog still on its
+  default and `Connor wins!` for one renamed on
+  [game setup](game-setup.md). If the game was ended before anybody got home,
+  it reads `Game over` instead, because announcing a winner who did not win is
+  worse than announcing nobody.
+
+    It used to read `<Colour> frog wins!`. The word went for the same reason it
+    went from the [game board](game-board.md)'s turn banner: `Connor frog
+    wins!` is not a sentence, and composing the headline one way for a default
+    name and another for a typed one is a rule with an edge case in it. Nothing
+    appends anything to a name. See
+    [#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310)
+    question 4.
+- **Standings row × 2–4** — place number, frog swatch, name, and how far
   it got: `Home — 8 of 8` for a finisher, `6 of 8` for everyone else. The winner
   row is drawn heavier; every row is otherwise identical, because second place
   and last place are the same kind of fact.
 - **`Play again`** — primary [button](shared-components.md#button). Starts a new
-  game with **the same frogs, in the same turn order**, straight to the
-  [game board](game-board.md) with everyone back on their Start log.
+  game with **the same frogs, in the same turn order, under the same names**,
+  straight to the [game board](game-board.md) with everyone back on their Start
+  log. The names come along because the frogs do: this button skips
+  [game setup](game-setup.md), so there is nowhere for a name to be re-entered
+  and no reason to make anybody re-enter it.
 - **`Back to the title`** — secondary button. Returns to the
   [title screen](title-screen.md).
 
@@ -93,8 +107,8 @@ through the title screen.
 
     | Route | What the headline says |
     | --- | --- |
-    | The last frog reaches its End log, and the game ends itself | `<Colour> frog wins!` |
-    | `End the game` confirmed from [end-game confirm](end-game-confirm.md) | `<Colour> frog wins!` if anyone got home, otherwise `Game over` |
+    | The last frog reaches its End log, and the game ends itself | `<Name> wins!` |
+    | `End the game` confirmed from [end-game confirm](end-game-confirm.md) | `<Name> wins!` if anyone got home, otherwise `Game over` |
 
     The first route needs no input from anybody. When the last frog lands on its
     End log, the hop finishes, and this screen follows — see

--- a/docs/specs/ui/game-setup.md
+++ b/docs/specs/ui/game-setup.md
@@ -1,15 +1,26 @@
 # Game setup
 
-Pick which frogs are playing. Tap a frog to put it in the game, tap it again to
-take it out, then start.
+Pick which frogs are playing and what they are called. Tap a frog to put it in
+the game, tap its name to change it, then start.
 
 ## Invariants
 
 **Invariant:** a game cannot start with fewer than two frogs or more than four.
 The cap of four is a recorded rule change from the classroom game's 2–8 — see
 [future ideas](../future-ideas.md).
-**Invariant:** no keyboard ever appears on this screen. See
-[why there is no typing](shared-components.md#why-there-is-no-typing).
+**Invariant:** the keyboard on this screen is one the game draws, never the
+Android system keyboard. A keyboard whose height is not knowable at design time
+cannot be drawn in a mockup, and a screen nobody can draw is a screen nobody can
+review — see [the keyboard](#the-keyboard) below.
+**Invariant:** every seat always shows a word. A seat that is playing shows its
+name — the colour name until somebody changes it — and never its colour alone.
+This is the [player chip's identification
+invariant](shared-components.md#player-chip) applied to the seat.
+**Invariant:** a seat that is not playing has no name and cannot be given one.
+Naming a frog that is not in the game is a state with no meaning.
+**Invariant:** removing a player is a deliberate tap on a target that does
+nothing else. There is still no confirm, and there does not need to be one,
+because there is no longer a large target that removes a player by accident.
 **Invariant:** turn order is the order the frogs are listed in, left to right,
 and that order is visible before the game starts. A player should not have to
 discover whose turn is next by watching.
@@ -21,10 +32,11 @@ tapped by four children at once, reaching across each other.
 
 | Region | Job |
 | --- | --- |
-| `header` | The question: *Who is playing?* |
+| `header` | The question: *Who is playing?* — or, while a name is being typed, which frog is being named |
 | `seats` | The four frog seats, in a row |
 | `hint` | One line saying what to do, and what is stopping you if `Start` is off |
 | `controls` | `Back` and `Start` |
+| `keyboard` | The letter keys, present only while a name is being typed |
 
 ## Anchors
 
@@ -36,6 +48,23 @@ tapped by four children at once, reaching across each other.
 - `hint` sits `HintGap` beneath `seats`, centred.
 - `controls` pinned to the bottom safe area: `Back` at the left, `Start` at the
   right, both `SafeMargin` from their edge.
+- `keyboard` pinned to the bottom safe area, centred, `NameKeyboardHeight` tall.
+  It is laid out over `hint` and `controls` rather than beside them, and both
+  are hidden while it is up.
+
+### The screen has two layouts, not one
+
+Everything above describes the screen at rest. While a name is being typed the
+keyboard takes the bottom `NameKeyboardHeight` of the canvas, and the seat row
+moves up from `SeatRowTop` to `SeatRowEditingTop` to clear it. Nothing else
+moves and nothing resizes — the seats are the same seats at the same size, 150
+px higher up.
+
+That the seats move at all is the reason question 3 of
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310) had
+to be answered before anything was drawn. With the system keyboard the distance
+they move is whatever that device's keyboard happens to be, which is not a
+number a spec can carry.
 
 ## Named constants
 
@@ -44,17 +73,36 @@ tapped by four children at once, reaching across each other.
 | Safe margin | `SafeMargin` | 48 px |
 | Header size | `SetupHeaderSize` | 72 px |
 | Seat width | `SeatWidth` | 360 px |
-| Seat height | `SeatHeight` | 440 px |
+| Seat height | `SeatHeight` | 480 px |
 | Gap between seats | `SeatGap` | 48 px |
 | Seat corner radius | `SeatRadius` | 32 px |
 | Frog swatch in a seat | `SeatSwatchDiameter` | 200 px |
-| Seat colour-name size | `SeatLabelSize` | 48 px |
+| Seat name size | `SeatLabelSize` | 48 px |
 | Ring on a chosen seat | `SeatChosenRing` | 8 px |
 | Gap between the seat row and the hint | `HintGap` | 56 px |
 | Hint size | `SetupHintSize` | 36 px |
 | Turn-order badge diameter | `SeatOrderBadge` | 72 px |
-| Gap between a seat's swatch and the content below it | `SeatContentGap` | 32 px |
+| Space above a seat's swatch, holding the two corner targets | `SeatTopBand` | 136 px |
+| Gap between a seat's swatch and the name row below it | `SeatContentGap` | 16 px |
 | Turn-order badge inset from the seat's corner | `SeatBadgeInset` | 24 px |
+| Remove target diameter | `SeatCornerTarget` | 96 px |
+| Remove target inset from the seat's corner | `SeatCornerInset` | 16 px |
+| Name row width | `SeatNameRowWidth` | 312 px |
+| Name row height | `SeatNameRowHeight` | 96 px |
+| Name row corner radius | `SeatNameRowRadius` | 20 px |
+| Horizontal padding inside the name row | `SeatNameRowPaddingX` | 16 px |
+| Seat row top, at rest | `SeatRowTop` | 300 px |
+| Seat row top, while a name is being typed | `SeatRowEditingTop` | 150 px |
+| Longest name a player can type | `PlayerNameMaxLength` | 10 |
+| Keyboard block height | `NameKeyboardHeight` | 480 px |
+| Keyboard block width | `NameKeyboardWidth` | 1664 px |
+| Letter key width | `NameKeyWidth` | 152 px |
+| Letter key height | `NameKeyHeight` | 108 px |
+| Gap between keys | `NameKeyGap` | 16 px |
+| Key corner radius | `NameKeyRadius` | 20 px |
+| Key label size | `NameKeyLabelSize` | 52 px |
+| Space bar width | `NameSpaceKeyWidth` | 1160 px |
+| `Done` key width | `NameDoneKeyWidth` | 488 px |
 | Fewest frogs a game can start with | `GameSetupMinFrogs` | 2 |
 | Most frogs a game can start with | `GameSetupMaxFrogs` | 4 |
 
@@ -62,51 +110,187 @@ Four seats at 360 px with three 48 px gaps is 1584 px, centred in 1920 with
 168 px either side. The row is deliberately not full-bleed: the empty space is
 what makes it obvious there are four seats and no more.
 
-`SeatContentGap` and `SeatBadgeInset` distil what
-[`mockups/game-setup.html`](mockups/game-setup.html) already draws: every seat
-column has `gap:32px` between its swatch and the content below it, and the
+`SeatBadgeInset` distils what
+[`mockups/game-setup.html`](mockups/game-setup.html) already drew: the
 turn-order badge sits at a fixed `left:24px; top:24px` inset from the seat's
 own corner. `GameSetupMinFrogs` and `GameSetupMaxFrogs` distil the Invariants
 section's own prose above ("a game cannot start with fewer than two frogs or
 more than four") into the names the code declares them under.
 
+### Why the seat grew from 440 px to 480 px
+
+A seat used to hold a swatch and a line of text. It now holds a swatch, a
+96 px name row, and a 96 px remove target — and `MinTouchTarget` sets both of
+those 96s, so neither can shrink. At `SeatHeight` 440 the remove target in the
+top-right corner overlapped the swatch: a 96 px target inset 16 px reaches
+136 px down the seat, and a 200 px swatch centred in what was left started
+above that.
+
+Two ways out, and the seat growing is the cheaper one. Shrinking
+`SeatSwatchDiameter` would have kept the seat at 440 px by making the frog
+smaller, and the frog is the thing a child actually looks at when picking a
+colour. 40 px of empty canvas is worth more to the layout than 24 px of frog.
+
+`SeatContentGap` fell from 32 px to 16 px in the same pass, for the same
+reason: the name row is a bordered box rather than bare text, so it already
+reads as separate from the swatch without a large gap doing that work.
+
+### Where `PlayerNameMaxLength` comes from, and why a count is not enough
+
+Ten characters of ordinary mixed-case text is about 270 px at `SeatLabelSize`
+48, and the name row holds 274 px inside its padding. So ten is what the seat
+can draw, and [`mockups/game-setup-names-set.html`](mockups/game-setup-names-set.html)
+is where that was read off.
+
+**A character count cannot promise a width.** `Mohammed` is eight characters
+and 314 px; `Alexander` is nine and 274 px. So the count is the cap the
+keyboard enforces, and any surface that still cannot fit the string it is given
+truncates it with an ellipsis. On the seat that is rare. On the board's
+[player chip](shared-components.md#player-chip) it is the normal case, and it
+already was before this issue: the chip's label column is 128 px, and `Orange`
+— the game's own longest default name — renders at 132 px in it.
+
+**The cap is not derived from the chip**, which is what
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310)
+question 5 proposed. 128 px at `PlayerChipLabelSize` 32 holds about five
+characters, so a chip-derived cap would refuse `Connor` at the sixth keystroke.
+The chip is a readout that cannot refuse anything anyway; the seat is where the
+typing happens and where a refusal is visible. So the seat sets the cap and the
+chip truncates.
+
 ## Elements
 
 - **Frog seat ×4** — Green, Blue, Orange, Pink, in that order, using
-  [frog colours](shared-components.md#frog-colours). Two states, and only two:
+  [frog colours](shared-components.md#frog-colours). Three states:
 
-    | State | What it looks like | What tapping does |
+    | State | What it looks like | What tapping the seat's body does |
     | --- | --- | --- |
-    | Empty | Dashed outline, grey swatch, `Tap to play` | Adds this frog; it takes the next free turn-order number |
-    | Chosen | Filled, `SeatChosenRing` ring, colour name, turn-order badge | Removes this frog; the badges after it renumber |
+    | Empty | Dashed outline, grey swatch, `Tap to play` | Adds this frog; it takes the next free turn-order number and the colour name as its name |
+    | Chosen | Filled, `SeatChosenRing` ring, name row, turn-order badge, remove target | **Nothing.** The two things a chosen seat can do each have their own target |
+    | Editing | As Chosen, ring in the accent colour, name row replaced by the name field, no remove target | Nothing |
 
+    **A chosen seat's body is inert, and that is the change.** It used to be
+    the remove target — "tapping a chosen seat removes it", no confirm. Adding
+    an edit target inside a 360 × 480 destructive target means a child aiming
+    at the name and missing loses the player, and there is no confirm to catch
+    it. Moving removal onto its own target costs a smaller target for a rare
+    action, and buys a screen where a mis-tap costs nothing at all.
+
+- **Name row** — on a chosen seat, `SeatNameRowWidth` × `SeatNameRowHeight`,
+  below the swatch, showing the frog's name at `SeatLabelSize`. It is the edit
+  target: tapping it opens the keyboard on this seat. It is drawn as a field
+  rather than as a caption, because it is the one part of a seat that a player
+  can change and it has to look like it.
+- **Remove target** — on a chosen seat, `SeatCornerTarget` at
+  `SeatCornerInset` from the top-right corner, in the warning colour. Removes
+  this frog; the badges after it renumber. It is `MinTouchTarget` exactly, and
+  it is the only way a player leaves the game.
 - **Turn-order badge** — `1`–`4` on a chosen seat, top-left corner. This is the
   only thing on the screen that says what turn order is, and it is why the
-  numbers renumber immediately when a frog is removed rather than at start.
+  numbers renumber immediately when a frog is removed rather than at start. It
+  is a readout, not a target, which is why it is `SeatOrderBadge` 72 px and the
+  remove target opposite it is 96 px.
+- **Name field** — on the seat being edited, replacing the name row: the text
+  typed so far and a caret, in the accent colour.
 - **`Start`** — primary [button](shared-components.md#button). Disabled below
-  two frogs.
+  two frogs. Not drawn while the keyboard is up.
 - **`Back`** — secondary button. Returns to the [title screen](title-screen.md).
+  Not drawn while the keyboard is up.
 - **Hint** — `Pick two to four frogs` while `Start` is disabled;
-  `Green goes first` once it is enabled. One line, always present, so the
-  layout does not jump when it changes.
+  `<name> goes first` once it is enabled, using the first frog's name — so
+  `Connor goes first`, not `Green goes first`, once Green has been renamed. One
+  line, always present, so the layout does not jump when it changes. Not drawn
+  while the keyboard is up.
+
+### The keyboard
+
+A keyboard **this game draws**, not Android's. Four rows, `NameKeyWidth` ×
+`NameKeyHeight` per key, laid out in the block described by the constants
+table — the same approach the
+[working-out grid](working-out-grid.md) already takes for its digit keypad, and
+sized to the same tap-target family as everything else in the game.
+
+| Row | Keys |
+| --- | --- |
+| 1 | `Q W E R T Y U I O P` |
+| 2 | `A S D F G H J K L` |
+| 3 | `⇧ Z X C V B N M ⌫` |
+| 4 | space, `Done` |
+
+`Done` is the primary [button](shared-components.md#button) kind and the only
+way out of the keyboard. There is no cancel: a name is edited in place and
+every keystroke has already happened, so there is nothing a cancel would undo
+that backspace does not.
+
+**Why not the system keyboard.** It is free and familiar, and it would have
+been the smaller change. It also has a height nobody knows at design time,
+covering an unknown part of the screen — which means no mockup can honestly
+draw this screen, and a screen that cannot be drawn cannot go through the
+[wireframe loop](../../engineering/ui-design-process.md#the-loop) that every
+other screen in this game went through. The cost is an alphabet to lay out and
+build, which is 26 keys of the same key.
 
 ## Behaviour
 
 - Entering: seats all empty, every time. The game does not remember the last
   line-up, because it does not remember anything between sessions in v1 and
-  because the players at the table are usually different ones.
-- Tapping a chosen seat removes it. There is no confirm — nothing has started
-  yet, and a confirm on an action with no cost teaches children to dismiss
-  confirms.
+  because the players at the table are usually different ones. No name survives
+  either, for the same reason.
+- Seating a frog gives it the bare colour name — `Blue`, not `Blue Frog`. A
+  default name is a real name, not a placeholder: it is stored, drawn and
+  spoken about exactly like a typed one, and nothing anywhere appends a word to
+  it.
+- Tapping the remove target removes that frog. There is still no confirm —
+  nothing has started yet, and a confirm on an action with no cost teaches
+  children to dismiss confirms.
+- Tapping a chosen seat's name row opens the keyboard on that seat and puts the
+  caret at the end of the name. Only one seat is being edited at a time.
+- Typing appends a character. **At `PlayerNameMaxLength` the next keystroke is
+  refused** — the key does nothing, the name is unchanged, and nothing explains
+  itself, which is how a
+  [disabled button](shared-components.md#button) already behaves in this game.
+- Backspace deletes the last character. Clearing the name to empty and pressing
+  `Done` restores the frog's colour name — a nameless frog is not a state this
+  screen can reach.
+- `Done` closes the keyboard, puts the seat row back at `SeatRowTop`, and
+  brings `hint` and the controls back.
+- Hardware back does what `Done` does while the keyboard is up, and what `Back`
+  does otherwise. This follows the
+  [dialog rule](shared-components.md#dialog) that back does what the least
+  destructive button does, `Done` being the only button there is.
+- **Two seats may hold the same name.** Nothing prevents it, nothing numbers
+  them, nothing warns. The two players are sitting next to each other and can
+  sort it out, and a collision flow is machinery for a case nobody has hit yet.
 - `Start` begins the game with the chosen frogs in badge order and goes to
   [game board](game-board.md), with frog 1's turn active and nothing rolled.
-- Hardware back does what `Back` does.
+  Their names go with them, and are what every later screen shows.
+- Names last as long as the game does, which includes
+  [`Play again`](game-over.md) — that button starts a new game with the same
+  frogs in the same turn order without passing through this screen, so it keeps
+  their names too. Changing a name means going back to the title screen and
+  through setup again, exactly as changing who is playing already does.
 
 ## Mockup
 
-[`mockups/game-setup.html`](mockups/game-setup.html) — drawn with three frogs
-chosen and one seat empty, which is the state that shows both seat appearances
-and the renumbering at once.
+Three, all at 1920 × 1200:
+
+| Mockup | What it draws |
+| --- | --- |
+| [`game-setup-names-set.html`](mockups/game-setup-names-set.html) | **The screen at rest**, with two frogs renamed and one still on its colour name. This is the authoritative at-rest picture. |
+| [`game-setup-name-edit-inline.html`](mockups/game-setup-name-edit-inline.html) | **A name being typed**, keyboard up and seats raised. The agreed answer to where the edit target lives. |
+| [`game-setup-name-edit-pencil.html`](mockups/game-setup-name-edit-pencil.html) | The **alternative that was considered** — a pencil target for edit, the seat's body still removing. Kept as the record of the comparison, not a live option. |
+
+The two editing files share every number and differ on one thing: which part of
+a chosen seat means *edit* and which means *remove*. Derek picked the inline
+one. See
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310).
+
+[`mockups/game-setup.html`](mockups/game-setup.html) draws this screen **before
+names existed** — no name row, no remove target, and `SeatHeight` at its old
+440 px. It is superseded by `game-setup-names-set.html` and kept as the record
+of what the screen was, the way
+[`working-out-grid.md`](working-out-grid.md) keeps the invariants it used to
+carry. Do not build from it.
 
 ## Open questions
 
@@ -121,3 +305,11 @@ and the renumbering at once.
 - **Should the four colours be reorderable?** Proposed: no. Turn order is
   tap order, which is one gesture rather than two, and re-ordering is a drag
   interaction on a screen four children are all reaching at.
+- **Are the letter keys in QWERTY order or alphabetical order?** The mockups
+  draw QWERTY, because that is the arrangement on every keyboard a child has
+  seen, including the one on the tablet this game runs on. The case for
+  `A B C D E …` is that an eight-year-old who does not touch-type finds a
+  letter by hunting for it, and hunting is faster in the order they already
+  know by heart. This is a taste call and it is Connor's — it changes only
+  which glyph is on which key, so it can be settled after the layout is agreed
+  and costs nothing to change later.

--- a/docs/specs/ui/mockups/game-setup-name-edit-inline.html
+++ b/docs/specs/ui/mockups/game-setup-name-edit-inline.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<!--
+  Multiplying Frogs — Game setup, editing a player name — CANDIDATE B (name row)
+  Device: kids' Android tablet, held landscape.
+  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+
+  THIS IS THE CHOSEN ONE. Derek picked B over A. The spec page is written
+  against this drawing; game-setup-name-edit-pencil.html is kept as the
+  alternative that was considered, not as a live option.
+
+  The two drawings share every number. They differ on ONE thing: which part of a
+  chosen seat means "edit the name", and which part means "throw this player out
+  of the game".
+
+    A (game-setup-name-edit-pencil.html) — the corner target is a PENCIL and
+                    means edit. The rest of the seat still means remove.
+    B (this file) — the corner target is a CROSS and means remove. The name row
+                    means edit, and the seat's body means nothing at all.
+
+  That last clause is the argument for B. In A the biggest target on the screen
+  still removes a player with no confirm, and the edit target sits inside it. In
+  B the biggest target is inert, both actions are deliberate, and there is no
+  mis-tap that costs a player.
+
+  The green frog is mid-edit. The keyboard is drawn, not implied: it is a
+  keyboard this game paints, sized to the same tap targets as everything else,
+  the way the working-out grid paints its own digit keypad.
+
+  NOTE ON SeatHeight: the seat is 480 here, not the 440 it is today. A seat that
+  has to carry a 96 px name row and a 96 px corner target as well as a 200 px
+  swatch does not fit in 440 without the corner target overlapping the frog. The
+  frog is the thing children look at, so the seat grew rather than the swatch
+  shrinking. See the spec page.
+
+  Shapes, sizes and positions only. The colours are placeholders so the frogs
+  can be told apart in a picture; the palette is an area:art decision.
+  Numbers here are the numbers in the spec page's constants table.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Multiplying Frogs — Name edit, candidate B (name row)</title>
+<style>
+  :root{
+    --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
+    --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
+  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+         background:var(--bg);color:var(--ink);
+         font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  .abs{position:absolute}
+  .row{display:flex;align-items:center}
+  .col{display:flex;flex-direction:column}
+  .mid{display:flex;align-items:center;justify-content:center}
+
+  /* A seat. SeatWidth 360 x SeatHeight 480, SeatRadius 32.
+     SeatTopBand 136 is the space above the swatch that the two corner targets
+     live in; SeatContentGap 16 sits between the swatch and the name band. */
+  .seat{width:360px;height:480px;border-radius:32px;position:relative;
+        padding-top:136px;align-items:center;gap:16px}
+  .seat.chosen{background:#fff;border:8px solid var(--ink)}
+  .seat.editing{background:#fff;border:8px solid var(--accent)}
+  .seat.empty{background:transparent;border:6px dashed var(--faint)}
+  .sw{width:200px;height:200px;border-radius:50%;flex:none}
+  /* Turn-order badge: SeatOrderBadge 72, SeatBadgeInset 24, top-left. */
+  .badge{position:absolute;left:24px;top:24px;width:72px;height:72px;border-radius:50%;
+         background:var(--ink);color:#fff;font-size:38px;font-weight:700}
+  /* CANDIDATE B's remove target: SeatCornerTarget 96 (= MinTouchTarget), inset
+     SeatCornerInset 16 from the seat's top-right corner. Bigger than the
+     turn-order badge opposite it, because that one is a readout and this one is
+     the only way a player leaves the game. */
+  .remove{position:absolute;right:16px;top:16px;width:96px;height:96px;border-radius:50%;
+          border:4px solid var(--warn);color:var(--warn);font-size:48px;font-weight:700;background:#FBF1F0}
+  /* CANDIDATE B's edit target: the name row itself, SeatNameRowWidth 312 x
+     SeatNameRowHeight 96, drawn as a field so it reads as something you can
+     change rather than as a caption. */
+  .namerow{width:312px;height:96px;border-radius:20px;background:#F4F7F5;border:3px solid var(--faint);
+           display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:700;
+           padding:0 16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;
+           line-height:90px;text-align:center}
+
+  /* The name field, while this seat is being edited. */
+  .field{width:312px;height:96px;border-radius:20px;background:#fff;border:5px solid var(--accent);
+         display:flex;align-items:center;justify-content:center;gap:4px;font-size:48px;font-weight:700;
+         padding:0 16px}
+  .caret{display:block;width:5px;height:56px;background:var(--ink)}
+
+  /* The keyboard this game draws. NameKeyWidth 152 x NameKeyHeight 108,
+     NameKeyGap 16, NameKeyRadius 20. */
+  .kbd{position:absolute;left:128px;top:672px;width:1664px}
+  .krow{display:flex;gap:16px;margin-bottom:16px}
+  .krow:last-child{margin-bottom:0}
+  .k{width:152px;height:108px;border:3px solid var(--line);border-radius:20px;background:#fff;
+     display:flex;align-items:center;justify-content:center;font-size:52px;font-weight:700;flex:none}
+  .k.space{width:1160px;font-size:30px;font-weight:400;color:#7A8783}
+  .k.done{width:488px;background:var(--accent);color:#fff;border-color:var(--accent);font-size:44px}
+</style>
+</head>
+<body>
+<div class="frame">
+
+  <!-- While a name is being edited the header carries the prompt, because the
+       hint line's resting position is underneath the keyboard. -->
+  <div class="abs" style="left:0;right:0;top:40px;text-align:center;font-size:72px;font-weight:700">Name the green frog</div>
+
+  <!-- SeatRowEditingTop 150: the seat row moves up from its resting 300 to make
+       room for the keyboard. Four seats at 360 with three 48 gaps = 1584,
+       centred in 1920 with 168 either side, exactly as at rest. -->
+  <div class="abs row" style="left:168px;top:150px;gap:48px">
+
+    <!-- Green: being edited. Name typed so far is "Connor". The remove badge is
+         not drawn on the seat being edited — Done first, then remove if that is
+         what you meant. -->
+    <div class="col seat editing">
+      <div class="badge mid">1</div>
+      <div class="sw" style="background:var(--green)"></div>
+      <div class="field">Connor<i class="caret"></i></div>
+    </div>
+
+    <!-- Blue: chosen, already renamed. The name row edits; the corner badge
+         removes; the seat's body does nothing at all. -->
+    <div class="col seat chosen">
+      <div class="badge mid">2</div>
+      <div class="remove mid">&times;</div>
+      <div class="sw" style="background:var(--blue)"></div>
+      <div class="namerow">Dad</div>
+    </div>
+
+    <!-- Orange: chosen, never renamed, so it still carries its colour name. A
+         default name is a real name, drawn exactly like a typed one. -->
+    <div class="col seat chosen">
+      <div class="badge mid">3</div>
+      <div class="remove mid">&times;</div>
+      <div class="sw" style="background:var(--orange)"></div>
+      <div class="namerow">Orange</div>
+    </div>
+
+    <!-- Pink: empty. No name row and no remove badge — naming a frog that is
+         not playing is a state with no meaning. Its whole body still means
+         "seat this frog", unchanged from today. -->
+    <div class="col seat empty">
+      <div class="sw" style="background:#DDE4E1"></div>
+      <div style="height:96px;display:flex;align-items:center;font-size:44px;color:#8C9793">Tap to play</div>
+    </div>
+  </div>
+
+  <!-- NameKeyboardHeight 480: four rows of 108 with three 16 gaps. Its bottom
+       edge sits SafeMargin 48 off the bottom of the canvas. Back and Start are
+       not drawn while typing — the keyboard is over them, and Done is the way
+       out. -->
+  <div class="kbd">
+    <div class="krow">
+      <div class="k">Q</div><div class="k">W</div><div class="k">E</div><div class="k">R</div><div class="k">T</div>
+      <div class="k">Y</div><div class="k">U</div><div class="k">I</div><div class="k">O</div><div class="k">P</div>
+    </div>
+    <div class="krow" style="margin-left:84px">
+      <div class="k">A</div><div class="k">S</div><div class="k">D</div><div class="k">F</div><div class="k">G</div>
+      <div class="k">H</div><div class="k">J</div><div class="k">K</div><div class="k">L</div>
+    </div>
+    <div class="krow" style="margin-left:84px">
+      <div class="k" style="font-size:44px">&#8679;</div>
+      <div class="k">Z</div><div class="k">X</div><div class="k">C</div><div class="k">V</div><div class="k">B</div>
+      <div class="k">N</div><div class="k">M</div>
+      <div class="k" style="font-size:44px">&#9003;</div>
+    </div>
+    <div class="krow">
+      <div class="k space">space</div>
+      <div class="k done">Done</div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/specs/ui/mockups/game-setup-name-edit-pencil.html
+++ b/docs/specs/ui/mockups/game-setup-name-edit-pencil.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<!--
+  Multiplying Frogs — Game setup, editing a player name — CANDIDATE A (pencil)
+  Device: kids' Android tablet, held landscape.
+  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+
+  This is one of two drawings of the same feature. Every number in them is the
+  same. They differ on ONE thing: which part of a chosen seat means "edit the
+  name", and which part means "throw this player out of the game".
+
+    A (this file) — the corner target is a PENCIL and means edit. The rest of
+                    the seat still means remove, exactly as it does today.
+    B (game-setup-name-edit-inline.html) — the corner target is a CROSS and
+                    means remove. The name row means edit, and the seat's body
+                    means nothing at all.
+
+  A keeps today's behaviour ("tapping a chosen seat removes it") untouched and
+  adds a small target inside it. The cost is drawn here honestly: the biggest
+  target on the screen still removes a player with no confirm, and the edit
+  target sits inside it. The dashed ring around the pencil is SeatEditClearance
+  — a dead zone that is neither edit nor remove, so a near miss costs nothing.
+
+  The green frog is mid-edit. The keyboard is drawn, not implied: it is a
+  keyboard this game paints, sized to the same tap targets as everything else,
+  the way the working-out grid paints its own digit keypad.
+
+  NOTE ON SeatHeight: the seat is 480 here, not the 440 it is today. A seat that
+  has to carry a 96 px name row and a 96 px corner target as well as a 200 px
+  swatch does not fit in 440 without the corner target overlapping the frog. The
+  frog is the thing children look at, so the seat grew rather than the swatch
+  shrinking. See the spec page.
+
+  Shapes, sizes and positions only. The colours are placeholders so the frogs
+  can be told apart in a picture; the palette is an area:art decision.
+  Numbers here are the numbers in the spec page's constants table.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Multiplying Frogs — Name edit, candidate A (pencil)</title>
+<style>
+  :root{
+    --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
+    --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
+  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+         background:var(--bg);color:var(--ink);
+         font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  .abs{position:absolute}
+  .row{display:flex;align-items:center}
+  .col{display:flex;flex-direction:column}
+  .mid{display:flex;align-items:center;justify-content:center}
+
+  /* A seat. SeatWidth 360 x SeatHeight 480, SeatRadius 32.
+     SeatTopBand 136 is the space above the swatch that the two corner targets
+     live in; SeatContentGap 16 sits between the swatch and the name band. */
+  .seat{width:360px;height:480px;border-radius:32px;position:relative;
+        padding-top:136px;align-items:center;gap:16px}
+  .seat.chosen{background:#fff;border:8px solid var(--ink)}
+  .seat.editing{background:#fff;border:8px solid var(--accent)}
+  .seat.empty{background:transparent;border:6px dashed var(--faint)}
+  .sw{width:200px;height:200px;border-radius:50%;flex:none}
+  /* The name band. In candidate A a chosen seat's name is a plain label — it is
+     not a target, so it is not drawn as a field. */
+  .name{height:96px;display:flex;align-items:center;font-size:48px;font-weight:700}
+  /* Turn-order badge: SeatOrderBadge 72, SeatBadgeInset 24, top-left. */
+  .badge{position:absolute;left:24px;top:24px;width:72px;height:72px;border-radius:50%;
+         background:var(--ink);color:#fff;font-size:38px;font-weight:700}
+  /* CANDIDATE A's edit target: SeatCornerTarget 96 (= MinTouchTarget), inset
+     SeatCornerInset 16 from the seat's top-right corner. */
+  .pencil{position:absolute;right:16px;top:16px;width:96px;height:96px;border-radius:24px;
+          border:4px solid var(--accent);color:var(--accent);font-size:46px;background:#F2F8F4}
+  /* SeatEditClearance 16: the dead ring around the pencil. Neither edit nor
+     remove — a tap that lands here does nothing rather than costing a player. */
+  .clearance{position:absolute;right:0;top:0;width:128px;height:128px;border-radius:32px;
+             border:3px dashed var(--faint)}
+
+  /* The name field, while this seat is being edited. */
+  .field{width:312px;height:96px;border-radius:20px;background:#fff;border:5px solid var(--accent);
+         display:flex;align-items:center;justify-content:center;gap:4px;font-size:48px;font-weight:700;
+         padding:0 16px}
+  .caret{display:block;width:5px;height:56px;background:var(--ink)}
+
+  /* The keyboard this game draws. NameKeyWidth 152 x NameKeyHeight 108,
+     NameKeyGap 16, NameKeyRadius 20. */
+  .kbd{position:absolute;left:128px;top:672px;width:1664px}
+  .krow{display:flex;gap:16px;margin-bottom:16px}
+  .krow:last-child{margin-bottom:0}
+  .k{width:152px;height:108px;border:3px solid var(--line);border-radius:20px;background:#fff;
+     display:flex;align-items:center;justify-content:center;font-size:52px;font-weight:700;flex:none}
+  .k.space{width:1160px;font-size:30px;font-weight:400;color:#7A8783}
+  .k.done{width:488px;background:var(--accent);color:#fff;border-color:var(--accent);font-size:44px}
+</style>
+</head>
+<body>
+<div class="frame">
+
+  <!-- While a name is being edited the header carries the prompt, because the
+       hint line's resting position is underneath the keyboard. -->
+  <div class="abs" style="left:0;right:0;top:40px;text-align:center;font-size:72px;font-weight:700">Name the green frog</div>
+
+  <!-- SeatRowEditingTop 150: the seat row moves up from its resting 300 to make
+       room for the keyboard. Four seats at 360 with three 48 gaps = 1584,
+       centred in 1920 with 168 either side, exactly as at rest. -->
+  <div class="abs row" style="left:168px;top:150px;gap:48px">
+
+    <!-- Green: being edited. Name typed so far is "Connor". No pencil while the
+         seat is already open for editing. -->
+    <div class="col seat editing">
+      <div class="badge mid">1</div>
+      <div class="sw" style="background:var(--green)"></div>
+      <div class="field">Connor<i class="caret"></i></div>
+    </div>
+
+    <!-- Blue: chosen, already renamed. Tapping the pencil edits; tapping
+         anywhere else in the seat removes the player. -->
+    <div class="col seat chosen">
+      <div class="badge mid">2</div>
+      <div class="clearance"></div>
+      <div class="pencil mid">&#9998;</div>
+      <div class="sw" style="background:var(--blue)"></div>
+      <div class="name">Dad</div>
+    </div>
+
+    <!-- Orange: chosen, never renamed, so it still carries its colour name. -->
+    <div class="col seat chosen">
+      <div class="badge mid">3</div>
+      <div class="clearance"></div>
+      <div class="pencil mid">&#9998;</div>
+      <div class="sw" style="background:var(--orange)"></div>
+      <div class="name">Orange</div>
+    </div>
+
+    <!-- Pink: empty. An empty seat has no name and no pencil — naming a frog
+         that is not playing is a state with no meaning. Its whole body still
+         means "seat this frog", unchanged from today. -->
+    <div class="col seat empty">
+      <div class="sw" style="background:#DDE4E1"></div>
+      <div class="name" style="font-size:44px;color:#8C9793;font-weight:400">Tap to play</div>
+    </div>
+  </div>
+
+  <!-- NameKeyboardHeight 480: four rows of 108 with three 16 gaps. Its bottom
+       edge sits SafeMargin 48 off the bottom of the canvas. Back and Start are
+       not drawn while typing — the keyboard is over them, and Done is the way
+       out. -->
+  <div class="kbd">
+    <div class="krow">
+      <div class="k">Q</div><div class="k">W</div><div class="k">E</div><div class="k">R</div><div class="k">T</div>
+      <div class="k">Y</div><div class="k">U</div><div class="k">I</div><div class="k">O</div><div class="k">P</div>
+    </div>
+    <div class="krow" style="margin-left:84px">
+      <div class="k">A</div><div class="k">S</div><div class="k">D</div><div class="k">F</div><div class="k">G</div>
+      <div class="k">H</div><div class="k">J</div><div class="k">K</div><div class="k">L</div>
+    </div>
+    <div class="krow" style="margin-left:84px">
+      <div class="k" style="font-size:44px">&#8679;</div>
+      <div class="k">Z</div><div class="k">X</div><div class="k">C</div><div class="k">V</div><div class="k">B</div>
+      <div class="k">N</div><div class="k">M</div>
+      <div class="k" style="font-size:44px">&#9003;</div>
+    </div>
+    <div class="krow">
+      <div class="k space">space</div>
+      <div class="k done">Done</div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/docs/specs/ui/mockups/game-setup-names-set.html
+++ b/docs/specs/ui/mockups/game-setup-names-set.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<!--
+  Multiplying Frogs — Game setup at rest, with names set
+  Device: kids' Android tablet, held landscape.
+  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+
+  The ordinary state: nobody is typing, the keyboard is gone, the seat row is
+  back at its resting top of 300, and Back and Start are visible again. This is
+  what the screen looks like for almost all of the time it is on screen, which
+  is why it gets a picture of its own rather than being left to the imagination
+  between the two editing mockups.
+
+  This is the at-rest drawing for the screen once names exist. It supersedes
+  game-setup.html, which draws the same screen before names and before the seat
+  grew from 440 to 480.
+
+  Drawn in candidate B's dressing — the name row edits, the corner badge
+  removes — because that is the candidate Derek picked.
+
+  Three things are being shown at once:
+
+    Green  — a short typed name, the ordinary case.
+    Blue   — a long typed name. "Isabella" is 211 px at SeatLabelSize 48,
+             against the 274 px a name row has inside its padding.
+    Orange — never renamed, so it still carries its bare colour name. A default
+             name is a real name, not a placeholder, and it is drawn identically.
+
+  ON THE CAP: PlayerNameMaxLength is 10 characters, and the name row is where
+  that number comes from — ten characters of ordinary mixed-case text is about
+  270 px at SeatLabelSize 48, which is what the row holds. A character count
+  cannot promise a width, though: "Mohammed" is eight characters and 314 px,
+  wider than "Alexander" at nine. So the count is the cap the keyboard enforces,
+  and any surface that still cannot fit the string it is given truncates with an
+  ellipsis. On this row that is rare. On the board's player chip, whose label
+  column is 128 px, it is the normal case — see shared-components.md.
+
+  The hint reads "Connor goes first", not "Green goes first". A name that only
+  the seat knows about is a name nobody plays with.
+
+  Shapes, sizes and positions only. The colours are placeholders so the frogs
+  can be told apart in a picture; the palette is an area:art decision.
+  Numbers here are the numbers in the spec page's constants table.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Multiplying Frogs — Game setup with names set</title>
+<style>
+  :root{
+    --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
+    --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
+  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+         background:var(--bg);color:var(--ink);
+         font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  .abs{position:absolute}
+  .row{display:flex;align-items:center}
+  .col{display:flex;flex-direction:column}
+  .mid{display:flex;align-items:center;justify-content:center}
+  .btn{height:112px;min-width:320px;padding:0 48px;border-radius:24px;display:flex;align-items:center;
+       justify-content:center;font-size:44px;font-weight:700}
+  .btn.p{background:var(--accent);color:#fff}
+  .btn.s{border:4px solid var(--line);color:var(--ink)}
+
+  /* A seat. SeatWidth 360 x SeatHeight 480, SeatRadius 32. */
+  .seat{width:360px;height:480px;border-radius:32px;position:relative;
+        padding-top:136px;align-items:center;gap:16px}
+  .seat.chosen{background:#fff;border:8px solid var(--ink)}
+  .seat.empty{background:transparent;border:6px dashed var(--faint)}
+  .sw{width:200px;height:200px;border-radius:50%;flex:none}
+  .badge{position:absolute;left:24px;top:24px;width:72px;height:72px;border-radius:50%;
+         background:var(--ink);color:#fff;font-size:38px;font-weight:700}
+  .remove{position:absolute;right:16px;top:16px;width:96px;height:96px;border-radius:50%;
+          border:4px solid var(--warn);color:var(--warn);font-size:48px;font-weight:700;background:#FBF1F0}
+  .namerow{width:312px;height:96px;border-radius:20px;background:#F4F7F5;border:3px solid var(--faint);
+           display:flex;align-items:center;justify-content:center;font-size:48px;font-weight:700;
+           padding:0 16px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;
+           line-height:90px;text-align:center}
+</style>
+</head>
+<body>
+<div class="frame">
+
+  <div class="abs" style="left:0;right:0;top:64px;text-align:center;font-size:72px;font-weight:700">Who is playing?</div>
+
+  <!-- The seat row at its resting top of 300. -->
+  <div class="abs row" style="left:168px;top:300px;gap:48px">
+
+    <!-- Green, renamed. -->
+    <div class="col seat chosen">
+      <div class="badge mid">1</div>
+      <div class="remove mid">&times;</div>
+      <div class="sw" style="background:var(--green)"></div>
+      <div class="namerow">Connor</div>
+    </div>
+
+    <!-- Blue, renamed to a long name: 8 characters, 211 px of the 274 the row
+         holds inside its padding. Comfortable, and about as long as a name
+         normally gets. -->
+    <div class="col seat chosen">
+      <div class="badge mid">2</div>
+      <div class="remove mid">&times;</div>
+      <div class="sw" style="background:var(--blue)"></div>
+      <div class="namerow">Isabella</div>
+    </div>
+
+    <!-- Orange, never renamed. Its default name is its bare colour name — no
+         "frog" appended, here or anywhere else. -->
+    <div class="col seat chosen">
+      <div class="badge mid">3</div>
+      <div class="remove mid">&times;</div>
+      <div class="sw" style="background:var(--orange)"></div>
+      <div class="namerow">Orange</div>
+    </div>
+
+    <!-- Pink, empty. No name row and no remove badge; its body still seats the
+         frog, unchanged from today. -->
+    <div class="col seat empty">
+      <div class="sw" style="background:#DDE4E1"></div>
+      <div style="height:96px;display:flex;align-items:center;font-size:44px;color:#8C9793">Tap to play</div>
+    </div>
+  </div>
+
+  <!-- HintGap 56 below the seat row, which now ends at 780. -->
+  <div class="abs" style="left:0;right:0;top:836px;text-align:center;font-size:36px;color:#6C7873">Connor goes first</div>
+  <div class="abs btn s" style="left:48px;bottom:48px">Back</div>
+  <div class="abs btn p" style="right:48px;bottom:48px">Start</div>
+</div>
+</body>
+</html>

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -12,7 +12,10 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Screen | Mockup | Spec page |
 | --- | --- | --- |
 | Title screen | [`title-screen.html`](title-screen.html) | [Title screen](../title-screen.md) |
-| Game setup | [`game-setup.html`](game-setup.html) | [Game setup](../game-setup.md) |
+| Game setup, at rest with names | [`game-setup-names-set.html`](game-setup-names-set.html) | [Game setup](../game-setup.md) |
+| Game setup, naming a frog | [`game-setup-name-edit-inline.html`](game-setup-name-edit-inline.html) | [Game setup](../game-setup.md) |
+| Game setup, naming a frog — the alternative | [`game-setup-name-edit-pencil.html`](game-setup-name-edit-pencil.html) | [Game setup](../game-setup.md) |
+| Game setup, before names | [`game-setup.html`](game-setup.html) | [Game setup](../game-setup.md) |
 | Game board | [`game-board.html`](game-board.html) | [Game board](../game-board.md) |
 | Game board, paler water | [`game-board-paler-water.html`](game-board-paler-water.html) | [Game board](../game-board.md) |
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
@@ -47,6 +50,19 @@ the same canvas differing in exactly one value — the water's blue. Connor pick
 one on the tablet, the spec page takes the answer, and the losing file is
 deleted. Until then, an edit to the board's layout has to be made in **both**
 files, which is the cost of the pair and the reason it does not stay open long.
+
+Game setup has **four** files, which is three more than a screen should need,
+and each has a different job. `game-setup-names-set.html` is the screen at
+rest and the one to build from. The two `name-edit-` files are the third kind
+of pair — a real choice drawn twice, differing only in which part of a seat
+means *edit* and which means *remove* — and Derek picked the inline one, so the
+pencil file stays as the record of the comparison rather than as a live option.
+`game-setup.html` is the fourth kind: a **superseded** drawing, of the screen
+before frogs had editable names and before the seat grew from 440 px to 480 px.
+It is kept for the same reason
+[`working-out-grid.md`](../working-out-grid.md) keeps the invariants it used to
+carry — the history of a layout is worth more than the disk it costs — and it
+is marked on its spec page as not to be built from.
 
 The title screen used to have a pair too — `title-screen.html` and
 `title-screen-resume-primary.html`, differing in exactly which of `RESUME` and

--- a/docs/specs/ui/roll-and-card.md
+++ b/docs/specs/ui/roll-and-card.md
@@ -106,8 +106,11 @@ centred in one with room around it.
   header behind it is dimmed.
 - **`rolled`** — the word beside the chip, `RolledLabelSize`, `RolledLabelGap`
   past it, in the same quiet grey as a chip's second line. It is what makes
-  `whose` a sentence — *Green rolled* — rather than a chip sitting on its own,
-  and it is why this dialog needs no title of its own.
+  `whose` a sentence — *Green rolled*, or *Connor rolled* once that frog has
+  been renamed on [game setup](game-setup.md) — rather than a chip sitting on
+  its own, and it is why this dialog needs no title of its own. The word beside
+  the chip is `rolled` and only `rolled`; nothing is appended to the name
+  inside the chip to make the sentence read.
 - **Die** — one six-sided die, drawn with pips rather than a numeral. There is
   exactly one die: the rules card says "Dice", and three piles × two faces
   accounts for all six faces of one — see

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -275,13 +275,34 @@ Used by: [game board](game-board.md), [roll and card](roll-and-card.md),
 
 #### 2. Invariants
 
-**Invariant:** a frog is identified by its colour **and** its colour's name, in
-words, always together. Colour alone excludes a colour-blind player from knowing
-whose turn it is, in a game where four players share one screen.
+**Invariant:** a frog is identified by its colour **and** a word, always
+together, and never by colour alone. The word is the frog's name: its colour's
+name by default, or whatever was typed on
+[game setup](game-setup.md) instead. Colour alone excludes a colour-blind
+player from knowing whose turn it is, in a game where four players share one
+screen.
 **Invariant:** the chip for the player whose turn it is is visibly different
 from every other chip on screen, by something other than colour.
-**Invariant:** no chip anywhere contains a name a player typed. See
-[why there is no typing](#why-there-is-no-typing).
+**Invariant:** nothing is ever appended to a frog's name. The chip shows the
+name and only the name — not `Blue frog`, not `Blue (you)`.
+**Invariant:** the chip never refuses or alters a name it is given; if a name
+does not fit, the chip truncates it with an ellipsis. A readout is not where a
+limit is enforced. The limit is `PlayerNameMaxLength`, and
+[game setup](game-setup.md#where-playernamemaxlength-comes-from-and-why-a-count-is-not-enough)
+is where it is enforced.
+
+The identification invariant was previously worded as colour **and its
+colour's name** — literally the colour word. That letter cannot survive a
+rename: a chip reading `Connor` beside a blue swatch says "Blue" nowhere. Its
+purpose survives intact, because a typed name is also a word, and the reason
+the rule exists is that a colour-blind player needs something other than the
+swatch to read. So the rule now requires a word rather than that specific word.
+
+**Two frogs may end up with the same word**, which is the one case where the
+identifying word stops identifying. Nothing prevents it. They are two children
+sitting next to each other who chose the same name on purpose, and they can
+sort it out; the swatch still tells them apart, and colour-plus-word is still
+what the chip shows.
 
 #### 3. Named constants
 
@@ -305,13 +326,30 @@ so they win: `PlayerChipLabelSize` is corrected to 32 px, and
 `PlayerChipPadCountSize` — a value this table previously had no name for at
 all — is added at 24 px.
 
+**The label column is 128 px, and it is tighter than it looks.**
+`PlayerChipWidth` 256 less 20 px padding either side, less
+`PlayerSwatchDiameter` 64, less `PlayerChipSwatchGap` 24, leaves 128 px for the
+name and the pad count. The pad count fits easily at 24 px. The name often does
+not: `Orange` renders at 132 px at `PlayerChipLabelSize` 32 and overflows by
+4 px — the game's own longest default name, overflowing before anybody has
+typed anything. This is why the chip truncates rather than refuses, per the
+invariant above, and why `PlayerNameMaxLength` is derived from the setup seat
+instead of from here. Widening the chip is not free: `PlayerChipWidth` is part
+of the [game board](game-board.md)'s lane arithmetic, so it is a board layout
+change and would need its own wireframe.
+
 #### 4. States
 
 | State | Appearance |
 | --- | --- |
-| Default | Swatch, colour name, pad count |
+| Default | Swatch, name, pad count |
 | Active (this player's turn) | `PlayerChipActiveRing` ring, label at full weight |
 | Home (frog has finished) | Pad count replaced by `Home!` |
+
+The Default row said "colour name" until names became editable. It is the same
+row: the chip has always drawn the frog's name, and until
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310) a
+frog's name was always its colour's.
 
 The Active row dropped "filled background": the mockups' `.chip.act` rule
 gives the ring and the bold weight but leaves the base chip background
@@ -345,17 +383,42 @@ element's four colour constants for its own swatch.
 The chip is a readout on every screen that uses it. It has no button state in
 v0.2 — no tap handler, on any screen, in any state.
 
-#### Why there is no typing
+#### Why there is now typing
 
-Four players share one tablet, and the setup screen is the first thing they
-touch. Asking four children to each type a name means a soft keyboard, a
-misspelling, an editing flow, and — reliably — somebody typing something rude
-about somebody else. Frogs are identified by colour, exactly as the classroom
-pieces are, and the whole of setup is tapping the colour you want.
+A frog's name can be typed, on [game setup](game-setup.md) and nowhere else.
+This reverses a rule this page used to carry, and the old reasoning is kept
+below rather than deleted, because it was right about what it predicted.
 
-This is a **presentation** decision under
-[ADR-0001](../../adr/0001-rules-sacred-presentation-ours.md): the cardboard
-pieces have no names either.
+**What this page used to say:**
+
+> Four players share one tablet, and the setup screen is the first thing they
+> touch. Asking four children to each type a name means a soft keyboard, a
+> misspelling, an editing flow, and — reliably — somebody typing something rude
+> about somebody else. Frogs are identified by colour, exactly as the classroom
+> pieces are, and the whole of setup is tapping the colour you want.
+
+Derek asked for editable names anyway, in
+[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310),
+and per [CLAUDE.md](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/CLAUDE.md)
+an explicit instruction from Derek beats the docs. Three of the four costs that
+paragraph predicts are simply accepted — the keyboard, the misspellings and the
+editing flow **are** the feature, and they are specified on the setup page
+rather than worked around.
+
+The fourth is worth a sentence, because it is the one that sounds like a safety
+question. The app is fully offline, with no accounts and no network, so a rude
+name reaches exactly the four children already sitting at the table who could
+have said it out loud. That is a different thing from a name other people see,
+and it is why this is a taste call rather than a safety one.
+
+**What survives untouched** is the accessibility rule, in a rewritten form: a
+frog is still identified by a word and never by colour alone. See the
+invariants above. That rule was never about the word being a colour.
+
+This remains a **presentation** decision under
+[ADR-0001](../../adr/0001-rules-sacred-presentation-ours.md). The cardboard
+pieces have no names; the game they came from does not care what a player is
+called, and neither does any rule in it.
 
 ---
 


### PR DESCRIPTION
Frogs can be named by the people playing them. On game setup, every frog that
is in the game shows a name — its colour name to begin with, `Blue` rather than
`Blue Frog` — and tapping that name opens a keyboard to change it. The name
follows the frog everywhere afterwards, so the board says `Connor's turn` and
the end of the game says `Connor wins!`.

This is the wireframe, so nothing is built yet: three pictures at 1920 × 1200
and the spec pages that describe them.

Closes #310

## How the spec is changing

Typing a player's name was forbidden in three places, each with an argument
behind it. Derek reversed that in the issue, and per CLAUDE.md his instruction
beats the docs. The old reasoning is kept visible rather than deleted.

- **`product-scope.md`** — the audience row was *"No player ever types anything
  but digits"*. It is now *"Digits to answer with, and a player's own name.
  Nothing else"*, with the old rule and why each of its four predicted costs
  was accepted.
- **`game-setup.md`** — *"no keyboard ever appears on this screen"* becomes
  *the keyboard on this screen is one the game draws, never Android's*.
- **`shared-components.md`** — *"no chip anywhere contains a name a player
  typed"* is removed. *"Why there is no typing"* becomes *"Why there is now
  typing"*, quoting the old paragraph in full.
- **`shared-components.md`** — the identification invariant was colour **and
  its colour's name**. Its letter cannot survive a rename: a chip reading
  `Connor` beside a blue swatch says "Blue" nowhere. It now requires **a word,
  always, and never colour alone**, which is what the rule was always for — a
  colour-blind player needs something other than the swatch to read, and a
  typed name is also a word.
- **`game-board.md` / `game-over.md`** — `Green frog's turn` → `Green's turn`,
  `Blue frog wins!` → `Blue wins!`. Nothing appends anything to a name, ever.
  The justification changed too, not just the example: the banner's reason used
  to be *"because frogs have no other name"*, which is the premise this issue
  removes.

## Spec invariants

- **Every seat and every chip still shows a word, never colour alone.** The
  accessibility rule is the one thing here that is not Derek's to reverse, so
  it was rewritten to keep its purpose rather than dropped. A seat cannot reach
  a nameless state: clearing the field and confirming restores the colour name.
- **`MinTouchTarget` 96 px holds everywhere.** Both new targets — the name row
  and the remove badge — are 96 px or larger. This is what forced `SeatHeight`
  from 440 to 480; see below.
- **No new typing surface beyond the one asked for.** One keyboard, on one
  screen, for one field. Nothing typed leaves the device, because there is no
  network to leave by.
- **Every dialog gets its own wireframe (rule 8).** Editing is a state of the
  setup screen, not a dialog — no scrim, no panel, the other seats stay live —
  so it needs no second wireframe. Picking the "separate edit dialog" option
  would have needed one, which is part of why it was not picked.

## Deviations and Decisions

- **Derek picked candidate B mid-review, so the spec is written against it.**
  Both mockups are still committed, as the issue asked. B makes the name row
  the edit target, moves removal to a 96 px corner badge, and leaves the seat's
  body **inert**. A kept today's "tap the seat to remove" and added a pencil
  inside it. The issue's own worry — *"a child aiming at the name and hitting
  the seat loses the seat"* — is eliminated by B and merely mitigated by A.
- **`SeatHeight` grew from 440 px to 480 px, which the issue did not ask for.**
  A seat now carries a 96 px name row and a 96 px remove target as well as a
  200 px swatch, and at 440 px the corner target overlapped the frog. The
  alternative was shrinking `SeatSwatchDiameter`, and the frog is the thing a
  child looks at when picking a colour. `SeatContentGap` dropped 32 → 16 in the
  same pass, since the name row is a bordered box and no longer needs a large
  gap to read as separate.
- **The character cap is NOT derived from the player chip, contrary to question
  5 of the issue.** I measured the chip's label column: it is 128 px, and
  `Orange` renders at 132 px in it — the game's own longest default name
  already overflows, before anybody types anything. A chip-derived cap would be
  about five characters and would refuse `Connor` at the sixth keystroke. So
  the **seat** sets `PlayerNameMaxLength` (10, read off the at-rest mockup) and
  the **chip truncates**.
- **Both halves of question 5's fork are used, in different places.** The issue
  offered "refuse the keystroke" or "truncate with an ellipsis"; triage proposed
  refuse. A character count cannot promise a width — `Mohammed` is 8 characters
  and 314 px, wider than `Alexander` at 9 — so the keyboard refuses past the
  count, and any surface that still cannot fit the string ellipsizes it. The
  chip was going to need that regardless.
- **Names survive `Play again`.** The issue says a name does not outlive the
  game, and setup opens empty every time — both still true. But `Play again`
  restarts with the same frogs *without* passing through setup, so there is
  nowhere to re-enter a name. Recorded on `game-over.md`.
- **Left open for Connor: QWERTY or alphabetical key order.** The mockups draw
  QWERTY. The case for `A B C D E` is that a child who does not touch-type
  hunts for letters, and hunting is faster in the order they know by heart.
  That is a taste call and it is his; it changes which glyph is on which key
  and nothing about the layout, so it costs nothing to settle later. Logged as
  an open question rather than guessed at.
- **`game-setup.html` is marked superseded, not edited or deleted.** It draws
  the screen before names and at the old 440 px seat. It is kept as the record
  and flagged on the spec page as not to build from.
- **No test in this PR.** The proposal's checklist had a Core test for the cap;
  the issue's own "Not in this issue" section excludes building any of it, and
  its closing paragraph agrees. Docs-only, so nothing behavioural changed to
  test. The cap test belongs to the implementation issue.

**Docs:** `docs/specs/product-scope.md` — typing is no longer forbidden, it is
scoped to digits and a player's own name. `docs/specs/ui/game-setup.md` — the
no-keyboard invariant is replaced, the seat gains a name row and a remove
target, `SeatHeight` is 480, and 22 new constants are named.
`docs/specs/ui/shared-components.md` — the chip's identification invariant is
rewritten to require a word rather than the colour word, the no-typed-names
invariant is removed, and the old reasoning is preserved.
`docs/specs/ui/game-board.md` and `docs/specs/ui/game-over.md` — "frog" comes
out of the turn banner and the win headline, with the reason given for it.
`docs/specs/ui/roll-and-card.md` and `docs/specs/ui/answer-result.md` — wording
only, `<Colour>` becomes `<Name>`. `docs/specs/ui/mockups/index.md` — the three
new files and what each is for.

## How this closes

Connor looks at the two editing mockups on the tablet at 1:1 and confirms B
still looks right at real size; Derek reads the spec pages. Closing the issue
is the approval.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lat3QiPPh6SBsC4k7oJ9Z2)_