### PR TITLE
fix(working-out-grid): typing an answer straight in enters it forwards

### DIFF
--- a/Assets/Scripts/Core/DigitRow.cs
+++ b/Assets/Scripts/Core/DigitRow.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Text;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One editable row of the working-out grid — a row of boxes a player
+    /// types digits into, and the number that row reads as.
+    /// docs/specs/ui/working-out-grid.md#behaviour.
+    ///
+    /// Every editable row is one of these: the answer row, each addition row,
+    /// and each carry strip. Only the answer row's <see cref="ReadLeftToRight"/>
+    /// is ever graded, and this type does not know which row it is — grading
+    /// is <see cref="Lane.Resolve"/>'s, and nothing here has any idea what a
+    /// right answer would be.
+    ///
+    /// **Why this is in Core.** What a row of boxes reads as, and which box
+    /// the next digit goes in, can both be right or wrong with no screen
+    /// attached — and being wrong about the second made the first wrong in
+    /// front of a player
+    /// ([#305](https://github.com/derekwinters/connor-multiplying-frogs/issues/305)).
+    /// The shell owns where the boxes are drawn and which row the caret is in;
+    /// this type owns the column the caret is in within a row, so the rule
+    /// that broke is one a two-second test can hold down.
+    ///
+    /// Columns are the grid's own, so the shell can index cells and this type
+    /// with the same number: column 0 is the operator column on every row and
+    /// is never typed into, and the digit columns run from
+    /// <see cref="FirstDigitColumn"/> to <see cref="LastDigitColumn"/>.
+    /// </summary>
+    public sealed class DigitRow
+    {
+        readonly int?[] _digits;
+        readonly int[] _stamps;
+
+        /// <summary>
+        /// A row with <paramref name="columnCount"/> columns in total, of
+        /// which the ones from <paramref name="firstDigitColumn"/> onwards can
+        /// hold a digit.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="firstDigitColumn"/> is negative, or the row has no
+        /// digit column at all.
+        /// </exception>
+        public DigitRow(int columnCount, int firstDigitColumn)
+        {
+            if (firstDigitColumn < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(firstDigitColumn),
+                    firstDigitColumn,
+                    "The first digit column cannot be negative.");
+            }
+
+            if (columnCount <= firstDigitColumn)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(columnCount),
+                    columnCount,
+                    "A row needs at least one digit column after the operator column.");
+            }
+
+            FirstDigitColumn = firstDigitColumn;
+            _digits = new int?[columnCount];
+            _stamps = new int[columnCount];
+        }
+
+        /// <summary>
+        /// The leftmost column a digit can go in, and — since
+        /// [#305](https://github.com/derekwinters/connor-multiplying-frogs/issues/305)
+        /// — where the caret starts in a row nobody has typed in yet.
+        /// </summary>
+        public int FirstDigitColumn { get; }
+
+        /// <summary>
+        /// The rightmost column a digit can go in. The caret stops here rather
+        /// than wrapping to another row or reaching the operator column.
+        /// </summary>
+        public int LastDigitColumn
+        {
+            get { return _digits.Length - 1; }
+        }
+
+        /// <summary>
+        /// Where the caret goes after a digit lands in
+        /// <paramref name="column"/>: one cell to the **right**, stopping at
+        /// <see cref="LastDigitColumn"/>.
+        ///
+        /// This is the whole of #305. The grid used to fill right to left,
+        /// "which is the direction the digits are worked out in", while
+        /// <see cref="ReadLeftToRight"/> read it back the other way — so a
+        /// player who typed 3, 4, 0 for 340 submitted 43. One direction now,
+        /// in every row kind, and it is the reading one.
+        /// </summary>
+        public int NextColumnAfterTyping(int column)
+        {
+            if (column < FirstDigitColumn)
+            {
+                return FirstDigitColumn;
+            }
+
+            return column < LastDigitColumn ? column + 1 : LastDigitColumn;
+        }
+
+        /// <summary>Whether <paramref name="column"/> holds a digit.</summary>
+        public bool HasDigit(int column)
+        {
+            return column >= 0 && column < _digits.Length && _digits[column].HasValue;
+        }
+
+        /// <summary>
+        /// What <paramref name="column"/> reads as — the digit, or the empty
+        /// string when the box is empty.
+        /// </summary>
+        public string TextAt(int column)
+        {
+            return HasDigit(column) ? _digits[column].Value.ToString() : string.Empty;
+        }
+
+        /// <summary>
+        /// Puts <paramref name="digit"/> in <paramref name="column"/>,
+        /// overwriting whatever was there. <paramref name="stamp"/> orders it
+        /// against every other digit in the grid, which is what
+        /// <see cref="LastEnteredColumn"/> reads. A column outside the row, or
+        /// the operator column, is ignored rather than throwing: a tap that
+        /// cannot land is not an error.
+        /// </summary>
+        public void Write(int column, int digit, int stamp)
+        {
+            if (column < FirstDigitColumn || column >= _digits.Length)
+            {
+                return;
+            }
+
+            _digits[column] = digit;
+            _stamps[column] = stamp;
+        }
+
+        /// <summary>Empties <paramref name="column"/>.</summary>
+        public void Erase(int column)
+        {
+            if (column < 0 || column >= _digits.Length)
+            {
+                return;
+            }
+
+            _digits[column] = null;
+            _stamps[column] = 0;
+        }
+
+        /// <summary>
+        /// Empties every column — what `clear` does to the row the caret is
+        /// in, and to no other row.
+        /// </summary>
+        public void EraseAll()
+        {
+            for (var column = 0; column < _digits.Length; column++)
+            {
+                _digits[column] = null;
+                _stamps[column] = 0;
+            }
+        }
+
+        /// <summary>Whether the row holds no digits at all.</summary>
+        public bool IsEmpty()
+        {
+            for (var column = 0; column < _digits.Length; column++)
+            {
+                if (_digits[column].HasValue)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The column of the digit typed most recently anywhere in this row,
+        /// which is what backspace takes away when the caret's own cell is
+        /// already empty, or -1 when the row is empty.
+        /// </summary>
+        public int LastEnteredColumn()
+        {
+            var best = -1;
+
+            for (var column = 0; column < _digits.Length; column++)
+            {
+                if (!_digits[column].HasValue)
+                {
+                    continue;
+                }
+
+                if (best < 0 || _stamps[column] > _stamps[best])
+                {
+                    best = column;
+                }
+            }
+
+            return best;
+        }
+
+        /// <summary>
+        /// The row's digits read left to right, with empty boxes contributing
+        /// nothing — the string `Check it` submits when this is the answer
+        /// row.
+        ///
+        /// Empty boxes are skipped rather than filled with zeroes, so `36_`
+        /// and `_36` both read `36`. That is deliberate and settled: ADR-0002
+        /// checks the answer row's *value*, and lining a short answer up under
+        /// the place-value columns is the player's job, not the grid's.
+        /// </summary>
+        public string ReadLeftToRight()
+        {
+            var builder = new StringBuilder();
+
+            for (var column = 0; column < _digits.Length; column++)
+            {
+                if (_digits[column].HasValue)
+                {
+                    builder.Append(_digits[column].Value);
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/Core/DigitRow.cs.meta
+++ b/Assets/Scripts/Core/DigitRow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f79570e37b3040cda52258f0c4a67358
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Frogs.Core;
 using UnityEngine;
 using UnityEngine.UI;
@@ -270,9 +269,9 @@ namespace Frogs.Unity.Views
         // What the player has typed, held by row *identity* rather than by
         // display index: growing the section shifts every row below it down by
         // one, and a digit must not move with it.
-        readonly List<RowContents> _carryRows = new List<RowContents>();
-        readonly List<RowContents> _additionRows = new List<RowContents>();
-        RowContents _answerRow;
+        readonly List<DigitRow> _carryRows = new List<DigitRow>();
+        readonly List<DigitRow> _additionRows = new List<DigitRow>();
+        DigitRow _answerRow;
         int _columnCount;
         int _nextStamp;
 
@@ -505,8 +504,8 @@ namespace Frogs.Unity.Views
         /// <summary>
         /// Points the grid at the turn it was opened on, and at the router
         /// `Check it` navigates through, then opens it. The caret starts in
-        /// the rightmost answer cell — "the first empty answer cell is the
-        /// focused one; typing fills the answer row right to left."
+        /// the **leftmost** answer cell — "typing fills the answer row left to
+        /// right, which is the direction the answer is read in" (#305).
         ///
         /// The router is optional for the same reason
         /// <c>RollAndCardDialogView.Initialize</c>'s is: a test that only
@@ -529,9 +528,9 @@ namespace Frogs.Unity.Views
 
             Refresh();
 
-            // The rightmost answer cell, which on a grid nobody has typed in
-            // yet is also the first empty one.
-            MoveCaretTo(GridRowKind.AnswerRow, 0, _columnCount - 1);
+            // The leftmost answer cell: the first box of the number, so the
+            // first digit typed is the first digit read.
+            MoveCaretTo(GridRowKind.AnswerRow, 0, _answerRow.FirstDigitColumn);
 
             _dialog.Open();
         }
@@ -1242,15 +1241,15 @@ namespace Frogs.Unity.Views
 
             for (var index = 0; index < WorkingOutGrid.CarryStripCount; index++)
             {
-                _carryRows.Add(new RowContents(columnCount));
+                _carryRows.Add(NewRow(columnCount));
             }
 
             for (var index = 0; index < WorkingOutGrid.GridAdditionRowsAtStart; index++)
             {
-                _additionRows.Add(new RowContents(columnCount));
+                _additionRows.Add(NewRow(columnCount));
             }
 
-            _answerRow = new RowContents(columnCount);
+            _answerRow = NewRow(columnCount);
         }
 
         void HandleCellTapped(WorkingOutGridCell cell)
@@ -1303,11 +1302,11 @@ namespace Frogs.Unity.Views
                 RebuildGrid();
             }
 
-            // Right to left, "which is the direction the digits are worked
-            // out in": the next digit goes in the cell to the left, until
-            // there is no cell to the left.
-            var nextColumn = Mathf.Max(_caretColumn - 1, OperatorColumn + 1);
-            MoveCaretTo(_caretRowKind, _caretRowOrdinal, nextColumn);
+            // "After a digit lands, the caret steps one cell to the right, in
+            // whatever row it is in, and stops at the last digit column."
+            // Which column that is is the row's own business — #305, and the
+            // reason it is Core's rather than this view's.
+            MoveCaretTo(_caretRowKind, _caretRowOrdinal, contents.NextColumnAfterTyping(_caretColumn));
         }
 
         // "Typing a single digit into the section's current bottom row appends
@@ -1331,7 +1330,7 @@ namespace Frogs.Unity.Views
                 return false;
             }
 
