### PR TITLE
feat(setup): let a player set their name, defaulting to the frog's colour

### DIFF
--- a/Assets/Scripts/Core/DisplayText.cs
+++ b/Assets/Scripts/Core/DisplayText.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// Fitting a string into a column that may be too narrow for it —
+    /// docs/specs/ui/shared-components.md#player-chip: "the chip never
+    /// refuses or alters a name it is given; if a name does not fit, the chip
+    /// truncates it with an ellipsis. A readout is not where a limit is
+    /// enforced."
+    ///
+    /// The cut is Core's rule and the measuring is the renderer's job. That
+    /// split exists because <b>a character count cannot promise a width</b>:
+    /// `Mohammed` is eight characters and 314 px, wider than `Alexander` at
+    /// nine and 274 px. So the caller passes something that can measure its
+    /// own font — a Unity <c>Text</c>'s generator, in practice — and no
+    /// engine type crosses into Core to do it.
+    /// </summary>
+    public static class DisplayText
+    {
+        /// <summary>
+        /// The single character a truncated string ends with. One glyph
+        /// rather than three dots, because three dots are three characters
+        /// wide in a column that is already short of room.
+        /// </summary>
+        public const string Ellipsis = "…";
+
+        /// <summary>
+        /// <paramref name="text"/> if it fits inside
+        /// <paramref name="availableWidth"/>; otherwise as much of it as fits
+        /// alongside an <see cref="Ellipsis"/>, ending in one.
+        /// </summary>
+        /// <param name="measure">
+        /// How wide a given string renders in the caller's own font. When
+        /// null, nothing can be known about width, so the text is handed back
+        /// untouched rather than cut on a guess.
+        /// </param>
+        public static string TruncateToWidth(string text, float availableWidth, Func<string, float> measure)
+        {
+            if (string.IsNullOrEmpty(text) || measure == null)
+            {
+                return text;
+            }
+
+            if (measure(text) <= availableWidth)
+            {
+                return text;
+            }
+
+            // The longest prefix that still leaves room for the ellipsis.
+            // Walked down from the whole string rather than solved for,
+            // because a proportional font gives no arithmetic relationship
+            // between a character count and a width — the very reason this
+            // takes a measuring function at all.
+            for (var length = text.Length - 1; length > 0; length--)
+            {
+                var candidate = text.Substring(0, length) + Ellipsis;
+
+                if (measure(candidate) <= availableWidth)
+                {
+                    return candidate;
+                }
+            }
+
+            // Not even one character and an ellipsis fit. The ellipsis alone
+            // still says "there is a name here, and it is longer than this",
+            // which is the one thing the column has to convey.
+            return Ellipsis;
+        }
+    }
+}

--- a/Assets/Scripts/Core/DisplayText.cs.meta
+++ b/Assets/Scripts/Core/DisplayText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e43935ac21c459c91ce03562e7cd589
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/Game.cs
+++ b/Assets/Scripts/Core/Game.cs
@@ -42,6 +42,7 @@ namespace Frogs.Core
         /// </summary>
         public const int MaxFrogsPerGame = 4;
 
+        readonly RosterEntry[] _roster;
         readonly FrogColour[] _turnOrder;
         readonly IReadOnlyDictionary<FrogColour, Lane> _lanes;
         readonly Rng _rng;
@@ -71,28 +72,60 @@ namespace Frogs.Core
         /// frogs in the same game are never the same colour.
         /// </exception>
         public Game(IReadOnlyList<FrogColour> turnOrder, ulong seed)
+            : this(AsRoster(turnOrder), seed)
         {
-            if (turnOrder == null)
+        }
+
+        /// <summary>
+        /// A game for <paramref name="roster"/> — already-ordered, first frog
+        /// to last — running on <paramref name="seed"/>. This is the
+        /// constructor game setup uses once names have been typed; the
+        /// colour-only one above is the same thing with every frog on its
+        /// default name.
+        ///
+        /// docs/specs/ui/game-setup.md#behaviour: "Their names go with them,
+        /// and are what every later screen shows." Two entries may carry the
+        /// same name — "nothing prevents it, nothing numbers them, nothing
+        /// warns" — so only colours are checked for duplicates here.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="roster"/> is null, or holds a null entry.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="roster"/> has fewer than <see cref="MinFrogsPerGame"/>
+        /// or more than <see cref="MaxFrogsPerGame"/> frogs.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="roster"/> lists the same colour twice — two frogs
+        /// in the same game are never the same colour.
+        /// </exception>
+        public Game(IReadOnlyList<RosterEntry> roster, ulong seed)
+        {
+            if (roster == null)
             {
-                throw new ArgumentNullException(nameof(turnOrder));
+                throw new ArgumentNullException(nameof(roster));
             }
 
-            if (turnOrder.Count < MinFrogsPerGame || turnOrder.Count > MaxFrogsPerGame)
+            if (roster.Count < MinFrogsPerGame || roster.Count > MaxFrogsPerGame)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(turnOrder),
-                    turnOrder.Count,
-                    $"a game is {MinFrogsPerGame} to {MaxFrogsPerGame} frogs; {turnOrder.Count} is neither.");
+                    nameof(roster),
+                    roster.Count,
+                    $"a game is {MinFrogsPerGame} to {MaxFrogsPerGame} frogs; {roster.Count} is neither.");
             }
 
-            if (turnOrder.Distinct().Count() != turnOrder.Count)
+            if (roster.Any(entry => entry == null))
+            {
+                throw new ArgumentNullException(nameof(roster), "a roster holds no null entries.");
+            }
+
+            if (roster.Select(entry => entry.Colour).Distinct().Count() != roster.Count)
             {
                 throw new ArgumentException(
                     "two frogs in the same game are never the same colour.",
-                    nameof(turnOrder));
+                    nameof(roster));
             }
 
-            _turnOrder = turnOrder.ToArray();
+            _roster = roster.ToArray();
+            _turnOrder = _roster.Select(entry => entry.Colour).ToArray();
 
             var lanes = new Dictionary<FrogColour, Lane>();
             foreach (var colour in _turnOrder)
@@ -107,10 +140,52 @@ namespace Frogs.Core
             _phase = TurnPhase.WaitingToRoll;
         }
 
+        // A colour-only line-up is a roster of frogs on their default names —
+        // docs/specs/ui/game-setup.md#behaviour: "A default name is a real
+        // name, not a placeholder." So there is one roster path, not two.
+        static RosterEntry[] AsRoster(IReadOnlyList<FrogColour> turnOrder)
+        {
+            if (turnOrder == null)
+            {
+                throw new ArgumentNullException(nameof(turnOrder));
+            }
+
+            return turnOrder.Select(colour => new RosterEntry(colour)).ToArray();
+        }
+
         /// <summary>The roster, first frog to last — the order turns are taken in.</summary>
         public IReadOnlyList<FrogColour> TurnOrder
         {
             get { return _turnOrder; }
+        }
+
+        /// <summary>
+        /// The roster with its names, first frog to last. What
+        /// <c>Play again</c> starts the next game from, so that names last as
+        /// long as the frogs do — docs/specs/ui/game-over.md.
+        /// </summary>
+        public IReadOnlyList<RosterEntry> Roster
+        {
+            get { return _roster; }
+        }
+
+        /// <summary>
+        /// What this frog's player is called — its colour name until somebody
+        /// changed it on game setup. Every screen that draws a frog reads it
+        /// from here, so nothing has to look a name up anywhere else.
+        /// </summary>
+        /// <exception cref="ArgumentException"><paramref name="colour"/> is not in this game's roster.</exception>
+        public string NameFor(FrogColour colour)
+        {
+            foreach (var entry in _roster)
+            {
+                if (entry.Colour == colour)
+                {
+                    return entry.Name;
+                }
+            }
+
+            throw new ArgumentException($"{colour} is not in this game's roster.", nameof(colour));
         }
 
         /// <summary>The frog whose turn it currently is.</summary>
@@ -275,7 +350,7 @@ namespace Frogs.Core
 
                     var place = tiedWithPrevious ? rows[index - 1].Place : index + 1;
 
-                    rows.Add(new StandingsRow(colour, place, lane.Position, lane.IsHome));
+                    rows.Add(new StandingsRow(colour, NameFor(colour), place, lane.Position, lane.IsHome));
                 }
 
                 return rows;

--- a/Assets/Scripts/Core/PlayerName.cs
+++ b/Assets/Scripts/Core/PlayerName.cs
@@ -1,0 +1,55 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// The rules a player's name obeys — docs/specs/ui/game-setup.md.
+    ///
+    /// They live in Core rather than in the text field that collects them,
+    /// because "a Core rule the UI happens to respect is one the UI can stop
+    /// respecting": the cap, and the fall back to the colour name, hold for
+    /// every caller and not only for the one screen that types.
+    /// </summary>
+    public static class PlayerName
+    {
+        /// <summary>
+        /// The longest name a player can have —
+        /// docs/specs/ui/game-setup.md#named-constants,
+        /// <c>PlayerNameMaxLength</c>. Read off the setup seat's name row and
+        /// not off the board's player chip: the chip's label column holds
+        /// about five characters, so a chip-derived cap would refuse
+        /// <c>Connor</c> at the sixth keystroke. The chip truncates instead —
+        /// see <see cref="DisplayText.TruncateToWidth"/>.
+        /// </summary>
+        public const int PlayerNameMaxLength = 10;
+
+        /// <summary>
+        /// The name a frog carries until somebody changes it: the bare colour
+        /// name, <c>Blue</c> rather than <c>Blue Frog</c>.
+        /// </summary>
+        public static string DefaultFor(FrogColour colour)
+        {
+            return colour.ToString();
+        }
+
+        /// <summary>
+        /// <paramref name="typed"/> as a name this game will actually carry:
+        /// blank — empty, whitespace or null — becomes
+        /// <see cref="DefaultFor"/> <paramref name="colour"/>, and anything
+        /// past <see cref="PlayerNameMaxLength"/> is cut to it.
+        ///
+        /// The cap is applied here, and not only at the keyboard that refuses
+        /// the eleventh keystroke, so that no caller can hand the game a name
+        /// no surface was designed to draw.
+        /// </summary>
+        public static string Resolve(string typed, FrogColour colour)
+        {
+            if (string.IsNullOrWhiteSpace(typed))
+            {
+                return DefaultFor(colour);
+            }
+
+            return typed.Length > PlayerNameMaxLength
+                ? typed.Substring(0, PlayerNameMaxLength)
+                : typed;
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerName.cs.meta
+++ b/Assets/Scripts/Core/PlayerName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92225f9bdbfa4a568cd7cd345a6ffa38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/PlayerNameEditor.cs
+++ b/Assets/Scripts/Core/PlayerNameEditor.cs
@@ -15,6 +15,9 @@ namespace Frogs.Core
     /// </summary>
     public sealed class PlayerNameEditor
     {
+        // What separates one word from the next, for the capitalisation rule.
+        const char WordSeparator = ' ';
+
         readonly FrogColour _colour;
         readonly StringBuilder _text;
 
@@ -54,6 +57,15 @@ namespace Frogs.Core
         /// Appends one character, unless the name is already
         /// <see cref="PlayerName.PlayerNameMaxLength"/> long — in which case
         /// the keystroke is refused and nothing changes.
+        ///
+        /// The character's case is **derived from where it lands**, not taken
+        /// from the caller: a capital at the start of the name and after a
+        /// space, lowercase everywhere else. So `C O N N O R` is `Connor` and
+        /// `M A R Y` space `J A N E` is `Mary Jane`, and the field reads that
+        /// way while it is being typed rather than being corrected at the
+        /// end. docs/specs/ui/game-setup.md#behaviour, settling #319 — the
+        /// keyboard has no shift key, so this is the only thing that decides
+        /// case.
         /// </summary>
         /// <returns>
         /// Whether the character landed. False is the refusal the keyboard
@@ -67,8 +79,16 @@ namespace Frogs.Core
                 return false;
             }
 
-            _text.Append(character);
+            _text.Append(StartsAWord() ? char.ToUpperInvariant(character) : char.ToLowerInvariant(character));
             return true;
+        }
+
+        // Read off the text as it stands rather than remembered, which is
+        // what makes backspacing and retyping re-derive the case instead of
+        // carrying a stale flag.
+        bool StartsAWord()
+        {
+            return _text.Length == 0 || _text[_text.Length - 1] == WordSeparator;
         }
 
         /// <summary>Deletes the last character. A no-op on an empty name.</summary>

--- a/Assets/Scripts/Core/PlayerNameEditor.cs
+++ b/Assets/Scripts/Core/PlayerNameEditor.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Text;
+
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One naming session on one seat — docs/specs/ui/game-setup.md#behaviour.
+    /// The setup screen's keyboard is a set of buttons on top of this: a
+    /// letter key calls <see cref="Append"/>, backspace calls
+    /// <see cref="Backspace"/>, and `Done` calls <see cref="Commit"/>.
+    ///
+    /// There is no cancel, and this type deliberately offers none: "a name is
+    /// edited in place and every keystroke has already happened, so there is
+    /// nothing a cancel would undo that backspace does not."
+    /// </summary>
+    public sealed class PlayerNameEditor
+    {
+        readonly FrogColour _colour;
+        readonly StringBuilder _text;
+
+        /// <summary>
+        /// Opens a session on <paramref name="entry"/>, starting from the
+        /// name that seat already carries — docs/specs/ui/game-setup.md#behaviour:
+        /// tapping a name row "puts the caret at the end of the name."
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="entry"/> is null.</exception>
+        public PlayerNameEditor(RosterEntry entry)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            _colour = entry.Colour;
+            _text = new StringBuilder(entry.Name);
+        }
+
+        /// <summary>The frog being named — the one the header's prompt names.</summary>
+        public FrogColour Colour
+        {
+            get { return _colour; }
+        }
+
+        /// <summary>
+        /// What has been typed so far. May be empty part-way through an edit;
+        /// <see cref="Commit"/> is where empty becomes the colour name again.
+        /// </summary>
+        public string Text
+        {
+            get { return _text.ToString(); }
+        }
+
+        /// <summary>
+        /// Appends one character, unless the name is already
+        /// <see cref="PlayerName.PlayerNameMaxLength"/> long — in which case
+        /// the keystroke is refused and nothing changes.
+        /// </summary>
+        /// <returns>
+        /// Whether the character landed. False is the refusal the keyboard
+        /// renders as a key that does nothing: "nothing explains itself,
+        /// which is how a disabled button already behaves in this game."
+        /// </returns>
+        public bool Append(char character)
+        {
+            if (_text.Length >= PlayerName.PlayerNameMaxLength)
+            {
+                return false;
+            }
+
+            _text.Append(character);
+            return true;
+        }
+
+        /// <summary>Deletes the last character. A no-op on an empty name.</summary>
+        public void Backspace()
+        {
+            if (_text.Length > 0)
+            {
+                _text.Length -= 1;
+            }
+        }
+
+        /// <summary>Empties the name — what holding backspace down arrives at.</summary>
+        public void Clear()
+        {
+            _text.Length = 0;
+        }
+
+        /// <summary>
+        /// Closes the session: the seat under the name typed, or — if that
+        /// name is blank — back under its colour name, because "a nameless
+        /// frog is not a state this screen can reach."
+        /// </summary>
+        public RosterEntry Commit()
+        {
+            return new RosterEntry(_colour, Text);
+        }
+    }
+}

--- a/Assets/Scripts/Core/PlayerNameEditor.cs.meta
+++ b/Assets/Scripts/Core/PlayerNameEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92bf5b9cf7f1440bb6e5ae5a9ee9bffe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/RosterEntry.cs
+++ b/Assets/Scripts/Core/RosterEntry.cs
@@ -1,0 +1,54 @@
+namespace Frogs.Core
+{
+    /// <summary>
+    /// One seat's worth of roster: which frog, and what that player is
+    /// called. docs/specs/ui/game-setup.md#behaviour — "Seating a frog gives
+    /// it the bare colour name — `Blue`, not `Blue Frog`. A default name is a
+    /// real name, not a placeholder: it is stored, drawn and spoken about
+    /// exactly like a typed one, and nothing anywhere appends a word to it."
+    ///
+    /// A name is roster data, so it lives here with the rest of the roster
+    /// rather than in the setup screen that happens to collect it: a name the
+    /// Unity layer keeps to itself is a name the board cannot draw, and — per
+    /// docs/adr/0004-core-owns-the-save-format.md — a save that restores a
+    /// game without its players' names restores the wrong game.
+    /// </summary>
+    public sealed class RosterEntry
+    {
+        /// <summary>This seat's frog, on its default name.</summary>
+        public RosterEntry(FrogColour colour)
+            : this(colour, null)
+        {
+        }
+
+        /// <summary>
+        /// This seat's frog under <paramref name="name"/>, put through
+        /// <see cref="PlayerName.Resolve"/> — so a blank name is the colour
+        /// name and an over-long one is capped, whoever the caller is.
+        /// </summary>
+        public RosterEntry(FrogColour colour, string name)
+        {
+            Colour = colour;
+            Name = PlayerName.Resolve(name, colour);
+        }
+
+        /// <summary>Which frog this seat holds.</summary>
+        public FrogColour Colour { get; }
+
+        /// <summary>
+        /// What this player is called — never empty, and never anything but
+        /// the name itself.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The same seat under a different name. Blank restores the colour
+        /// name; anything longer than <see cref="PlayerName.PlayerNameMaxLength"/>
+        /// is capped.
+        /// </summary>
+        public RosterEntry WithName(string name)
+        {
+            return new RosterEntry(Colour, name);
+        }
+    }
+}

