### PR TITLE
fix(game-board): the top and bottom bars reach the screen's edges

### DIFF
--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -145,7 +145,6 @@ namespace Frogs.Unity.Views
         // for the frame before *any* screen has painted.
 
         RectTransform _rect;
-        RectTransform _contentRect;
         Image _background;
 
         RectTransform _headerRect;
@@ -242,17 +241,7 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>Everything laid out in reference pixels — the 1920 x 1200 reference canvas, centred.</summary>
-        public RectTransform ContentRect
-        {
-            get
-            {
-                EnsureInitialized();
-                return _contentRect;
-            }
-        }
-
-        /// <summary>`header` — pinned to the top, <see cref="BoardHeaderHeight"/> tall, full width.</summary>
+        /// <summary>`header` — pinned to the top of the screen, <see cref="BoardHeaderHeight"/> tall, as wide as the screen.</summary>
         public RectTransform HeaderRect
         {
             get
@@ -312,7 +301,7 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>`pond` — everything between the two pinned bands.</summary>
+        /// <summary>`pond` — everything between the two pinned bands, and the water it paints there.</summary>
         public RectTransform PondRect
         {
             get
@@ -379,7 +368,7 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>`controls` — pinned to the bottom, <see cref="BoardControlsHeight"/> tall, full width.</summary>
+        /// <summary>`controls` — pinned to the bottom of the screen, <see cref="BoardControlsHeight"/> tall, as wide as the screen.</summary>
         public RectTransform ControlsRect
         {
             get
@@ -525,13 +514,17 @@ namespace Frogs.Unity.Views
             // The root fills the whole canvas, which on a device that is not
             // 16:10 is larger than the 1920 x 1200 reference — see
             // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
-            // Only the background hangs off it. Everything that is laid out in
-            // reference pixels hangs off `Content` instead, so the extra space
-            // a wider or taller device gives us is painted and nothing else.
+            //
+            // The background and the three bands hang off it, because all four
+            // are paint that reaches the screen's edges: the bands are the top
+            // and the bottom *of the screen*, not panels laid on the pond
+            // (#303). What is laid out in reference pixels is what the bands
+            // contain — the lanes and the two shared logs, which are placed by
+            // game-board.md's own arithmetic and so are measured from the
+            // pond's centre rather than from its edges.
             StretchToFill(_rect);
 
             BuildBackground();
-            BuildContent();
 
             BuildHeader();
             BuildPond();
@@ -552,32 +545,20 @@ namespace Frogs.Unity.Views
             StretchToFill(backgroundRect);
         }
 
-        void BuildContent()
-        {
-            // The reference canvas, centred — exactly the rect the root used
-            // to be, so every child below keeps the anchors, sizes and offsets
-            // it already had and nothing on the board moves by a pixel.
-            var contentGO = new GameObject("Content", typeof(RectTransform));
-            _contentRect = (RectTransform)contentGO.transform;
-            _contentRect.SetParent(_rect, worldPositionStays: false);
-            _contentRect.anchorMin = new Vector2(0.5f, 0.5f);
-            _contentRect.anchorMax = new Vector2(0.5f, 0.5f);
-            _contentRect.pivot = new Vector2(0.5f, 0.5f);
-            _contentRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
-            _contentRect.anchoredPosition = Vector2.zero;
-        }
-
         void BuildHeader()
         {
-            // header — pinned to the top, full width, not shrinking on a
-            // shorter screen.
+            // header — pinned to the top of the *screen*, as wide as the
+            // screen, not shrinking on a shorter one. The chip and the gear
+            // inside it are anchored to its own left and right edges, so they
+            // follow the real edge with it: SafeMargin is a margin from the
+            // screen, not from a virtual rectangle (#303).
             var headerGO = new GameObject("Header", typeof(RectTransform), typeof(Image));
             var headerImage = headerGO.GetComponent<Image>();
             headerImage.color = BoardColours.BandFill;
             headerImage.raycastTarget = false;
 
             _headerRect = headerImage.rectTransform;
-            _headerRect.SetParent(_contentRect, worldPositionStays: false);
+            _headerRect.SetParent(_rect, worldPositionStays: false);
             _headerRect.anchorMin = new Vector2(0f, 1f);
             _headerRect.anchorMax = new Vector2(1f, 1f);
             _headerRect.pivot = new Vector2(0.5f, 1f);
@@ -663,11 +644,23 @@ namespace Frogs.Unity.Views
 
         void BuildPond()
         {
-            // pond — everything between the other two bands. A shorter screen
-            // loses height from here and nothing else.
-            var pondGO = new GameObject("Pond", typeof(RectTransform));
-            _pondRect = (RectTransform)pondGO.transform;
-            _pondRect.SetParent(_contentRect, worldPositionStays: false);
+            // pond — everything between the other two bands, edge to edge with
+            // the screen. A shorter screen loses height from here and nothing
+            // else, and a taller one gives its extra height to here and
+            // nothing else.
+            //
+            // It paints its own water rather than letting the background show
+            // through, which is the half of #303 that was invisible: the band
+            // had the same anchoring fault as the other two and nobody could
+            // see it, because a bare RectTransform's gap and the water behind
+            // it are the same colour by definition.
+            var pondGO = new GameObject("Pond", typeof(RectTransform), typeof(Image));
+            var pondImage = pondGO.GetComponent<Image>();
+            pondImage.color = BoardColours.PondWater;
+            pondImage.raycastTarget = false;
+
+            _pondRect = pondImage.rectTransform;
+            _pondRect.SetParent(_rect, worldPositionStays: false);
             _pondRect.anchorMin = Vector2.zero;
             _pondRect.anchorMax = Vector2.one;
             _pondRect.offsetMin = new Vector2(0f, BoardControlsHeight);
@@ -685,19 +678,29 @@ namespace Frogs.Unity.Views
             // after it. The End log is pinned to the right of the safe area,
             // where every lane's track ends. Neither is placed by a number of
             // its own.
+            //
+            // Both are measured from the **centre** of the pond outwards, by
+            // the reference canvas's own half-width, rather than from the
+            // band's edges. The band reaches the screen's edges now (#303) and
+            // a lane does not: a log anchored to the band would slide out from
+            // under the lane whose position 0 and position 8 it is.
             _startLogOutline = BuildSharedLog(
                 "StartLog",
                 0f,
-                SafeMargin + GameBoardLaneView.LaneGutterWidth + GameBoardLaneView.LaneGutterGap,
+                -(CanvasWidth / 2f) + SafeMargin + GameBoardLaneView.LaneGutterWidth + GameBoardLaneView.LaneGutterGap,
                 out _startLogFill);
 
-            _endLogOutline = BuildSharedLog("EndLog", 1f, -SafeMargin, out _endLogFill);
+            _endLogOutline = BuildSharedLog("EndLog", 1f, (CanvasWidth / 2f) - SafeMargin, out _endLogFill);
         }
 
         // One shared log — LogWidth across, SharedLogHeight tall, vertically
         // centred on the pond and so on the lane stack the pond centres too.
         // Every lane's centre line crosses it, which is what lets a frog on a
         // log still sit on its own lane's line.
+        //
+        // `edge` is which of the log's own sides <paramref name="offsetX"/>
+        // places — its left (0) or its right (1) — and offsetX is measured
+        // from the pond's centre, in reference pixels.
         Image BuildSharedLog(string logName, float edge, float offsetX, out Image fill)
         {
             var logGO = new GameObject(logName, typeof(RectTransform), typeof(Image));
@@ -709,8 +712,8 @@ namespace Frogs.Unity.Views
 
             var logRect = outline.rectTransform;
             logRect.SetParent(_pondRect, worldPositionStays: false);
-            logRect.anchorMin = new Vector2(edge, 0.5f);
-            logRect.anchorMax = new Vector2(edge, 0.5f);
+            logRect.anchorMin = new Vector2(0.5f, 0.5f);
+            logRect.anchorMax = new Vector2(0.5f, 0.5f);
             logRect.pivot = new Vector2(edge, 0.5f);
             logRect.sizeDelta = new Vector2(LogWidth, SharedLogHeight);
             logRect.anchoredPosition = new Vector2(offsetX, 0f);
@@ -734,15 +737,16 @@ namespace Frogs.Unity.Views
 
         void BuildControls()
         {
-            // controls — pinned to the bottom, full width. A smaller `Roll`
-            // is the wrong thing to trade away, so this band does not shrink.
+            // controls — pinned to the bottom of the *screen*, as wide as the
+            // screen. A smaller `Roll` is the wrong thing to trade away, so
+            // this band does not shrink.
             var controlsGO = new GameObject("Controls", typeof(RectTransform), typeof(Image));
             var controlsImage = controlsGO.GetComponent<Image>();
             controlsImage.color = BoardColours.BandFill;
             controlsImage.raycastTarget = false;
 
             _controlsRect = controlsImage.rectTransform;
-            _controlsRect.SetParent(_contentRect, worldPositionStays: false);
+            _controlsRect.SetParent(_rect, worldPositionStays: false);
             _controlsRect.anchorMin = new Vector2(0f, 0f);
             _controlsRect.anchorMax = new Vector2(1f, 0f);
             _controlsRect.pivot = new Vector2(0.5f, 0f);
@@ -790,6 +794,11 @@ namespace Frogs.Unity.Views
             // One lane per frog in the game, in turn order — two, three, or
             // four. Every frog is visible at once, with no scrolling, paging
             // or zooming, and an absent frog gets no placeholder lane.
+            //
+            // A lane is the reference canvas's safe area wide and centred on
+            // the pond, on every screen. The band around it reaches the
+            // screen's edges; the nine positions on it are game-board.md's
+            // arithmetic and do not stretch (#303).
             var turnOrder = _game.TurnOrder;
             var laneWidth = CanvasWidth - (2f * SafeMargin);
             var groupTop = (turnOrder.Count * GameBoardLaneView.LaneHeight) / 2f;

--- a/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
+++ b/Assets/Tests/EditMode/FullBleedBackgroundTests.cs
@@ -27,6 +27,12 @@ namespace Frogs.Unity.EditModeTests
     ///   fix cannot pass by stretching the layout instead. Every constant on
     ///   every spec page means what it meant before.
     ///
+    /// The game board's three full-width bands are the one exception to the
+    /// second half, and issue #303 is where that was decided: a band that
+    /// reads as the top or the bottom of the screen reaches the screen's
+    /// edges, and what it *contains* is what stays in reference pixels. The
+    /// board's case below asserts both halves of that.
+    ///
     /// The canvas used here is bigger in *both* directions than the reference,
     /// which is not a shape any real device has — it is the shape that makes a
     /// background that only stretched one way fail here rather than on
@@ -49,8 +55,22 @@ namespace Frogs.Unity.EditModeTests
 
         const ulong AnySeed = 20260812UL;
 
+        /// <summary>
+        /// The board is the one screen whose full-width **bands** reach the
+        /// edges as well as its background — issue #303, and
+        /// docs/specs/ui/game-board.md's "The bands reach the edges too". The
+        /// bands are the top and the bottom of the screen rather than panels
+        /// on the pond, so they are measured against the canvas exactly as the
+        /// water behind them is.
+        ///
+        /// What that does *not* license is stretching the layout: everything
+        /// the bands contain that the spec places by geometry is still in
+        /// reference pixels. Both halves are asserted here, and the split is
+        /// pinned down in full by
+        /// <see cref="GameBoardBandsToTheEdgeTests"/>.
+        /// </summary>
         [Test]
-        public void GameBoard_PaintsItsBackgroundToEveryEdge_AndLeavesTheBoardAtReferenceSize()
+        public void GameBoard_PaintsItsBackgroundToEveryEdge_AndLeavesItsContentsAtReferenceSize()
         {
             var canvas = OversizedCanvas();
 
@@ -62,7 +82,6 @@ namespace Frogs.Unity.EditModeTests
                 view.Initialize(new Game(new[] { FrogColour.Green, FrogColour.Blue }, AnySeed));
 
                 AssertCoversTheWholeCanvas(view.BackgroundImage.rectTransform, canvas, "the board's background");
-                AssertIsTheReferenceCanvasCentred(view.ContentRect, canvas, "the board's content");
 
                 // The board is the one screen that paints something other than
                 // the shared app background: its own water — issue #291,
@@ -79,25 +98,42 @@ namespace Frogs.Unity.EditModeTests
                     "the fixture, not the assertion — if these two are ever the same value "
                     + "the test above proves nothing");
 
-                // The layout itself is untouched: the header and the controls
-                // band are full width *of the reference canvas*, not of the
-                // device. If either of these reads 2400 the fix stretched the
-                // board instead of the background, and every constant on
-                // docs/specs/ui/game-board.md has quietly stopped meaning what
-                // it says.
+                // The three bands are the screen's own top, middle and bottom,
+                // so each is as wide as the screen. A band that reads 1920 here
+                // is a band with a strip of water past each of its ends, which
+                // is the bug #303 was reported for.
                 Assert.That(
                     view.HeaderRect.rect.width,
-                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
-                    "the header is still the reference canvas wide, not the device wide");
+                    Is.EqualTo(OversizedCanvasWidth).Within(Tolerance),
+                    "the header is the device wide, so it is the top of the screen rather than a "
+                    + "panel floating on the pond");
                 Assert.That(
                     view.ControlsRect.rect.width,
-                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
-                    "the controls band is still the reference canvas wide, not the device wide");
+                    Is.EqualTo(OversizedCanvasWidth).Within(Tolerance),
+                    "the controls band is the device wide");
                 Assert.That(
                     view.PondRect.rect.width,
-                    Is.EqualTo(ReferenceWidth).Within(Tolerance),
-                    "the pond is still the reference canvas wide, so every lane is where "
-                    + "docs/specs/ui/game-board.md puts it");
+                    Is.EqualTo(OversizedCanvasWidth).Within(Tolerance),
+                    "the pond band paints its own water to the device's edges rather than "
+                    + "relying on the background showing through");
+
+                // And the layout inside them is untouched. If a lane reads
+                // 2400 the fix stretched the board instead of its bands, and
+                // every constant on docs/specs/ui/game-board.md has quietly
+                // stopped meaning what it says.
+                foreach (var lane in view.Lanes)
+                {
+                    Assert.That(
+                        lane.RectTransform.rect.width,
+                        Is.EqualTo(ReferenceWidth - (2f * GameBoardScreenView.SafeMargin)).Within(Tolerance),
+                        "a lane is still the reference canvas's safe area wide, not the device's");
+                }
+
+                Assert.That(
+                    view.StartLogOutline.rectTransform.rect.height,
+                    Is.EqualTo(GameBoardScreenView.SharedLogHeight).Within(Tolerance),
+                    "the logs are still the reference pond's height — the extra height a taller "
+                    + "device gives us is water, not log");
             }
             finally
             {

--- a/Assets/Tests/EditMode/GameBoardBandsToTheEdgeTests.cs
+++ b/Assets/Tests/EditMode/GameBoardBandsToTheEdgeTests.cs
@@ -1,0 +1,571 @@
+using NUnit.Framework;
+using UnityEngine;
+using Frogs.Core;
+using Frogs.Unity.Views;
+using BoardColours = Frogs.Unity.UI.BoardColours;
+using Image = UnityEngine.UI.Image;
+using PlayerChip = Frogs.Unity.UI.PlayerChip;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// **The bands are the top and the bottom of the screen, not panels
+    /// floating on the pond** — issue #303, and the rule
+    /// docs/specs/ui/game-board.md now states under "The bands reach the edges
+    /// too".
+    ///
+    /// #290 gave the board a background that reaches all four edges. It left
+    /// `header`, `pond` and `controls` laid out inside a rect fixed at the
+    /// 1920 x 1200 reference, so on any screen that is not 16:10 the two
+    /// painted bands stopped short of the real edge and the one thing that did
+    /// reach it — the water — showed past their ends.
+    ///
+    /// What this fixture pins down is the split that fixes it, because either
+    /// half alone is wrong:
+    ///
+    /// - the three bands' **fills** are measured against the canvas, so they
+    ///   reach its edges on any aspect ratio, and an edge-anchored control
+    ///   inside a band follows the real edge with it;
+    /// - everything the bands **contain** that is placed by the spec's
+    ///   geometry — the lanes, the two shared logs — is still measured in
+    ///   reference pixels, so a frog on a log is still on its own lane's
+    ///   position 0 whatever shape the screen is.
+    ///
+    /// And the test that makes the whole thing safe: at exactly 1920 x 1200
+    /// nothing moved at all. This fix is invisible on the tablet it was
+    /// reported from and on every mockup in the repo.
+    ///
+    /// The oversized canvas here is bigger than the reference in *both*
+    /// directions, which is not a shape any real device has — it is the shape
+    /// that makes a band that only grew one way fail here rather than on
+    /// somebody's tablet.
+    /// </summary>
+    public sealed class GameBoardBandsToTheEdgeTests
+    {
+        // The one canvas every screen is measured in —
+        // docs/specs/ui/shared-components.md#the-canvas-every-component-is-measured-in.
+        const float ReferenceWidth = 1920f;
+        const float ReferenceHeight = 1200f;
+
+        // What `ScreenMatchMode.Expand` produces on a device that is not
+        // 16:10 — the same canvas FullBleedBackgroundTests uses, for the same
+        // reason.
+        const float OversizedCanvasWidth = 2400f;
+        const float OversizedCanvasHeight = 1400f;
+
+        const float Tolerance = 0.001f;
+
+        const ulong AnySeed = 20260813UL;
+
+        /// <summary>
+        /// The bug as Derek reported it from the tablet: "the pond expanded
+        /// but not the top and bottom bars". Before the fix the two painted
+        /// bands are <see cref="ReferenceWidth"/> wide and centred, so this
+        /// fails on the very first edge it checks.
+        /// </summary>
+        [Test]
+        public void Header_And_Controls_ReachTheCanvasEdges_OnAScreenThatIsNot1610()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var screen = BoundsOf(canvas, canvas);
+                var header = BoundsOf(view.HeaderRect, canvas);
+                var controls = BoundsOf(view.ControlsRect, canvas);
+
+                Assert.That(
+                    header.xMin,
+                    Is.EqualTo(screen.xMin).Within(Tolerance),
+                    "the header stops short of the left edge of the screen, and the strip it "
+                    + "leaves is filled by the water behind it");
+                Assert.That(
+                    header.xMax,
+                    Is.EqualTo(screen.xMax).Within(Tolerance),
+                    "the header stops short of the right edge of the screen");
+                Assert.That(
+                    header.yMax,
+                    Is.EqualTo(screen.yMax).Within(Tolerance),
+                    "the header's top is not the top of the screen, so there is a band of water "
+                    + "above it");
+
+                Assert.That(
+                    controls.xMin,
+                    Is.EqualTo(screen.xMin).Within(Tolerance),
+                    "the controls band stops short of the left edge of the screen");
+                Assert.That(
+                    controls.xMax,
+                    Is.EqualTo(screen.xMax).Within(Tolerance),
+                    "the controls band stops short of the right edge of the screen");
+                Assert.That(
+                    controls.yMin,
+                    Is.EqualTo(screen.yMin).Within(Tolerance),
+                    "the controls band's bottom is not the bottom of the screen, so there is a "
+                    + "band of water below it");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// The half of the bug that looks fixed and is not. `pond` has the
+        /// identical anchoring fault as the other two bands; it is invisible
+        /// only because the band painted nothing of its own and the background
+        /// showed through the gap. So the pond gets a fill, and it is that
+        /// fill — not the background behind it — that has to cover everything
+        /// between the two bands.
+        /// </summary>
+        [Test]
+        public void Pond_PaintsItsOwnWaterBetweenTheTwoBands_RatherThanShowingTheBackgroundThrough()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var pondFill = view.PondRect.GetComponent<Image>();
+
+                Assert.That(
+                    pondFill,
+                    Is.Not.Null,
+                    "the pond band paints nothing, so what looks like the pond reaching the edge "
+                    + "is the background showing through the pond's own gap");
+                Assert.That(
+                    pondFill.color,
+                    Is.EqualTo(BoardColours.PondWater),
+                    "the pond is painted in the water");
+
+                var screen = BoundsOf(canvas, canvas);
+                var pond = BoundsOf(view.PondRect, canvas);
+                var header = BoundsOf(view.HeaderRect, canvas);
+                var controls = BoundsOf(view.ControlsRect, canvas);
+
+                Assert.That(pond.xMin, Is.EqualTo(screen.xMin).Within(Tolerance), "the pond reaches the left edge");
+                Assert.That(pond.xMax, Is.EqualTo(screen.xMax).Within(Tolerance), "the pond reaches the right edge");
+                Assert.That(
+                    pond.yMax,
+                    Is.EqualTo(header.yMin).Within(Tolerance),
+                    "the pond starts where the header ends — the three bands meet with no gaps");
+                Assert.That(
+                    pond.yMin,
+                    Is.EqualTo(controls.yMax).Within(Tolerance),
+                    "the pond ends where the controls band starts");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// Where a taller screen's extra height goes, which is the same answer
+        /// the code already gave for a shorter one: the pond, and nowhere
+        /// else. A smaller `Roll` is the wrong thing to trade away, and a
+        /// taller header is not something any mockup describes.
+        /// </summary>
+        [Test]
+        public void TheExtraHeightOfATallerScreen_GoesToThePond_AndNowhereElse()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                Assert.That(
+                    view.HeaderRect.rect.height,
+                    Is.EqualTo(GameBoardScreenView.BoardHeaderHeight).Within(Tolerance),
+                    "the header is its specified height on every screen");
+                Assert.That(
+                    view.ControlsRect.rect.height,
+                    Is.EqualTo(GameBoardScreenView.BoardControlsHeight).Within(Tolerance),
+                    "the controls band is its specified height on every screen");
+                Assert.That(
+                    view.PondRect.rect.height,
+                    Is.EqualTo(OversizedCanvasHeight
+                        - GameBoardScreenView.BoardHeaderHeight
+                        - GameBoardScreenView.BoardControlsHeight).Within(Tolerance),
+                    "every pixel of extra height belongs to the pond");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// The hairline the mockup draws under `header` and over `controls`.
+        /// It travels with its band: still `BoardBandOutline` tall, still
+        /// inside the band's own bounds so the band's height is untouched, and
+        /// now as wide as the band it edges — a hairline that stopped at 1920
+        /// would be a line that ends before the band does.
+        /// </summary>
+        [Test]
+        public void TheBandHairlines_SpanTheWidenedBand_AndStayInsideIt()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var header = BoundsOf(view.HeaderRect, canvas);
+                var controls = BoundsOf(view.ControlsRect, canvas);
+                var headerHairline = BoundsOf(view.HeaderHairline.rectTransform, canvas);
+                var controlsHairline = BoundsOf(view.ControlsHairline.rectTransform, canvas);
+
+                Assert.That(
+                    headerHairline.height,
+                    Is.EqualTo(GameBoardScreenView.BoardBandOutline).Within(Tolerance));
+                Assert.That(
+                    controlsHairline.height,
+                    Is.EqualTo(GameBoardScreenView.BoardBandOutline).Within(Tolerance));
+
+                Assert.That(
+                    headerHairline.xMin,
+                    Is.EqualTo(header.xMin).Within(Tolerance),
+                    "the hairline ends before the band it edges does");
+                Assert.That(headerHairline.xMax, Is.EqualTo(header.xMax).Within(Tolerance));
+                Assert.That(
+                    headerHairline.yMin,
+                    Is.EqualTo(header.yMin).Within(Tolerance),
+                    "the hairline is drawn inside the band, along its bottom");
+
+                Assert.That(controlsHairline.xMin, Is.EqualTo(controls.xMin).Within(Tolerance));
+                Assert.That(controlsHairline.xMax, Is.EqualTo(controls.xMax).Within(Tolerance));
+                Assert.That(
+                    controlsHairline.yMax,
+                    Is.EqualTo(controls.yMax).Within(Tolerance),
+                    "the hairline is drawn inside the band, along its top");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// Derek's call on the one thing #303 left to decide: an
+        /// edge-anchored control follows the **real** screen edge, not the
+        /// reference one, because `SafeMargin` is a margin from the screen and
+        /// not from a virtual rectangle. A gear sitting 288 px in from the
+        /// right of a 2400-wide screen reads as a mistake.
+        ///
+        /// `Roll` is centred and does not care either way, so what is asserted
+        /// of it is that it stayed centred.
+        /// </summary>
+        [Test]
+        public void TheGearAndTheTurnChip_FollowTheRealScreenEdge_NotTheReferenceEdge()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var screen = BoundsOf(canvas, canvas);
+                var gear = BoundsOf(view.SettingsButton.RectTransform, canvas);
+                var chip = BoundsOf(view.TurnBannerChip.RectTransform, canvas);
+                var roll = BoundsOf(view.RollButton.RectTransform, canvas);
+                var controls = BoundsOf(view.ControlsRect, canvas);
+
+                Assert.That(
+                    gear.xMax,
+                    Is.EqualTo(screen.xMax - GameBoardScreenView.SafeMargin).Within(Tolerance),
+                    "the gear is a safe margin in from the edge of the screen, not from the edge "
+                    + "of the reference rectangle");
+                Assert.That(
+                    chip.xMin,
+                    Is.EqualTo(screen.xMin + GameBoardScreenView.SafeMargin).Within(Tolerance),
+                    "the turn chip is a safe margin in from the edge of the screen");
+
+                Assert.That(
+                    roll.center.x,
+                    Is.EqualTo(screen.center.x).Within(Tolerance),
+                    "`Roll` is centred on the screen");
+                Assert.That(
+                    roll.center.y,
+                    Is.EqualTo(controls.center.y).Within(Tolerance),
+                    "`Roll` is centred in its band");
+                Assert.That(
+                    roll.width,
+                    Is.EqualTo(GameBoardScreenView.RollButtonWidth).Within(Tolerance),
+                    "`Roll` is its own specified size, not the screen's");
+                Assert.That(
+                    roll.height,
+                    Is.EqualTo(GameBoardScreenView.RollButtonHeight).Within(Tolerance));
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// The other half of the split. A band grows; what a band *contains*
+        /// that the spec places by geometry does not, because the two shared
+        /// logs are position 0 and position 8 of every lane and a log that
+        /// slid out to the real edge would no longer be under the lane it
+        /// belongs to.
+        /// </summary>
+        [Test]
+        public void TheLogsAndTheLanes_StayAtReferenceGeometry_WhileTheirBandGrows()
+        {
+            var canvas = OversizedCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var pond = BoundsOf(view.PondRect, canvas);
+                var startLog = BoundsOf(view.StartLogOutline.rectTransform, canvas);
+                var endLog = BoundsOf(view.EndLogOutline.rectTransform, canvas);
+
+                Assert.That(
+                    startLog.xMin,
+                    Is.EqualTo(pond.center.x - (ReferenceWidth / 2f)
+                        + GameBoardScreenView.SafeMargin
+                        + GameBoardLaneView.LaneGutterWidth
+                        + GameBoardLaneView.LaneGutterGap).Within(Tolerance),
+                    "the Start log has followed the widened band away from the lanes whose "
+                    + "position 0 it is");
+                Assert.That(
+                    endLog.xMax,
+                    Is.EqualTo(pond.center.x + (ReferenceWidth / 2f) - GameBoardScreenView.SafeMargin).Within(Tolerance),
+                    "the End log has followed the widened band away from the lanes whose "
+                    + "position 8 it is");
+
+                Assert.That(
+                    startLog.height,
+                    Is.EqualTo(GameBoardScreenView.SharedLogHeight).Within(Tolerance),
+                    "the logs are the pond band's reference height — a taller screen gives its "
+                    + "extra height to the water, not to the logs");
+                Assert.That(
+                    endLog.height,
+                    Is.EqualTo(GameBoardScreenView.SharedLogHeight).Within(Tolerance));
+
+                foreach (var lane in view.Lanes)
+                {
+                    Assert.That(
+                        lane.RectTransform.rect.width,
+                        Is.EqualTo(ReferenceWidth - (2f * GameBoardScreenView.SafeMargin)).Within(Tolerance),
+                        "a lane is the reference canvas's safe area wide, on every screen");
+                    Assert.That(
+                        BoundsOf(lane.RectTransform, canvas).center.x,
+                        Is.EqualTo(pond.center.x).Within(Tolerance),
+                        "and centred, so it still crosses both of the logs");
+                }
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        /// <summary>
+        /// The test that makes the rest of this fixture safe to have written:
+        /// on the canvas every mockup is drawn at, nothing moved. Every band
+        /// and every element inside it is exactly where
+        /// docs/specs/ui/game-board.md puts it, measured from the screen's own
+        /// corners rather than from anything the view computed.
+        /// </summary>
+        [Test]
+        public void AtExactlyTheReferenceCanvas_EveryBandAndEverythingInItIsWhereItAlwaysWas()
+        {
+            var canvas = ReferenceCanvas();
+
+            try
+            {
+                var view = BoardOn(canvas);
+
+                var left = -ReferenceWidth / 2f;
+                var right = ReferenceWidth / 2f;
+                var top = ReferenceHeight / 2f;
+                var bottom = -ReferenceHeight / 2f;
+
+                var headerBottom = top - GameBoardScreenView.BoardHeaderHeight;
+                var controlsTop = bottom + GameBoardScreenView.BoardControlsHeight;
+
+                AssertBounds(
+                    view.HeaderRect,
+                    canvas,
+                    Rect.MinMaxRect(left, headerBottom, right, top),
+                    "the header");
+                AssertBounds(
+                    view.PondRect,
+                    canvas,
+                    Rect.MinMaxRect(left, controlsTop, right, headerBottom),
+                    "the pond");
+                AssertBounds(
+                    view.ControlsRect,
+                    canvas,
+                    Rect.MinMaxRect(left, bottom, right, controlsTop),
+                    "the controls band");
+
+                AssertBounds(
+                    view.HeaderHairline.rectTransform,
+                    canvas,
+                    Rect.MinMaxRect(left, headerBottom, right, headerBottom + GameBoardScreenView.BoardBandOutline),
+                    "the header's hairline");
+                AssertBounds(
+                    view.ControlsHairline.rectTransform,
+                    canvas,
+                    Rect.MinMaxRect(left, controlsTop - GameBoardScreenView.BoardBandOutline, right, controlsTop),
+                    "the controls band's hairline");
+
+                // The header's contents: the chip against the left safe
+                // margin, the gear against the right one, both centred on the
+                // band.
+                var headerCentre = (top + headerBottom) / 2f;
+                var chipLeft = left + GameBoardScreenView.SafeMargin;
+
+                AssertBounds(
+                    view.TurnBannerChip.RectTransform,
+                    canvas,
+                    Rect.MinMaxRect(
+                        chipLeft,
+                        headerCentre - (PlayerChip.PlayerChipHeight / 2f),
+                        chipLeft + PlayerChip.PlayerChipWidth,
+                        headerCentre + (PlayerChip.PlayerChipHeight / 2f)),
+                    "the turn chip");
+
+                var gear = BoundsOf(view.SettingsButton.RectTransform, canvas);
+                Assert.That(
+                    gear.xMax,
+                    Is.EqualTo(right - GameBoardScreenView.SafeMargin).Within(Tolerance),
+                    "the gear is against the right safe margin");
+                Assert.That(gear.center.y, Is.EqualTo(headerCentre).Within(Tolerance), "the gear is centred on the band");
+
+                Assert.That(
+                    BoundsOf(view.TurnBannerText.rectTransform, canvas).xMin,
+                    Is.EqualTo(chipLeft + PlayerChip.PlayerChipWidth + GameBoardScreenView.TurnBannerGap).Within(Tolerance),
+                    "the banner's words sit a gap past the chip beside them");
+
+                // The controls band's contents: `Roll`, oversized and centred.
+                var controlsCentre = (bottom + controlsTop) / 2f;
+
+                AssertBounds(
+                    view.RollButton.RectTransform,
+                    canvas,
+                    Rect.MinMaxRect(
+                        -GameBoardScreenView.RollButtonWidth / 2f,
+                        controlsCentre - (GameBoardScreenView.RollButtonHeight / 2f),
+                        GameBoardScreenView.RollButtonWidth / 2f,
+                        controlsCentre + (GameBoardScreenView.RollButtonHeight / 2f)),
+                    "`Roll`");
+
+                // The pond's contents: the two shared logs, in the columns
+                // every lane's track starts and ends in.
+                var pondCentre = (controlsTop + headerBottom) / 2f;
+                var startLogLeft = left
+                    + GameBoardScreenView.SafeMargin
+                    + GameBoardLaneView.LaneGutterWidth
+                    + GameBoardLaneView.LaneGutterGap;
+
+                AssertBounds(
+                    view.StartLogOutline.rectTransform,
+                    canvas,
+                    Rect.MinMaxRect(
+                        startLogLeft,
+                        pondCentre - (GameBoardScreenView.SharedLogHeight / 2f),
+                        startLogLeft + GameBoardScreenView.LogWidth,
+                        pondCentre + (GameBoardScreenView.SharedLogHeight / 2f)),
+                    "the Start log");
+                AssertBounds(
+                    view.EndLogOutline.rectTransform,
+                    canvas,
+                    Rect.MinMaxRect(
+                        right - GameBoardScreenView.SafeMargin - GameBoardScreenView.LogWidth,
+                        pondCentre - (GameBoardScreenView.SharedLogHeight / 2f),
+                        right - GameBoardScreenView.SafeMargin,
+                        pondCentre + (GameBoardScreenView.SharedLogHeight / 2f)),
+                    "the End log");
+
+                // At the reference canvas the log fills the pond band exactly,
+                // which is the sentence game-board.md writes about it.
+                Assert.That(
+                    GameBoardScreenView.SharedLogHeight,
+                    Is.EqualTo(view.PondRect.rect.height).Within(Tolerance),
+                    "at 1920 x 1200 the logs fill the pond band, edge to edge with the two "
+                    + "hairlines");
+            }
+            finally
+            {
+                DestroyCanvas(canvas);
+            }
+        }
+
+        // --- helpers ---------------------------------------------------------
+
+        static GameBoardScreenView BoardOn(RectTransform canvas)
+        {
+            var view = new GameObject(nameof(GameBoardScreenView), typeof(RectTransform))
+                .AddComponent<GameBoardScreenView>();
+            view.transform.SetParent(canvas, worldPositionStays: false);
+            view.Initialize(new Game(new[] { FrogColour.Green, FrogColour.Blue }, AnySeed));
+
+            return view;
+        }
+
+        static RectTransform ReferenceCanvas()
+        {
+            return CanvasOf(ReferenceWidth, ReferenceHeight);
+        }
+
+        static RectTransform OversizedCanvas()
+        {
+            return CanvasOf(OversizedCanvasWidth, OversizedCanvasHeight);
+        }
+
+        // The view under a canvas exactly as AppRoot's "Screens" host holds
+        // it — the same fixture FullBleedBackgroundTests builds.
+        static RectTransform CanvasOf(float width, float height)
+        {
+            var host = new GameObject("Canvas", typeof(RectTransform));
+            var rect = (RectTransform)host.transform;
+
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = new Vector2(width, height);
+            rect.anchoredPosition = Vector2.zero;
+
+            return rect;
+        }
+
+        static void DestroyCanvas(RectTransform canvas)
+        {
+            UnityEngine.Object.DestroyImmediate(canvas.gameObject);
+        }
+
+        static void AssertBounds(RectTransform rect, RectTransform canvas, Rect expected, string what)
+        {
+            var actual = BoundsOf(rect, canvas);
+
+            Assert.That(actual.xMin, Is.EqualTo(expected.xMin).Within(Tolerance), $"{what}: left edge");
+            Assert.That(actual.xMax, Is.EqualTo(expected.xMax).Within(Tolerance), $"{what}: right edge");
+            Assert.That(actual.yMin, Is.EqualTo(expected.yMin).Within(Tolerance), $"{what}: bottom edge");
+            Assert.That(actual.yMax, Is.EqualTo(expected.yMax).Within(Tolerance), $"{what}: top edge");
+        }
+
+        // Where something actually is on the screen, in the canvas's own
+        // coordinates — measured from world corners rather than from anchors
+        // and offsets, so no anchoring arrangement can satisfy these tests
+        // without putting the pixels where they say.
+        static Rect BoundsOf(RectTransform rect, RectTransform canvas)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+
+            var min = canvas.InverseTransformPoint(corners[0]);
+            var max = canvas.InverseTransformPoint(corners[2]);
+
+            return Rect.MinMaxRect(min.x, min.y, max.x, max.y);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameBoardBandsToTheEdgeTests.cs.meta
+++ b/Assets/Tests/EditMode/GameBoardBandsToTheEdgeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a589b75c15d40cea2930d2abc6024cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -1006,11 +1006,31 @@ namespace Frogs.Unity.EditModeTests
             return (corners[0].y + corners[2].y) / 2f;
         }
 
+        // The board under a canvas that is exactly the reference size — the
+        // shape every mockup is drawn at, and the shape the target tablet is.
+        //
+        // It is stated rather than implied because the board's three bands are
+        // measured against the canvas rather than against a reference
+        // rectangle inside it (#303): a test that wants the mockup's numbers
+        // has to say which canvas it is holding. Everything below is therefore
+        // the same picture the mockup is, asserted at the one size the mockup
+        // exists at — what happens on a screen that is not 16:10 is
+        // GameBoardBandsToTheEdgeTests'.
         static GameBoardScreenView CreateView(Game game)
         {
-            var host = new GameObject(nameof(GameBoardScreenViewTests), typeof(RectTransform));
-            var view = host.AddComponent<GameBoardScreenView>();
+            var canvas = new GameObject(nameof(GameBoardScreenViewTests), typeof(RectTransform));
+            var canvasRect = (RectTransform)canvas.transform;
+            canvasRect.anchorMin = new Vector2(0.5f, 0.5f);
+            canvasRect.anchorMax = new Vector2(0.5f, 0.5f);
+            canvasRect.pivot = new Vector2(0.5f, 0.5f);
+            canvasRect.sizeDelta = new Vector2(CanvasWidth, CanvasHeight);
+            canvasRect.anchoredPosition = Vector2.zero;
+
+            var view = new GameObject(nameof(GameBoardScreenView), typeof(RectTransform))
+                .AddComponent<GameBoardScreenView>();
+            view.transform.SetParent(canvasRect, worldPositionStays: false);
             view.Initialize(game);
+
             return view;
         }
 
@@ -1044,10 +1064,16 @@ namespace Frogs.Unity.EditModeTests
 
         static void Destroy(GameBoardScreenView view)
         {
-            if (view != null)
+            if (view == null)
             {
-                UnityEngine.Object.DestroyImmediate(view.gameObject);
+                return;
             }
+
+            // The canvas CreateView built, if the view is still under it —
+            // destroying only the view would leave one host per test behind.
+            var canvas = view.transform.parent;
+
+            UnityEngine.Object.DestroyImmediate(canvas != null ? canvas.gameObject : view.gameObject);
         }
     }
 }

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -67,6 +67,12 @@ height, in this order and with no gaps:
   clinging to the top.
 - `controls` — pinned to the bottom, `BoardControlsHeight` tall, full width.
 
+"Full width" and "the top" mean the screen's, not the reference canvas's, on a
+device that is not 16:10 — a band reaches the edges the way the water does. What
+the bands *contain* is measured in the reference canvas, which is what every
+number below is in. The whole of that rule, and the one control it moves, is
+[the bands reach the edges too](#the-bands-reach-the-edges-too).
+
 Across the pond, the nine positions occupy the same nine columns in every lane,
 and their total width is fixed by the position count rather than by the space
 available:
@@ -77,14 +83,20 @@ available:
   from each other, and from the End log.
 - `end-log` — pinned to the **right** edge of the safe area.
 
-Both logs are `SharedLogHeight` tall, which is the height of the `pond` band
-itself: they fill it, edge to edge with the two hairlines, whether two frogs are
-playing or four. Every lane's centre line therefore crosses both of them, and a
-frog on a log still sits on its own lane's line. A shorter screen loses height
-from `pond` and nothing else — and the logs lose it with the band, because they
-are the band's height rather than a number typed in beside it. The header and
-the controls do not shrink, because a smaller `Roll` button is the wrong thing
-to trade away.
+Both logs are `SharedLogHeight` tall, which is the height of the `pond` band on
+the reference canvas: they fill it, edge to edge with the two hairlines, whether
+two frogs are playing or four. Every lane's centre line therefore crosses both
+of them, and a frog on a log still sits on its own lane's line. A shorter screen
+loses height from `pond` and nothing else — and the logs lose it with the band,
+because they are the band's height rather than a number typed in beside it. The
+header and the controls do not shrink, because a smaller `Roll` button is the
+wrong thing to trade away.
+
+A *taller* screen is the other side of that, and it is not symmetric: the extra
+height is all `pond`, and it is all water. The logs and the lane stack stay
+their reference size, centred in the band, because they are the board rather
+than the backdrop — see
+[the bands reach the edges too](#the-bands-reach-the-edges-too).
 
 ## Why the lanes run across
 
@@ -249,9 +261,17 @@ the board on the tablet. They are honest placeholders in exactly the sense the
 
 ### The water is the whole screen
 
-`PondWater` is not the pond band's fill. It is what this screen paints to all
-four edges of the device, on any aspect ratio — the header and controls bands
-are drawn on top of it, and so is everything else.
+`PondWater` is what this screen paints to all four edges of the device, on any
+aspect ratio. It is the `pond` band's own fill **and** the paint behind
+everything else — the header and controls bands are drawn on top of it, and so
+is every lane, log and frog.
+
+Both, and written down as both, because it used to be only the second one: the
+`pond` band painted nothing at all and what read as the pond was the screen-wide
+paint showing through where the band was not. That is invisible while the two
+agree about where the band is, and it is why nobody noticed the band had the
+same bug the header and the controls had — see
+[the bands reach the edges too](#the-bands-reach-the-edges-too).
 
 That makes the board the one screen that does not paint the app's own
 background. Every other screen paints `#EDF1EF`, and so does the scene camera,
@@ -260,6 +280,39 @@ rule from
 [the canvas every component is measured in](shared-components.md#what-fills-a-screen-that-is-not-1610)
 is unchanged and still holds here: nothing behind the canvas is ever visible,
 because this screen's own paint reaches the edges.
+
+### The bands reach the edges too
+
+**Invariant:** every one of the three bands is as wide as the screen, `header`'s
+top edge is the top of the screen, and `controls`' bottom edge is the bottom of
+it — on every aspect ratio, exactly as the water is.
+
+A band is the top or the bottom **of the screen**, not a panel laid on the pond.
+A band that stopped at 1920 px on a wider device would show a strip of water past
+each of its ends, and two grey bars floating on a pond is a rendering fault
+rather than a design. That is what the tablet was doing until this was written
+down.
+
+**Invariant:** what a band *contains* is still laid out in the reference canvas,
+centred. The lanes are the reference canvas's safe area wide and the two shared
+logs stand in the columns those lanes' tracks start and end in, on every screen,
+so every constant in the table below keeps meaning exactly what it says and
+position 0 is still on the Start log. The band grows; the board inside it does
+not.
+
+**A control anchored to a band's edge follows the screen's edge.** The turn chip
+and the settings gear sit `SafeMargin` in from the real left and right edges of
+the screen, because `SafeMargin` is a margin from the screen and not from a
+rectangle nobody can see. `Roll` is centred and does not care either way.
+
+**Extra height goes to `pond` and nowhere else** — the same answer
+[Anchors](#anchors) already gives for a *shorter* screen, in the other
+direction. The two bands keep their heights, because a smaller `Roll` is the
+wrong thing to trade away, and what a taller screen shows more of is water: the
+logs and the lane stack keep their reference size, centred in the band.
+
+At exactly 1920 × 1200 all of this is pixel-identical to the mockups, which is
+why it is a rule stated on this page rather than a new picture to draw.
 
 ### Keeping the frogs visible
 

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -91,6 +91,21 @@ appears there, and no element grows into it. An element that only exists on
 some devices is an element nobody can review against a mockup, and every mockup
 in this repo is drawn at exactly one size.
 
+**The one exception: a band that is background.** A full-width band whose job is
+to be the top or the bottom of the screen — the game board's `header`, `pond`
+and `controls`, and nothing else today — reaches the screen's edges by the same
+rule the background does, and a control anchored to such a band's left or right
+edge sits `SafeMargin` in from the screen's edge with it. Everything the band
+*contains* keeps this invariant untouched.
+
+The exception is narrow on purpose, and the test for it is what the element
+would look like if it did not grow: a band that stops short leaves a strip of
+background past each of its ends, which reads as a rendering fault. A button, a
+card or a dialog that stops short simply looks placed. Only the first kind grows
+— see
+[the bands reach the edges too](game-board.md#the-bands-reach-the-edges-too),
+which is where it was decided and why.
+
 **Invariant:** nothing behind the canvas is ever visible. Whatever a screen
 paints, it paints to all four edges, and the scene camera clears to the app's
 background rather than to the engine's default sky — so even a frame drawn


### PR DESCRIPTION
Closes #303

On the tablet the pond water reached all four edges of the screen but the two grey
bars did not — they stopped short, with a strip of water past each of their ends, so
they read as panels floating on the pond rather than as the top and the bottom of the
screen. Now the two bars, and the pond between them, are as wide as the screen is, the
header's top is the screen's top and the controls band's bottom is the screen's bottom,
and the gear and the turn chip sit their safe margin in from the real edge instead of
from an invisible 1920-wide rectangle. On the exact 1920 × 1200 the mockups are drawn
at, nothing moved by a pixel.

The pond band had the same bug and nobody could see it: it painted nothing at all, so
what looked like "the pond expanded" was the background showing through the gap where
the band was not. It paints its own water now.

**Docs:** `docs/specs/ui/game-board.md` — new "The bands reach the edges too" section:
a band is as wide as the screen, what it contains stays in reference pixels, an
edge-anchored control follows the real edge, and a taller screen's extra height is all
pond and all water; the logs' "the height of the pond band" is now "the height of the
pond band **on the reference canvas**". `docs/specs/ui/shared-components.md` — the "no
element grows into it" invariant gains its one named exception.

## Spec invariants this had to keep true

| Invariant | How it is known |
| --- | --- |
| Nothing behind the canvas is ever visible (#290) | `FullBleedBackgroundTests` is unchanged in what it asks of the background: it still covers the whole canvas, in `PondWater` |
| Everything laid out is laid out in the reference canvas, centred | `TheLogsAndTheLanes_StayAtReferenceGeometry_WhileTheirBandGrows` — a lane is still 1824 wide and the logs still stand in their lanes' columns on a 2400 × 1400 canvas |
| Every frog's position 0 and position 8 are on the two shared logs (#296) | the same test — this is *why* the logs are measured from the pond's centre rather than from the band's edges |
| The three bands fill the height in order with no gaps | `Pond_PaintsItsOwnWaterBetweenTheTwoBands…` asserts the pond starts exactly where the header ends and ends exactly where the controls band starts |
| Every size is a named constant | no new literals; `check_geometry_literals.py` clean |
| The mockups are still accurate pictures of the board | `AtExactlyTheReferenceCanvas_EveryBandAndEverythingInItIsWhereItAlwaysWas` — every band, hairline, chip, gear, `Roll` and log measured from the screen's own corners |

The red was watched in CI, since there is no editor here: the tests-only commit
(`0fc8d05`) ran **5 failed of 273**, which is exactly the five that assert the new
behaviour — the three that could only pass after the fix, the gear-and-chip one, and
`FullBleedBackgroundTests`' board case. The other three new tests are guards and passed
both before and after.

## How the spec is changing

**Old rule** (`shared-components.md`): "the extra space is background and nothing else.
No element appears there, and no element grows into it."

**New rule:** the same, with one named exception — a full-width band whose job is to be
the top or the bottom of the screen reaches the screen's edges, as does a control
anchored to such a band's left or right edge. Everything a band contains keeps the old
rule untouched.

**Why the new one is better:** the test is what the element looks like when it *does not*
grow. A band that stops short leaves a strip of background past each of its ends, which
reads as a rendering fault — that is precisely what Derek saw. A button, a card or a
dialog that stops short simply looks placed. The old rule was written for the second kind
and applied to the first by accident, and `game-board.md` already said the water reaches
all four edges "and the header and controls bands are drawn on top of it" — the bands
were drawn on top of *part* of it.

The board's own page changes with it: "full width" now means the screen's, the logs'
height is the pond band's *at the reference canvas*, and a taller screen's extra height
is stated to be water rather than log.

## Deviations and Decisions

- **`Content` and the public `ContentRect` are gone from the board.** That rect existed
  to hold the three bands at reference geometry; with the bands on the canvas, nothing
  was left in it, and an empty rect with a public accessor is the kind of thing the next
  change reaches for by mistake. The other three screens keep theirs.
- **On a taller-than-reference screen the logs stay `SharedLogHeight` (896) tall rather
  than growing with the pond band.** Both readings of "the log fills the band" were
  defensible; this one follows the approved plan's "only the bands' fills change what
  they are measured against", and it keeps the log the same height as the lane stack it
  is under. The doc sentence is qualified rather than deleted, so the other reading is a
  visible edit if anyone wants it.
- **An existing test's assertion was inverted rather than added to.**
  `FullBleedBackgroundTests` asserted the bands were the *reference* canvas wide — that
  was #290's encoding of the rule this issue changes, so it now asserts the opposite for
  the board and asserts the reference geometry of the lanes and logs in its place.
  `GameBoardScreenViewTests` also builds the board under a 1920 × 1200 canvas now,
  because a board whose bands are measured against the canvas has to be told what canvas
  it is on.
- **The screenshot box on the checklist is not ticked**, and it is the only one.
  Rendering needs an editor session with a licence and a display; #314 is open in
  `Direct Involvement Needed` asking for the wide and tall screenshots. Nothing else on
  the checklist depends on it.


---
_Generated by [Claude Code](https://claude.ai/code)_