### PR TITLE
fix(working-out-grid): you can see which box the next digit goes in

### DIFF
--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
@@ -154,12 +154,39 @@ namespace Frogs.Unity.Views
         // Button.cs, PlayerChip.cs, DialogPanel.cs and RollAndCardDialogView.cs
         // each draw for their own colours: not a geometry constant on any spec
         // page's table, so not declared as a named spec constant.
+        //
+        // GridFocusFill below is the exception, and it is public for the same
+        // reason the sizes are: it is on working-out-grid.md's own table.
         static readonly Color InkColor = new Color32(0x1E, 0x24, 0x22, 0xFF); // mockups' --ink
         static readonly Color LineColor = new Color32(0x6C, 0x78, 0x73, 0xFF); // mockups' --line
         static readonly Color FaintColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockups' --faint
         static readonly Color AccentColor = new Color32(0x2E, 0x7D, 0x4F, 0xFF); // mockups' --accent
         static readonly Color PaperColor = Color.white; // mockups' --paper / #fff
         static readonly Color AnswerTintColor = new Color32(0xF3, 0xF8, 0xF5, 0xFF); // mockups' answer-row fill
+
+        /// <summary>
+        /// The fill of the cell the caret is in —
+        /// docs/specs/ui/working-out-grid.md's `GridFocusFill`, and the whole
+        /// of what makes the focused cell visible.
+        ///
+        /// Until #304 focus was the accent outline and nothing else: `#6C7873`
+        /// grey becoming `#2E7D4F` green on a 3 px line, which is two mid-tone
+        /// colours on a hairline and is not visible at the distance a child
+        /// holds a tablet. The outline stays; this is what carries the signal.
+        ///
+        /// It is the accent green over paper at 55 %, which is where it clears
+        /// the project's separability bar — 1.9 : 1 contrast *and* ΔE*ab 30 —
+        /// against **both** fills a focused cell can land on, the ordinary
+        /// <see cref="PaperColor"/> and the answer row's own
+        /// <see cref="AnswerTintColor"/>. The ratios are recorded on the spec
+        /// page; the bar itself is game-board.md's.
+        ///
+        /// Nothing about the cell's geometry changes with it. A focused cell
+        /// that were bigger or more heavily outlined than its neighbours would
+        /// be a change to the layout the mockups draw, and layout is gated on a
+        /// wireframe (docs/engineering/ui-design-process.md).
+        /// </summary>
+        public static readonly Color GridFocusFill = new Color32(0x8C, 0xB8, 0x9E, 0xFF);
 
         static Sprite s_cellSprite;
         static Sprite s_carryBoxSprite;
@@ -940,10 +967,7 @@ namespace Frogs.Unity.Views
                         LineColor,
                         out fill);
 
-                    if (row.Kind == GridRowKind.AnswerRow)
-                    {
-                        fill.color = AnswerTintColor;
-                    }
+                    fill.color = UnfocusedFillFor(row.Kind);
 
                     label = BuildText("Digit", border.rectTransform, DigitSizeFor(row.Kind), InkColor, TextAnchor.MiddleCenter);
                     StretchToFill(label.rectTransform);
@@ -1477,6 +1501,15 @@ namespace Frogs.Unity.Views
                     cell.Border.color = focused
                         ? AccentColor
                         : cell.Kind == GridCellKind.CarryBox ? FaintColor : LineColor;
+
+                    if (cell.Fill != null)
+                    {
+                        // The whole of #304: the focused cell is *filled*, not
+                        // just outlined. When the caret leaves, the cell goes
+                        // back to the fill it was built with — the tint says
+                        // where the next digit goes, never where one has been.
+                        cell.Fill.color = focused ? GridFocusFill : UnfocusedFillFor(cell.RowKind);
+                    }
                 }
             }
 
@@ -1484,6 +1517,14 @@ namespace Frogs.Unity.Views
             {
                 _checkItButton.SetDisabled(AnswerText.Length == 0);
             }
+        }
+
+        // What a cell is filled with when the caret is somewhere else: the
+        // answer row is tinted, everything else is paper. The one place that
+        // knows this, so BuildCell and RefreshCells cannot drift apart.
+        static Color UnfocusedFillFor(GridRowKind rowKind)
+        {
+            return rowKind == GridRowKind.AnswerRow ? AnswerTintColor : PaperColor;
         }
 
         static string PileNameFor(Pile pile)

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
@@ -618,6 +618,14 @@ namespace Frogs.Unity.EditModeTests
                 // A grown row is indistinguishable from a dealt one: same
                 // cells, same size, same colours, no badge.
                 GrowSectionBy(view, 1);