-            _additionRows.Add(new RowContents(_columnCount));
+            _additionRows.Add(NewRow(_columnCount));
             return true;
         }
 
@@ -1436,12 +1435,21 @@ namespace Frogs.Unity.Views
             }
         }
 
-        RowContents CaretContents()
+        // Every editable row is the same Core type, and every one of them
+        // starts its digit columns after the operator column. What a row holds
+        // and which box the next digit goes in are both Core's — see
+        // <see cref="DigitRow"/> on why they are not this view's.
+        static DigitRow NewRow(int columnCount)
+        {
+            return new DigitRow(columnCount, OperatorColumn + 1);
+        }
+
+        DigitRow CaretContents()
         {
             return ContentsFor(_caretRowKind, _caretRowOrdinal);
         }
 
-        RowContents ContentsFor(GridRowKind kind, int ordinal)
+        DigitRow ContentsFor(GridRowKind kind, int ordinal)
         {
             switch (kind)
             {
@@ -1585,119 +1593,6 @@ namespace Frogs.Unity.Views
             text.raycastTarget = false;
             text.rectTransform.SetParent(parent, worldPositionStays: false);
             return text;
-        }
-
-        /// <summary>
-        /// What one row of the grid holds, and in what order it was typed.
-        /// Kept per row *identity* — the second carry strip, the fourth
-        /// addition row — rather than per drawn row, so a digit stays where it
-        /// was put when the section grows or shrinks underneath it.
-        ///
-        /// It holds digits and nothing else: no correct value, no flag for
-        /// whether a digit is right, nothing that could be rendered as a mark.
-        /// </summary>
-        sealed class RowContents
-        {
-            readonly int?[] _digits;
-            readonly int[] _stamps;
-
-            internal RowContents(int columnCount)
-            {
-                _digits = new int?[columnCount];
-                _stamps = new int[columnCount];
-            }
-
-            internal bool HasDigit(int column)
-            {
-                return column >= 0 && column < _digits.Length && _digits[column].HasValue;
-            }
-
-            internal string TextAt(int column)
-            {
-                return HasDigit(column) ? _digits[column].Value.ToString() : string.Empty;
-            }
-
-            internal void Write(int column, int digit, int stamp)
-            {
-                if (column < 0 || column >= _digits.Length)
-                {
-                    return;
-                }
-
-                _digits[column] = digit;
-                _stamps[column] = stamp;
-            }
-
-            internal void Erase(int column)
-            {
-                if (column < 0 || column >= _digits.Length)
-                {
-                    return;
-                }
-
-                _digits[column] = null;
-                _stamps[column] = 0;
-            }
-
-            internal void EraseAll()
-            {
-                for (var column = 0; column < _digits.Length; column++)
-                {
-                    _digits[column] = null;
-                    _stamps[column] = 0;
-                }
-            }
-
-            internal bool IsEmpty()
-            {
-                for (var column = 0; column < _digits.Length; column++)
-                {
-                    if (_digits[column].HasValue)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            // The digit typed most recently anywhere in this row, which is
-            // what backspace takes away when the caret's own cell is already
-            // empty.
-            internal int LastEnteredColumn()
-            {
-                var best = -1;
-
-                for (var column = 0; column < _digits.Length; column++)
-                {
-                    if (!_digits[column].HasValue)
-                    {
-                        continue;
-                    }
-
-                    if (best < 0 || _stamps[column] > _stamps[best])
-                    {
-                        best = column;
-                    }
-                }
-
-                return best;
-            }
-
-            internal string ReadLeftToRight()
-            {
-                var builder = new StringBuilder();
-
-                for (var column = 0; column < _digits.Length; column++)
-                {
-                    if (_digits[column].HasValue)
-                    {
-                        builder.Append(_digits[column].Value);
-                    }
-                }
-
-                return builder.ToString();
-            }
         }
     }
 }

--- a/Assets/Tests/EditMode/AppRootTests.cs
+++ b/Assets/Tests/EditMode/AppRootTests.cs
@@ -487,13 +487,14 @@ namespace Frogs.Unity.EditModeTests
 
         static void TypeAnswer(WorkingOutGridView view, int answer)
         {
-            // The caret starts on the rightmost answer cell and walks left, so
-            // an answer is typed units first — the way it is written.
+            // The caret starts on the leftmost answer cell and walks right
+            // (#305), so an answer is typed the way it is written and read:
+            // most significant digit first, no tapping between digits.
             var digits = answer.ToString();
 
-            for (var index = digits.Length - 1; index >= 0; index--)
+            foreach (var character in digits)
             {
-                var digit = digits[index] - '0';
+                var digit = character - '0';
                 Tap(view.Keys.Single(key => key.Kind == KeypadKeyKind.Digit && key.Digit == digit));
             }
 

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
@@ -425,6 +425,55 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
+        public void TheCaretStepsRightInEveryRowKind_NotOnlyInTheAnswerRow()
+        {
+            // "One rule everywhere": the scratch paper fills the same way the
+            // answer does, so there is one direction to learn rather than one
+            // for the answer row and another for everything above it. Each
+            // block below is tapped into once and then typed straight through.
+            var view = CreateView(Turn(Pile.Hard));
+
+            try
+            {
+                var blocks = new[]
+                {
+                    // The top carry strip, the second carry strip, and an
+                    // addition row that is not the section's bottom — so the
+                    // section does not grow underneath the assertion.
+                    RowIndexOf(view, GridRowKind.CarryStrip, 0),
+                    RowIndexOf(view, GridRowKind.CarryStrip, 1),
+                    RowIndexOf(view, GridRowKind.AdditionRow, 0),
+                };
+
+                foreach (var row in blocks)
+                {
+                    Tap(view.Cells[row][FirstDigitColumn]);
+
+                    Type(view, 4);
+                    Type(view, 5);
+                    Type(view, 6);
+
+                    Assert.That(view.Cells[row][FirstDigitColumn].Content, Is.EqualTo("4"));
+                    Assert.That(view.Cells[row][FirstDigitColumn + 1].Content, Is.EqualTo("5"));
+                    Assert.That(view.Cells[row][FirstDigitColumn + 2].Content, Is.EqualTo("6"));
+                    Assert.That(
+                        view.CaretCell,
+                        Is.EqualTo(view.Cells[row][FirstDigitColumn + 3]),
+                        "and the caret is on the next box to the right, still in this row");
+                }
+
+                Assert.That(
+                    view.AdditionRowCount,
+                    Is.EqualTo(WorkingOutGrid.GridAdditionRowsAtStart),
+                    "nothing here was typed into the section's bottom row, so nothing grew");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
         public void AShortAnswerTypedFromATappedCell_StaysInTheColumnsItWasTappedInto()
         {
             // The consequence of boxes-as-slots that Derek chose deliberately:

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
@@ -57,6 +57,11 @@ namespace Frogs.Unity.EditModeTests
         const int EasyColumnCount = 4;
         const int HardColumnCount = 6;
 
+        // The operator column is column 0 on every row, and is never typed
+        // into; the digit columns run from the one after it to the last.
+        const int OperatorColumnIndex = 0;
+        const int FirstDigitColumn = OperatorColumnIndex + 1;
+
         [Test]
         public void Grid_ForTheEasyShape_DrawsCoresOwnRowSequence_WithARuleUnderTheMultiplierAndUnderTheSection()
         {
@@ -283,7 +288,51 @@ namespace Frogs.Unity.EditModeTests
         }
 
         [Test]
-        public void Caret_OpensOnTheRightmostAnswerCell_AndEachDigitFillsTheNextCellToItsLeft()
+        public void TypingAnAnswerStraightIn_SubmitsTheNumberThatWasTyped()
+        {
+            // #305, as Derek reported it from the tablet. A player who knows
+            // `68 × 5` is 340 types 3, 4, 0 — the order anybody writes a
+            // number — without tapping anything first.
+            //
+            // Before this issue the caret opened on the *rightmost* answer
+            // cell and stepped left, so those keystrokes landed as `__3`,
+            // `_43`, `043`, and `Check it` submitted **43**: the
+            // multiplication done correctly and the frog left where it was.
+            // The only way to enter 340 was to tap each box in turn, which is
+            // the workaround the report describes rather than a preference.
+            var turn = Turn(Pile.Easy);
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.WorkingOutGrid);
+
+            var view = CreateView(turn, router);
+
+            try
+            {
+                var answerRow = RowIndexOf(view, GridRowKind.AnswerRow);
+
+                Assert.That(
+                    view.CaretCell,
+                    Is.EqualTo(view.Cells[answerRow][FirstDigitColumn]),
+                    "the answer row's leftmost digit column, so the first digit typed is the first digit read");
+
+                Type(view, 3);
+                Type(view, 4);
+                Type(view, 0);
+
+                Assert.That(view.AnswerText, Is.EqualTo("340"), "the number on the screen is the number that was typed");
+
+                Tap(view.CheckItButton);
+
+                Assert.That(turn.Submitted, Is.EqualTo(new[] { 340 }), "and the number submitted is the same one again");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Caret_OpensOnTheLeftmostAnswerCell_AndEachDigitFillsTheNextCellToItsRight()
         {
             var view = CreateView(Turn(Pile.Hard));
 
@@ -293,23 +342,122 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(
                     view.CaretCell,
-                    Is.EqualTo(view.Cells[answerRow][HardColumnCount - 1]),
-                    "the first empty answer cell, filling right to left");
+                    Is.EqualTo(view.Cells[answerRow][FirstDigitColumn]),
+                    "the leftmost digit column, filling left to right");
 
                 Type(view, 1);
-                Assert.That(view.Cells[answerRow][HardColumnCount - 1].Content, Is.EqualTo("1"));
-                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][HardColumnCount - 2]));
+                Assert.That(view.Cells[answerRow][FirstDigitColumn].Content, Is.EqualTo("1"));
+                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][FirstDigitColumn + 1]));
 