--- a/Assets/Scripts/Core/RosterEntry.cs.meta
+++ b/Assets/Scripts/Core/RosterEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d725d9a5fc04c0ba159001565c79fd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/StandingsRow.cs
+++ b/Assets/Scripts/Core/StandingsRow.cs
@@ -9,9 +9,17 @@ namespace Frogs.Core
     /// </summary>
     public sealed class StandingsRow
     {
+        /// <summary>A row for a frog on its default name — its colour's.</summary>
         public StandingsRow(FrogColour colour, int place, int position, bool isHome)
+            : this(colour, PlayerName.DefaultFor(colour), place, position, isHome)
+        {
+        }
+
+        /// <summary>A row for a frog under the name its player is playing as.</summary>
+        public StandingsRow(FrogColour colour, string name, int place, int position, bool isHome)
         {
             Colour = colour;
+            Name = PlayerName.Resolve(name, colour);
             Place = place;
             Position = position;
             IsHome = isHome;
@@ -19,6 +27,13 @@ namespace Frogs.Core
 
         /// <summary>Which frog this row is about.</summary>
         public FrogColour Colour { get; }
+
+        /// <summary>
+        /// What this frog's player is called — the word game over's standings
+        /// row draws. Its colour's name by default, whatever was typed on
+        /// game setup otherwise, and never a colour with a word stapled to it.
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// This frog's rank, 1-based. Frogs tied on <see cref="Position"/>

--- a/Assets/Scripts/Unity/GameAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/GameAnswerResultTurn.cs
@@ -46,6 +46,12 @@ namespace Frogs.Unity
         public FrogColour Frog { get; }
 
         /// <inheritdoc />
+        public string FrogName
+        {
+            get { return _game.NameFor(Frog); }
+        }
+
+        /// <inheritdoc />
         public int Multiplicand
         {
             get { return _card.Multiplicand; }

--- a/Assets/Scripts/Unity/GameRollAndCardReadout.cs
+++ b/Assets/Scripts/Unity/GameRollAndCardReadout.cs
@@ -30,6 +30,12 @@ namespace Frogs.Unity
         }
 
         /// <inheritdoc />
+        public string FrogName
+        {
+            get { return _game.NameFor(_game.ActiveFrog); }
+        }
+
+        /// <inheritdoc />
         public int Face
         {
             get { return RequireRoll().Face; }

--- a/Assets/Scripts/Unity/GameWorkingOutTurn.cs
+++ b/Assets/Scripts/Unity/GameWorkingOutTurn.cs
@@ -58,6 +58,12 @@ namespace Frogs.Unity
         public FrogColour Frog { get; }
 
         /// <inheritdoc />
+        public string FrogName
+        {
+            get { return _game.NameFor(Frog); }
+        }
+
+        /// <inheritdoc />
         public Pile Pile { get; }
 
         /// <inheritdoc />

--- a/Assets/Scripts/Unity/IAnswerResultTurn.cs
+++ b/Assets/Scripts/Unity/IAnswerResultTurn.cs
@@ -25,6 +25,13 @@ namespace Frogs.Unity
         /// <summary>The frog whose answer this was — the chip, and the name in the consequence sentence.</summary>
         FrogColour Frog { get; }
 
+        /// <summary>
+        /// What this frog's player is called — their colour's name unless
+        /// they typed one on game setup. The chip draws the name and only the
+        /// name; nothing appends anything to it.
+        /// </summary>
+        string FrogName { get; }
+
         /// <summary>The card's first operand — the `331` in `331 × 41 = 13,571`.</summary>
         int Multiplicand { get; }
 

--- a/Assets/Scripts/Unity/IRollAndCardReadout.cs
+++ b/Assets/Scripts/Unity/IRollAndCardReadout.cs
@@ -29,6 +29,13 @@ namespace Frogs.Unity
         /// <summary>The frog taking this turn — the chip in `whose`.</summary>
         FrogColour Frog { get; }
 
+        /// <summary>
+        /// What this frog's player is called — their colour's name unless
+        /// they typed one on game setup. The chip draws the name and only the
+        /// name; nothing appends anything to it.
+        /// </summary>
+        string FrogName { get; }
+
         /// <summary>The face that came up, <see cref="Roll.MinimumFace"/> to <see cref="Roll.MaximumFace"/>.</summary>
         int Face { get; }
 

--- a/Assets/Scripts/Unity/IWorkingOutTurn.cs
+++ b/Assets/Scripts/Unity/IWorkingOutTurn.cs
@@ -27,6 +27,13 @@ namespace Frogs.Unity
         /// <summary>The frog taking this turn — the chip in the header.</summary>
         FrogColour Frog { get; }
 
+        /// <summary>
+        /// What this frog's player is called — their colour's name unless
+        /// they typed one on game setup. The chip draws the name and only the
+        /// name; nothing appends anything to it.
+        /// </summary>
+        string FrogName { get; }
+
         /// <summary>The pile the card came from, as Core reported it. Named in the header, never re-derived here.</summary>
         Pile Pile { get; }
 

--- a/Assets/Scripts/Unity/UI/PlayerChip.cs
+++ b/Assets/Scripts/Unity/UI/PlayerChip.cs
@@ -1,3 +1,4 @@
+using Frogs.Core;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -27,6 +28,28 @@ namespace Frogs.Unity.UI
         public const float PlayerChipPadCountSize = 24f;
         public const float PlayerChipRadius = 20f;
         public const float PlayerChipActiveRing = 6f;
+
+        /// <summary>
+        /// docs/specs/ui/shared-components.md#player-chip — the horizontal
+        /// padding the label column is derived through. Named here because
+        /// the page states it in prose ("less 20 px padding either side")
+        /// and the derivation below has to be reproducible.
+        /// </summary>
+        public const float PlayerChipLabelPaddingX = 20f;
+
+        /// <summary>
+        /// How much room the name actually has —
+        /// docs/specs/ui/shared-components.md#player-chip: "`PlayerChipWidth`
+        /// 256 less 20 px padding either side, less `PlayerSwatchDiameter`
+        /// 64, less `PlayerChipSwatchGap` 24, leaves 128 px."
+        ///
+        /// It is tighter than it looks: `Orange` renders at 132 px at
+        /// `PlayerChipLabelSize` 32 and overflows it — the game's own longest
+        /// default name, overflowing before anybody has typed anything. That
+        /// is why the chip truncates rather than refuses.
+        /// </summary>
+        public const float PlayerChipLabelColumn =
+            PlayerChipWidth - (PlayerChipLabelPaddingX * 2f) - PlayerSwatchDiameter - PlayerChipSwatchGap;
 
         const string HomeLabel = "Home!";
 
@@ -85,6 +108,7 @@ namespace Frogs.Unity.UI
         bool _initialized;
         PlayerChipState _state = PlayerChipState.Default;
         string _padCount = string.Empty;
+        string _name = string.Empty;
 
         /// <summary>The chip's own <see cref="RectTransform"/>, sized to <see cref="PlayerChipWidth"/> x <see cref="PlayerChipHeight"/>.</summary>
         public RectTransform RectTransform
@@ -151,15 +175,58 @@ namespace Frogs.Unity.UI
         }
 
         /// <summary>
-        /// Sets the frog's colour and its colour's name, in words —
+        /// Sets the frog's colour and the name its player is playing under —
         /// docs/specs/ui/shared-components.md#player-chip's first invariant:
-        /// colour and name always together, never colour alone.
+        /// colour and a word always together, never colour alone.
+        ///
+        /// The name is drawn as given, truncated with an ellipsis if it does
+        /// not fit: "the chip never refuses or alters a name it is given ...
+        /// A readout is not where a limit is enforced." <see cref="Name"/>
+        /// still reports the whole name.
         /// </summary>
-        public void SetFrog(Color color, string colourName)
+        public void SetFrog(Color color, string name)
         {
             EnsureInitialized();
             _swatch.color = color;
-            _label.text = colourName;
+            _name = name;
+            RefreshLabel();
+        }
+
+        /// <summary>
+        /// The whole name this chip was given, untruncated — what it is
+        /// drawing an abbreviation of when the column is too narrow.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                EnsureInitialized();
+                return _name;
+            }
+        }
+
+        void RefreshLabel()
+        {
+            _label.text = DisplayText.TruncateToWidth(_name, PlayerChipLabelColumn, MeasureLabel);
+        }
+
+        // How wide a string renders in this label's own font. The chip cannot
+        // reason about this from a character count — `Mohammed` is eight
+        // characters and wider than `Alexander` at nine — so Core asks the
+        // renderer, and this is the renderer answering.
+        float MeasureLabel(string text)
+        {
+            if (string.IsNullOrEmpty(text) || _label.font == null)
+            {
+                return 0f;
+            }
+
+            var settings = _label.GetGenerationSettings(Vector2.zero);
+            settings.horizontalOverflow = HorizontalWrapMode.Overflow;
+            settings.verticalOverflow = VerticalWrapMode.Overflow;
+            settings.generateOutOfBounds = true;
+
+            return _label.cachedTextGeneratorForLayout.GetPreferredWidth(text, settings) / _label.pixelsPerUnit;
         }
 
         /// <summary>

--- a/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
+++ b/Assets/Scripts/Unity/Views/AnswerResultDialogView.cs
@@ -481,7 +481,7 @@ namespace Frogs.Unity.Views
                 ? string.Format(RightConsequenceFormat, movement)
                 : string.Format(WrongConsequenceFormat, equation, movement);
 
-            _chip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _chip.SetFrog(FrogColours.For(frog), _turn.FrogName);
             _chip.SetPadCount(string.Format(
                 ChipMoveFormat,
                 resolution.PositionBefore,

--- a/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardLaneView.cs
@@ -336,13 +336,18 @@ namespace Frogs.Unity.Views
             EnsureInitialized();
         }
 
-        /// <summary>Sets which frog this lane belongs to, and paints it.</summary>
-        public void Initialize(FrogColour colour)
+        /// <summary>
+        /// Sets which frog this lane belongs to and what its player is
+        /// called, and paints it. The name comes in rather than being
+        /// derived from the colour, because a renamed frog's lane has to
+        /// say the typed name.
+        /// </summary>
+        public void Initialize(FrogColour colour, string name = null)
         {
             EnsureInitialized();
 
             _colour = colour;
-            _chip.SetFrog(FrogColours.For(colour), colour.ToString());
+            _chip.SetFrog(FrogColours.For(colour), name ?? PlayerName.DefaultFor(colour));
             _piece.color = FrogColours.For(colour);
         }
 

--- a/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameBoardScreenView.cs
@@ -123,7 +123,12 @@ namespace Frogs.Unity.Views
         // "Whose turn it is is stated in words in the header, not only shown
         // by a highlight." The wording is the frog's colour name, because
         // frogs have no other name.
-        const string TurnBannerFormat = "{0} frog's turn";
+        // docs/specs/ui/game-setup.md#behaviour and
+        // docs/specs/ui/shared-components.md#player-chip: nothing appends
+        // anything to a name. This format used to staple `frog` onto a
+        // colour, which read as `Connor frog's turn` the moment a name was
+        // typed.
+        const string TurnBannerFormat = "{0}'s turn";
         const string RollLabel = "Roll";
 
         // No imported font — matches Button.cs's, PlayerChip.cs's and
@@ -281,7 +286,7 @@ namespace Frogs.Unity.Views
             }
         }
 
-        /// <summary>The turn banner — `Green frog's turn`, in words.</summary>
+        /// <summary>The turn banner — `Green's turn`, in words.</summary>
         public Text TurnBannerText
         {
             get
@@ -438,8 +443,10 @@ namespace Frogs.Unity.Views
 
             var active = _game.ActiveFrog;
 
-            _turnBannerText.text = string.Format(TurnBannerFormat, active);
-            _turnBannerChip.SetFrog(FrogColours.For(active), active.ToString());
+            var activeName = _game.NameFor(active);
+
+            _turnBannerText.text = string.Format(TurnBannerFormat, activeName);
+            _turnBannerChip.SetFrog(FrogColours.For(active), activeName);
             _turnBannerChip.SetState(PlayerChipState.Active);
 
             foreach (var lane in _lanes)
@@ -823,7 +830,7 @@ namespace Frogs.Unity.Views
                     groupTop - ((index + 0.5f) * GameBoardLaneView.LaneHeight));
 
                 var lane = laneGO.AddComponent<GameBoardLaneView>();
-                lane.Initialize(colour);
+                lane.Initialize(colour, _game.NameFor(colour));
 
                 _lanes.Add(lane);
                 _lanesByColour[colour] = lane;

--- a/Assets/Scripts/Unity/Views/GameOverScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameOverScreenView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Frogs.Core;
 using UnityEngine;
 using UnityEngine.UI;
@@ -109,7 +110,11 @@ namespace Frogs.Unity.Views
         const float CanvasHeight = 1200f;
 
         const string NoWinnerHeadline = "Game over";
-        const string WinnerHeadlineSuffix = " frog wins!";
+        // docs/specs/ui/shared-components.md#player-chip: nothing appends
+        // anything to a name. This suffix used to staple `frog` onto a
+        // colour, which read as `Connor frog wins!` the moment a name was
+        // typed.
+        const string WinnerHeadlineSuffix = " wins!";
         const string HomePrefix = "Home — ";
         const string OfSeparator = " of ";
         const string PlayAgainLabel = "Play again";
@@ -231,6 +236,7 @@ namespace Frogs.Unity.Views
         FrogColour? _winner;
         readonly List<StandingsRow> _standings = new List<StandingsRow>();
         readonly List<FrogColour> _turnOrder = new List<FrogColour>();
+        readonly List<RosterEntry> _roster = new List<RosterEntry>();
 
         bool _initialized;
         float _revealElapsed;
@@ -433,7 +439,7 @@ namespace Frogs.Unity.Views
                 throw new ArgumentNullException(nameof(endedGame));
             }
 
-            Show(endedGame.Winner, endedGame.Standings, endedGame.TurnOrder);
+            Show(endedGame.Winner, endedGame.Standings, endedGame.Roster);
         }
 
         /// <summary>
@@ -451,7 +457,31 @@ namespace Frogs.Unity.Views
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="standings"/> or <paramref name="turnOrder"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="standings"/> has more than <see cref="MaxStandingsRows"/> rows.</exception>
+        public void Show(FrogColour? winner, IReadOnlyList<StandingsRow> standings, IReadOnlyList<RosterEntry> roster)
+        {
+            if (roster == null)
+            {
+                throw new ArgumentNullException(nameof(roster));
+            }
+
+            Show(winner, standings, roster.Select(entry => entry.Colour).ToArray(), roster);
+        }
+
+        /// <summary>
+        /// The same, for a caller that has only colours to hand — every frog
+        /// then plays under its default name, which is a real name and not a
+        /// gap.
+        /// </summary>
         public void Show(FrogColour? winner, IReadOnlyList<StandingsRow> standings, IReadOnlyList<FrogColour> turnOrder)
+        {
+            Show(winner, standings, turnOrder, null);
+        }
+
+        void Show(
+            FrogColour? winner,
+            IReadOnlyList<StandingsRow> standings,
+            IReadOnlyList<FrogColour> turnOrder,
+            IReadOnlyList<RosterEntry> roster)
         {
             EnsureInitialized();
 
@@ -487,10 +517,57 @@ namespace Frogs.Unity.Views
                 _turnOrder.Add(colour);
             }
 
+            // Names last as long as the game does, which includes
+            // `Play again` — docs/specs/ui/game-setup.md#behaviour. When the
+            // caller had only colours to hand, the standings still know each
+            // frog's name, and a frog missing from them plays under its
+            // default name, which is a real name and not a gap.
+            _roster.Clear();
+            foreach (var colour in turnOrder)
+            {
+                _roster.Add(roster != null
+                    ? RosterEntryFor(roster, colour)
+                    : new RosterEntry(colour, NameFromStandings(colour)));
+            }
+
             // Entering: the reveal starts over for the result now on screen.
             _revealElapsed = 0f;
 
             RefreshAll();
+        }
+
+        // The name the standings already carry for this frog. Nothing has to
+        // be looked up anywhere else: Core hands the name out with the row.
+        string NameFromStandings(FrogColour colour)
+        {
+            foreach (var row in _standings)
+            {
+                if (row.Colour == colour)
+                {
+                    return row.Name;
+                }
+            }
+
+            return PlayerName.DefaultFor(colour);
+        }
+
+        static RosterEntry RosterEntryFor(IReadOnlyList<RosterEntry> roster, FrogColour colour)
+        {
+            foreach (var entry in roster)
+            {
+                if (entry.Colour == colour)
+                {
+                    return entry;
+                }
+            }
+
+            return new RosterEntry(colour);
+        }
+
+        // The winner's own name, for the headline. Null when nobody won.
+        string WinnerName()
+        {
+            return _winner.HasValue ? NameFromStandings(_winner.Value) : null;
         }
 
         /// <summary>The frog row <paramref name="index"/> is about, in the order Core handed the standings over.</summary>
@@ -589,7 +666,7 @@ namespace Frogs.Unity.Views
             // Constructed exactly the way `Start` on game setup constructs
             // one — the same roster order in, a fresh seed from the Unity
             // layer — just without the tap-through.
-            StartedGame = new Frogs.Core.Game(_turnOrder.ToArray(), _seedFactory());
+            StartedGame = new Frogs.Core.Game(_roster.ToArray(), _seedFactory());
 
             _router?.NavigateToScreen(CoreScreen.GameBoard);
         }
@@ -614,16 +691,30 @@ namespace Frogs.Unity.Views
         }
 
         /// <summary>
-        /// The `headline` region's line: `&lt;Colour&gt; frog wins!` when Core
-        /// reports a winner — on both routes that produce one — and
-        /// `Game over` when it does not, because "announcing a winner who did
-        /// not win is worse than announcing nobody".
+        /// The `headline` region's line: `&lt;Name&gt; wins!` when Core reports
+        /// a winner — on both routes that produce one — and `Game over` when
+        /// it does not, because "announcing a winner who did not win is worse
+        /// than announcing nobody".
+        /// </summary>
+        /// <param name="winnerName">
+        /// What the winning player is called — their colour's name unless
+        /// they typed one. Null when nobody won.
+        /// </param>
+        public static string FormatHeadline(string winnerName)
+        {
+            return string.IsNullOrEmpty(winnerName)
+                ? NoWinnerHeadline
+                : winnerName + WinnerHeadlineSuffix;
+        }
+
+        /// <summary>
+        /// The same headline for a frog on its default name. Kept for callers
+        /// that have only a colour to hand; the name-carrying overload is the
+        /// one this screen itself uses.
         /// </summary>
         public static string FormatHeadline(FrogColour? winner)
         {
-            return winner.HasValue
-                ? winner.Value.ToString() + WinnerHeadlineSuffix
-                : NoWinnerHeadline;
+            return FormatHeadline(winner.HasValue ? PlayerName.DefaultFor(winner.Value) : null);
         }
 
         /// <summary>