+
+                // With the caret parked outside the section, because #304's
+                // focus tint is drawn wherever the caret is and growing a row
+                // leaves the caret in it. A tinted cell is "the next digit goes
+                // here", not "you added this row" — the marking this bullet
+                // rules out is one the row keeps after the caret has left.
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+
                 var rows = Enumerable.Range(0, view.AdditionRowCount)
                     .Select(ordinal => view.Cells[RowIndexOf(view, GridRowKind.AdditionRow, ordinal)])
                     .ToArray();
@@ -1032,7 +1040,15 @@ namespace Frogs.Unity.EditModeTests
 
                 // Only the caret's own cell differs, and it differs because it
                 // is the caret's, not because of what is in it.
-                var differences = before.Zip(after, (first, second) => first == second).Count(same => !same);
+                //
+                // The threshold is **cells**, not colour slots, which is what
+                // this always meant: #304 gives the focused cell a tinted fill
+                // as well as its accent outline, so the two cells the caret
+                // left and arrived at each legitimately differ in two of their
+                // three colours. Counting cells says the invariant — *only*
+                // those two ever differ — without being a number that has to
+                // be edited every time the focused cell's treatment changes.
+                var differences = ChangedCells(before, after);
                 Assert.That(differences, Is.LessThanOrEqualTo(2), "nothing is marked; only the caret moves");
 
                 var forbidden = new[] { "Correct", "Wrong", "Grade", "Verdict", "Score", "Marked", "Valid", "Product" };