-                Type(view, 7);
-                Assert.That(view.Cells[answerRow][HardColumnCount - 2].Content, Is.EqualTo("7"));
+                Type(view, 3);
+                Assert.That(view.Cells[answerRow][FirstDigitColumn + 1].Content, Is.EqualTo("3"));
 
                 Type(view, 5);
-                Type(view, 3);
+                Type(view, 7);
                 Type(view, 1);
 
-                // Typed units-first, which is the direction the digits are
-                // worked out in — and reads left to right as the answer.
+                // Typed the way it is written and read the way it is written:
+                // one direction to learn, and it is the reading one.
                 Assert.That(view.AnswerText, Is.EqualTo("13571"));
+                Assert.That(
+                    view.CaretCell,
+                    Is.EqualTo(view.Cells[answerRow][HardColumnCount - 1]),
+                    "and the caret has come to rest on the last digit column");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Caret_StopsAtTheLastDigitColumn_SoAnOverlongAnswerOverwritesItRatherThanEscapingTheRow()
+        {
+            // The mirror of the bound the leftward caret used to hold at the
+            // first digit column. A player who keeps typing past the width of
+            // the grid must not wrap to the next row, walk into the operator
+            // column, or leave the row at all — the last box just takes the
+            // newest digit.
+            var view = CreateView(Turn(Pile.Easy));
+
+            try
+            {
+                var answerRow = RowIndexOf(view, GridRowKind.AnswerRow);
+                var lastColumn = EasyColumnCount - 1;
+
+                // The `=` the answer row's operator column is drawn with, so
+                // the assertion below is "still that" rather than "empty".
+                var operatorGlyph = view.Cells[answerRow][OperatorColumnIndex].Content;
+
+                Type(view, 3);
+                Type(view, 4);
+                Type(view, 0);
+
+                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][lastColumn]));
+
+                Type(view, 7);
+
+                Assert.That(view.AnswerText, Is.EqualTo("347"), "the last box took the new digit");
+                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][lastColumn]), "and the caret stayed on it");
+
+                Type(view, 9);
+
+                Assert.That(view.AnswerText, Is.EqualTo("349"), "however many more are typed");
+                Assert.That(view.CaretCell, Is.EqualTo(view.Cells[answerRow][lastColumn]));
+
+                // Nothing escaped the row: not into the operator column, and
+                // not into the row above.
+                Assert.That(
+                    view.Cells[answerRow][OperatorColumnIndex].Content,
+                    Is.EqualTo(operatorGlyph),
+                    "the operator column is not somewhere a digit can go");
+                Assert.That(
+                    view.Cells[RowIndexOf(view, GridRowKind.CarryStrip, 1)]
+                        .Where(cell => cell.IsEditable)
+                        .All(cell => cell.Content.Length == 0),
+                    Is.True,
+                    "and no digit reached the strip above the answer row");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void AShortAnswerTypedFromATappedCell_StaysInTheColumnsItWasTappedInto()
+        {
+            // The consequence of boxes-as-slots that Derek chose deliberately:
+            // the grid does not shuffle a short answer into place. `68 × 5`'s
+            // shape gets three digit columns, and a two-digit answer typed
+            // from the middle box occupies the middle and the right. Lining an
+            // answer up under the columns is the player's job.
+            var turn = Turn(Pile.Easy);
+            var router = new ScreenRouter();
+            router.OpenDialog(Frogs.Core.Dialog.WorkingOutGrid);
+
+            var view = CreateView(turn, router);
+
+            try
+            {
+                var answerRow = RowIndexOf(view, GridRowKind.AnswerRow);
+                var middleColumn = FirstDigitColumn + 1;
+
+                Tap(view.Cells[answerRow][middleColumn]);
+                Type(view, 3);
+                Type(view, 6);
+
+                Assert.That(view.Cells[answerRow][FirstDigitColumn].Content, Is.Empty, "the box that was not tapped into");
+                Assert.That(view.Cells[answerRow][middleColumn].Content, Is.EqualTo("3"));
+                Assert.That(view.Cells[answerRow][EasyColumnCount - 1].Content, Is.EqualTo("6"));
+
+                // And grading does not care which columns they landed in —
+                // ADR-0002 checks the answer row's *value*, and only that.
+                Assert.That(view.AnswerText, Is.EqualTo("36"));
+
+                Tap(view.CheckItButton);
+
+                Assert.That(turn.Submitted, Is.EqualTo(new[] { 36 }));
             }
             finally
             {
@@ -374,20 +522,20 @@ namespace Frogs.Unity.EditModeTests
                 // The answer row: two digits, then backspace with the caret on
                 // an empty cell — it takes the last one entered in this row,
                 // and leaves the addition row alone.
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn));
                 Type(view, 2);
                 Type(view, 8);
 