@@ -935,7 +1026,7 @@ namespace Frogs.Unity.Views
 
         void RefreshAll()
         {
-            _headlineText.text = FormatHeadline(_winner);
+            _headlineText.text = FormatHeadline(WinnerName());
 
             for (var index = 0; index < _rows.Count; index++)
             {
@@ -979,7 +1070,7 @@ namespace Frogs.Unity.Views
 
             row.Swatch.color = FrogColours.For(standings.Colour);
 
-            row.Name.text = standings.Colour.ToString();
+            row.Name.text = standings.Name;
             row.Name.fontStyle = weight;
 
             row.Progress.text = FormatProgress(standings);

--- a/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
@@ -119,7 +119,6 @@ namespace Frogs.Unity.Views
 
         const string RemoveKeyLabel = "×";
         const string BackspaceKeyLabel = "⌫";
-        const string ShiftKeyLabel = "⇧";
         const string SpaceKeyLabel = "space";
         const string DoneKeyLabel = "Done";
         const char SpaceCharacter = ' ';
@@ -634,12 +633,6 @@ namespace Frogs.Unity.Views
             get { return KeyOfKind(NameKeyKind.Backspace); }
         }
 
-        /// <summary>The shift key — drawn, and disabled; see this type's own note.</summary>
-        public NameKeyboardKey ShiftKey
-        {
-            get { return KeyOfKind(NameKeyKind.Shift); }
-        }
-
         /// <summary>`Done` — the only way out of the keyboard.</summary>
         public NameKeyboardKey DoneKey
         {
@@ -876,18 +869,14 @@ namespace Frogs.Unity.Views
                 var letters = LetterRows[rowIndex];
                 var isLastLetterRow = rowIndex == LetterRows.Length - 1;
 
-                // Row 3 carries shift and backspace either side of its seven
-                // letters — docs/specs/ui/game-setup.md#the-keyboard.
-                var keyCount = isLastLetterRow ? letters.Length + 2 : letters.Length;
+                // Row 3 carries backspace after its seven letters, and
+                // nothing before them — docs/specs/ui/game-setup.md#the-keyboard.
+                // There is no shift key: case is derived from position as the
+                // name is built (#319), so there is nothing for one to do.
+                var keyCount = isLastLetterRow ? letters.Length + 1 : letters.Length;
                 var rowWidth = (keyCount * NameKeyWidth) + ((keyCount - 1) * NameKeyGap);
                 var x = -(rowWidth / 2f) + (NameKeyWidth / 2f);
                 var y = (NameKeyboardHeight / 2f) - (NameKeyHeight / 2f) - (rowIndex * rowPitch);
-
-                if (isLastLetterRow)
-                {
-                    BuildKey(NameKeyKind.Shift, default(char), ShiftKeyLabel, NameKeyGlyphLabelSize, NameKeyWidth, new Vector2(x, y));
-                    x += NameKeyWidth + NameKeyGap;
-                }
 
                 foreach (var letter in letters)
                 {
@@ -908,12 +897,6 @@ namespace Frogs.Unity.Views
 
             BuildKey(NameKeyKind.Space, SpaceCharacter, SpaceKeyLabel, NameSpaceKeyLabelSize, NameSpaceKeyWidth, new Vector2(spaceX, bottomY));
             BuildKey(NameKeyKind.Done, default(char), DoneKeyLabel, NameDoneKeyLabelSize, NameDoneKeyWidth, new Vector2(doneX, bottomY));
-
-            // The shift key is drawn because the agreed mockup draws it, and
-            // disabled because what it does is not settled — see this type's
-            // note at the top of the naming section.
-            ShiftKey.SetDisabled(true);
-            ApplyKeyColours(ShiftKey);
 
             _keyboardRoot.SetActive(false);
         }

--- a/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
+++ b/Assets/Scripts/Unity/Views/GameSetupScreenView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Frogs.Core;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -42,7 +43,7 @@ namespace Frogs.Unity.Views
         public const float SafeMargin = 48f;
         public const float SetupHeaderSize = 72f;
         public const float SeatWidth = 360f;
-        public const float SeatHeight = 440f;
+        public const float SeatHeight = 480f;
         public const float SeatGap = 48f;
         public const float SeatRadius = 32f;
         public const float SeatSwatchDiameter = 200f;
@@ -51,16 +52,41 @@ namespace Frogs.Unity.Views
         public const float HintGap = 56f;
         public const float SetupHintSize = 36f;
         public const float SeatOrderBadge = 72f;
-
-        // docs/specs/ui/game-setup.md#named-constants — added by this issue's
-        // PR, distilling values already stated in the Invariants section
-        // (SeatContentGap, SeatBadgeInset) and already drawn in the
-        // committed mockup: docs/specs/ui/mockups/game-setup.html draws
-        // every seat column with `gap:32px` between the swatch and the
-        // content below it, and the turn-order badge at a fixed
-        // `left:24px; top:24px` inset from the seat's own corner.
-        public const float SeatContentGap = 32f;
+        public const float SeatContentGap = 16f;
         public const float SeatBadgeInset = 24f;
+
+        // docs/specs/ui/game-setup.md#named-constants — the rows #310's
+        // wireframe added when the seat gained a name row and a remove
+        // target of its own.
+        public const float SeatTopBand = 136f;
+        public const float SeatCornerTarget = 96f;
+        public const float SeatCornerInset = 16f;
+        public const float SeatNameRowWidth = 312f;
+        public const float SeatNameRowHeight = 96f;
+        public const float SeatNameRowRadius = 20f;
+        public const float SeatNameRowPaddingX = 16f;
+        public const float SeatRowTop = 300f;
+        public const float SeatRowEditingTop = 150f;
+
+        // docs/specs/ui/game-setup.md#the-keyboard — a keyboard this game
+        // draws, never Android's.
+        public const float NameKeyboardHeight = 480f;
+        public const float NameKeyboardWidth = 1664f;
+        public const float NameKeyWidth = 152f;
+        public const float NameKeyHeight = 108f;
+        public const float NameKeyGap = 16f;
+        public const float NameKeyRadius = 20f;
+        public const float NameKeyLabelSize = 52f;
+        public const float NameSpaceKeyWidth = 1160f;
+        public const float NameDoneKeyWidth = 488f;
+
+        /// <summary>
+        /// docs/specs/ui/game-setup.md#named-constants — the longest name a
+        /// player can type. Read off <see cref="Frogs.Core.PlayerName"/>'s
+        /// own constant rather than repeating the number, because the cap is
+        /// Core's rule and this screen only renders the refusal.
+        /// </summary>
+        public const int PlayerNameMaxLength = Frogs.Core.PlayerName.PlayerNameMaxLength;
 
         // docs/specs/ui/game-setup.md#named-constants — added by this
         // issue's PR, distilling the Invariants section's prose: "a game
@@ -83,6 +109,26 @@ namespace Frogs.Unity.Views
         const string StartLabel = "Start";
         const string HintDisabledText = "Pick two to four frogs";
         const string HintGoesFirstSuffix = " goes first";
+
+        // While a name is being typed the header carries the prompt, because
+        // the hint line's resting position is underneath the keyboard —
+        // docs/specs/ui/mockups/game-setup-name-edit-inline.html draws
+        // "Name the green frog". The word `frog` here is attached to a
+        // colour, not to a name; nothing appends anything to a name.
+        const string NamingHeaderFormat = "Name the {0} frog";
+
+        const string RemoveKeyLabel = "×";
+        const string BackspaceKeyLabel = "⌫";
+        const string ShiftKeyLabel = "⇧";
+        const string SpaceKeyLabel = "space";
+        const string DoneKeyLabel = "Done";
+        const char SpaceCharacter = ' ';
+
+        // docs/specs/ui/game-setup.md#the-keyboard, rows 1-3. QWERTY, which
+        // is what the mockups draw; whether it should be alphabetical instead
+        // is a taste call left open for Connor and changes only which glyph
+        // sits on which key.
+        static readonly string[] LetterRows = { "QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM" };
 
         // No imported font — matches Button.cs's and TitleScreenView.cs's
         // own choice, for the same reason (no external assets).
@@ -123,8 +169,31 @@ namespace Frogs.Unity.Views
         static readonly Color EmptySwatchColor = new Color32(0xDD, 0xE4, 0xE1, 0xFF); // mockup's empty-seat swatch fill
         static readonly Color EmptyLabelColor = new Color32(0x8C, 0x97, 0x93, 0xFF); // mockup's "Tap to play" colour
         static readonly Color NoFillColor = new Color(1f, 1f, 1f, 0f); // "background:transparent" — fully transparent
+        static readonly Color AccentColor = new Color32(0x2E, 0x7D, 0x4F, 0xFF); // mockups' --accent
+        static readonly Color WarnColor = new Color32(0xB0, 0x3A, 0x2E, 0xFF); // mockups' --warn
+        static readonly Color RemoveFillColor = new Color32(0xFB, 0xF1, 0xF0, 0xFF); // mockups' .remove background
+        static readonly Color NameRowFillColor = new Color32(0xF4, 0xF7, 0xF5, 0xFF); // mockups' .namerow background
+        static readonly Color SpaceKeyLabelColor = new Color32(0x7A, 0x87, 0x83, 0xFF); // mockups' .k.space colour
+        static readonly Color DisabledKeyColor = new Color32(0xB9, 0xC0, 0xBD, 0xFF); // mockups' --faint, as a disabled key reads
 
         const float FullyOpaqueByte = 255f;
+
+        // Stroke widths the mockups draw but game-setup.md's constants table
+        // does not name — the same line SeatBadgeLabelSize and
+        // SeatEmptyBorderWidth above already draw: a rendering detail the
+        // spec leaves to presentation (ADR-0001), kept as a named private
+        // constant rather than a bare literal.
+        const float SeatNameRowBorderWidth = 3f;
+        const float SeatNameFieldBorderWidth = 5f;
+        const float SeatRemoveBorderWidth = 4f;
+        const float CaretWidth = 5f;
+        const float CaretHeight = 56f;
+        const float CaretGap = 4f;
+        const float NameKeyBorderWidth = 3f;
+        const float SeatRemoveLabelSize = 48f;
+        const float NameKeyGlyphLabelSize = 44f;
+        const float NameSpaceKeyLabelSize = 30f;
+        const float NameDoneKeyLabelSize = 44f;
 
         // No imported texture, sprite, or font — docs/specs/ui/shared-components.md
         // "no external assets". Same procedural rounded-rect technique as
@@ -135,6 +204,48 @@ namespace Frogs.Unity.Views
         static Sprite s_panelSprite;
         static Sprite s_swatchSprite;
         static Sprite s_badgeSprite;
+        static Sprite s_nameRowSprite;
+        static Sprite s_removeSprite;
+        static Sprite s_keySprite;
+
+        static Sprite NameRowSprite
+        {
+            get
+            {
+                if (s_nameRowSprite == null)
+                {
+                    s_nameRowSprite = CreateRoundedRectSprite(Mathf.RoundToInt(SeatNameRowRadius));
+                }
+
+                return s_nameRowSprite;
+            }
+        }
+
+        static Sprite RemoveSprite
+        {
+            get
+            {
+                if (s_removeSprite == null)
+                {
+                    s_removeSprite = CreateRoundedRectSprite(Mathf.RoundToInt(SeatCornerTarget / 2f));
+                }
+
+                return s_removeSprite;
+            }
+        }
+
+        static Sprite KeySprite
+        {
+            get
+            {
+                if (s_keySprite == null)
+                {
+                    s_keySprite = CreateRoundedRectSprite(Mathf.RoundToInt(NameKeyRadius));
+                }
+
+                return s_keySprite;
+            }
+        }
 
         static Sprite PanelSprite
         {
@@ -232,7 +343,16 @@ namespace Frogs.Unity.Views
         Button _backButton;
         Button _startButton;
 
-        readonly List<FrogColour> _chosenOrder = new List<FrogColour>();
+        RectTransform _keyboardRect;
+        GameObject _keyboardRoot;
+        readonly List<NameKeyboardKey> _nameKeys = new List<NameKeyboardKey>();
+
+        // Tap order, first tapped to last — the badge order, and the roster
+        // Start hands to Core. A frog that is removed loses its entry
+        // entirely, so re-seating it starts from its colour name again.
+        readonly List<RosterEntry> _chosen = new List<RosterEntry>();
+
+        PlayerNameEditor _editor;
 
         bool _initialized;
         ScreenRouter _router;
@@ -349,15 +469,81 @@ namespace Frogs.Unity.Views
         }
 
         /// <summary>
-        /// Tap order, first tapped to last — the badge order <see cref="Start"/>
-        /// hands to Core. Empty on a clean slate.
+        /// Tap order, first tapped to last — the badge order `Start` hands to
+        /// Core. Empty on a clean slate.
         /// </summary>
         public IReadOnlyList<FrogColour> ChosenOrder
         {
             get
             {
                 EnsureInitialized();
-                return _chosenOrder;
+                return _chosen.Select(entry => entry.Colour).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The roster as it stands — every chosen frog with the name it will
+        /// take into the game, in badge order.
+        /// </summary>
+        public IReadOnlyList<RosterEntry> ChosenRoster
+        {
+            get
+            {
+                EnsureInitialized();
+                return _chosen.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Which seat's name is being typed, or null when the keyboard is
+        /// down. Only one seat is edited at a time.
+        /// </summary>
+        public FrogColour? EditingSeat
+        {
+            get
+            {
+                EnsureInitialized();
+                return _editor == null ? (FrogColour?)null : _editor.Colour;
+            }
+        }
+
+        /// <summary>What has been typed so far in the open naming session — empty when the keyboard is down.</summary>
+        public string TypedName
+        {
+            get
+            {
+                EnsureInitialized();
+                return _editor == null ? string.Empty : _editor.Text;
+            }
+        }
+
+        /// <summary>The `keyboard` region's root — active only while a name is being typed.</summary>
+        public GameObject KeyboardRoot
+        {
+            get
+            {
+                EnsureInitialized();
+                return _keyboardRoot;
+            }
+        }
+
+        /// <summary>The `keyboard` region's <see cref="RectTransform"/>, <see cref="NameKeyboardWidth"/> x <see cref="NameKeyboardHeight"/>.</summary>
+        public RectTransform KeyboardRect
+        {
+            get
+            {
+                EnsureInitialized();
+                return _keyboardRect;
+            }
+        }
+
+        /// <summary>Every key on the name keyboard, in layout order.</summary>
+        public IReadOnlyList<NameKeyboardKey> NameKeys
+        {
+            get
+            {
+                EnsureInitialized();
+                return _nameKeys;
             }
         }
 
@@ -412,7 +598,123 @@ namespace Frogs.Unity.Views
         {
             EnsureInitialized();
 
-            _chosenOrder.Clear();
+            _chosen.Clear();
+            _editor = null;
+            RefreshAll();
+        }
+
+        /// <summary>The key that types <paramref name="character"/>, or null if the keyboard has none.</summary>
+        public NameKeyboardKey NameKey(char character)
+        {
+            EnsureInitialized();
+
+            var wanted = char.ToUpperInvariant(character);
+
+            foreach (var key in _nameKeys)
+            {
+                if ((key.Kind == NameKeyKind.Letter || key.Kind == NameKeyKind.Space)
+                    && char.ToUpperInvariant(key.Character) == wanted)
+                {
+                    return key;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>The space bar.</summary>
+        public NameKeyboardKey SpaceKey
+        {
+            get { return KeyOfKind(NameKeyKind.Space); }
+        }
+
+        /// <summary>The backspace key.</summary>
+        public NameKeyboardKey BackspaceKey
+        {
+            get { return KeyOfKind(NameKeyKind.Backspace); }
+        }
+
+        /// <summary>The shift key — drawn, and disabled; see this type's own note.</summary>
+        public NameKeyboardKey ShiftKey
+        {
+            get { return KeyOfKind(NameKeyKind.Shift); }
+        }
+
+        /// <summary>`Done` — the only way out of the keyboard.</summary>
+        public NameKeyboardKey DoneKey
+        {
+            get { return KeyOfKind(NameKeyKind.Done); }
+        }
+
+        NameKeyboardKey KeyOfKind(NameKeyKind kind)
+        {
+            EnsureInitialized();
+
+            foreach (var key in _nameKeys)
+            {
+                if (key.Kind == kind)
+                {
+                    return key;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// What this seat's player is called, or the empty string while the
+        /// seat is empty — "a seat that is not playing has no name and cannot
+        /// be given one."
+        /// </summary>
+        public string NameFor(FrogColour colour)
+        {
+            EnsureInitialized();
+
+            var entry = EntryFor(colour);
+            return entry == null ? string.Empty : entry.Name;
+        }
+
+        /// <summary>
+        /// Empties the name being typed, without closing the keyboard — what
+        /// holding backspace down arrives at. A no-op when nothing is being
+        /// typed.
+        /// </summary>
+        public void ClearName()
+        {
+            EnsureInitialized();
+
+            if (_editor == null)
+            {
+                return;
+            }
+
+            _editor.Clear();
+            RefreshAll();
+        }
+
+        /// <summary>
+        /// `Done`: closes the keyboard, puts the seat row back at
+        /// <see cref="SeatRowTop"/>, and brings the hint and the controls
+        /// back. A blank name becomes the frog's colour name again.
+        /// </summary>
+        public void DoneNaming()
+        {
+            EnsureInitialized();
+
+            if (_editor == null)
+            {
+                return;
+            }
+
+            var committed = _editor.Commit();
+            var index = IndexOf(committed.Colour);
+
+            if (index >= 0)
+            {
+                _chosen[index] = committed;
+            }
+
+            _editor = null;
             RefreshAll();
         }
 
@@ -443,19 +745,62 @@ namespace Frogs.Unity.Views
         /// <summary>The turn-order badge's digit.</summary>
         public Text SeatBadgeText(FrogColour colour) => SeatFor(colour).BadgeText;
 
+        /// <summary>
+        /// The seat's name row — the edit target. Tapping it opens the
+        /// keyboard on this seat. Present only on a chosen seat.
+        /// </summary>
+        public RectTransform SeatNameRowRect(FrogColour colour) => SeatFor(colour).NameRowRect;
+
+        /// <summary>The name row's root — active only while the seat is chosen.</summary>
+        public GameObject SeatNameRowRoot(FrogColour colour) => SeatFor(colour).NameRowRoot;
+
+        /// <summary>The name row's tap target — the edit target, and nothing else.</summary>
+        public SeatTapTarget SeatNameRowTapTarget(FrogColour colour) => SeatFor(colour).NameRowTapTarget;
+
+        /// <summary>The remove target's root — active only while the seat is chosen and not being edited.</summary>
+        public GameObject SeatRemoveRoot(FrogColour colour) => SeatFor(colour).RemoveRoot;
+
+        /// <summary>The remove target's <see cref="RectTransform"/> — <see cref="SeatCornerTarget"/> at <see cref="SeatCornerInset"/> from the top-right corner.</summary>
+        public RectTransform SeatRemoveRect(FrogColour colour) => SeatFor(colour).RemoveRect;
+
+        /// <summary>The remove target's tap target — the only way a player leaves the game.</summary>
+        public SeatTapTarget SeatRemoveTapTarget(FrogColour colour) => SeatFor(colour).RemoveTapTarget;
+
+        /// <summary>The caret drawn in the name field while this seat is being edited.</summary>
+        public GameObject SeatCaret(FrogColour colour) => SeatFor(colour).Caret;
+
         /// <summary>Whether this seat currently holds a frog.</summary>
         public bool IsSeatChosen(FrogColour colour)
         {
             EnsureInitialized();
-            return _chosenOrder.Contains(colour);
+            return IndexOf(colour) >= 0;
         }
 
         /// <summary>This seat's turn-order badge (1-based), or null while the seat is empty.</summary>
         public int? SeatBadgeNumber(FrogColour colour)
         {
             EnsureInitialized();
-            var index = _chosenOrder.IndexOf(colour);
+            var index = IndexOf(colour);
             return index >= 0 ? index + 1 : (int?)null;
+        }
+
+        int IndexOf(FrogColour colour)
+        {
+            for (var index = 0; index < _chosen.Count; index++)
+            {
+                if (_chosen[index].Colour == colour)
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        RosterEntry EntryFor(FrogColour colour)
+        {
+            var index = IndexOf(colour);
+            return index >= 0 ? _chosen[index] : null;
         }
 
         Seat SeatFor(FrogColour colour)
@@ -506,6 +851,174 @@ namespace Frogs.Unity.Views
             BuildSeats();
             BuildHint();
             BuildControls();
+            BuildKeyboard();
+        }
+
+        // keyboard — pinned to the bottom safe area, centred,
+        // NameKeyboardHeight tall, laid out over hint and controls rather
+        // than beside them. docs/specs/ui/game-setup.md#the-keyboard.
+        void BuildKeyboard()
+        {
+            var keyboardGO = new GameObject("Keyboard", typeof(RectTransform));
+            _keyboardRoot = keyboardGO;
+            _keyboardRect = (RectTransform)keyboardGO.transform;
+            _keyboardRect.SetParent(_contentRect, worldPositionStays: false);
+            _keyboardRect.anchorMin = new Vector2(0.5f, 0f);
+            _keyboardRect.anchorMax = new Vector2(0.5f, 0f);
+            _keyboardRect.pivot = new Vector2(0.5f, 0f);
+            _keyboardRect.sizeDelta = new Vector2(NameKeyboardWidth, NameKeyboardHeight);
+            _keyboardRect.anchoredPosition = new Vector2(0f, SafeMargin);
+
+            var rowPitch = NameKeyHeight + NameKeyGap;
+
+            for (var rowIndex = 0; rowIndex < LetterRows.Length; rowIndex++)
+            {
+                var letters = LetterRows[rowIndex];
+                var isLastLetterRow = rowIndex == LetterRows.Length - 1;
+
+                // Row 3 carries shift and backspace either side of its seven
+                // letters — docs/specs/ui/game-setup.md#the-keyboard.
+                var keyCount = isLastLetterRow ? letters.Length + 2 : letters.Length;
+                var rowWidth = (keyCount * NameKeyWidth) + ((keyCount - 1) * NameKeyGap);
+                var x = -(rowWidth / 2f) + (NameKeyWidth / 2f);
+                var y = (NameKeyboardHeight / 2f) - (NameKeyHeight / 2f) - (rowIndex * rowPitch);
+
+                if (isLastLetterRow)
+                {
+                    BuildKey(NameKeyKind.Shift, default(char), ShiftKeyLabel, NameKeyGlyphLabelSize, NameKeyWidth, new Vector2(x, y));
+                    x += NameKeyWidth + NameKeyGap;
+                }
+
+                foreach (var letter in letters)
+                {
+                    BuildKey(NameKeyKind.Letter, letter, letter.ToString(), NameKeyLabelSize, NameKeyWidth, new Vector2(x, y));
+                    x += NameKeyWidth + NameKeyGap;
+                }
+
+                if (isLastLetterRow)
+                {
+                    BuildKey(NameKeyKind.Backspace, default(char), BackspaceKeyLabel, NameKeyGlyphLabelSize, NameKeyWidth, new Vector2(x, y));
+                }
+            }
+
+            // Row 4: the space bar and `Done`, filling the block's width.
+            var bottomY = (NameKeyboardHeight / 2f) - (NameKeyHeight / 2f) - (LetterRows.Length * rowPitch);
+            var spaceX = -(NameKeyboardWidth / 2f) + (NameSpaceKeyWidth / 2f);
+            var doneX = (NameKeyboardWidth / 2f) - (NameDoneKeyWidth / 2f);
+
+            BuildKey(NameKeyKind.Space, SpaceCharacter, SpaceKeyLabel, NameSpaceKeyLabelSize, NameSpaceKeyWidth, new Vector2(spaceX, bottomY));
+            BuildKey(NameKeyKind.Done, default(char), DoneKeyLabel, NameDoneKeyLabelSize, NameDoneKeyWidth, new Vector2(doneX, bottomY));
+
+            // The shift key is drawn because the agreed mockup draws it, and
+            // disabled because what it does is not settled — see this type's
+            // note at the top of the naming section.
+            ShiftKey.SetDisabled(true);
+            ApplyKeyColours(ShiftKey);
+
+            _keyboardRoot.SetActive(false);
+        }
+
+        void BuildKey(NameKeyKind kind, char character, string label, float labelSize, float width, Vector2 position)
+        {
+            var keyGO = new GameObject("Key" + label, typeof(RectTransform));
+            var keyRect = (RectTransform)keyGO.transform;
+            keyRect.SetParent(_keyboardRect, worldPositionStays: false);
+            keyRect.anchorMin = new Vector2(0.5f, 0.5f);
+            keyRect.anchorMax = new Vector2(0.5f, 0.5f);
+            keyRect.pivot = new Vector2(0.5f, 0.5f);
+            keyRect.sizeDelta = new Vector2(width, NameKeyHeight);
+            keyRect.anchoredPosition = position;
+
+            // The key's hit area: the outline, covering the whole key, with
+            // the fill and the label refusing the raycast underneath it.
+            // Without it there is nothing raycastable under the key, the
+            // GraphicRaycaster never finds it, and the keyboard types
+            // nothing (#288).
+            var borderGO = new GameObject("Border", typeof(RectTransform), typeof(Image));
+            var border = borderGO.GetComponent<Image>();
+            border.sprite = KeySprite;
+            border.type = Image.Type.Sliced;
+            border.raycastTarget = true;
+            var borderRect = border.rectTransform;
+            borderRect.SetParent(keyRect, worldPositionStays: false);
+            StretchToFill(borderRect);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            var fill = fillGO.GetComponent<Image>();
+            fill.sprite = KeySprite;
+            fill.type = Image.Type.Sliced;
+            fill.raycastTarget = false;
+            var fillRect = fill.rectTransform;
+            fillRect.SetParent(borderRect, worldPositionStays: false);
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = new Vector2(NameKeyBorderWidth, NameKeyBorderWidth);
+            fillRect.offsetMax = new Vector2(-NameKeyBorderWidth, -NameKeyBorderWidth);
+
+            var textGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            var text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            text.fontSize = (int)labelSize;
+            text.alignment = TextAnchor.MiddleCenter;
+            text.text = label;
+            text.fontStyle = kind == NameKeyKind.Space ? FontStyle.Normal : FontStyle.Bold;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false;
+            text.rectTransform.SetParent(borderRect, worldPositionStays: false);
+            StretchToFill(text.rectTransform);
+
+            var key = keyGO.AddComponent<NameKeyboardKey>();
+            key.Describe(kind, character, border, fill, text);
+            ApplyKeyColours(key);
+            key.Tapped += HandleKeyTapped;
+
+            _nameKeys.Add(key);
+        }
+
+        static void ApplyKeyColours(NameKeyboardKey key)
+        {
+            var isDone = key.Kind == NameKeyKind.Done;
+
+            key.Border.color = key.IsDisabled
+                ? DisabledKeyColor
+                : (isDone ? AccentColor : LineColor);
+            key.Fill.color = isDone && !key.IsDisabled ? AccentColor : PaperColor;
+            key.Label.color = key.IsDisabled
+                ? DisabledKeyColor
+                : (isDone ? PaperColor : (key.Kind == NameKeyKind.Space ? SpaceKeyLabelColor : InkColor));
+        }
+
+        void HandleKeyTapped(NameKeyboardKey key)
+        {
+            if (_editor == null)
+            {
+                return;
+            }
+
+            switch (key.Kind)
+            {
+                case NameKeyKind.Letter:
+                case NameKeyKind.Space:
+                    // A refusal at the cap is silently ignored: the key does
+                    // nothing, the name is unchanged, and nothing explains
+                    // itself.
+                    _editor.Append(key.Character);
+                    break;
+
+                case NameKeyKind.Backspace:
+                    _editor.Backspace();
+                    break;
+
+                case NameKeyKind.Done:
+                    DoneNaming();
+                    return;
+
+                default:
+                    return;
+            }
+
+            RefreshAll();
         }
 
         void BuildBackground()
@@ -631,6 +1144,31 @@ namespace Frogs.Unity.Views
             swatchRect.pivot = new Vector2(0.5f, 0.5f);
             swatchRect.sizeDelta = new Vector2(SeatSwatchDiameter, SeatSwatchDiameter);
 
+            // The name band. On a chosen seat it is drawn as a field — a
+            // bordered box — because it is the one part of a seat a player
+            // can change and it has to look like it. On an empty seat only
+            // the text inside it shows, reading `Tap to play`.
+            var nameRowGO = new GameObject("NameRow", typeof(RectTransform), typeof(Image));
+            var nameRowBorder = nameRowGO.GetComponent<Image>();
+            nameRowBorder.sprite = NameRowSprite;
+            nameRowBorder.type = Image.Type.Sliced;
+            nameRowBorder.raycastTarget = true;
+            var nameRowRect = nameRowBorder.rectTransform;
+            nameRowRect.SetParent(seatRect, worldPositionStays: false);
+            nameRowRect.anchorMin = new Vector2(0.5f, 0.5f);
+            nameRowRect.anchorMax = new Vector2(0.5f, 0.5f);
+            nameRowRect.pivot = new Vector2(0.5f, 0.5f);
+            nameRowRect.sizeDelta = new Vector2(SeatNameRowWidth, SeatNameRowHeight);
+
+            var nameRowFillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            var nameRowFill = nameRowFillGO.GetComponent<Image>();
+            nameRowFill.sprite = NameRowSprite;
+            nameRowFill.type = Image.Type.Sliced;
+            nameRowFill.raycastTarget = false;
+            var nameRowFillRect = nameRowFill.rectTransform;
+            nameRowFillRect.SetParent(nameRowRect, worldPositionStays: false);
+            StretchToFill(nameRowFillRect);
+
             var labelGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
             var label = labelGO.GetComponent<Text>();
             label.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
@@ -639,12 +1177,78 @@ namespace Frogs.Unity.Views
             label.horizontalOverflow = HorizontalWrapMode.Overflow;
             label.verticalOverflow = VerticalWrapMode.Overflow;
             label.raycastTarget = false;
+            // The label and the caret hang off the seat rather than off the
+            // name row, because an empty seat hides the row but still shows a
+            // word in the same place — `Tap to play`.
             var labelRect = label.rectTransform;
             labelRect.SetParent(seatRect, worldPositionStays: false);
             labelRect.anchorMin = new Vector2(0.5f, 0.5f);
             labelRect.anchorMax = new Vector2(0.5f, 0.5f);
             labelRect.pivot = new Vector2(0.5f, 0.5f);
-            labelRect.sizeDelta = Vector2.zero;
+            labelRect.sizeDelta = new Vector2(SeatNameRowWidth - (SeatNameRowPaddingX * 2f), SeatNameRowHeight);
+
+            // The caret, drawn only on the seat being edited.
+            var caretGO = new GameObject("Caret", typeof(RectTransform), typeof(Image));
+            var caret = caretGO.GetComponent<Image>();
+            caret.color = InkColor;
+            caret.raycastTarget = false;
+            var caretRect = caret.rectTransform;
+            caretRect.SetParent(seatRect, worldPositionStays: false);
+            caretRect.anchorMin = new Vector2(0.5f, 0.5f);
+            caretRect.anchorMax = new Vector2(0.5f, 0.5f);
+            caretRect.pivot = new Vector2(0.5f, 0.5f);
+            caretRect.sizeDelta = new Vector2(CaretWidth, CaretHeight);
+            caretGO.SetActive(false);
+
+            var nameRowTapTarget = nameRowGO.AddComponent<SeatTapTarget>();
+            nameRowTapTarget.Clicked += () => HandleNameRowTapped(colour);
+
+            // The remove target — SeatCornerTarget at SeatCornerInset from
+            // the seat's top-right corner, and the only way a player leaves
+            // the game.
+            var removeGO = new GameObject("Remove", typeof(RectTransform), typeof(Image));
+            var removeBorder = removeGO.GetComponent<Image>();
+            removeBorder.sprite = RemoveSprite;
+            removeBorder.type = Image.Type.Sliced;
+            removeBorder.color = WarnColor;
+            removeBorder.raycastTarget = true;
+            var removeRect = removeBorder.rectTransform;
+            removeRect.SetParent(seatRect, worldPositionStays: false);
+            removeRect.anchorMin = new Vector2(1f, 1f);
+            removeRect.anchorMax = new Vector2(1f, 1f);
+            removeRect.pivot = new Vector2(1f, 1f);
+            removeRect.sizeDelta = new Vector2(SeatCornerTarget, SeatCornerTarget);
+            removeRect.anchoredPosition = new Vector2(-SeatCornerInset, -SeatCornerInset);
+
+            var removeFillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            var removeFill = removeFillGO.GetComponent<Image>();
+            removeFill.sprite = RemoveSprite;
+            removeFill.type = Image.Type.Sliced;
+            removeFill.color = RemoveFillColor;
+            removeFill.raycastTarget = false;
+            var removeFillRect = removeFill.rectTransform;
+            removeFillRect.SetParent(removeRect, worldPositionStays: false);
+            removeFillRect.anchorMin = Vector2.zero;
+            removeFillRect.anchorMax = Vector2.one;
+            removeFillRect.offsetMin = new Vector2(SeatRemoveBorderWidth, SeatRemoveBorderWidth);
+            removeFillRect.offsetMax = new Vector2(-SeatRemoveBorderWidth, -SeatRemoveBorderWidth);
+
+            var removeLabelGO = new GameObject("Glyph", typeof(RectTransform), typeof(Text));
+            var removeLabel = removeLabelGO.GetComponent<Text>();
+            removeLabel.font = Resources.GetBuiltinResource<Font>(BuiltinLabelFontName);
+            removeLabel.fontSize = (int)SeatRemoveLabelSize;
+            removeLabel.alignment = TextAnchor.MiddleCenter;
+            removeLabel.color = WarnColor;
+            removeLabel.fontStyle = FontStyle.Bold;
+            removeLabel.text = RemoveKeyLabel;
+            removeLabel.horizontalOverflow = HorizontalWrapMode.Overflow;
+            removeLabel.verticalOverflow = VerticalWrapMode.Overflow;
+            removeLabel.raycastTarget = false;
+            removeLabel.rectTransform.SetParent(removeRect, worldPositionStays: false);
+            StretchToFill(removeLabel.rectTransform);
+
+            var removeTapTarget = removeGO.AddComponent<SeatTapTarget>();
+            removeTapTarget.Clicked += () => HandleRemoveTapped(colour);
 
             var badgeGO = new GameObject("Badge", typeof(RectTransform), typeof(Image));
             var badgeImage = badgeGO.GetComponent<Image>();
@@ -686,7 +1290,16 @@ namespace Frogs.Unity.Views
                 Label = label,
                 BadgeRoot = badgeGO,
                 BadgeRect = badgeRect,
-                BadgeText = badgeText
+                BadgeText = badgeText,
+                NameRowRoot = nameRowGO,
+                NameRowRect = nameRowRect,
+                NameRowBorder = nameRowBorder,
+                NameRowFill = nameRowFill,
+                NameRowTapTarget = nameRowTapTarget,
+                Caret = caretGO,
+                RemoveRoot = removeGO,
+                RemoveRect = removeRect,
+                RemoveTapTarget = removeTapTarget
             };
 
             PositionSeatContent(seat);
@@ -696,19 +1309,23 @@ namespace Frogs.Unity.Views
             return seat;
         }
 
-        // The swatch and the label below it, centred as a block within the
-        // seat, SeatContentGap apart — docs/specs/ui/mockups/game-setup.html:
-        // every seat column draws `gap:32px` between the swatch and the
-        // content below it.
-        void PositionSeatContent(Seat seat)
+        // The swatch sits SeatTopBand below the seat's top edge — that band
+        // is the space the two corner targets live in — and the name band
+        // sits SeatContentGap below the swatch. Both mockups draw exactly
+        // this: `.seat{padding-top:136px; gap:16px}`.
+        static void PositionSeatContent(Seat seat)
         {
-            var labelHeight = SeatLabelSize;
-            var stackHeight = SeatSwatchDiameter + SeatContentGap + labelHeight;
-            var swatchCenterY = (stackHeight / 2f) - (SeatSwatchDiameter / 2f);
-            var labelCenterY = swatchCenterY - (SeatSwatchDiameter / 2f) - SeatContentGap - (labelHeight / 2f);
+            var seatTop = SeatHeight / 2f;
+            var swatchCenterY = seatTop - SeatTopBand - (SeatSwatchDiameter / 2f);
+            var nameRowCenterY = swatchCenterY
+                - (SeatSwatchDiameter / 2f)
+                - SeatContentGap
+                - (SeatNameRowHeight / 2f);
 
             seat.Swatch.rectTransform.anchoredPosition = new Vector2(0f, swatchCenterY);
-            seat.Label.rectTransform.anchoredPosition = new Vector2(0f, labelCenterY);
+            seat.NameRowRect.anchoredPosition = new Vector2(0f, nameRowCenterY);
+            seat.Label.rectTransform.anchoredPosition = new Vector2(0f, nameRowCenterY);
+            seat.Caret.GetComponent<RectTransform>().anchoredPosition = new Vector2(0f, nameRowCenterY);
         }
 
         void BuildHint()
@@ -769,26 +1386,21 @@ namespace Frogs.Unity.Views
             return button;
         }
 
-        // seats centred both ways in the space between header and controls
-        // — docs/specs/ui/game-setup.md's Anchors section. Unlike
-        // title-screen.md, game-setup.md names no absolute pixel offset for
-        // this: the header and controls zones are derived from the
-        // constants that describe them (SafeMargin/SetupHeaderSize for the
-        // header, SafeMargin/ButtonHeight for controls), and the seats+hint
-        // block is centred in whatever is left.
+        // The seat row's top edge is a named number now, not a centring
+        // calculation — docs/specs/ui/game-setup.md#named-constants gives
+        // SeatRowTop 300 at rest and SeatRowEditingTop 150 while a name is
+        // being typed. It has to be named, because "the distance they move"
+        // is the whole reason the game draws its own keyboard rather than
+        // Android's: a system keyboard's height is not a number a spec can
+        // carry.
         static float ComputeSeatsCenterY()
         {
-            var topReserved = SafeMargin + SetupHeaderSize;
-            var bottomReserved = SafeMargin + Button.ButtonHeight;
-            var hintBlockHeight = HintGap + SetupHintSize;
+            return SeatsCenterYFor(SeatRowTop);
+        }
 
-            var availableMiddle = CanvasHeight - topReserved - bottomReserved;
-            var blockHeight = SeatHeight + hintBlockHeight;
-
-            var topOfMiddleZone = (CanvasHeight / 2f) - topReserved;
-            var topOfBlock = topOfMiddleZone - ((availableMiddle - blockHeight) / 2f);
-
-            return topOfBlock - (SeatHeight / 2f);
+        static float SeatsCenterYFor(float rowTop)
+        {
+            return (CanvasHeight / 2f) - rowTop - (SeatHeight / 2f);
         }
 
         // hint sits HintGap beneath seats, centred —
@@ -800,38 +1412,81 @@ namespace Frogs.Unity.Views
 
         void HandleSeatTapped(FrogColour colour)
         {
-            // Empty: adds this frog; it takes the next free turn-order
-            // number. Chosen: removes this frog; the badges after it
-            // renumber — computed fresh on every refresh below, never
-            // cached, so removal renumbers immediately rather than at
-            // Start. docs/specs/ui/game-setup.md's Elements section.
-            if (_chosenOrder.Contains(colour))
+            // **A chosen seat's body is inert, and that is the change.** It
+            // used to be the remove target. Adding an edit target inside a
+            // 360 x 480 destructive target means a child aiming at the name
+            // and missing loses the player, with no confirm to catch it.
+            // An empty seat's body still seats the frog, unchanged.
+            if (IsSeatChosen(colour))
             {
-                _chosenOrder.Remove(colour);
-            }
-            else
-            {
-                _chosenOrder.Add(colour);
+                return;
             }
 
+            _chosen.Add(new RosterEntry(colour));
+            RefreshAll();
+        }
+
+        void HandleNameRowTapped(FrogColour colour)
+        {
+            // "A seat that is not playing has no name and cannot be given
+            // one. Naming a frog that is not in the game is a state with no
+            // meaning."
+            var entry = EntryFor(colour);
+
+            if (entry == null)
+            {
+                return;
+            }
+
+            // Only one seat is being edited at a time, so opening this one
+            // commits whatever the last one had typed.
+            DoneNaming();
+
+            _editor = new PlayerNameEditor(entry);
+            RefreshAll();
+        }
+
+        void HandleRemoveTapped(FrogColour colour)
+        {
+            var index = IndexOf(colour);
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            if (_editor != null && _editor.Colour == colour)
+            {
+                _editor = null;
+            }
+
+            // The badges after it renumber — computed fresh on every refresh
+            // below, never cached, so removal renumbers immediately rather
+            // than at Start.
+            _chosen.RemoveAt(index);
             RefreshAll();
         }
 
         void RefreshAll()
         {
+            var editing = EditingSeat;
+
             foreach (var colour in SeatOrder)
             {
                 var seat = _seats[colour];
-                var index = _chosenOrder.IndexOf(colour);
-                ApplySeatState(seat, index >= 0, index + 1);
+                var index = IndexOf(colour);
+                ApplySeatState(seat, index, editing.HasValue && editing.Value == colour);
             }
 
-            RefreshControls();
+            RefreshKeyboard(editing);
+            RefreshControls(editing);
         }
 
-        void ApplySeatState(Seat seat, bool isChosen, int badgeNumber)
+        void ApplySeatState(Seat seat, int index, bool isEditing)
         {
-            seat.Outline.color = isChosen ? InkColor : FaintColor;
+            var isChosen = index >= 0;
+
+            seat.Outline.color = isEditing ? AccentColor : (isChosen ? InkColor : FaintColor);
 
             var ringWidth = isChosen ? SeatChosenRing : SeatEmptyBorderWidth;
             seat.Fill.rectTransform.offsetMin = new Vector2(ringWidth, ringWidth);
@@ -840,29 +1495,82 @@ namespace Frogs.Unity.Views
 
             seat.Swatch.color = isChosen ? FrogColours.For(seat.Colour) : EmptySwatchColor;
 
-            seat.Label.text = isChosen ? seat.Colour.ToString() : EmptySeatLabel;
+            // An empty seat has no name row and no remove target, but its
+            // body still seats the frog and it still shows a word in the name
+            // band's place.
+            seat.NameRowRoot.SetActive(isChosen);
+            seat.NameRowBorder.color = isEditing ? AccentColor : FaintColor;
+            seat.NameRowFill.color = isEditing ? PaperColor : NameRowFillColor;
+
+            var borderWidth = isEditing ? SeatNameFieldBorderWidth : SeatNameRowBorderWidth;
+            seat.NameRowFill.rectTransform.offsetMin = new Vector2(borderWidth, borderWidth);
+            seat.NameRowFill.rectTransform.offsetMax = new Vector2(-borderWidth, -borderWidth);
+
+            seat.Label.text = isEditing
+                ? _editor.Text
+                : (isChosen ? _chosen[index].Name : EmptySeatLabel);
             seat.Label.color = isChosen ? InkColor : EmptyLabelColor;
             seat.Label.fontStyle = isChosen ? FontStyle.Bold : FontStyle.Normal;
+
+            seat.Caret.SetActive(isEditing);
+            if (isEditing)
+            {
+                // Just to the right of the text, the way the mockup draws it.
+                var caretRect = (RectTransform)seat.Caret.transform;
+                caretRect.anchoredPosition = new Vector2(
+                    (seat.Label.preferredWidth / 2f) + CaretGap,
+                    seat.NameRowRect.anchoredPosition.y);
+            }
+
+            // The remove target is not drawn on the seat being edited —
+            // "Done first, then remove if that is what you meant."
+            seat.RemoveRoot.SetActive(isChosen && !isEditing);
 
             seat.BadgeRoot.SetActive(isChosen);
             if (isChosen)
             {
-                seat.BadgeText.text = badgeNumber.ToString();
+                seat.BadgeText.text = (index + 1).ToString();
             }
         }
 
-        void RefreshControls()
+        void RefreshKeyboard(FrogColour? editing)
+        {
+            var isTyping = editing.HasValue;
+
+            _keyboardRoot.SetActive(isTyping);
+
+            // While a name is being typed the seat row moves up to clear the
+            // keyboard. Nothing else moves and nothing resizes.
+            _seatsRect.anchoredPosition = new Vector2(
+                0f,
+                SeatsCenterYFor(isTyping ? SeatRowEditingTop : SeatRowTop));
+
+            _headerText.text = isTyping
+                ? string.Format(NamingHeaderFormat, editing.Value.ToString().ToLowerInvariant())
+                : HeaderLabel;
+        }
+
+        void RefreshControls(FrogColour? editing)
         {
             // Start disabled below GameSetupMinFrogs, enabled from
             // GameSetupMinFrogs up to GameSetupMaxFrogs (all four seats
             // chosen) — there are exactly four seats, so the seat count is
             // the maximum; no separate ceiling check is needed.
-            var startEnabled = _chosenOrder.Count >= GameSetupMinFrogs;
+            var startEnabled = _chosen.Count >= GameSetupMinFrogs;
             _startButton.SetDisabled(!startEnabled);
 
+            // The hint names whoever goes first by their name, so
+            // `Connor goes first` rather than `Green goes first` once Green
+            // has been renamed.
             _hintText.text = startEnabled
-                ? _chosenOrder[0].ToString() + HintGoesFirstSuffix
+                ? _chosen[0].Name + HintGoesFirstSuffix
                 : HintDisabledText;
+
+            // hint and the controls are laid out under the keyboard rather
+            // than beside it, so both are hidden while it is up.
+            var isTyping = editing.HasValue;
+            _hintRect.gameObject.SetActive(!isTyping);
+            _controlsRect.gameObject.SetActive(!isTyping);
         }
 
         void HandleBackClicked()
@@ -872,17 +1580,19 @@ namespace Frogs.Unity.Views
 
         void HandleStartClicked()
         {
-            // Button never invokes Clicked while disabled, so `_chosenOrder`
+            // Button never invokes Clicked while disabled, so `_chosen`
             // is always between GameSetupMinFrogs and GameSetupMaxFrogs
             // here, already unique (a seat can only ever appear once in tap
             // order) — exactly what Frogs.Core.Game's constructor itself
             // re-validates. This screen adds no game rules of its own;
             // docs/specs/ui/game-setup.md#behaviour: "`Start` begins the
             // game with the chosen frogs in badge order."
-            var turnOrder = _chosenOrder.ToArray();
+            // Their names go with them, and are what every later screen
+            // shows — docs/specs/ui/game-setup.md#behaviour.
+            var roster = _chosen.ToArray();
             var seed = _seedFactory();
 
-            StartedGame = new Frogs.Core.Game(turnOrder, seed);
+            StartedGame = new Frogs.Core.Game(roster, seed);
 
             _router?.NavigateToScreen(CoreScreen.GameBoard);
         }
@@ -923,6 +1633,15 @@ namespace Frogs.Unity.Views
             public GameObject BadgeRoot;
             public RectTransform BadgeRect;
             public Text BadgeText;
+            public GameObject NameRowRoot;
+            public RectTransform NameRowRect;
+            public Image NameRowBorder;
+            public Image NameRowFill;
+            public SeatTapTarget NameRowTapTarget;
+            public GameObject Caret;
+            public GameObject RemoveRoot;
+            public RectTransform RemoveRect;
+            public SeatTapTarget RemoveTapTarget;
         }
 
         /// <summary>

--- a/Assets/Scripts/Unity/Views/NameKeyKind.cs
+++ b/Assets/Scripts/Unity/Views/NameKeyKind.cs
@@ -1,0 +1,29 @@
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// What one key of game setup's name keyboard does —
+    /// docs/specs/ui/game-setup.md#the-keyboard.
+    /// </summary>
+    public enum NameKeyKind
+    {
+        /// <summary>Appends its own letter.</summary>
+        Letter,
+
+        /// <summary>Appends a space.</summary>
+        Space,
+
+        /// <summary>Deletes the last character.</summary>
+        Backspace,
+
+        /// <summary>
+        /// The shift key the mockups draw. What it does is not yet settled —
+        /// see <c>GameSetupScreenView</c>'s note and the open
+        /// <c>type:question</c> issue — so it is drawn disabled rather than
+        /// wired to a guess.
+        /// </summary>
+        Shift,
+
+        /// <summary>Closes the keyboard. The only way out of it.</summary>
+        Done
+    }
+}

--- a/Assets/Scripts/Unity/Views/NameKeyKind.cs
+++ b/Assets/Scripts/Unity/Views/NameKeyKind.cs
@@ -15,14 +15,6 @@ namespace Frogs.Unity.Views
         /// <summary>Deletes the last character.</summary>
         Backspace,
 
-        /// <summary>
-        /// The shift key the mockups draw. What it does is not yet settled —
-        /// see <c>GameSetupScreenView</c>'s note and the open
-        /// <c>type:question</c> issue — so it is drawn disabled rather than
-        /// wired to a guess.
-        /// </summary>
-        Shift,
-
         /// <summary>Closes the keyboard. The only way out of it.</summary>
         Done
     }

--- a/Assets/Scripts/Unity/Views/NameKeyKind.cs.meta
+++ b/Assets/Scripts/Unity/Views/NameKeyKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27b9a48bed3b4757b5a743f3a979a790
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/NameKeyboardKey.cs
+++ b/Assets/Scripts/Unity/Views/NameKeyboardKey.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Frogs.Unity.Views
+{
+    /// <summary>
+    /// One key of game setup's name keyboard — docs/specs/ui/game-setup.md#the-keyboard.
+    ///
+    /// Deliberately not the shared <see cref="Frogs.Unity.UI.Button"/>, for
+    /// the same reason <see cref="WorkingOutKeypadKey"/> is not: that
+    /// component is 112 px tall with a 320 px minimum width, and this page
+    /// gives its keys their own named size. The one shared Button behaviour
+    /// this borrows is the disabled one — a key that is refused "does nothing,
+    /// and nothing explains itself".
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public sealed class NameKeyboardKey : MonoBehaviour, IPointerClickHandler
+    {
+        /// <summary>This key was tapped. Never raised while <see cref="IsDisabled"/>.</summary>
+        public event Action<NameKeyboardKey> Tapped;
+
+        /// <summary>What the key does.</summary>
+        public NameKeyKind Kind { get; private set; }
+
+        /// <summary>The character a <see cref="NameKeyKind.Letter"/> or <see cref="NameKeyKind.Space"/> key types.</summary>
+        public char Character { get; private set; }
+
+        /// <summary>
+        /// The key's outline — and its hit area. #288's lesson: without a
+        /// raycast target of its own there is nothing raycastable under the
+        /// key, the <c>GraphicRaycaster</c> never finds it, and the keyboard
+        /// types nothing.
+        /// </summary>
+        public Image Border { get; private set; }
+
+        /// <summary>The key's fill, inside its outline.</summary>
+        public Image Fill { get; private set; }
+
+        /// <summary>The key's label.</summary>
+        public Text Label { get; private set; }
+
+        /// <summary>Whether this key is refused. A disabled key emits nothing.</summary>
+        public bool IsDisabled { get; private set; }
+
+        /// <summary>The key's own <see cref="RectTransform"/>.</summary>
+        public RectTransform RectTransform
+        {
+            get { return (RectTransform)transform; }
+        }
+
+        /// <summary>Records what this key is, as the view builds it.</summary>
+        public void Describe(NameKeyKind kind, char character, Image border, Image fill, Text label)
+        {
+            Kind = kind;
+            Character = character;
+            Border = border;
+            Fill = fill;
+            Label = label;
+        }
+
+        /// <summary>Turns the key off, or back on.</summary>
+        public void SetDisabled(bool disabled)
+        {
+            IsDisabled = disabled;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (IsDisabled)
+            {
+                return;
+            }
+
+            var handler = Tapped;
+            if (handler != null)
+            {
+                handler(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Unity/Views/NameKeyboardKey.cs.meta
+++ b/Assets/Scripts/Unity/Views/NameKeyboardKey.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 49d7955c5d3c414bbb4f5a5f9209a81c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs
+++ b/Assets/Scripts/Unity/Views/RollAndCardDialogView.cs
@@ -582,7 +582,7 @@ namespace Frogs.Unity.Views
             }
 
             var frog = _readout.Frog;
-            _whoseChip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _whoseChip.SetFrog(FrogColours.For(frog), _readout.FrogName);
             _whoseChip.SetState(PlayerChipState.Active);
 
             var pile = _readout.Pile;

--- a/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
+++ b/Assets/Scripts/Unity/Views/WorkingOutGridView.cs
@@ -550,7 +550,7 @@ namespace Frogs.Unity.Views
             }
 
             var frog = _turn.Frog;
-            _whoseChip.SetFrog(FrogColours.For(frog), frog.ToString());
+            _whoseChip.SetFrog(FrogColours.For(frog), _turn.FrogName);
             _whoseChip.SetState(PlayerChipState.Active);
 
             var card = _turn.Card;

--- a/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
+++ b/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
@@ -763,6 +763,16 @@ namespace Frogs.Unity.EditModeTests
 
             public FrogColour Frog { get; }
 
+            // A fake plays under its frog's default name unless a test sets
+            // one — a default name is a real name, not a placeholder.
+            string _frogName;
+
+            public string FrogName
+            {
+                get { return string.IsNullOrEmpty(_frogName) ? PlayerName.DefaultFor(Frog) : _frogName; }
+                set { _frogName = value; }
+            }
+
             public int Multiplicand => AnswerResultDialogViewTests.Multiplicand;
 
             public int Multiplier => AnswerResultDialogViewTests.Multiplier;

--- a/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
+++ b/Assets/Tests/EditMode/AnswerResultDialogViewTests.cs
@@ -446,7 +446,7 @@ namespace Frogs.Unity.EditModeTests
                 // The board is back in play through #220's own seam, not
                 // through a second one invented here.
                 Assert.That(board.RollButton.IsDisabled, Is.False);
-                Assert.That(board.TurnBannerText.text, Is.EqualTo("Blue frog's turn"));
+                Assert.That(board.TurnBannerText.text, Is.EqualTo("Blue's turn"));
             }
             finally
             {

--- a/Assets/Tests/EditMode/AppRootTests.cs
+++ b/Assets/Tests/EditMode/AppRootTests.cs
@@ -308,7 +308,7 @@ namespace Frogs.Unity.EditModeTests
                 // to be dismissed."
                 Assert.That(root.Router.CurrentScreen, Is.EqualTo(CoreScreen.GameOver));
                 Assert.That(root.Router.CurrentDialog, Is.Null);
-                Assert.That(root.GameOver.HeadlineText.text, Is.EqualTo("Green frog wins!"),
+                Assert.That(root.GameOver.HeadlineText.text, Is.EqualTo("Green wins!"),
                     "Green rolled first, so Green got home first");
                 Assert.That(root.GameOver.RowCount, Is.EqualTo(game.Standings.Count));
             }

--- a/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
+++ b/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
@@ -128,7 +128,7 @@ namespace Frogs.Unity.EditModeTests
 
                 view.Show(game);
 
-                Assert.That(view.HeadlineText.text, Is.EqualTo("Green frog wins!"));
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Green wins!"));
                 Assert.That(view.RowCount, Is.EqualTo(game.Standings.Count));
                 Assert.That(view.RowColour(0), Is.EqualTo(FrogColour.Green), "the first finisher leads the standings");
                 Assert.That(view.RowColour(1), Is.EqualTo(FrogColour.Blue));

--- a/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
+++ b/Assets/Tests/EditMode/EndToEndAcceptanceTests.cs
@@ -406,6 +406,16 @@ namespace Frogs.Unity.EditModeTests
         {
             public FrogColour Frog { get; set; }
 
+            // A fake plays under its frog's default name unless a test sets
+            // one — a default name is a real name, not a placeholder.
+            string _frogName;
+
+            public string FrogName
+            {
+                get { return string.IsNullOrEmpty(_frogName) ? PlayerName.DefaultFor(Frog) : _frogName; }
+                set { _frogName = value; }
+            }
+
             public Pile Pile { get; set; }
 
             public Card Card { get; set; }

--- a/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameBoardScreenViewTests.cs
@@ -52,7 +52,7 @@ namespace Frogs.Unity.EditModeTests
             try
             {
                 // Blue is first in turn order, so Core reports Blue active.
-                Assert.That(view.TurnBannerText.text, Is.EqualTo("Blue frog's turn"));
+                Assert.That(view.TurnBannerText.text, Is.EqualTo("Blue's turn"));
                 Assert.That(view.TurnBannerChip.Label.text, Is.EqualTo("Blue"));
                 Assert.That(view.TurnBannerChip.State, Is.EqualTo(PlayerChipState.Active));
                 Assert.That(view.TurnBannerChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Blue)));
@@ -62,7 +62,7 @@ namespace Frogs.Unity.EditModeTests
                 PassTheTurn(game);
                 view.Refresh();
 
-                Assert.That(view.TurnBannerText.text, Is.EqualTo("Green frog's turn"));
+                Assert.That(view.TurnBannerText.text, Is.EqualTo("Green's turn"));
                 Assert.That(view.TurnBannerChip.Label.text, Is.EqualTo("Green"));
                 Assert.That(view.TurnBannerChip.Swatch.color, Is.EqualTo(FrogColours.For(FrogColour.Green)));
             }

--- a/Assets/Tests/EditMode/GameOverScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameOverScreenViewTests.cs
@@ -39,7 +39,7 @@ namespace Frogs.Unity.EditModeTests
             {
                 view.Show(FrogColour.Blue, MockupStandings(), MockupRoster());
 
-                Assert.That(view.HeadlineText.text, Is.EqualTo("Blue frog wins!"));
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Blue wins!"));
             }
             finally
             {
@@ -66,8 +66,8 @@ namespace Frogs.Unity.EditModeTests
                 new StandingsRow(FrogColour.Green, 2, 4, false)
             };
 
-            AssertHeadline(FrogColour.Pink, everybodyHome, "Pink frog wins!");
-            AssertHeadline(FrogColour.Pink, endedWithOneHome, "Pink frog wins!");
+            AssertHeadline(FrogColour.Pink, everybodyHome, "Pink wins!");
+            AssertHeadline(FrogColour.Pink, endedWithOneHome, "Pink wins!");
         }
 
         [Test]
@@ -607,7 +607,7 @@ namespace Frogs.Unity.EditModeTests
             {
                 view.Show(FrogColour.Blue, MockupStandings(), MockupRoster());
 
-                Assert.That(view.HeadlineText.text, Is.EqualTo("Blue frog wins!"));
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Blue wins!"));
                 Assert.That(view.HeadlineText.fontSize, Is.EqualTo((int)GameOverScreenView.GameOverHeadlineSize));
                 Assert.That(view.HeadlineRect.anchoredPosition.y, Is.EqualTo(-GameOverScreenView.GameOverHeadlineTop));
 
@@ -675,7 +675,7 @@ namespace Frogs.Unity.EditModeTests
 
                 view.Show(game);
 
-                Assert.That(view.HeadlineText.text, Is.EqualTo("Green frog wins!"));
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Green wins!"));
                 Assert.That(view.RowCount, Is.EqualTo(game.Standings.Count));
                 Assert.That(view.RowColour(0), Is.EqualTo(FrogColour.Green));
                 Assert.That(view.RowProgressText(0).text, Is.EqualTo("Home — 8 of 8"));

--- a/Assets/Tests/EditMode/GameSetupNamingTests.cs
+++ b/Assets/Tests/EditMode/GameSetupNamingTests.cs
@@ -1,0 +1,756 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Frogs.Core;
+using Frogs.Unity.Views;
+// UnityEngine.UI also declares a Button type — the same collision every other
+// view test works around — so this is pulled in by explicit alias, and a bare
+// `Button` in this file always means the shared component's.
+using Button = Frogs.Unity.UI.Button;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// Naming a player on game setup — issue #311, built against
+    /// docs/specs/ui/game-setup.md and the two authoritative mockups
+    /// `game-setup-names-set.html` (at rest) and
+    /// `game-setup-name-edit-inline.html` (typing).
+    ///
+    /// The wireframe (#310) settled the two things these tests are mostly
+    /// about: the name row is the edit target and the corner badge is the
+    /// remove target, so **a chosen seat's body does nothing at all**; and the
+    /// keyboard is one this game draws rather than Android's.
+    /// </summary>
+    public sealed class GameSetupNamingTests
+    {
+        static readonly FrogColour[] AllColours =
+        {
+            FrogColour.Green, FrogColour.Blue, FrogColour.Orange, FrogColour.Pink
+        };
+
+        // ---- The seat at rest -------------------------------------------
+
+        [Test]
+        public void ASeatedFrog_ShowsItsBareColourName_WithNothingAppendedToIt()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Blue);
+
+                Assert.That(view.NameFor(FrogColour.Blue), Is.EqualTo("Blue"));
+                Assert.That(view.SeatLabel(FrogColour.Blue).text, Is.EqualTo("Blue"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void AnEmptySeat_HasNoNameRowAndNoRemoveTarget_ButItsBodyStillSeatsTheFrog()
+        {
+            var view = CreateView();
+
+            try
+            {
+                Assert.That(view.SeatNameRowRoot(FrogColour.Pink).activeSelf, Is.False);
+                Assert.That(view.SeatRemoveRoot(FrogColour.Pink).activeSelf, Is.False);
+
+                TapSeatBody(view, FrogColour.Pink);
+
+                Assert.That(view.IsSeatChosen(FrogColour.Pink), Is.True);
+                Assert.That(view.SeatNameRowRoot(FrogColour.Pink).activeSelf, Is.True);
+                Assert.That(view.SeatRemoveRoot(FrogColour.Pink).activeSelf, Is.True);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // The change the wireframe exists for. This is #310's question 2, and
+        // the test is the thing that stops the fix drifting back into one
+        // target.
+        [Test]
+        public void TheEditTargetAndTheRemoveTargetAreSeparate_AndAChosenSeatsBodyIsInert()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                Assert.That(view.IsSeatChosen(FrogColour.Green), Is.True);
+
+                // Tapping the body of a chosen seat does nothing at all — it
+                // does not remove the frog, and it does not open the editor.
+                TapSeatBody(view, FrogColour.Green);
+                Assert.That(view.IsSeatChosen(FrogColour.Green), Is.True, "a chosen seat's body must not remove the frog");
+                Assert.That(view.EditingSeat, Is.Null, "a chosen seat's body must not open the editor");
+
+                // The name row edits, and does not remove.
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                Assert.That(view.EditingSeat, Is.EqualTo(FrogColour.Green));
+                Assert.That(view.IsSeatChosen(FrogColour.Green), Is.True);
+
+                view.DoneNaming();
+
+                // The remove target removes, and does not edit.
+                TapTarget(view.SeatRemoveTapTarget(FrogColour.Green));
+                Assert.That(view.IsSeatChosen(FrogColour.Green), Is.False);
+                Assert.That(view.EditingSeat, Is.Null);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void BothTargets_AreMinTouchTargetSafe_ByGeometryRatherThanByInspection()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+
+                var nameRow = view.SeatNameRowRect(FrogColour.Green).sizeDelta;
+                var remove = view.SeatRemoveRect(FrogColour.Green).sizeDelta;
+
+                Assert.That(nameRow.x, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+                Assert.That(nameRow.y, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+                Assert.That(remove.x, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+                Assert.That(remove.y, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+
+                // The remove target is MinTouchTarget exactly, per the spec's
+                // Elements section, and larger than the readout opposite it.
+                Assert.That(remove.x, Is.EqualTo(GameSetupScreenView.SeatCornerTarget));
+                Assert.That(GameSetupScreenView.SeatCornerTarget, Is.GreaterThan(GameSetupScreenView.SeatOrderBadge));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void RemovingAFrog_RenumbersTheBadgesAfterItImmediately()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapSeatBody(view, FrogColour.Blue);
+                TapSeatBody(view, FrogColour.Orange);
+
+                TapTarget(view.SeatRemoveTapTarget(FrogColour.Blue));
+
+                Assert.That(view.SeatBadgeNumber(FrogColour.Green), Is.EqualTo(1));
+                Assert.That(view.SeatBadgeNumber(FrogColour.Blue), Is.Null);
+                Assert.That(view.SeatBadgeNumber(FrogColour.Orange), Is.EqualTo(2));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // ---- The keyboard -----------------------------------------------
+
+        [Test]
+        public void TheKeyboard_IsOneThisGameDraws_AndIsUpOnlyWhileANameIsBeingTyped()
+        {
+            var view = CreateView();
+
+            try
+            {
+                Assert.That(view.KeyboardRoot.activeSelf, Is.False);
+
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                Assert.That(view.KeyboardRoot.activeSelf, Is.True);
+
+                // hint and the controls are hidden while it is up — the
+                // keyboard is laid out over them, not beside them.
+                Assert.That(view.HintRect.gameObject.activeSelf, Is.False);
+                Assert.That(view.ControlsRect.gameObject.activeSelf, Is.False);
+
+                view.DoneNaming();
+
+                Assert.That(view.KeyboardRoot.activeSelf, Is.False);
+                Assert.That(view.HintRect.gameObject.activeSelf, Is.True);
+                Assert.That(view.ControlsRect.gameObject.activeSelf, Is.True);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheKeyboard_LaysOutItsFourQwertyRows_AtItsNamedConstants()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                Assert.That(view.KeyboardRect.sizeDelta, Is.EqualTo(
+                    new Vector2(GameSetupScreenView.NameKeyboardWidth, GameSetupScreenView.NameKeyboardHeight)));
+
+                var letters = string.Concat(view.NameKeys
+                    .Where(key => key.Kind == NameKeyKind.Letter)
+                    .Select(key => key.Character));
+
+                Assert.That(letters, Is.EqualTo("QWERTYUIOPASDFGHJKLZXCVBNM"), "the mockups draw QWERTY");
+
+                foreach (var key in view.NameKeys.Where(key => key.Kind == NameKeyKind.Letter))
+                {
+                    Assert.That(key.RectTransform.sizeDelta, Is.EqualTo(
+                        new Vector2(GameSetupScreenView.NameKeyWidth, GameSetupScreenView.NameKeyHeight)));
+                }
+
+                Assert.That(view.SpaceKey.RectTransform.sizeDelta.x, Is.EqualTo(GameSetupScreenView.NameSpaceKeyWidth));
+                Assert.That(view.DoneKey.RectTransform.sizeDelta.x, Is.EqualTo(GameSetupScreenView.NameDoneKeyWidth));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // #288's lesson: without a raycast target of its own there is nothing
+        // raycastable under the key, the GraphicRaycaster never finds it, and
+        // the keyboard types nothing.
+        [Test]
+        public void EveryKey_HasARaycastTargetOfItsOwn()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                foreach (var key in view.NameKeys)
+                {
+                    Assert.That(key.Border.raycastTarget, Is.True, $"{key.name} needs its own raycast target");
+                    Assert.That(key.Label.raycastTarget, Is.False, $"{key.name}'s label must not steal the tap");
+                }
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void EveryKey_IsMinTouchTargetSafeInHeight()
+        {
+            Assert.That(GameSetupScreenView.NameKeyHeight, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+            Assert.That(GameSetupScreenView.NameKeyWidth, Is.GreaterThanOrEqualTo(Button.MinTouchTarget));
+        }
+
+        [Test]
+        public void TypingAName_ReplacesTheSeatsNameOnDone()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                view.ClearName();
+                TapKeys(view, "DAD");
+                view.DoneNaming();
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("DAD"));
+                Assert.That(view.SeatLabel(FrogColour.Green).text, Is.EqualTo("DAD"));
+                Assert.That(view.EditingSeat, Is.Null);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Backspace_DeletesTheLastCharacter()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                view.ClearName();
+                TapKeys(view, "DAD");
+                TapKey(view.BackspaceKey);
+                view.DoneNaming();
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("DA"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "At `PlayerNameMaxLength` the
+        // next keystroke is refused — the key does nothing, the name is
+        // unchanged, and nothing explains itself." At the boundary exactly.
+        [Test]
+        public void AtThePlayerNameMaxLength_TheNextKeystrokeIsRefusedSilently()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                view.ClearName();
+
+                for (var i = 0; i < GameSetupScreenView.PlayerNameMaxLength; i++)
+                {
+                    TapKey(view.NameKey('A'));
+                }
+
+                var atTheCap = view.TypedName;
+                Assert.That(atTheCap.Length, Is.EqualTo(GameSetupScreenView.PlayerNameMaxLength));
+
+                TapKey(view.NameKey('B'));
+
+                Assert.That(view.TypedName, Is.EqualTo(atTheCap), "the eleventh keystroke does nothing");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ClearingTheNameAndPressingDone_RestoresTheColourName()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Orange);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Orange));
+
+                view.ClearName();
+                TapKeys(view, "ZZ");
+                view.DoneNaming();
+                Assert.That(view.NameFor(FrogColour.Orange), Is.EqualTo("ZZ"));
+
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Orange));
+                view.ClearName();
+                view.DoneNaming();
+
+                Assert.That(view.NameFor(FrogColour.Orange), Is.EqualTo("Orange"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void AnEmptySeat_CannotBeNamed()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Pink));
+
+                Assert.That(view.EditingSeat, Is.Null, "naming a frog that is not in the game is a state with no meaning");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void OnlyOneSeatIsEditedAtATime()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapSeatBody(view, FrogColour.Blue);
+
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                Assert.That(view.EditingSeat, Is.EqualTo(FrogColour.Green));
+
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Blue));
+                Assert.That(view.EditingSeat, Is.EqualTo(FrogColour.Blue));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheSeatBeingEdited_HidesItsRemoveTarget()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                Assert.That(view.SeatRemoveRoot(FrogColour.Green).activeSelf, Is.False,
+                    "Done first, then remove if that is what you meant");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheSeatRow_MovesUpToClearTheKeyboard_AndBackDownOnDone()
+        {
+            var view = CreateView();
+
+            try
+            {
+                var atRest = view.SeatsRect.anchoredPosition.y;
+
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                var editing = view.SeatsRect.anchoredPosition.y;
+
+                Assert.That(editing - atRest, Is.EqualTo(
+                    GameSetupScreenView.SeatRowTop - GameSetupScreenView.SeatRowEditingTop).Within(0.001f));
+
+                // Nothing else moves and nothing resizes.
+                Assert.That(view.SeatRect(FrogColour.Green).sizeDelta, Is.EqualTo(
+                    new Vector2(GameSetupScreenView.SeatWidth, GameSetupScreenView.SeatHeight)));
+
+                view.DoneNaming();
+
+                Assert.That(view.SeatsRect.anchoredPosition.y, Is.EqualTo(atRest).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void WhileTyping_TheHeaderSaysWhichFrogIsBeingNamed()
+        {
+            var view = CreateView();
+
+            try
+            {
+                Assert.That(view.HeaderText.text, Is.EqualTo("Who is playing?"));
+
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                Assert.That(view.HeaderText.text, Is.EqualTo("Name the green frog"));
+
+                view.DoneNaming();
+
+                Assert.That(view.HeaderText.text, Is.EqualTo("Who is playing?"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // ---- The hint and Start ------------------------------------------
+
+        [Test]
+        public void TheHint_NamesWhoeverGoesFirst_ByTheirTypedName()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapSeatBody(view, FrogColour.Blue);
+
+                Assert.That(view.HintText.text, Is.EqualTo("Green goes first"));
+
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                view.ClearName();
+                TapKeys(view, "CONNOR");
+                view.DoneNaming();
+
+                Assert.That(view.HintText.text, Is.EqualTo("CONNOR goes first"),
+                    "not `Green goes first` once Green has been renamed");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void Start_HandsTheTypedNamesToCore_InBadgeOrder()
+        {
+            var view = CreateView();
+
+            try
+            {
+                view.Initialize(new ScreenRouter(), () => 311UL);
+
+                TapSeatBody(view, FrogColour.Orange);
+                TapSeatBody(view, FrogColour.Green);
+
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Orange));
+                view.ClearName();
+                TapKeys(view, "CONNOR");
+                view.DoneNaming();
+
+                TapButton(view.StartButton);
+
+                var game = view.StartedGame;
+
+                Assert.That(game, Is.Not.Null);
+                Assert.That(game.TurnOrder, Is.EqualTo(new[] { FrogColour.Orange, FrogColour.Green }));
+                Assert.That(game.NameFor(FrogColour.Orange), Is.EqualTo("CONNOR"));
+                Assert.That(game.NameFor(FrogColour.Green), Is.EqualTo("Green"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ResetToEmptySeats_ForgetsEveryTypedName()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                view.ClearName();
+                TapKeys(view, "CONNOR");
+                view.DoneNaming();
+
+                view.ResetToEmptySeats();
+                TapSeatBody(view, FrogColour.Green);
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Green"),
+                    "no name survives re-entering setup");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void ReSeatingAFrogAfterRemovingIt_ForgetsItsTypedName()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+                view.ClearName();
+                TapKeys(view, "CONNOR");
+                view.DoneNaming();
+
+                TapTarget(view.SeatRemoveTapTarget(FrogColour.Green));
+                TapSeatBody(view, FrogColour.Green);
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Green"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TwoSeatsMayHoldTheSameName_NothingPreventsNumbersOrWarns()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapSeatBody(view, FrogColour.Blue);
+
+                foreach (var colour in new[] { FrogColour.Green, FrogColour.Blue })
+                {
+                    TapTarget(view.SeatNameRowTapTarget(colour));
+                    view.ClearName();
+                    TapKeys(view, "SAM");
+                    view.DoneNaming();
+                }
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("SAM"));
+                Assert.That(view.NameFor(FrogColour.Blue), Is.EqualTo("SAM"));
+                Assert.That(view.StartButton.IsDisabled, Is.False);
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // ---- Seat geometry, against the spec's table ---------------------
+
+        [Test]
+        public void TheSeat_IsFourEightyTall_WithItsContentGapAtSixteen()
+        {
+            Assert.That(GameSetupScreenView.SeatHeight, Is.EqualTo(480f));
+            Assert.That(GameSetupScreenView.SeatContentGap, Is.EqualTo(16f));
+            Assert.That(GameSetupScreenView.SeatTopBand, Is.EqualTo(136f));
+        }
+
+        [Test]
+        public void TheNameRow_SitsSeatContentGapBelowTheSwatch_AtItsNamedSize()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+
+                var swatch = view.SeatSwatch(FrogColour.Green).rectTransform;
+                var nameRow = view.SeatNameRowRect(FrogColour.Green);
+
+                Assert.That(nameRow.sizeDelta, Is.EqualTo(
+                    new Vector2(GameSetupScreenView.SeatNameRowWidth, GameSetupScreenView.SeatNameRowHeight)));
+
+                var swatchBottom = swatch.anchoredPosition.y - (GameSetupScreenView.SeatSwatchDiameter / 2f);
+                var nameRowTop = nameRow.anchoredPosition.y + (GameSetupScreenView.SeatNameRowHeight / 2f);
+
+                Assert.That(swatchBottom - nameRowTop, Is.EqualTo(GameSetupScreenView.SeatContentGap).Within(0.001f));
+
+                // SeatTopBand is the space above the swatch that the two
+                // corner targets live in.
+                var seatTop = GameSetupScreenView.SeatHeight / 2f;
+                var swatchTop = swatch.anchoredPosition.y + (GameSetupScreenView.SeatSwatchDiameter / 2f);
+
+                Assert.That(seatTop - swatchTop, Is.EqualTo(GameSetupScreenView.SeatTopBand).Within(0.001f));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheRemoveTarget_SitsInTheTopRightCorner_AtItsNamedInset()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+
+                var remove = view.SeatRemoveRect(FrogColour.Green);
+
+                // Anchored to the seat's top-right, inset by SeatCornerInset.
+                Assert.That(remove.anchorMin, Is.EqualTo(new Vector2(1f, 1f)));
+                Assert.That(remove.anchorMax, Is.EqualTo(new Vector2(1f, 1f)));
+                Assert.That(remove.anchoredPosition.x, Is.EqualTo(-GameSetupScreenView.SeatCornerInset).Within(0.001f));
+                Assert.That(remove.anchoredPosition.y, Is.EqualTo(-GameSetupScreenView.SeatCornerInset).Within(0.001f));
+
+                // It does not overlap the swatch — the whole reason the seat
+                // grew from 440 to 480.
+                var removeBottom = (GameSetupScreenView.SeatHeight / 2f)
+                    - GameSetupScreenView.SeatCornerInset
+                    - GameSetupScreenView.SeatCornerTarget;
+                var swatchTop = view.SeatSwatch(FrogColour.Green).rectTransform.anchoredPosition.y
+                    + (GameSetupScreenView.SeatSwatchDiameter / 2f);
+
+                Assert.That(removeBottom, Is.GreaterThanOrEqualTo(swatchTop));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // ---- Harness ------------------------------------------------------
+
+        static GameSetupScreenView CreateView()
+        {
+            var go = new GameObject("GameSetupScreenView", typeof(RectTransform));
+            return go.AddComponent<GameSetupScreenView>();
+        }
+
+        static void Destroy(GameSetupScreenView view)
+        {
+            Object.DestroyImmediate(view.gameObject);
+        }
+
+        static void TapSeatBody(GameSetupScreenView view, FrogColour colour)
+        {
+            TapTarget(view.SeatTapTargetFor(colour));
+        }
+
+        static void TapTarget(GameSetupScreenView.SeatTapTarget target)
+        {
+            var eventData = EventDataAt(target.RectTransform, inside: true);
+
+            target.OnPointerDown(eventData);
+            target.OnPointerUp(eventData);
+        }
+
+        static void TapKeys(GameSetupScreenView view, string letters)
+        {
+            foreach (var letter in letters)
+            {
+                TapKey(view.NameKey(letter));
+            }
+        }
+
+        static void TapKey(NameKeyboardKey key)
+        {
+            key.OnPointerClick(new PointerEventData(null));
+        }
+
+        static void TapButton(Button button)
+        {
+            var eventData = EventDataAt(button.RectTransform, inside: true);
+
+            button.OnPointerDown(eventData);
+            button.OnPointerUp(eventData);
+        }
+
+        static PointerEventData EventDataAt(RectTransform rect, bool inside)
+        {
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+
+            var center = (Vector2)(corners[0] + corners[2]) / 2f;
+            var width = corners[2].x - corners[0].x;
+
+            var outside = center + new Vector2(Mathf.Abs(width) + (Button.MinTouchTarget * 10f), 0f);
+
+            return new PointerEventData(null)
+            {
+                position = inside ? center : outside
+            };
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameSetupNamingTests.cs
+++ b/Assets/Tests/EditMode/GameSetupNamingTests.cs
@@ -226,6 +226,101 @@ namespace Frogs.Unity.EditModeTests
             }
         }
 
+        // #319: the keyboard has no shift key, because case is derived from
+        // position as the name is built. Row 3 is eight keys — seven letters
+        // and backspace — centred in the block.
+        [Test]
+        public void TheKeyboard_HasNoShiftKey_AndRowThreeIsEightKeysCentred()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                Assert.That(view.NameKeys.Select(key => key.Label.text), Does.Not.Contain("⇧"));
+
+                var rowThree = view.NameKeys
+                    .Where(key => "ZXCVBNM".Contains(key.Character.ToString())
+                        || key.Kind == NameKeyKind.Backspace)
+                    .ToArray();
+
+                Assert.That(rowThree.Length, Is.EqualTo(8));
+
+                // 8 x 152 + 7 x 16 = 1328, centred in NameKeyboardWidth 1664,
+                // which is an offset of 168 either side.
+                var rowWidth = (8 * GameSetupScreenView.NameKeyWidth) + (7 * GameSetupScreenView.NameKeyGap);
+                Assert.That(rowWidth, Is.EqualTo(1328f));
+
+                var leftEdge = rowThree.Min(key => key.RectTransform.anchoredPosition.x)
+                    - (GameSetupScreenView.NameKeyWidth / 2f);
+
+                Assert.That(leftEdge, Is.EqualTo(-(GameSetupScreenView.NameKeyboardWidth / 2f) + 168f).Within(0.001f));
+
+                // Every key on that row shares one y — it is one row.
+                Assert.That(rowThree.Select(key => key.RectTransform.anchoredPosition.y).Distinct().Count(), Is.EqualTo(1));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        // The key caps stay uppercase, exactly as the mockups draw them —
+        // only what gets appended to the name is case-derived.
+        [Test]
+        public void TheKeyCapsStayUppercase_EvenThoughTypingProducesMixedCase()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                foreach (var key in view.NameKeys.Where(key => key.Kind == NameKeyKind.Letter))
+                {
+                    Assert.That(key.Label.text, Is.EqualTo(key.Label.text.ToUpperInvariant()));
+                }
+
+                view.ClearName();
+                TapKeys(view, "CONNOR");
+
+                Assert.That(view.TypedName, Is.EqualTo("Connor"));
+                Assert.That(view.SeatLabel(FrogColour.Green).text, Is.EqualTo("Connor"),
+                    "the field reads Connor while it is being typed, not CONNOR corrected at the end");
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
+        [Test]
+        public void TheSpaceBar_StartsANewCapitalisedWord()
+        {
+            var view = CreateView();
+
+            try
+            {
+                TapSeatBody(view, FrogColour.Green);
+                TapTarget(view.SeatNameRowTapTarget(FrogColour.Green));
+
+                view.ClearName();
+                TapKeys(view, "MARY");
+                TapKey(view.SpaceKey);
+                TapKeys(view, "JANE");
+                view.DoneNaming();
+
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Mary Jane"));
+            }
+            finally
+            {
+                Destroy(view);
+            }
+        }
+
         // #288's lesson: without a raycast target of its own there is nothing
         // raycastable under the key, the GraphicRaycaster never finds it, and
         // the keyboard types nothing.
@@ -272,8 +367,8 @@ namespace Frogs.Unity.EditModeTests
                 TapKeys(view, "DAD");
                 view.DoneNaming();
 
-                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("DAD"));
-                Assert.That(view.SeatLabel(FrogColour.Green).text, Is.EqualTo("DAD"));
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Dad"));
+                Assert.That(view.SeatLabel(FrogColour.Green).text, Is.EqualTo("Dad"));
                 Assert.That(view.EditingSeat, Is.Null);
             }
             finally
@@ -297,7 +392,7 @@ namespace Frogs.Unity.EditModeTests
                 TapKey(view.BackspaceKey);
                 view.DoneNaming();
 
-                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("DA"));
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Da"));
             }
             finally
             {
@@ -350,7 +445,7 @@ namespace Frogs.Unity.EditModeTests
                 view.ClearName();
                 TapKeys(view, "ZZ");
                 view.DoneNaming();
-                Assert.That(view.NameFor(FrogColour.Orange), Is.EqualTo("ZZ"));
+                Assert.That(view.NameFor(FrogColour.Orange), Is.EqualTo("Zz"));
 
                 TapTarget(view.SeatNameRowTapTarget(FrogColour.Orange));
                 view.ClearName();
@@ -496,7 +591,7 @@ namespace Frogs.Unity.EditModeTests
                 TapKeys(view, "CONNOR");
                 view.DoneNaming();
 
-                Assert.That(view.HintText.text, Is.EqualTo("CONNOR goes first"),
+                Assert.That(view.HintText.text, Is.EqualTo("Connor goes first"),
                     "not `Green goes first` once Green has been renamed");
             }
             finally
@@ -528,7 +623,7 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(game, Is.Not.Null);
                 Assert.That(game.TurnOrder, Is.EqualTo(new[] { FrogColour.Orange, FrogColour.Green }));
-                Assert.That(game.NameFor(FrogColour.Orange), Is.EqualTo("CONNOR"));
+                Assert.That(game.NameFor(FrogColour.Orange), Is.EqualTo("Connor"));
                 Assert.That(game.NameFor(FrogColour.Green), Is.EqualTo("Green"));
             }
             finally
@@ -604,8 +699,8 @@ namespace Frogs.Unity.EditModeTests
                     view.DoneNaming();
                 }
 
-                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("SAM"));
-                Assert.That(view.NameFor(FrogColour.Blue), Is.EqualTo("SAM"));
+                Assert.That(view.NameFor(FrogColour.Green), Is.EqualTo("Sam"));
+                Assert.That(view.NameFor(FrogColour.Blue), Is.EqualTo("Sam"));
                 Assert.That(view.StartButton.IsDisabled, Is.False);
             }
             finally

--- a/Assets/Tests/EditMode/GameSetupNamingTests.cs.meta
+++ b/Assets/Tests/EditMode/GameSetupNamingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 521c0289160e4dc99a486195c445b502
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameSetupScreenViewTests.cs
+++ b/Assets/Tests/EditMode/GameSetupScreenViewTests.cs
@@ -104,8 +104,11 @@ namespace Frogs.Unity.EditModeTests
             }
         }
 
+        // Removal moved off the seat's body and onto its own corner target in
+        // #311 — see GameSetupNamingTests for the separation itself. What
+        // this test still owns is the renumbering.
         [Test]
-        public void TappingAChosenSeat_RemovesIt_AndRenumbersLaterBadgesDownImmediately()
+        public void RemovingAChosenSeat_RenumbersLaterBadgesDownImmediately()
         {
             var view = CreateView();
 
@@ -115,7 +118,7 @@ namespace Frogs.Unity.EditModeTests
                 Tap(view, FrogColour.Blue); // badge 2
                 Tap(view, FrogColour.Orange); // badge 3
 
-                Tap(view, FrogColour.Blue); // remove — no confirm, just the tap
+                TapRemove(view, FrogColour.Blue); // remove — no confirm, just the tap
 
                 Assert.That(view.IsSeatChosen(FrogColour.Blue), Is.False);
                 Assert.That(view.SeatBadgeNumber(FrogColour.Blue), Is.Null);
@@ -168,7 +171,7 @@ namespace Frogs.Unity.EditModeTests
 
                 Assert.That(view.HintText.text, Is.EqualTo("Pink goes first"));
 
-                Tap(view, FrogColour.Pink); // remove Pink; Blue now holds badge 1
+                TapRemove(view, FrogColour.Pink); // remove Pink; Blue now holds badge 1
                 Assert.That(view.HintText.text, Is.EqualTo("Pick two to four frogs"), "only one frog left — Start is disabled again");
 
                 Tap(view, FrogColour.Orange);
@@ -355,13 +358,13 @@ namespace Frogs.Unity.EditModeTests
                 Assert.That(view.SeatsRect.sizeDelta.x, Is.EqualTo(rowWidth));
                 Assert.That(view.SeatsRect.anchoredPosition.x, Is.EqualTo(0f), "the row is centred as a whole");
 
-                // The swatch and the label below it are SeatContentGap
-                // apart — docs/specs/ui/mockups/game-setup.html.
+                // The swatch and the name band below it are SeatContentGap
+                // apart — docs/specs/ui/mockups/game-setup-names-set.html.
                 var swatchRect = view.SeatSwatch(FrogColour.Green).rectTransform;
-                var labelRect = view.SeatLabel(FrogColour.Green).rectTransform;
+                var nameBand = view.SeatNameRowRect(FrogColour.Green);
                 var swatchBottom = swatchRect.anchoredPosition.y - (GameSetupScreenView.SeatSwatchDiameter / 2f);
-                var labelTop = labelRect.anchoredPosition.y + (GameSetupScreenView.SeatLabelSize / 2f);
-                Assert.That(swatchBottom - labelTop, Is.EqualTo(GameSetupScreenView.SeatContentGap).Within(0.001f));
+                var nameBandTop = nameBand.anchoredPosition.y + (GameSetupScreenView.SeatNameRowHeight / 2f);
+                Assert.That(swatchBottom - nameBandTop, Is.EqualTo(GameSetupScreenView.SeatContentGap).Within(0.001f));
 
                 // hint sits HintGap beneath seats.
                 var seatsBottom = view.SeatsRect.anchoredPosition.y - (GameSetupScreenView.SeatHeight / 2f);
@@ -424,7 +427,16 @@ namespace Frogs.Unity.EditModeTests
 
         static void Tap(GameSetupScreenView view, FrogColour colour)
         {
-            var target = view.SeatTapTargetFor(colour);
+            TapTarget(view.SeatTapTargetFor(colour));
+        }
+
+        static void TapRemove(GameSetupScreenView view, FrogColour colour)
+        {
+            TapTarget(view.SeatRemoveTapTarget(colour));
+        }
+
+        static void TapTarget(GameSetupScreenView.SeatTapTarget target)
+        {
             var eventData = EventDataAt(target.RectTransform, inside: true);
 
             target.OnPointerDown(eventData);

--- a/Assets/Tests/EditMode/PlayerNamesAcrossScreensTests.cs
+++ b/Assets/Tests/EditMode/PlayerNamesAcrossScreensTests.cs
@@ -1,0 +1,244 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using Frogs.Core;
+using Frogs.Unity.UI;
+using Frogs.Unity.Views;
+
+namespace Frogs.Unity.EditModeTests
+{
+    /// <summary>
+    /// A typed name is what every screen after game setup shows — issue #311.
+    ///
+    /// Two format strings used to staple a word onto a colour, and the
+    /// wireframe (#310) settled that **nothing appends anything to a name**:
+    /// the turn banner reads `Blue's turn` and the game over headline
+    /// `Blue wins!`, with the word `frog` in neither.
+    /// </summary>
+    public sealed class PlayerNamesAcrossScreensTests
+    {
+        const ulong AnySeed = 311UL;
+
+        static Game GameWith(params RosterEntry[] roster)
+        {
+            return new Game(roster, AnySeed);
+        }
+
+        // ---- The turn banner ----------------------------------------------
+
+        [Test]
+        public void TheTurnBanner_ReadsTheNameAndNothingElse_ForADefaultFrogAndARenamedOne()
+        {
+            var board = CreateBoard();
+
+            try
+            {
+                board.Initialize(GameWith(
+                    new RosterEntry(FrogColour.Blue),
+                    new RosterEntry(FrogColour.Green).WithName("Connor")));
+
+                Assert.That(board.TurnBannerText.text, Is.EqualTo("Blue's turn"));
+                Assert.That(board.TurnBannerText.text, Does.Not.Contain("frog"));
+
+                board.Initialize(GameWith(
+                    new RosterEntry(FrogColour.Green).WithName("Connor"),
+                    new RosterEntry(FrogColour.Blue)));
+
+                Assert.That(board.TurnBannerText.text, Is.EqualTo("Connor's turn"));
+                Assert.That(board.TurnBannerText.text, Does.Not.Contain("frog"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(board.gameObject);
+            }
+        }
+
+        [Test]
+        public void TheTurnBannersChip_CarriesTheTypedName()
+        {
+            var board = CreateBoard();
+
+            try
+            {
+                board.Initialize(GameWith(
+                    new RosterEntry(FrogColour.Green).WithName("Connor"),
+                    new RosterEntry(FrogColour.Blue)));
+
+                Assert.That(board.TurnBannerChip.Label.text, Is.EqualTo("Connor"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(board.gameObject);
+            }
+        }
+
+        [Test]
+        public void EveryLanesChip_CarriesItsFrogsName_AndFallsBackToTheColourName()
+        {
+            var board = CreateBoard();
+
+            try
+            {
+                board.Initialize(GameWith(
+                    new RosterEntry(FrogColour.Green).WithName("Connor"),
+                    new RosterEntry(FrogColour.Blue)));
+
+                Assert.That(board.LaneFor(FrogColour.Green).Chip.Label.text, Is.EqualTo("Connor"));
+                Assert.That(board.LaneFor(FrogColour.Blue).Chip.Label.text, Is.EqualTo("Blue"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(board.gameObject);
+            }
+        }
+
+        // ---- Game over ------------------------------------------------------
+
+        [Test]
+        public void TheGameOverHeadline_ReadsTheNameAndNothingElse()
+        {
+            Assert.That(GameOverScreenView.FormatHeadline("Blue"), Is.EqualTo("Blue wins!"));
+            Assert.That(GameOverScreenView.FormatHeadline("Connor"), Is.EqualTo("Connor wins!"));
+            Assert.That(GameOverScreenView.FormatHeadline("Connor"), Does.Not.Contain("frog"));
+            Assert.That(GameOverScreenView.FormatHeadline((string)null), Is.EqualTo("Game over"));
+        }
+
+        [Test]
+        public void TheGameOverScreen_HeadlinesTheWinnersTypedName_AndNamesEveryStandingsRow()
+        {
+            var view = CreateGameOver();
+
+            try
+            {
+                var game = GameWith(
+                    new RosterEntry(FrogColour.Green).WithName("Connor"),
+                    new RosterEntry(FrogColour.Blue));
+
+                var standings = new[]
+                {
+                    new StandingsRow(FrogColour.Green, "Connor", 1, Lane.LaneWinningPosition, true),
+                    new StandingsRow(FrogColour.Blue, "Blue", 2, 4, false)
+                };
+
+                view.Show(FrogColour.Green, standings, game.Roster);
+
+                Assert.That(view.HeadlineText.text, Is.EqualTo("Connor wins!"));
+                Assert.That(view.RowNameText(0).text, Is.EqualTo("Connor"));
+                Assert.That(view.RowNameText(1).text, Is.EqualTo("Blue"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(view.gameObject);
+            }
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "Names last as long as the
+        // game does, which includes `Play again` — that button starts a new
+        // game with the same frogs in the same turn order without passing
+        // through this screen, so it keeps their names too."
+        [Test]
+        public void PlayAgain_KeepsEveryTypedName()
+        {
+            var view = CreateGameOver();
+
+            try
+            {
+                view.Initialize(new ScreenRouter(), () => AnySeed);
+
+                var ended = GameWith(
+                    new RosterEntry(FrogColour.Green).WithName("Connor"),
+                    new RosterEntry(FrogColour.Blue).WithName("Dad"));
+
+                view.Show(ended);
+                view.PlayAgain();
+
+                var next = view.StartedGame;
+
+                Assert.That(next, Is.Not.Null);
+                Assert.That(next.TurnOrder, Is.EqualTo(new[] { FrogColour.Green, FrogColour.Blue }));
+                Assert.That(next.NameFor(FrogColour.Green), Is.EqualTo("Connor"));
+                Assert.That(next.NameFor(FrogColour.Blue), Is.EqualTo("Dad"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(view.gameObject);
+            }
+        }
+
+        // ---- The chip's own truncation ---------------------------------------
+
+        // docs/specs/ui/shared-components.md#player-chip: "the chip never
+        // refuses or alters a name it is given; if a name does not fit, the
+        // chip truncates it with an ellipsis." `Orange` is the game's own
+        // longest default name and it already overflows the 128 px label
+        // column at 132 px, before anybody has typed anything.
+        [Test]
+        public void TheChip_TruncatesANameItCannotFit_RatherThanRefusingIt()
+        {
+            var chip = CreatePlayerChip();
+
+            try
+            {
+                chip.SetFrog(Color.blue, "Alexandras");
+
+                Assert.That(chip.Name, Is.EqualTo("Alexandras"), "the chip never alters the name it was given");
+                Assert.That(chip.Label.text, Does.EndWith(DisplayText.Ellipsis));
+                Assert.That(chip.Label.text.Length, Is.LessThan("Alexandras".Length));
+            }
+            finally
+            {
+                Object.DestroyImmediate(chip.gameObject);
+            }
+        }
+
+        [Test]
+        public void TheChip_LeavesAShortNameAlone()
+        {
+            var chip = CreatePlayerChip();
+
+            try
+            {
+                chip.SetFrog(Color.blue, "Sam");
+
+                Assert.That(chip.Label.text, Is.EqualTo("Sam"));
+                Assert.That(chip.Label.text, Does.Not.Contain(DisplayText.Ellipsis));
+            }
+            finally
+            {
+                Object.DestroyImmediate(chip.gameObject);
+            }
+        }
+
+        [Test]
+        public void TheChipsLabelColumn_IsTheOneTheSpecDerives()
+        {
+            var expected = PlayerChip.PlayerChipWidth
+                - (PlayerChip.PlayerChipLabelPaddingX * 2f)
+                - PlayerChip.PlayerSwatchDiameter
+                - PlayerChip.PlayerChipSwatchGap;
+
+            Assert.That(PlayerChip.PlayerChipLabelColumn, Is.EqualTo(expected));
+            Assert.That(PlayerChip.PlayerChipLabelColumn, Is.EqualTo(128f));
+        }
+
+        // ---- Harness -----------------------------------------------------
+
+        static GameBoardScreenView CreateBoard()
+        {
+            var go = new GameObject("GameBoardScreenView", typeof(RectTransform));
+            return go.AddComponent<GameBoardScreenView>();
+        }
+
+        static GameOverScreenView CreateGameOver()
+        {
+            var go = new GameObject("GameOverScreenView", typeof(RectTransform));
+            return go.AddComponent<GameOverScreenView>();
+        }
+
+        static PlayerChip CreatePlayerChip()
+        {
+            var go = new GameObject("PlayerChip", typeof(RectTransform));
+            return go.AddComponent<PlayerChip>();
+        }
+    }
+}

--- a/Assets/Tests/EditMode/PlayerNamesAcrossScreensTests.cs.meta
+++ b/Assets/Tests/EditMode/PlayerNamesAcrossScreensTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb22af9676f14836a5e545d678afb6d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs
+++ b/Assets/Tests/EditMode/RollAndCardDialogViewTests.cs
@@ -723,6 +723,16 @@ namespace Frogs.Unity.EditModeTests
         sealed class StubReadout : IRollAndCardReadout
         {
             public FrogColour Frog { get; set; }
+
+            // A fake plays under its frog's default name unless a test sets
+            // one — a default name is a real name, not a placeholder.
+            string _frogName;
+
+            public string FrogName
+            {
+                get { return string.IsNullOrEmpty(_frogName) ? PlayerName.DefaultFor(Frog) : _frogName; }
+                set { _frogName = value; }
+            }
             public int Face { get; set; }
             public Pile Pile { get; set; }
             public int Multiplicand { get; set; }

--- a/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
+++ b/Assets/Tests/EditMode/WorkingOutGridViewTests.cs
@@ -2168,6 +2168,16 @@ namespace Frogs.Unity.EditModeTests
         {
             public FrogColour Frog { get; set; }
 
+            // A fake plays under its frog's default name unless a test sets
+            // one — a default name is a real name, not a placeholder.
+            string _frogName;
+
+            public string FrogName
+            {
+                get { return string.IsNullOrEmpty(_frogName) ? PlayerName.DefaultFor(Frog) : _frogName; }
+                set { _frogName = value; }
+            }
+
             public Pile Pile { get; set; }
 
             public Card Card { get; set; }

--- a/Tests/Core/DisplayTextTests.cs
+++ b/Tests/Core/DisplayTextTests.cs
@@ -1,0 +1,84 @@
+using System;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// Fitting a name into a column that may be too narrow for it —
+    /// docs/specs/ui/shared-components.md#player-chip: "the chip never
+    /// refuses or alters a name it is given; if a name does not fit, the chip
+    /// truncates it with an ellipsis."
+    ///
+    /// The rule is Core's and the measuring is the renderer's, because a
+    /// character count cannot promise a width: `Mohammed` is eight characters
+    /// and wider than `Alexander` at nine. So the caller passes in whatever
+    /// can measure its own font, and Core owns where the cut goes.
+    /// </summary>
+    public sealed class DisplayTextTests
+    {
+        // A stand-in for a real font: every character is ten pixels wide, and
+        // so is the ellipsis. Keeps these tests about where the cut lands
+        // rather than about font metrics.
+        static readonly Func<string, float> TenPixelsPerCharacter =
+            text => text == null ? 0f : text.Length * 10f;
+
+        [Test]
+        public void ANameThatFits_IsLeftExactlyAsItIs()
+        {
+            Assert.That(DisplayText.TruncateToWidth("Blue", 128f, TenPixelsPerCharacter), Is.EqualTo("Blue"));
+        }
+
+        [Test]
+        public void ANameThatFitsExactly_IsNotTruncated()
+        {
+            // "Isabella" is eight characters — 80 px — in exactly 80 px.
+            Assert.That(DisplayText.TruncateToWidth("Isabella", 80f, TenPixelsPerCharacter), Is.EqualTo("Isabella"));
+        }
+
+        [Test]
+        public void ANameOnePixelTooWide_IsCutBackAndGivenAnEllipsis()
+        {
+            // 80 px of name in 79 px: the longest prefix that leaves room for
+            // the ellipsis is seven characters, less the ellipsis's own ten,
+            // so six characters and the ellipsis — 70 px.
+            var fitted = DisplayText.TruncateToWidth("Isabella", 79f, TenPixelsPerCharacter);
+
+            Assert.That(fitted, Is.EqualTo("Isabel" + DisplayText.Ellipsis));
+            Assert.That(TenPixelsPerCharacter(fitted), Is.LessThanOrEqualTo(79f));
+        }
+
+        // The case the spec calls out by name: `Orange` is the game's own
+        // longest default name and it overflows the chip's 128 px label
+        // column before anybody has typed anything.
+        [Test]
+        public void TheChipsOwnWorstDefaultName_Truncates()
+        {
+            Func<string, float> asOnTheChip = text => text == null ? 0f : text.Length * 22f;
+
+            var fitted = DisplayText.TruncateToWidth("Orange", 128f, asOnTheChip);
+
+            Assert.That(fitted, Does.EndWith(DisplayText.Ellipsis));
+            Assert.That(asOnTheChip(fitted), Is.LessThanOrEqualTo(128f));
+        }
+
+        [Test]
+        public void AColumnTooNarrowForEvenOneCharacter_IsJustTheEllipsis()
+        {
+            Assert.That(DisplayText.TruncateToWidth("Isabella", 5f, TenPixelsPerCharacter), Is.EqualTo(DisplayText.Ellipsis));
+        }
+
+        [Test]
+        public void AnEmptyOrMissingName_IsHandedBackUnchanged()
+        {
+            Assert.That(DisplayText.TruncateToWidth("", 128f, TenPixelsPerCharacter), Is.Empty);
+            Assert.That(DisplayText.TruncateToWidth(null, 128f, TenPixelsPerCharacter), Is.Null);
+        }
+
+        [Test]
+        public void WithNoWayToMeasure_TheNameIsLeftAlone_RatherThanGuessed()
+        {
+            Assert.That(DisplayText.TruncateToWidth("Isabella", 5f, null), Is.EqualTo("Isabella"));
+        }
+    }
+}

--- a/Tests/Core/GameRosterTests.cs
+++ b/Tests/Core/GameRosterTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// A game's roster carries names, not only colours — so that no screen
+    /// has to look a name up anywhere else. docs/specs/ui/game-setup.md#behaviour:
+    /// "`Start` begins the game with the chosen frogs in badge order ... Their
+    /// names go with them, and are what every later screen shows."
+    /// </summary>
+    public sealed class GameRosterTests
+    {
+        const ulong AnySeed = 311UL;
+
+        [Test]
+        public void AGameBuiltFromColoursAlone_NamesEveryFrogAfterItsColour()
+        {
+            var game = new Game(new[] { FrogColour.Blue, FrogColour.Green }, AnySeed);
+
+            Assert.That(game.NameFor(FrogColour.Blue), Is.EqualTo("Blue"));
+            Assert.That(game.NameFor(FrogColour.Green), Is.EqualTo("Green"));
+        }
+
+        [Test]
+        public void AGameBuiltFromARoster_CarriesTheTypedNames_InTheSameTurnOrder()
+        {
+            var roster = new[]
+            {
+                new RosterEntry(FrogColour.Green).WithName("Connor"),
+                new RosterEntry(FrogColour.Blue)
+            };
+
+            var game = new Game(roster, AnySeed);
+
+            Assert.That(game.TurnOrder, Is.EqualTo(new[] { FrogColour.Green, FrogColour.Blue }));
+            Assert.That(game.NameFor(FrogColour.Green), Is.EqualTo("Connor"));
+            Assert.That(game.NameFor(FrogColour.Blue), Is.EqualTo("Blue"));
+            Assert.That(game.Roster.Select(entry => entry.Name), Is.EqualTo(new[] { "Connor", "Blue" }));
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "Two seats may hold the same
+        // name. Nothing prevents it, nothing numbers them, nothing warns."
+        // Pinned by a test either way, per this issue's checklist — and the
+        // way it is settled is: allowed.
+        [Test]
+        public void TwoFrogsMayHoldTheSameName_NothingPreventsNumbersOrWarns()
+        {
+            var roster = new[]
+            {
+                new RosterEntry(FrogColour.Green).WithName("Sam"),
+                new RosterEntry(FrogColour.Pink).WithName("Sam")
+            };
+
+            var game = new Game(roster, AnySeed);
+
+            Assert.That(game.NameFor(FrogColour.Green), Is.EqualTo("Sam"));
+            Assert.That(game.NameFor(FrogColour.Pink), Is.EqualTo("Sam"));
+        }
+
+        [Test]
+        public void TheStandingsCarryEachFrogsName_SoGameOverNeedsNoSecondLookup()
+        {
+            var roster = new[]
+            {
+                new RosterEntry(FrogColour.Green).WithName("Connor"),
+                new RosterEntry(FrogColour.Blue)
+            };
+
+            var game = new Game(roster, AnySeed);
+
+            var names = game.Standings.ToDictionary(row => row.Colour, row => row.Name);
+
+            Assert.That(names[FrogColour.Green], Is.EqualTo("Connor"));
+            Assert.That(names[FrogColour.Blue], Is.EqualTo("Blue"));
+        }
+
+        [Test]
+        public void AskingForTheNameOfAFrogThatIsNotPlaying_IsRefused()
+        {
+            var game = new Game(new[] { FrogColour.Blue, FrogColour.Green }, AnySeed);
+
+            Assert.That(() => game.NameFor(FrogColour.Pink), Throws.ArgumentException);
+        }
+    }
+}

--- a/Tests/Core/PlayerNameEditorTests.cs
+++ b/Tests/Core/PlayerNameEditorTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// One naming session — what the setup screen's keyboard is a set of
+    /// buttons on top of. docs/specs/ui/game-setup.md#behaviour is the whole
+    /// specification: typing appends, the cap refuses, backspace deletes, and
+    /// `Done` puts a blank name back to the colour name.
+    ///
+    /// It is Core's rather than the view's so that "the eleventh keystroke
+    /// does nothing" is a rule with a two-second test around it instead of a
+    /// rule the keyboard happens to follow.
+    /// </summary>
+    public sealed class PlayerNameEditorTests
+    {
+        [Test]
+        public void OpeningAnEditor_StartsFromTheNameTheSeatAlreadyCarries()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+
+            Assert.That(editor.Text, Is.EqualTo("Green"));
+            Assert.That(editor.Colour, Is.EqualTo(FrogColour.Green));
+        }
+
+        [Test]
+        public void Typing_AppendsTheCharacter()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            Assert.That(editor.Append('D'), Is.True);
+            Assert.That(editor.Append('a'), Is.True);
+            Assert.That(editor.Append('d'), Is.True);
+
+            Assert.That(editor.Text, Is.EqualTo("Dad"));
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "At `PlayerNameMaxLength` the
+        // next keystroke is refused — the key does nothing, the name is
+        // unchanged, and nothing explains itself." The boundary exactly: the
+        // tenth character lands, the eleventh does not.
+        [Test]
+        public void AtTheCap_TheNextKeystrokeIsRefusedSilently_AndTheNameIsUnchanged()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            for (var i = 0; i < PlayerName.PlayerNameMaxLength; i++)
+            {
+                Assert.That(editor.Append('a'), Is.True, $"keystroke {i + 1} of the cap should land");
+            }
+
+            Assert.That(editor.Text.Length, Is.EqualTo(PlayerName.PlayerNameMaxLength));
+
+            var atTheCap = editor.Text;
+            Assert.That(editor.Append('b'), Is.False);
+            Assert.That(editor.Text, Is.EqualTo(atTheCap));
+        }
+
+        [Test]
+        public void Backspace_DeletesTheLastCharacter_AndDoesNothingOnAnEmptyName()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Pink));
+
+            editor.Backspace();
+            Assert.That(editor.Text, Is.EqualTo("Pin"));
+
+            editor.Clear();
+            Assert.That(editor.Text, Is.Empty);
+
+            editor.Backspace();
+            Assert.That(editor.Text, Is.Empty);
+        }
+
+        [Test]
+        public void Done_OnATypedName_KeepsIt()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Blue));
+            editor.Clear();
+            foreach (var character in "Connor")
+            {
+                editor.Append(character);
+            }
+
+            var committed = editor.Commit();
+
+            Assert.That(committed.Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(committed.Name, Is.EqualTo("Connor"));
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "Clearing the name to empty
+        // and pressing `Done` restores the frog's colour name."
+        [Test]
+        public void Done_OnAClearedName_RestoresTheColourName()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Blue).WithName("Connor"));
+            editor.Clear();
+
+            Assert.That(editor.Commit().Name, Is.EqualTo("Blue"));
+        }
+    }
+}

--- a/Tests/Core/PlayerNameEditorTests.cs
+++ b/Tests/Core/PlayerNameEditorTests.cs
@@ -74,6 +74,80 @@ namespace Frogs.Core.Tests
             Assert.That(editor.Text, Is.Empty);
         }
 
+        // docs/specs/ui/game-setup.md#behaviour — the capitalisation rule
+        // that settled #319. The keyboard has no shift key; case is derived
+        // from position as the name is built, so the field reads `Connor`
+        // while it is being typed rather than `CONNOR` corrected at the end.
+        [Test]
+        public void TheFirstLetterOfTheNameIsACapital_AndTheRestAreLowercase()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            foreach (var character in "CONNOR")
+            {
+                editor.Append(character);
+            }
+
+            Assert.That(editor.Text, Is.EqualTo("Connor"));
+        }
+
+        [Test]
+        public void TheFirstLetterAfterASpace_IsAlsoACapital()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            foreach (var character in "MARY JANE")
+            {
+                editor.Append(character);
+            }
+
+            Assert.That(editor.Text, Is.EqualTo("Mary Jane"));
+        }
+
+        // The case comes from where the character lands, not from a pass over
+        // the finished string — so deleting back and typing again still
+        // capitalises correctly.
+        [Test]
+        public void BackspacingAndRetyping_ReDerivesTheCaseFromPosition()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            foreach (var character in "SAM")
+            {
+                editor.Append(character);
+            }
+            Assert.That(editor.Text, Is.EqualTo("Sam"));
+
+            editor.Backspace();
+            editor.Backspace();
+            editor.Backspace();
+            Assert.That(editor.Text, Is.Empty);
+
+            foreach (var character in "JO")
+            {
+                editor.Append(character);
+            }
+
+            Assert.That(editor.Text, Is.EqualTo("Jo"), "the first letter is a capital again");
+        }
+
+        [Test]
+        public void ALowercaseKeystroke_IsCapitalisedByPositionJustTheSame()
+        {
+            var editor = new PlayerNameEditor(new RosterEntry(FrogColour.Green));
+            editor.Clear();
+
+            foreach (var character in "connor")
+            {
+                editor.Append(character);
+            }
+
+            Assert.That(editor.Text, Is.EqualTo("Connor"));
+        }
+
         [Test]
         public void Done_OnATypedName_KeepsIt()
         {

--- a/Tests/Core/PlayerNameTests.cs
+++ b/Tests/Core/PlayerNameTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// The rules a player's name obeys, which are Core's and not the text
+    /// field's — docs/specs/ui/game-setup.md.
+    /// </summary>
+    public sealed class PlayerNameTests
+    {
+        // docs/specs/ui/game-setup.md#named-constants — PlayerNameMaxLength
+        // 10, read off the setup seat's name row.
+        [Test]
+        public void TheCap_IsTenCharacters()
+        {
+            Assert.That(PlayerName.PlayerNameMaxLength, Is.EqualTo(10));
+        }
+
+        // At the boundary exactly, not near it: ten characters is a name the
+        // seat can draw and survives untouched; eleven is one it cannot.
+        [Test]
+        public void AtTheCapExactly_TheNameSurvivesWhole()
+        {
+            var tenCharacters = "Alexandra";
+
+            Assert.That(tenCharacters.Length, Is.EqualTo(PlayerName.PlayerNameMaxLength - 1));
+            Assert.That(PlayerName.Resolve("Alexandras", FrogColour.Green), Is.EqualTo("Alexandras"));
+            Assert.That("Alexandras".Length, Is.EqualTo(PlayerName.PlayerNameMaxLength));
+        }
+
+        [Test]
+        public void OneCharacterPastTheCap_IsCutBackToIt_ByCoreAndNotByTheTextField()
+        {
+            var elevenCharacters = "Alexandras!";
+            Assert.That(elevenCharacters.Length, Is.EqualTo(PlayerName.PlayerNameMaxLength + 1));
+
+            var resolved = PlayerName.Resolve(elevenCharacters, FrogColour.Green);
+
+            Assert.That(resolved, Is.EqualTo("Alexandras"));
+            Assert.That(resolved.Length, Is.EqualTo(PlayerName.PlayerNameMaxLength));
+        }
+    }
+}

--- a/Tests/Core/RosterEntryTests.cs
+++ b/Tests/Core/RosterEntryTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Frogs.Core;
+
+namespace Frogs.Core.Tests
+{
+    /// <summary>
+    /// <see cref="RosterEntry"/> is one seat's worth of roster —
+    /// docs/specs/ui/game-setup.md#behaviour: "Seating a frog gives it the
+    /// bare colour name — `Blue`, not `Blue Frog`."
+    /// </summary>
+    public sealed class RosterEntryTests
+    {
+        [Test]
+        public void ASeatedFrog_IsNamedAfterItsColour_AndNothingIsAppendedToIt()
+        {
+            var entry = new RosterEntry(FrogColour.Blue);
+
+            Assert.That(entry.Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(entry.Name, Is.EqualTo("Blue"));
+        }
+
+        [Test]
+        public void ASeatedFrog_CanBeRenamed_AndKeepsItsColour()
+        {
+            var renamed = new RosterEntry(FrogColour.Blue).WithName("Connor");
+
+            Assert.That(renamed.Colour, Is.EqualTo(FrogColour.Blue));
+            Assert.That(renamed.Name, Is.EqualTo("Connor"));
+        }
+
+        // docs/specs/ui/game-setup.md#behaviour: "Clearing the name to empty
+        // and pressing `Done` restores the frog's colour name — a nameless
+        // frog is not a state this screen can reach."
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("\t")]
+        [TestCase(null)]
+        public void ANameThatIsBlank_FallsBackToTheColourName_RatherThanLeavingANamelessFrog(string blank)
+        {
+            var entry = new RosterEntry(FrogColour.Orange).WithName(blank);
+
+            Assert.That(entry.Name, Is.EqualTo("Orange"));
+        }
+    }
+}

--- a/Tests/Core/StandingsRowTests.cs
+++ b/Tests/Core/StandingsRowTests.cs
@@ -27,9 +27,11 @@ namespace Frogs.Core.Tests
         }
 
         // Structural, not behavioural: game-over.md's standings row needs
-        // exactly these four facts and nothing more.
+        // exactly these five facts and nothing more. It was four until names
+        // became editable (#311) — the row now carries the word it draws,
+        // because a row that knew only the colour could not draw `Connor`.
         [Test]
-        public void StandingsRow_ExposesNoPublicMembersBeyondTheFourFacts()
+        public void StandingsRow_ExposesNoPublicMembersBeyondTheFiveFacts()
         {
             var propertyNames = typeof(StandingsRow)
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -41,6 +43,7 @@ namespace Frogs.Core.Tests
             {
                 "Colour",
                 "IsHome",
+                "Name",
                 "Place",
                 "Position"
             }));

--- a/docs/specs/ui/game-setup.md
+++ b/docs/specs/ui/game-setup.md
@@ -214,13 +214,21 @@ sized to the same tap-target family as everything else in the game.
 | --- | --- |
 | 1 | `Q W E R T Y U I O P` |
 | 2 | `A S D F G H J K L` |
-| 3 | `⇧ Z X C V B N M ⌫` |
+| 3 | `Z X C V B N M ⌫` |
 | 4 | space, `Done` |
 
 `Done` is the primary [button](shared-components.md#button) kind and the only
 way out of the keyboard. There is no cancel: a name is edited in place and
 every keystroke has already happened, so there is nothing a cancel would undo
 that backspace does not.
+
+Row 3 is eight keys — seven letters and backspace — which is
+8 × `NameKeyWidth` + 7 × `NameKeyGap` = 1328 px, centred in the 1664 px
+`NameKeyboardWidth` block at an offset of 168 px either side.
+
+**There is no shift key**, and the key caps are drawn in uppercase anyway, the
+way key caps always are. Case is not something the player chooses — see the
+capitalisation rule under Behaviour.
 
 **Why not the system keyboard.** It is free and familiar, and it would have
 been the smaller change. It also has a height nobody knows at design time,
@@ -245,6 +253,23 @@ build, which is 26 keys of the same key.
   children to dismiss confirms.
 - Tapping a chosen seat's name row opens the keyboard on that seat and puts the
   caret at the end of the name. Only one seat is being edited at a time.
+- **The first letter of each word is a capital and every other letter is
+  lowercase**, derived from where the character lands rather than chosen. The
+  first character of the name is a capital, so is any character immediately
+  after a space, and nothing else is. Typing `C O N N O R` gives `Connor`;
+  `M A R Y` space `J A N E` gives `Mary Jane`. It is applied as the name is
+  built, so the field reads `Connor` while it is being typed rather than
+  `CONNOR` corrected on `Done`, and backspacing re-derives it from position —
+  deleting back to empty and typing again still capitalises. Default colour
+  names already obey it.
+
+    This is why there is no shift key, and it is the answer to
+    [#319](https://github.com/derekwinters/connor-multiplying-frogs/issues/319).
+    The cost is stated rather than hidden: `JJ` and `McKenzie` cannot be typed.
+    A shift key that a six-year-old has to find before the `M` of `McKenzie`
+    buys those two names and taxes every other name in the game, and the
+    players this is for are children typing their own first names.
+
 - Typing appends a character. **At `PlayerNameMaxLength` the next keystroke is
   refused** — the key does nothing, the name is unchanged, and nothing explains
   itself, which is how a
@@ -305,18 +330,14 @@ carry. Do not build from it.
 - **Should the four colours be reorderable?** Proposed: no. Turn order is
   tap order, which is one gesture rather than two, and re-ordering is a drag
   interaction on a screen four children are all reaching at.
-- **What does `⇧` do?** **Open, and it blocks nothing else.** The keyboard
-  table above lists a shift key and the Behaviour section never says what
-  pressing it does — so the built keyboard draws it, disabled, and types the
-  glyph on each key cap, which is uppercase. That is the literal reading of
-  "typing appends a character" and it is the only part of this screen a guess
-  could have filled in. The mockups draw names as `Connor` and `Isabella`, so
-  mixed case is clearly wanted; what is not settled is *how* — a one-shot
-  shift that capitalises the next letter and then releases, a caps-lock style
-  toggle, or an automatic capital on the first letter of a name. They differ in
-  how many taps a child spends to get `Connor`, which makes it a taste call
-  rather than a mechanical one. Until it is answered the built screen can only
-  produce `CONNOR`.
+- **What does `⇧` do?** **Answered: nothing — there is no shift key.** The
+  keyboard table used to list one and the Behaviour section never said what it
+  did, which was a genuine omission rather than a deferral;
+  [#319](https://github.com/derekwinters/connor-multiplying-frogs/issues/319)
+  exists because of it. Settled by making case automatic — first letter of each
+  word capital, everything else lowercase — and taking the key off the
+  keyboard, so row 3 lost a key and re-centred. The rule and its cost are under
+  Behaviour above.
 - **Are the letter keys in QWERTY order or alphabetical order?** The mockups
   draw QWERTY, because that is the arrangement on every keyboard a child has
   seen, including the one on the tablet this game runs on. The case for

--- a/docs/specs/ui/game-setup.md
+++ b/docs/specs/ui/game-setup.md
@@ -305,6 +305,18 @@ carry. Do not build from it.
 - **Should the four colours be reorderable?** Proposed: no. Turn order is
   tap order, which is one gesture rather than two, and re-ordering is a drag
   interaction on a screen four children are all reaching at.
+- **What does `⇧` do?** **Open, and it blocks nothing else.** The keyboard
+  table above lists a shift key and the Behaviour section never says what
+  pressing it does — so the built keyboard draws it, disabled, and types the
+  glyph on each key cap, which is uppercase. That is the literal reading of
+  "typing appends a character" and it is the only part of this screen a guess
+  could have filled in. The mockups draw names as `Connor` and `Isabella`, so
+  mixed case is clearly wanted; what is not settled is *how* — a one-shot
+  shift that capitalises the next letter and then releases, a caps-lock style
+  toggle, or an automatic capital on the first letter of a name. They differ in
+  how many taps a child spends to get `Connor`, which makes it a taste call
+  rather than a mechanical one. Until it is answered the built screen can only
+  produce `CONNOR`.
 - **Are the letter keys in QWERTY order or alphabetical order?** The mockups
   draw QWERTY, because that is the arrangement on every keyboard a child has
   seen, including the one on the tablet this game runs on. The case for

--- a/docs/specs/ui/mockups/game-setup-name-edit-inline.html
+++ b/docs/specs/ui/mockups/game-setup-name-edit-inline.html
@@ -160,8 +160,10 @@
       <div class="k">A</div><div class="k">S</div><div class="k">D</div><div class="k">F</div><div class="k">G</div>
       <div class="k">H</div><div class="k">J</div><div class="k">K</div><div class="k">L</div>
     </div>
-    <div class="krow" style="margin-left:84px">
-      <div class="k" style="font-size:44px">&#8679;</div>
+    <!-- Row 3 is eight keys: seven letters and backspace. There is no shift
+         key — case is automatic (first letter of each word a capital), so
+         8 x 152 + 7 x 16 = 1328, centred in 1664 at an offset of 168. -->
+    <div class="krow" style="margin-left:168px">
       <div class="k">Z</div><div class="k">X</div><div class="k">C</div><div class="k">V</div><div class="k">B</div>
       <div class="k">N</div><div class="k">M</div>
       <div class="k" style="font-size:44px">&#9003;</div>

--- a/docs/specs/ui/mockups/game-setup-name-edit-pencil.html
+++ b/docs/specs/ui/mockups/game-setup-name-edit-pencil.html
@@ -156,8 +156,10 @@
       <div class="k">A</div><div class="k">S</div><div class="k">D</div><div class="k">F</div><div class="k">G</div>
       <div class="k">H</div><div class="k">J</div><div class="k">K</div><div class="k">L</div>
     </div>
-    <div class="krow" style="margin-left:84px">
-      <div class="k" style="font-size:44px">&#8679;</div>
+    <!-- Row 3 is eight keys: seven letters and backspace. There is no shift
+         key — case is automatic (first letter of each word a capital), so
+         8 x 152 + 7 x 16 = 1328, centred in 1664 at an offset of 168. -->
+    <div class="krow" style="margin-left:168px">
       <div class="k">Z</div><div class="k">X</div><div class="k">C</div><div class="k">V</div><div class="k">B</div>
       <div class="k">N</div><div class="k">M</div>
       <div class="k" style="font-size:44px">&#9003;</div>

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -331,6 +331,8 @@ what the chip shows.
 | Pad-count text size | `PlayerChipPadCountSize` | 24 px |
 | Corner radius | `PlayerChipRadius` | 20 px |
 | Ring drawn around the active chip | `PlayerChipActiveRing` | 6 px |
+| Horizontal padding inside the chip | `PlayerChipLabelPaddingX` | 20 px |
+| Room the name actually has | `PlayerChipLabelColumn` | 128 px |
 
 `PlayerChipLabelSize` was 40 px on this page; the committed mockups' shared
 stylesheet — repeated across all eleven files — draws the name at 32 px and the
@@ -340,6 +342,13 @@ mockups are what Connor approved when each screen's wireframe was signed off,
 so they win: `PlayerChipLabelSize` is corrected to 32 px, and
 `PlayerChipPadCountSize` — a value this table previously had no name for at
 all — is added at 24 px.
+
+`PlayerChipLabelPaddingX` and `PlayerChipLabelColumn` distil the next
+paragraph's own arithmetic into the names the code declares them under — the
+same move [game setup](game-setup.md#named-constants) made for
+`SeatBadgeInset`. The padding was already stated in prose here, and the column
+is what truncation is measured against, so it cannot stay a number that only
+exists inside a sentence.
 
 **The label column is 128 px, and it is tighter than it looks.**
 `PlayerChipWidth` 256 less 20 px padding either side, less


### PR DESCRIPTION
Closes #311

Players can now type their own name on the setup screen. Tap a frog to sit it
down and it is called `Blue`; tap the box under it and a keyboard comes up so it
can be called `Connor` instead. The name follows that player everywhere — the
turn banner, their chip, the standings at the end — and nothing in the game
says "frog" after a name any more. Clearing a name and pressing `Done` puts the
colour name back, so no frog ever ends up nameless.

The other change on that screen is a safety one. A chosen seat used to remove
its player when you tapped it, with no confirm; now removal has its own small
target in the corner and the seat's body does nothing at all, so a child aiming
at the name and missing no longer loses a player.

**Docs:** `docs/specs/ui/game-setup.md`, `docs/specs/ui/game-board.md` and
`docs/specs/ui/game-over.md` — **verified, not changed.** All three were
written by #310 and already describe what was built; all 35 of game-setup.md's
named constants are declared in code with the spec's values (three of them by
reference to Core's own constant for the same rule, rather than repeating the
number). Two changes were needed:
`docs/specs/ui/shared-components.md` — `PlayerChipLabelPaddingX` (20 px) and
`PlayerChipLabelColumn` (128 px) added to the player chip's constants table,
distilling arithmetic the page already stated in prose, because the chip's
truncation is measured against the column and it could not stay a number that
only existed inside a sentence. `docs/specs/ui/game-setup.md` — one new entry
— the keyboard's row 3 loses `⇧`, the capitalisation rule is written into
Behaviour, and the Open question `⇧` raised is marked answered.
`docs/specs/ui/mockups/game-setup-name-edit-inline.html` and
`docs/specs/ui/mockups/game-setup-name-edit-pencil.html` — the `⇧` key removed
from row 3 and the row re-centred to a 168 px offset, in both, so the two
candidates keep sharing every number.

## Spec invariants this had to keep true

| Invariant | How it is held |
| --- | --- |
| "Every seat always shows a word" — never colour alone | `RosterEntryTests` (a seated frog is named after its colour) and `PlayerName.Resolve`, which turns blank into the colour name for every caller, not just the keyboard |
| "A seat that is not playing has no name and cannot be given one" | `AnEmptySeat_CannotBeNamed` — tapping an empty seat's name row opens nothing |
| "Removing a player is a deliberate tap on a target that does nothing else" | `TheEditTargetAndTheRemoveTargetAreSeparate_AndAChosenSeatsBodyIsInert` |
| Every seat and both new targets are `MinTouchTarget`-safe | `BothTargets_AreMinTouchTargetSafe_ByGeometryRatherThanByInspection`, by geometry rather than inspection |
| Turn order is visible before the game starts, and renumbers on removal | `RemovingAFrog_RenumbersTheBadgesAfterItImmediately` |
| The chip identifies by colour **and a word**, and never refuses a name | `TheChip_TruncatesANameItCannotFit_RatherThanRefusingIt` — `PlayerChip.Name` still reports the whole name |
| Two frogs are never the same colour; two players may be the same name | `TwoFrogsMayHoldTheSameName_NothingPreventsNumbersOrWarns` in Core, and the same on the screen |

## How the spec is changing

Nothing here moves the contract — #310 moved it and this builds to it. Three
rules the **code** was carrying are reversed, which is worth stating because
the diff shows them as string edits:

- `GameBoardScreenView`: `"{0} frog's turn"` → `"{0}'s turn"`. The old rule was
  that a frog is described as a frog; the new one is that nothing appends
  anything to a name, because `Connor frog's turn` is not a sentence.
- `GameOverScreenView`: `" frog wins!"` → `" wins!"`, same reason.
- `GameSetupScreenView`: `SeatHeight` 440 → 480 and `SeatContentGap` 32 → 16. A
  seat now carries a 96 px name row and a 96 px remove target as well as a
  200 px swatch, and at 440 the corner target overlapped the frog. The seat grew
  rather than the swatch shrinking, because the frog is what a child looks at.

## Where the logic lives

The naming rules are Core's, not the view's: `PlayerName` (the cap and the
fall back to the colour name), `PlayerNameEditor` (one naming session — append,
refuse at the cap, backspace, commit), `RosterEntry`, and `DisplayText` (where
an over-wide name gets cut). `Game` takes a roster as well as a colour list and
hands names out through `NameFor` and `StandingsRow.Name`, so no screen looks a
name up anywhere else. That is 30 new Core tests running in half a second,
against a keyboard that would otherwise only be testable in the editor.

`DisplayText.TruncateToWidth` takes a measuring function rather than a
character count, because a count cannot promise a width — `Mohammed` is eight
characters and wider than `Alexander` at nine. Core owns where the cut goes;
the chip's own font answers how wide things are.

## Red before green, in CI

EditMode tests cannot run in an agent environment, so the red was demonstrated
on the runner:

| | Commit | EditMode (Unity) |
| --- | --- | --- |
| Tests only | `ea3ccac` | **failure** |
| With the implementation | `f1996a2` | **success** |

Core, Docs, Debug APK, lint and the gates are green on `f1996a2` too, and on
`6522b71`, which added the capitalisation rule below. That rule's own red was
local and watchable — four failing Core tests reading `But was: "CONNOR"`
before `PlayerNameEditor` derived case from position.

## Deviations and Decisions

- **#319 is resolved: capitals are automatic and the shift key is gone.** The
  spec listed a `⇧` key and never said what it did, so I opened **#319** rather
  than guess. Derek was asked and expressed no preference, so the call was made
  for him: the first letter of each word is a capital, every other letter is
  lowercase, derived from where the character lands as the name is built. With
  case automatic there is nothing left for a shift key to do, so it came off
  the keyboard — row 3 is now eight keys re-centred at a 168 px offset, in the
  code, the spec and both editing mockups. **The cost, plainly: `JJ` and
  `McKenzie` cannot be typed.** That is the known trade, not an oversight — a
  shift key a six-year-old has to find before the `M` of `McKenzie` taxes every
  other name in the game, and these are children typing their own first names.
  #319 is closed with that reasoning recorded on it.
- **The built screen is not shown beside the mockup.** This environment has no
  Unity Editor, no licence and no display, so the screen cannot be rendered at
  all. Opened **#320** in `Direct Involvement Needed` for the two captures
  rather than dropping the checklist's last box quietly. This is the one box on
  the issue that is not ticked.
- **The player chip's rendered padding is unchanged.** Truncation is measured
  against the spec's derived 128 px label column, but the chip's own layout
  still puts the swatch flush against the fill rather than inset by
  `PlayerChipLabelPaddingX`. Bringing the two into line is a board layout change
  and the issue puts those out of scope; the effect is that the chip truncates
  slightly sooner than the pixels strictly require.
- **`Game` and `StandingsRow` kept their colour-only constructors**, delegating
  to the roster ones with default names. A colour-only line-up is a roster of
  frogs on their default names, and a default name is a real name — so there is
  one roster path rather than two, and about forty existing call sites did not
  have to churn inside this PR.


---
_Generated by [Claude Code](https://claude.ai/code)_