@@ -1065,6 +1081,177 @@ namespace Frogs.Unity.EditModeTests
                             || name.IndexOf("Countdown", StringComparison.OrdinalIgnoreCase) >= 0
                             || name.IndexOf("Deadline", StringComparison.OrdinalIgnoreCase) >= 0),
                     Is.Empty);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Which box the next digit goes in (#304).
+        //
+        // The grid always marked the focused cell — by swapping a 3 px
+        // outline between two mid-tone greys, which Derek could not see on the
+        // tablet. These three assert the treatment
+        // docs/specs/ui/working-out-grid.md now names: the focused cell is
+        // **filled** with `GridFocusFill`, at the sizes and outline widths it
+        // already had.
+        //
+        // `GridFocusFill` is written out as a literal below rather than read
+        // from the view, the same way GameBoardColoursTests.cs writes out the
+        // board's palette: a test that asserts a constant equals itself passes
+        // whatever the constant is changed to.
+        // ---------------------------------------------------------------
+
+        [Test]
+        public void TheFocusedCell_IsFilledWithTheFocusTint_SoItDiffersByMoreThanItsBorderColour()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var focused = view.CaretCell;
+
+                Assert.That(focused, Is.Not.Null, "the grid opens with a caret");
+                Assert.That(
+                    focused.Fill.color,
+                    Is.EqualTo(FocusFill),
+                    "the focused cell is filled with working-out-grid.md's `GridFocusFill`");
+
+                // The point of the issue: the difference survives being told
+                // to ignore the outline. Every other editable cell in the grid
+                // is filled with something clearly separable from it.
+                foreach (var other in EditableCells(view).Where(cell => cell != focused))
+                {
+                    Assert.That(
+                        other.Fill.color,
+                        Is.Not.EqualTo(FocusFill),
+                        "only the focused cell carries the tint");
+
+                    Assert.That(
+                        ContrastRatio(focused.Fill.color, other.Fill.color),
+                        Is.GreaterThanOrEqualTo(MinimumContrastRatio),
+                        "the focused fill against an unfocused one");
+                    Assert.That(
+                        ColourDistance(focused.Fill.color, other.Fill.color),
+                        Is.GreaterThanOrEqualTo(MinimumColourDistance),
+                        "the focused fill against an unfocused one");
+                }
+
+                // A digit typed into the focused cell still reads.
+                Assert.That(
+                    ContrastRatio(focused.Label.color, focused.Fill.color),
+                    Is.GreaterThanOrEqualTo(MinimumTextContrastRatio),
+                    "the digit against the tint it sits on");
+
+                // "Build the treatment without changing any cell's size or any
+                // outline width": the focused cell is the same box as the one
+                // beside it, filled differently.
+                var neighbour = CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 2);
+
+                Assert.That(focused.RectTransform.rect.size, Is.EqualTo(neighbour.RectTransform.rect.size));
+                Assert.That(focused.Border.rectTransform.rect.size, Is.EqualTo(neighbour.Border.rectTransform.rect.size));
+                Assert.That(
+                    BorderWidthOf(focused),
+                    Is.EqualTo(BorderWidthOf(neighbour)).Within(0.001f),
+                    "focus does not thicken the outline — that would be structure, and structure needs a wireframe");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ExactlyOneCell_CarriesTheFocusTint_AndItFollowsTheCaretEverywhereItGoes()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                AssertOnlyTheCaretIsTinted(view, "as the grid opens");
+
+                Type(view, 7);
+                AssertOnlyTheCaretIsTinted(view, "after a digit");
+
+                Backspace(view);
+                AssertOnlyTheCaretIsTinted(view, "after backspace");
+
+                Type(view, 4);
+                Clear(view);
+                AssertOnlyTheCaretIsTinted(view, "after clear");
+
+                Tap(CellAt(view, GridRowKind.CarryStrip, 0, 2));
+                AssertOnlyTheCaretIsTinted(view, "after tapping a cell");
+
+                Tap(CellAt(view, GridRowKind.AdditionRow, view.AdditionRowCount - 1, 1));
+                Type(view, 1);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart + 1));
+                AssertOnlyTheCaretIsTinted(view, "after the section grew");
+
+                GrowSectionBy(view, 3);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax));
+                AssertOnlyTheCaretIsTinted(view, "at the cap");
+
+                // And back down: backspacing a grown row's last digit takes the
+                // row away underneath the caret.
+                Tap(CellAt(view, GridRowKind.AdditionRow, view.AdditionRowCount - 1, 1));
+                Type(view, 1);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax), "the cap holds");
+
+                Backspace(view);
+                Assert.That(view.AdditionRowCount, Is.EqualTo(WorkingOutGrid.GridAdditionRowsMax - 1));
+                AssertOnlyTheCaretIsTinted(view, "after the section shrank");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheFocusTint_IsDrawnOnCarryBoxesAndAdditionCells_NotOnlyInTheAnswerRow()
+        {
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                // Every kind of cell the caret can reach: both carry strips,
+                // the addition section, and the answer row.
+                var reachable = new[]
+                {
+                    CellAt(view, GridRowKind.CarryStrip, 0, 1),
+                    CellAt(view, GridRowKind.CarryStrip, 1, HardColumnCount - 1),
+                    CellAt(view, GridRowKind.AdditionRow, 0, 2),
+                    CellAt(view, GridRowKind.AdditionRow, 1, HardColumnCount - 1),
+                    CellAt(view, GridRowKind.AnswerRow, 0, 1)
+                };
+
+                foreach (var cell in reachable)
+                {
+                    Tap(cell);
+
+                    Assert.That(view.CaretCell, Is.SameAs(cell), "tapping moves the caret here");
+                    Assert.That(
+                        cell.Fill.color,
+                        Is.EqualTo(FocusFill),
+                        cell.RowKind + " cell " + cell.Column + " is tinted while the caret is in it");
+
+                    // And it is separable from the unfocused cells of its own
+                    // kind — a carry box beside a carry box, not just against
+                    // the answer row.
+                    foreach (var sibling in EditableCells(view)
+                        .Where(other => other.RowKind == cell.RowKind && other != cell))
+                    {
+                        Assert.That(
+                            ContrastRatio(cell.Fill.color, sibling.Fill.color),
+                            Is.GreaterThanOrEqualTo(MinimumContrastRatio));
+                        Assert.That(
+                            ColourDistance(cell.Fill.color, sibling.Fill.color),
+                            Is.GreaterThanOrEqualTo(MinimumColourDistance));
+                    }
+                }
             }
             finally
             {
@@ -1582,6 +1769,137 @@ namespace Frogs.Unity.EditModeTests
                 .Where(cell => cell.Border != null)
                 .SelectMany(cell => new[] { cell.Border.color, cell.Fill.color, cell.Label.color })
                 .ToArray();
+        }
+
+        // ---------------------------------------------------------------
+        // The focused cell (#304).
+        // ---------------------------------------------------------------
+
+        // docs/specs/ui/working-out-grid.md § Named constants — `GridFocusFill`,
+        // the page's own value, copied here by hand rather than read from the
+        // view so the code cannot be repainted without the spec page moving too.
+        static readonly Color FocusFill = new Color32(0x8C, 0xB8, 0x9E, 0xFF);
+
+        // The bar the project already uses for "clearly separable" —
+        // docs/specs/ui/game-board.md#keeping-the-frogs-visible. Two measures,
+        // because either alone can be fooled: a luminance contrast ratio, and a
+        // CIE L*a*b* distance.
+        const float MinimumContrastRatio = 1.9f;
+        const float MinimumColourDistance = 30f;
+
+        // A digit on the tint it sits on is text, and text has a higher bar.
+        const float MinimumTextContrastRatio = 4.5f;
+
+        static IEnumerable<WorkingOutGridCell> EditableCells(WorkingOutGridView view)
+        {
+            return view.Cells.SelectMany(row => row).Where(cell => cell.IsEditable && cell.Border != null);
+        }
+
+        static float BorderWidthOf(WorkingOutGridCell cell)
+        {
+            // What BuildBox draws an outline with: the fill is inset from the
+            // border box by the outline's width on every side.
+            return cell.Fill.rectTransform.offsetMin.x;
+        }
+
+        static void AssertOnlyTheCaretIsTinted(WorkingOutGridView view, string when)
+        {
+            var tinted = EditableCells(view).Where(cell => cell.Fill.color == FocusFill).ToArray();
+
+            Assert.That(tinted.Length, Is.EqualTo(1), "exactly one cell is focused " + when);
+            Assert.That(tinted[0], Is.SameAs(view.CaretCell), "the tinted cell is the caret's " + when);
+        }
+
+        // How many cells' colours changed between two CellColours readings —
+        // three slots per cell, in the order CellColours emits them.
+        static int ChangedCells(Color[] before, Color[] after)
+        {
+            Assert.That(after.Length, Is.EqualTo(before.Length), "the same cells are drawn either side");
+
+            const int SlotsPerCell = 3;
+            var changed = 0;
+
+            for (var cell = 0; cell * SlotsPerCell < before.Length; cell++)
+            {
+                for (var slot = 0; slot < SlotsPerCell; slot++)
+                {
+                    var index = (cell * SlotsPerCell) + slot;
+
+                    if (before[index] != after[index])
+                    {
+                        changed++;
+                        break;
+                    }
+                }
+            }
+
+            return changed;
+        }
+
+        static float ContrastRatio(Color a, Color b)
+        {
+            var first = RelativeLuminance(a);
+            var second = RelativeLuminance(b);
+
+            return (Mathf.Max(first, second) + 0.05f) / (Mathf.Min(first, second) + 0.05f);
+        }
+
+        static float RelativeLuminance(Color colour)
+        {
+            return (0.2126f * ToLinear(colour.r))
+                + (0.7152f * ToLinear(colour.g))
+                + (0.0722f * ToLinear(colour.b));
+        }
+
+        static float ToLinear(float channel)
+        {
+            return channel <= 0.04045f
+                ? channel / 12.92f
+                : Mathf.Pow((channel + 0.055f) / 1.055f, 2.4f);
+        }
+
+        // Straight-line distance in CIE L*a*b* (ΔE*ab), the same arithmetic
+        // GameBoardColoursTests.cs measures the pond with.
+        static float ColourDistance(Color a, Color b)
+        {
+            var first = ToLab(a);
+            var second = ToLab(b);
+
+            var dl = first.x - second.x;
+            var da = first.y - second.y;
+            var db = first.z - second.z;
+
+            return Mathf.Sqrt((dl * dl) + (da * da) + (db * db));
+        }
+
+        static Vector3 ToLab(Color colour)
+        {
+            var r = ToLinear(colour.r);
+            var g = ToLinear(colour.g);
+            var b = ToLinear(colour.b);
+
+            // sRGB to CIE XYZ, D65.
+            var x = ((0.4124564f * r) + (0.3575761f * g) + (0.1804375f * b)) / 0.95047f;
+            var y = (0.2126729f * r) + (0.7151522f * g) + (0.0721750f * b);
+            var z = ((0.0193339f * r) + (0.1191920f * g) + (0.9503041f * b)) / 1.08883f;
+
+            var fx = LabF(x);
+            var fy = LabF(y);
+            var fz = LabF(z);
+
+            return new Vector3(
+                (116f * fy) - 16f,
+                500f * (fx - fy),
+                200f * (fy - fz));
+        }
+
+        static float LabF(float t)
+        {
+            const float Epsilon = 216f / 24389f;
+
+            return t > Epsilon
+                ? Mathf.Pow(t, 1f / 3f)
+                : ((841f / 108f) * t) + (4f / 29f);
         }
 
         // Grows the addition section by typing one digit into whatever its