-                Assert.That(view.AnswerText, Is.EqualTo("82"));
+                Assert.That(view.AnswerText, Is.EqualTo("28"));
 
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, 1));
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
                 Backspace(view);
 
                 Assert.That(view.AnswerText, Is.EqualTo("2"), "the last digit entered in this block, and only it");
                 Assert.That(additionCell.Content, Is.EqualTo("4"), "nothing outside the caret's block moved");
 
                 // Now with the caret's own cell filled: that digit goes.
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn));
                 Backspace(view);
 
                 Assert.That(view.AnswerText, Is.Empty);
@@ -419,12 +567,12 @@ namespace Frogs.Unity.EditModeTests
                 Tap(additionCell);
                 Type(view, 6);
 
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn));
                 Type(view, 1);
                 Type(view, 2);
                 Type(view, 3);
 
-                Assert.That(view.AnswerText, Is.EqualTo("321"));
+                Assert.That(view.AnswerText, Is.EqualTo("123"));
 
                 Clear(view);
 
@@ -470,10 +618,10 @@ namespace Frogs.Unity.EditModeTests
                 // A deliberately wrong answer, so the test cannot pass by the
                 // grid quietly grading anything: `340` is the largest product
                 // the easy shape can hold and is not this card's.
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, EasyColumnCount - 1));
-                Type(view, 0);
-                Type(view, 4);
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn));
                 Type(view, 3);