--- a/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
+++ b/docs/specs/ui/mockups/working-out-grid-331x41-grown.html
@@ -30,6 +30,8 @@
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
     --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    /* the cell the caret is in — working-out-grid.md's `GridFocusFill` */
+    --focus:#8CB89E;
     --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
   }
   *{box-sizing:border-box;margin:0;padding:0}
@@ -130,7 +132,7 @@
           <div class="cell fix" style="font-size:28px;color:#6C7873">=</div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5">1</div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5">3</div>
-          <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5;border-color:var(--accent)"></div>
+          <div class="cell" style="height:128px;border-width:6px;background:var(--focus);border-color:var(--accent)"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
         </div>

--- a/docs/specs/ui/mockups/working-out-grid-331x41.html
+++ b/docs/specs/ui/mockups/working-out-grid-331x41.html
@@ -20,6 +20,8 @@
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
     --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    /* the cell the caret is in — working-out-grid.md's `GridFocusFill` */
+    --focus:#8CB89E;
     --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
   }
   *{box-sizing:border-box;margin:0;padding:0}
@@ -94,11 +96,11 @@
           <div class="cell fix" style="font-size:28px;color:#6C7873">=</div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5">1</div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5">3</div>
-          <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5;border-color:var(--accent)"></div>
+          <div class="cell" style="height:128px;border-width:6px;background:var(--focus);border-color:var(--accent)"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
         </div>
-        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:664px;text-align:center">the answer row — the only row that counts</div>
+        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:664px;text-align:center">the answer row — the only row that counts · the filled box is where the next digit goes</div>
       </div>
 
       <!-- Annotation, not an element. -->

--- a/docs/specs/ui/mockups/working-out-grid-68x5.html
+++ b/docs/specs/ui/mockups/working-out-grid-68x5.html
@@ -23,6 +23,8 @@
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
     --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    /* the cell the caret is in — working-out-grid.md's `GridFocusFill` */
+    --focus:#8CB89E;
     --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
   }
   *{box-sizing:border-box;margin:0;padding:0}
@@ -96,11 +98,11 @@
         <div class="row" style="gap:8px"><div class="carry"></div><div class="carry"><i></i></div><div class="carry"><i></i></div><div class="carry"><i></i></div></div>
         <div class="row" style="gap:8px">
           <div class="cell fix" style="font-size:28px;color:#6C7873">=</div>
-          <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5;border-color:var(--accent)"></div>
+          <div class="cell" style="height:128px;border-width:6px;background:var(--focus);border-color:var(--accent)"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
           <div class="cell" style="height:128px;border-width:6px;background:#F3F8F5"></div>
         </div>
-        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:440px;text-align:center">the answer row — the only row that counts</div>
+        <div style="font-size:28px;color:#6C7873;margin-top:8px;width:440px;text-align:center">the answer row — the only row that counts · the filled box is where the next digit goes</div>
       </div>
 
       <!-- Annotation, not an element. -->

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -150,6 +150,7 @@ the screen is built to.
 | Card readout label | `GridCardReadoutLabelSize` | 40 px |
 | Addition rows a card is dealt | `GridAdditionRowsAtStart` | 2 rows |
 | Most addition rows the section can hold | `GridAdditionRowsMax` | 6 rows |
+| Fill of the cell the caret is in | `GridFocusFill` | `#8CB89E` |
 | Keypad, down from the panel's top edge | `KeypadTop` | 216 px |
 | Keypad key, square | `KeypadKeySize` | 140 px |
 | Gap between keys | `KeypadKeyGap` | 16 px |