+                Type(view, 4);
+                Type(view, 0);
 
                 Assert.That(view.AnswerText, Is.EqualTo("340"));
 
@@ -1028,7 +1176,7 @@ namespace Frogs.Unity.EditModeTests
                 // far is right or wrong.
                 var before = CellColours(view);
 
-                Tap(CellAt(view, GridRowKind.AnswerRow, 0, HardColumnCount - 1));
+                Tap(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn));
                 Type(view, 9);
                 Type(view, 9);
                 Type(view, 9);
@@ -1424,14 +1572,15 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(view.CheckItButton.IsDisabled, Is.True, "an empty answer is not a wrong answer");
 
-                screen.TapAt(CentreOf(CellAt(view, GridRowKind.AnswerRow, 0, EasyColumnCount - 1).RectTransform));
+                screen.TapAt(CentreOf(CellAt(view, GridRowKind.AnswerRow, 0, FirstDigitColumn).RectTransform));
 
                 // `340` again: the largest product the easy shape holds, and
                 // deliberately not this card's, so nothing can pass by the
-                // grid quietly grading it.
-                screen.TapAt(CentreOf(KeyFor(view, 0).RectTransform));
-                screen.TapAt(CentreOf(KeyFor(view, 4).RectTransform));
+                // grid quietly grading it. Typed in reading order, which
+                // since #305 is also the order the boxes fill in.
                 screen.TapAt(CentreOf(KeyFor(view, 3).RectTransform));
+                screen.TapAt(CentreOf(KeyFor(view, 4).RectTransform));
+                screen.TapAt(CentreOf(KeyFor(view, 0).RectTransform));
 
                 Assert.That(view.AnswerText, Is.EqualTo("340"), "three taps on the keypad, three digits in the answer row");
                 Assert.That(view.CheckItButton.IsDisabled, Is.False, "a digit is in, so the turn can be finished");

--- a/Tests/Core/DigitRowTests.cs
+++ b/Tests/Core/DigitRowTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Text;
+using Frogs.Core;
+using NUnit.Framework;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// One editable row of the working-out grid — issue #305, built to
+    /// docs/specs/ui/working-out-grid.md#behaviour.
+    ///
+    /// The rule this file exists for is the one #305 changed: a digit lands in
+    /// the caret's box and the caret steps one box to the **right**, stopping
+    /// at the last digit column. It used to step left, while the row was read
+    /// back left to right, so a player who typed 340 submitted 43.
+    ///
+    /// **Nothing here knows a correct answer.** A row reads as a number; what
+    /// that number is worth is <see cref="Lane.Resolve"/>'s business.
+    /// </summary>
+    public sealed class DigitRowTests
+    {
+        // The grid's own column numbering: column 0 is the operator column on
+        // every row and is never typed into. `68 × 5` gets three digit
+        // columns and `331 × 41` gets five, plus the operator column in both.
+        const int OperatorColumn = 0;
+        const int FirstDigitColumn = OperatorColumn + 1;
+        const int EasyColumnCount = 4;
+        const int HardColumnCount = 6;
+
+        static DigitRow EasyRow()
+        {
+            return new DigitRow(EasyColumnCount, FirstDigitColumn);
+        }
+
+        [Test]
+        public void ARowKnowsWhichColumnsCanHoldADigit()
+        {
+            var row = EasyRow();
+
+            Assert.That(row.FirstDigitColumn, Is.EqualTo(FirstDigitColumn));
+            Assert.That(row.LastDigitColumn, Is.EqualTo(EasyColumnCount - 1));
+            Assert.That(row.IsEmpty(), Is.True);
+            Assert.That(row.ReadLeftToRight(), Is.Empty);
+        }
+
+        [Test]
+        public void ARowNeedsAtLeastOneDigitColumn()
+        {
+            Assert.That(() => new DigitRow(1, FirstDigitColumn), Throws.TypeOf<ArgumentOutOfRangeException>());
+            Assert.That(() => new DigitRow(EasyColumnCount, -1), Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void AfterADigitLands_TheCaretStepsOneColumnToTheRight()
+        {
+            // #305, at the level the bug actually lives at. Typed in reading
+            // order, the digits occupy the columns in reading order.
+            var row = EasyRow();
+            var column = row.FirstDigitColumn;
+
+            column = Land(row, column, 3, 0);
+            Assert.That(column, Is.EqualTo(FirstDigitColumn + 1), "the box to the right of the one just filled");
+
+            column = Land(row, column, 4, 1);
+            Assert.That(column, Is.EqualTo(FirstDigitColumn + 2));
+
+            Land(row, column, 0, 2);
+
+            Assert.That(row.TextAt(FirstDigitColumn), Is.EqualTo("3"));
+            Assert.That(row.TextAt(FirstDigitColumn + 1), Is.EqualTo("4"));
+            Assert.That(row.TextAt(FirstDigitColumn + 2), Is.EqualTo("0"));
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("340"), "the number that was typed, not its reverse");
+        }
+
+        [Test]
+        public void TheCaretStopsAtTheLastDigitColumn_AndFurtherDigitsOverwriteIt()
+        {
+            // The mirror of the bound the leftward caret held at the first
+            // digit column: typing more digits than the grid is wide must not
+            // wrap, escape the row, or reach the operator column.
+            var row = EasyRow();
+
+            Assert.That(row.NextColumnAfterTyping(row.LastDigitColumn), Is.EqualTo(row.LastDigitColumn));
+
+            var column = row.FirstDigitColumn;
+
+            foreach (var digit in new[] { 3, 4, 0, 7, 9 })
+            {
+                column = Land(row, column, digit, 0);
+            }
+
+            Assert.That(column, Is.EqualTo(row.LastDigitColumn));
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("349"), "the last box took each new digit in turn");
+        }
+
+        [Test]
+        public void TheCaretNeverStepsIntoTheOperatorColumn_AndNoDigitCanBeWrittenThere()
+        {
+            var row = EasyRow();
+
+            Assert.That(row.NextColumnAfterTyping(OperatorColumn), Is.EqualTo(FirstDigitColumn));
+            Assert.That(row.NextColumnAfterTyping(-5), Is.EqualTo(FirstDigitColumn));
+
+            row.Write(OperatorColumn, 9, 0);
+            row.Write(EasyColumnCount, 9, 1);
+
+            Assert.That(row.IsEmpty(), Is.True, "the operator column is not a box a digit can go in");
+            Assert.That(row.ReadLeftToRight(), Is.Empty);
+        }
+
+        [Test]
+        public void AShortAnswerStaysInTheColumnsItWasTypedInto_AndStillReadsAsItsValue()
+        {
+            // Boxes are slots, and a slot is something you point at. The row
+            // does not shuffle a two-digit answer flush right, and grading
+            // does not care that it did not: ADR-0002 checks the answer row's
+            // value only.
+            var typedInTheMiddle = EasyRow();
+            var column = FirstDigitColumn + 1;
+            column = Land(typedInTheMiddle, column, 3, 0);
+            Land(typedInTheMiddle, column, 6, 1);
+
+            Assert.That(typedInTheMiddle.TextAt(FirstDigitColumn), Is.Empty);
+            Assert.That(typedInTheMiddle.ReadLeftToRight(), Is.EqualTo("36"));
+
+            var typedFlushLeft = EasyRow();
+            var left = typedFlushLeft.FirstDigitColumn;
+            left = Land(typedFlushLeft, left, 3, 0);
+            Land(typedFlushLeft, left, 6, 1);
+
+            Assert.That(typedFlushLeft.TextAt(FirstDigitColumn), Is.EqualTo("3"));
+            Assert.That(
+                typedFlushLeft.ReadLeftToRight(),
+                Is.EqualTo(typedInTheMiddle.ReadLeftToRight()),
+                "`36_` and `_36` are the same answer");
+        }
+
+        [Test]
+        public void TheWidestCardFillsLeftToRightToo_BecauseThereIsOneDirectionNotTwo()
+        {
+            var row = new DigitRow(HardColumnCount, FirstDigitColumn);
+            var column = row.FirstDigitColumn;
+
+            foreach (var digit in new[] { 1, 3, 5, 7, 1 })
+            {
+                column = Land(row, column, digit, 0);
+            }
+
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("13571"));
+            Assert.That(column, Is.EqualTo(HardColumnCount - 1), "come to rest on the last digit column");
+        }
+
+        [Test]
+        public void BackspaceTakesTheCaretsOwnDigit_OrTheRowsMostRecentOne()
+        {
+            var row = EasyRow();
+            var column = row.FirstDigitColumn;
+
+            column = Land(row, column, 2, 0);
+            Land(row, column, 8, 1);
+
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("28"));
+
+            // The caret parked on an empty box: the most recently typed digit
+            // anywhere in the row goes, wherever it is.
+            var empty = row.LastDigitColumn;
+            Assert.That(row.HasDigit(empty), Is.False);
+            Assert.That(row.LastEnteredColumn(), Is.EqualTo(FirstDigitColumn + 1), "the 8, typed second");
+
+            row.Erase(row.LastEnteredColumn());
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("2"));
+
+            // And with a digit under the caret, that one goes instead.
+            Assert.That(row.HasDigit(FirstDigitColumn), Is.True);
+            row.Erase(FirstDigitColumn);
+
+            Assert.That(row.IsEmpty(), Is.True);
+            Assert.That(row.LastEnteredColumn(), Is.EqualTo(-1), "nothing left to take");
+        }
+
+        [Test]
+        public void RecencyIsGridWide_SoTheOrderDigitsWereTypedInSurvivesAJumpBetweenRows()
+        {
+            // The stamps come from one counter shared across the whole grid,
+            // so "the digit most recently typed in this row" stays right after
+            // the player has been typing in another one.
+            var row = EasyRow();
+
+            row.Write(FirstDigitColumn, 1, 10);
+            row.Write(FirstDigitColumn + 2, 2, 4);
+
+            Assert.That(row.LastEnteredColumn(), Is.EqualTo(FirstDigitColumn), "the higher stamp, not the righter box");
+        }
+
+        [Test]
+        public void ClearEmptiesTheWholeRow()
+        {
+            var row = EasyRow();
+            var column = row.FirstDigitColumn;
+
+            foreach (var digit in new[] { 1, 2, 3 })
+            {
+                column = Land(row, column, digit, 0);
+            }
+
+            Assert.That(row.ReadLeftToRight(), Is.EqualTo("123"));
+
+            row.EraseAll();
+
+            Assert.That(row.IsEmpty(), Is.True);
+            Assert.That(row.ReadLeftToRight(), Is.Empty);
+            Assert.That(row.LastEnteredColumn(), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void ARowKnowsNothingAboutWhatWouldBeCorrect()
+        {
+            // The same guard the grid view carries: nothing in the working-out
+            // is marked, and a type with no way to grade cannot start.
+            var names = new StringBuilder();
+
+            foreach (var member in typeof(DigitRow).GetMembers())
+            {
+                names.Append(member.Name).Append(' ');
+            }
+
+            foreach (var word in new[] { "Correct", "Wrong", "Grade", "Verdict", "Score", "Marked", "Valid", "Product" })
+            {
+                Assert.That(names.ToString(), Does.Not.Contain(word), word + " has no business in a row of scratch boxes");
+            }
+        }
+
+        // Types one digit the way the shell does: write it where the caret is,
+        // then move the caret on. Returns where the caret ends up.
+        static int Land(DigitRow row, int column, int digit, int stamp)
+        {
+            row.Write(column, digit, stamp);
+            return row.NextColumnAfterTyping(column);
+        }
+    }
+}

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -359,9 +359,9 @@ past it.
 
 ## Behaviour
 