@@ -191,6 +192,50 @@ Growing the section therefore costs `GridAdditionRowHeight` + `GridCellGap` =
 64 px per row instead of the 112 px it would cost at full size, and the first
 grown row *shrinks* the grid rather than stretching it — see
 [Mockup](#mockup) for the whole sum.
+
+**`GridFocusFill` is the one colour on that table**, and it is there because it
+is the one colour that carries a rule rather than a picture's paint. The rest of
+this screen's palette is the mockups' — ink, line, faint, paper, accent — copied
+into the shell and named nowhere. This one has to clear a bar, and a bar needs
+somewhere to be written down.
+
+### What focus looks like
+
+**The cell the caret is in is filled with `GridFocusFill`**, and keeps the
+accent outline it already had. Nothing else about it changes: not
+`GridCellSize`, not `GridCarryBoxSize`, not `GridCellBorderWidth` or
+`GridAnswerBorderWidth`. A filled box among empty boxes reads from across a
+room; a box that is bigger or thicker than its neighbours is a different layout,
+and layout is what the mockups are for.
+
+Until [#304](https://github.com/derekwinters/connor-multiplying-frogs/issues/304)
+this page said nothing at all about focus, and the shell filled the blank with
+the quietest option available: the 3 px outline swapped from `#6C7873` grey to
+`#2E7D4F` accent green, and nothing else. That is two mid-tone colours on a
+hairline, and on the tablet Derek could not see it — knowing it was there. A
+player who cannot tell which box the next digit lands in taps a box before every
+digit, which is what he did.
+
+The fill is the accent green the outline already uses, laid over paper at 55 %,
+taken to where it clears the bar the project already sets for two colours being
+**clearly separable** — a luminance contrast of at least **1.9 : 1** *and* a CIE
+L\*a\*b\* distance (ΔE\*ab) of at least **30**, both measures, for the reasons
+[`game-board.md`](game-board.md#keeping-the-frogs-visible) gives.
+
+It has to clear that bar twice over, because a focused cell lands on two
+different fills depending on where the caret is: the ordinary cell fill, and the
+answer row's own tint. As *contrast : 1 / ΔE*:
+
+| | Paper, `#FFFFFF` — every cell but the answer row's | The answer row's tint, `#F3F8F5` |
+| --- | --- | --- |
+| `GridFocusFill` | 2.22 / 36.2 | 2.07 / 32.5 |
+
+Both clear it, the answer row being the tighter of the two, which is the pair
+the treatment was always going to be decided by. Two more ratios worth recording
+because they are what a darker tint would cost: a digit on the focused fill is
+**7.11 : 1** (`#1E2422` ink, against a 4.5 : 1 text bar), and the accent outline
+against the fill inside it is **2.27 : 1 / 30.4**, so the box still reads as a
+box rather than as a blob.
 
 ### How many columns and rows
 
@@ -289,8 +334,11 @@ past it.
   work, and pre-printing it would pick one — which is the thing ADR-0002 says
   not to do.
   - **A grown row is indistinguishable from a dealt one.** Same cells, same
-    size, same border, no tint, no badge, nothing that says "you added this".
+    size, same border, no badge, nothing that says "you added this".
     The section is scratch paper and scratch paper does not annotate itself.
+    The one fill a cell in the section can carry is `GridFocusFill`, and that is
+    not a mark on the row: it is on whichever single cell the caret is in, dealt
+    or grown, and it is gone the moment the caret leaves.
     The smaller `GridAdditionRowHeight` a grown section takes applies to *every*
     row in it, the two dealt ones included — a section where the first two rows
     were taller than the four below them would be exactly the "you added this"
@@ -310,6 +358,15 @@ past it.
 - Entering from [roll and card](roll-and-card.md). The first empty answer cell
   is the focused one; typing fills the answer row **right to left**, which is
   the direction the digits are worked out in.
+- **Exactly one cell is focused, always, and it is the one the next digit lands
+  in.** It is drawn filled with `GridFocusFill` — see
+  [what focus looks like](#what-focus-looks-like) — and the fill follows the
+  caret everywhere it goes: through typing, backspace, `clear`, a tap on another
+  cell, and a section that grows or shrinks underneath it. It is drawn on carry
+  boxes and addition cells exactly as it is in the answer row, because the caret
+  goes there too. When the caret leaves a cell, the cell goes back to the fill
+  it had — the tint is where the next digit goes, never a record of where one
+  has been.
 - Tapping any cell moves the caret there, so the grid can be filled in any
   order — a player who fills the addition rows first, then the answer, is not
   fighting the caret.
@@ -356,6 +413,14 @@ Three, all at 1920 × 1200.
 - **The widest card, as dealt:** [`mockups/working-out-grid-331x41.html`](mockups/working-out-grid-331x41.html)
 - **The easy pile, as dealt:** [`mockups/working-out-grid-68x5.html`](mockups/working-out-grid-68x5.html)
 - **The widest card, grown to the cap:** [`mockups/working-out-grid-331x41-grown.html`](mockups/working-out-grid-331x41-grown.html)
+
+**All three draw the focused cell**, filled with `GridFocusFill`. They always
+drew one — an answer cell with the accent outline — and until
+[#304](https://github.com/derekwinters/connor-multiplying-frogs/issues/304) that
+outline was the whole of it, in the drawings as in the shell. The cell is in the
+same place in each; what changed is that you can now see which one it is. A
+picture of this screen without a visible focused cell is a picture of a state
+the player never actually sees.
 
 The first two are the agreed pictures of the screen a card deals, and they are a
 pair for the reason they always were: "the grid shrinks to fit the card" is a

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -171,12 +171,16 @@ gets changed. They are the two rows on this table `Core` owns
 ([`WorkingOutGrid`](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/Assets/Scripts/Core/WorkingOutGrid.cs)),
 and the shell references them rather than keeping a copy.
 
-**Every value above is a number a drawing already fixed**, except two:
+**Every value above is a number a drawing already fixed**, except three:
+`GridFocusFill`, which is
+[#304](https://github.com/derekwinters/connor-multiplying-frogs/issues/304)'s
+and is arrived at against a bar rather than read off a picture — see
+[what focus looks like](#what-focus-looks-like);
 `GridAdditionRowHeight`, which is Derek's answer to
 [open question 3](#open-questions), and `GridSmallDigitSize`, which is what a
 digit has to shrink to in order to sit inside a 56 px-tall box. No committed
 drawing shows a digit in one — no mockup fills a carry box, and the grown
-drawing's rows are empty — so it is the one number here read off a proportion
+drawing's rows are empty — so it is read off a proportion
 instead of a picture: the same share of its box's height that `GridDigitSize`
 (56 px) is of `GridCellSize` (104 px), which lands on the 28 px the drawings
 already use for their smallest glyph.


### PR DESCRIPTION
Closes #304

The working-out grid already marked the box your next digit goes into — by
swapping a 3 px outline from grey to green, which is two mid-tone colours on a
hairline. Derek could not see it on the tablet, knowing it was there, and a
player who cannot see it taps a box before every single digit. The focused box
is now **filled** with a pale green as well, so you can tell from across the room
where you are typing. Nothing moved and nothing changed size: same boxes, same
outlines, one of them filled in.

**Docs:** `docs/specs/ui/working-out-grid.md` — the page had never said what
focus looks like, and now it does. A new `GridFocusFill` (`#8CB89E`) in the
constants table; a **What focus looks like** section giving the rule, the bar it
had to clear and the ratios it clears it by; a Behaviour bullet saying exactly
one cell is focused and the fill follows the caret through typing, backspace,
`clear`, a tap, and a section growing or shrinking; and the Elements bullet on
grown addition rows amended, because it said a cell in the section carries "no
tint" and one now can. All three mockups draw the focused cell filled.

## Spec invariants this had to keep true

| The rule | What holds it |
| --- | --- |
| Nothing in the grid is marked, ever | `Grid_MarksNothing_AndHasNoWayToKnowWhatWouldBeCorrect` — its colour-diff assertion now counts **cells** rather than colour slots, so it still says "only the caret's old and new cell ever differ" while the focused cell legitimately changes two of its three colours |
| A grown addition row is indistinguishable from a dealt one | `AdditionSection_GrowsADigitAtATime_…` parks the caret outside the section before comparing rows. The tint is on the caret's cell, dealt or grown, and is gone the moment the caret leaves — it is not a badge the row keeps |
| No cell's size and no outline width changes — a restyle, not structure, so the mockups stay accurate and no wireframe is gated on | `TheFocusedCell_IsFilledWithTheFocusTint_…` asserts the focused cell's rect, its border rect and its outline width all equal an unfocused neighbour's |
| The caret can be anywhere the player put it | `TheFocusTint_IsDrawnOnCarryBoxesAndAdditionCells_NotOnlyInTheAnswerRow` walks both carry strips, the addition section and the answer row |
| Exactly one cell is focused | `ExactlyOneCell_CarriesTheFocusTint_AndItFollowsTheCaretEverywhereItGoes`, through typing, backspace, `clear`, a tap, a grown section and a shrunk one |

## How the spec is changing

**Old rule:** none. The page named a constant for every outline width and a
colour for everything on the screen, and said of focus only that "the first
empty answer cell is the focused one". The accent outline in the shell was the
code filling a blank the page left.

**New rule:** the cell the caret is in is filled with `GridFocusFill`, keeps the
accent outline it already had, and changes size in no way. The fill is the
accent green over paper at 55 %, taken to where it clears the bar this project
already sets for two colours being clearly separable — 1.9 : 1 contrast *and*
ΔE\*ab 30, [`game-board.md`](docs/specs/ui/game-board.md#keeping-the-frogs-visible)'s
bar — against **both** fills a focused cell can land on:

| | Paper `#FFFFFF` | The answer row's tint `#F3F8F5` |
| --- | --- | --- |
| `GridFocusFill` | 2.22 : 1 / 36.2 | 2.07 : 1 / 32.5 |

**Why it is better:** the treatment that was there could only be seen by someone
looking for it, and a grid is a field of identical boxes where exactly one of
them is live. A filled box among empty boxes is the cheapest possible way to say
which, and it costs no layout — which is what keeps this a restyle rather than
something that needs a wireframe first.

## Red before green

The tests went up on their own commit (e0a8fd6) and CI turned the EditMode suite
red; the fix (2f47fb0) turned it green. The exact failed-of-total counts are in
the job log and the results artifact, and both are unreachable from this
environment, so what evidences the red is: the run reached **Verify the
results** — the step that reads the results XML — after a **2m10s** suite run,
which is the same duration as the last three green EditMode runs on `main`
(2m10s, 2m18s, 2m16s). A suite that failed to compile does not run for two
minutes or produce an XML for the verifier to read. The new tests also reference
no member the fix adds, so there was nothing there to fail to compile.

## Deviations and Decisions

- **The exact colour is mine, and it is the one thing here a reviewer might have
  chosen differently.** The issue settled the *treatment* — a tinted fill,
  keeping the accent outline, at the existing widths — and Derek approved it,
  but no agreed value existed. Rather than pick a shade by eye I derived one:
  the accent green the outline already uses, over paper, taken darker until it
  cleared game-board.md's existing separability bar against both the paper fill
  and the answer row's tint, which is the tighter of the two. That lands at
  `#8CB89E`. If Connor wants it another colour, the rule and the ratios are on
  the spec page and the value is one constant.
- **I reused `game-board.md`'s bar (1.9 : 1 and ΔE 30) rather than setting a new
  one for this page.** The checklist asked for contrast to be recorded "the way
  `game-board.md` records its ratios", and a second, different bar for the same
  question on another page is how two bars end up disagreeing.
- **One test outside the checklist changed.**
  `AdditionSection_GrowsADigitAtATime_…` asserts that every addition row is
  drawn identically, and growing a row leaves the caret in it — so the tint made
  that assertion fail for a legitimate reason. The caret is now parked in the
  answer row before the comparison, and the spec bullet it enforces says why.
  Same class of change as the `Grid_MarksNothing_…` threshold the plan called
  out, found the same way.
- **The `Grid_MarksNothing_…` threshold changed unit, not value.** The plan
  suggested raising `2` to the new number of colour slots (4). It now counts
  cells instead, and stays at 2 — the invariant is "only two cells ever differ",
  and a slot count is a number that has to be edited again the next time the
  focused cell's treatment moves.
- **The issue says no mockup drew a focused cell; all three did.** Each already
  had one answer cell with the accent outline. The spec's Mockup section now
  says so, and the change to the drawings is the fill, not a new cell.
- **Not done: looking at it on the tablet.** That is the issue's own "how to
  verify it's done", it needs the device, and it is Derek's and Connor's call on
  whether the green is the right green. I have not opened a
  `Direct Involvement Needed` issue for it, because it is this PR's review
  rather than a task that blocks anything.


---
_Generated by [Claude Code](https://claude.ai/code)_