-- Entering from [roll and card](roll-and-card.md). The first empty answer cell
-  is the focused one; typing fills the answer row **right to left**, which is
-  the direction the digits are worked out in.
+- Entering from [roll and card](roll-and-card.md). The answer row's **leftmost**
+  digit column is the focused one; typing fills the answer row **left to
+  right**, which is the direction the answer is written and read in.
 - **Exactly one cell is focused, always, and it is the one the next digit lands
   in.** It is drawn filled with `GridFocusFill` — see
   [what focus looks like](#what-focus-looks-like) — and the fill follows the
@@ -404,11 +404,65 @@ past it.
   already empty — the digit most recently typed anywhere in the same block, and
   moves the caret to wherever it just took one from. It never reaches outside
   the block.
-- After a digit lands, the caret steps one cell to the left, in whatever row it
-  is in, and stops at the leftmost digit column. That is the answer row's
-  right-to-left fill applied everywhere, because the addition rows and the carry
-  strips are worked out in the same direction.
+- After a digit lands, the caret steps one cell to the **right**, in whatever
+  row it is in, and stops at the **last** digit column. There is **one
+  direction everywhere** — the answer row, the addition rows and both carry
+  strips fill the same way, so there is one rule to learn rather than one for
+  the answer and another for the scratch paper.
+- **The last digit column is where the caret stops, not where it wraps.**
+  Typing more digits than the grid has columns overwrites the final box. The
+  caret does not wrap to another row, leave the row it is in, or reach the
+  operator column.
 - Hardware back does nothing.
+
+### The fill direction this page used to carry
+
+Until [#305](https://github.com/derekwinters/connor-multiplying-frogs/issues/305)
+the two bullets above read the other way round, and the shell was built to
+them. The old wording is quoted here so the change is visible rather than
+silently overwritten. Neither sentence is true anywhere else on this page.
+
+> The first empty answer cell is the focused one; typing fills the answer row
+> **right to left**, which is the direction the digits are worked out in.
+
+> After a digit lands, the caret steps one cell to the left, in whatever row it
+> is in, and stops at the leftmost digit column.
+
+**This is a change to the contract, not a correction of drifted code.** The page
+and the shell agreed with each other and were wrong together in front of a
+player: reading the row back left to right while filling it right to left meant
+a player who typed `3`, `4`, `0` for 340 submitted **43**. The multiplication
+done correctly, and the frog left where it was. The only way to enter 340 was to
+tap each box before typing into it — the workaround Derek found on the tablet,
+and what his report was actually describing.
+
+**Why this direction and not a calculator's.** Two options were put to Derek:
+calculator-style entry for the answer row, where digits shift left as they are
+typed and the answer stays flush right; or this one, where the caret starts at
+the left, steps right, and a digit stays in the box it landed in. He picked the
+second:
+
+> my version. calculator would work if it was not boxes, but boxes implies
+> explicit entry to me.
+
+That reasoning is the answer to the obvious objection — that a card whose answer
+is shorter than the grid is wide, like `12 × 3` in three digit columns, ends up
+as `36_` with the 6 in the tens column. **A row of boxes is a row of slots, and
+a slot is something you point at.** Tapping a cell already moves the caret
+there, so a player who wants their 36 under the tens and units taps the middle
+box and types it there. Lining the answer up under the columns stays the
+**player's** job, which for a game about learning to multiply on paper is where
+it belongs. A calculator would have done it for them, silently, which is the
+thing that makes it wrong for a grid drawn as boxes.
+
+**Grading does not care about columns, and that stays true.** The answer row's
+digits are read left to right with empty boxes contributing nothing, so `36_`
+and `_36` both read `36` and both grade correct — see the
+[Invariants](#invariants) above and
+[ADR-0002](../../adr/0002-structured-working-out-grid.md), which is emphatic
+that only the answer row's *value* is checked. A future change that rejects or
+re-grades a correctly-typed but left-aligned answer would be a new rule about
+place value being marked, and it needs its own decision.
 
 ## Mockup
 
@@ -425,6 +479,19 @@ outline was the whole of it, in the drawings as in the shell. The cell is in the
 same place in each; what changed is that you can now see which one it is. A
 picture of this screen without a visible focused cell is a picture of a state
 the player never actually sees.
+
+**All three were already drawn filling left to right**, and nothing about them
+changed for
+[#305](https://github.com/derekwinters/connor-multiplying-frogs/issues/305).
+The two `331 × 41` drawings put `1` and `3` in the first two answer boxes with
+the focused cell immediately to their right and the rest empty, and the
+`68 × 5` drawing focuses the leftmost answer box on an empty row. Under the
+right-to-left rule those were pictures of states the shell could not reach —
+a caret to the *right* of the digits already typed is only reachable if the
+digits fill towards it. The drawings were right about the direction before the
+Behaviour section was, which is worth saying out loud: fill direction is not
+something a static picture *states*, but it turns out to be something a picture
+can quietly contradict.
 
 The first two are the agreed pictures of the screen a card deals, and they are a
 pair for the reason they always were: "the grid shrinks to fit the card" is a

--- a/docs/specs/ui/working-out-grid.md
+++ b/docs/specs/ui/working-out-grid.md
@@ -418,9 +418,10 @@ past it.
 ### The fill direction this page used to carry
 
 Until [#305](https://github.com/derekwinters/connor-multiplying-frogs/issues/305)
-the two bullets above read the other way round, and the shell was built to
-them. The old wording is quoted here so the change is visible rather than
-silently overwritten. Neither sentence is true anywhere else on this page.
+two of the bullets above — the first one, and the one about where the caret
+steps — read the other way round, and the shell was built to them. The old
+wording is quoted here so the change is visible rather than silently
+overwritten. Neither sentence is true anywhere else on this page.
 
 > The first empty answer cell is the focused one; typing fills the answer row
 > **right to left**, which is the direction the digits are worked out in.


### PR DESCRIPTION
Closes #305

Typing an answer into the grid used to enter it backwards. The caret started in the rightmost box and moved **left** after every digit, but the row was read back left to right — so a player who worked out that `68 × 5` is 340 and typed `3`, `4`, `0` submitted **43**, and the frog stayed where it was. The only way to get 340 in was to tap each box before typing into it, which is the workaround Derek found on the tablet rather than a convenience he was asking for. Now the caret starts in the leftmost box and steps **right**, in every row of the grid, so the number on the screen is the number you typed.

**Docs:** `docs/specs/ui/working-out-grid.md` — the answer row now fills **left to right** and the caret steps **right**, stopping at the last digit column, in every row kind. The two superseded right-to-left sentences are quoted in a new "The fill direction this page used to carry" section, with Derek's reasoning for choosing explicit boxes over calculator-style entry, and a note that the three mockups were already drawn filling left to right.

## Spec invariants this had to keep true

| Invariant | How I know it held |
| --- | --- |
| Nothing in the grid is marked; only the answer row's *value* decides whether the frog moves | `Grid_MarksNothing_AndHasNoWayToKnowWhatWouldBeCorrect` still passes unchanged in substance, and `DigitRowTests.ARowKnowsNothingAboutWhatWouldBeCorrect` holds the same guard over the new Core type |
| `36_` and `_36` are the same answer — grading does not care about columns | `AShortAnswerTypedFromATappedCell_StaysInTheColumnsItWasTappedInto` and `DigitRowTests.AShortAnswerStaysInTheColumnsItWasTypedInto_AndStillReadsAsItsValue` |
| Tapping any cell moves the caret there, so the grid can be filled in any order | `TappingAnyEditableCell_MovesTheCaretThere_AndTheNextDigitLandsThere`, unchanged |
| Backspace takes the caret's own digit or the block's most recent one, and never reaches outside its block | `Backspace_TakesTheCaretsDigit_OrTheLastEnteredInItsBlock_AndNothingOutsideIt` (rewritten in the new direction, not weakened) and `DigitRowTests.BackspaceTakesTheCaretsOwnDigit_OrTheRowsMostRecentOne` |
| `clear` empties the caret's row and nothing above or below it | `Clear_EmptiesTheCaretsBlockOnly_AndThereIsNoUndoAnywhere`, rewritten in the new direction |
| Growing and shrinking the addition section fires on the same events | `AdditionSection_GrowsADigitAtATime_…` is **untouched** — growth keys on the row, not the column, so its typing sequences did not have to move at all, and `TheCaretStepsRightInEveryRowKind_NotOnlyInTheAnswerRow` asserts the section did not grow while typing through it |
| Exactly one cell is focused and the fill follows the caret (#304, merged just before this) | `ExactlyOneCell_CarriesTheFocusTint_AndItFollowsTheCaretEverywhereItGoes` untouched and passing; `RefreshCells` is not modified by this PR |

## How the spec is changing

**Old rule:** the first empty answer cell is focused; typing fills the answer row right to left, and the caret steps one cell left, stopping at the leftmost digit column.

**New rule:** the answer row's leftmost digit column is focused; typing fills left to right, and the caret steps one cell right, stopping at the last digit column — in the answer row, the addition rows and both carry strips alike.

**Why the new one is better:** the old rule and the code agreed with each other and were wrong together in front of a player, because the row was *read* in the opposite direction to the one it *filled* in. Derek chose explicit boxes over calculator-style entry — "boxes implies explicit entry to me" — which means a short answer stays in the columns it was typed into and lining it up under the place-value columns is the player's job. For a game about learning to multiply on paper, that is the right place for it; a calculator would have done it silently.

## Red, then green

EditMode cannot run in an agent environment, so CI is what watched it fail.

- **Red — `6136ce6`** (tests only): `EditMode (Unity)` **failed**, exactly as intended.
- **Still red — `e7ca832`** (the fix): the grid's own 30 tests all passed, including the bug repro. But **three whole-turn tests in `AppRootTests` failed**, and that is worth reading rather than skipping — see below.
- **Green — `afba8d5`**.

The Core half got a real local red as well: `DigitRow.NextColumnAfterTyping` was first written with the old leftward rule, and `dotnet test` reported 6 of 11 failures for exactly the right reason — every digit piling into one box, `ReadLeftToRight()` returning `"1"` where `"13571"` was expected — before the rule was flipped.

**What the three `AppRootTests` failures were.** Its `TypeAnswer` helper — the one that plays a whole turn through the real app — typed each answer *backwards*, units first, because until now the caret walked backwards too. With the fix in, typing `0`, `4`, `3` correctly spells `043`. The helper was wrong, not the app, and its closing assertion ("the answer row spells out what was typed") is what caught it. That assertion is unchanged; only the order of the keystrokes moved. Flagging it because "three tests failed and I edited the tests" is a sentence that deserves the detail rather than the summary.

## Deviations and Decisions

- **The digit-order rule went into `Core`, not the Unity layer, which the approved plan said it would be.** The plan's last checklist box reads "Unity layer only", and I did not keep to it. What a row of boxes reads as, and which box the next digit goes in, can both be right or wrong with no screen attached — and being wrong about the second is exactly what made the first wrong in front of a player, which is the whole bug. `core-unity-split`'s own test ("if a `MonoBehaviour` contains a rule, that rule is in the wrong assembly") pointed the same way, and the `Mathf.Max` doing integer arithmetic was a tell. So `RowContents`, a private nested class inside the `MonoBehaviour`, became `Frogs.Core.DigitRow` with the two column rules on it. **No behaviour moved with it** other than the direction change this issue is about, and the isolation check is clean. The practical difference: the rule that broke is now covered by 11 tests that run in half a second, instead of only by EditMode tests that need a licensed editor. Flagging it because it is a deliberate departure from what Derek approved, and reverting it is cheap if he would rather it stayed in the shell.
- **`DigitRow.Write` now refuses the operator column**, where `RowContents.Write` accepted any in-range index. No reachable path ever wrote there — the caret cannot enter a non-editable cell — so this is a guard made explicit rather than a behaviour change, and `TheCaretNeverStepsIntoTheOperatorColumn_AndNoDigitCanBeWrittenThere` now holds it.
- **No wireframe issue was opened.** The issue flagged the gate rather than deciding it, so: `ui-design-process.md`'s own test is whether the mockup would become wrong, and none of the three did — they were already drawn mid-fill left to right, and under the *old* rule they were pictures of a state the shell could not actually reach. The drawings were right about the direction before the Behaviour section was. I recorded that in the spec's Mockup section instead of redrawing anything.
- **`TheCaretStepsRightInEveryRowKind_NotOnlyInTheAnswerRow` was written after the fix, not before it**, so it was never watched failing. It covers the checklist's "every row kind" box for the carry strips and the addition rows, and it asserts the same rule the Core tests *were* watched failing on. Every other test here was red first.
- **The `331 × 41` caret test now types `1, 3, 5, 7, 1` where it used to type `1, 7, 5, 3, 1`** for the same `13571`. The digits move because the direction did; the assertion did not weaken.
