### PR TITLE
feat(ai-sdlc): adopt ai-sdlc at v0.4.2, starting with hygiene

### DIFF
--- a/.claude/ai-sdlc.pin
+++ b/.claude/ai-sdlc.pin
@@ -1,0 +1,1 @@
+v0.4.2 b95d6bb30481e24e4b9eb8c6cdfda1a85cdb20d3

--- a/.claude/ai-sdlc/house-rules.md
+++ b/.claude/ai-sdlc/house-rules.md
@@ -1,0 +1,73 @@
+# ai-sdlc: derekwinters/ai-sdlc@v0.4.2 hash=949b1f877d34b58d
+# Managed by `adopt`. Local edits are preserved but stop this file
+# being updated — `adopt verify` will report it.
+# House rules
+
+Shared across every repository that has adopted ai-sdlc. Maintained in one place; your
+repository's own `CLAUDE.md` holds everything specific to it.
+
+Where CI enforces a rule, this says so and names the check. The rules here that CI *cannot* check
+are the ones that need you to have read them.
+
+## Commits and pull requests
+
+**Every commit on the default branch is a Conventional Commit.** Pull requests merge by squash, so
+**the squash title is the commit** release-please parses — not a separate message written later. A
+title it cannot parse produces no version bump and no changelog entry, and the change ships
+unaccounted for. *Enforced: `pr-title-lint`.*
+
+Pick the type for the actual impact of the change, not for whichever word the branch used. A new
+user-facing capability is `feat:` even when it also fixes something.
+
+**One issue, one branch, one pull request.** A pull request closing four issues is not reviewable,
+and cannot be reverted for one of them. *Enforced: `closing-keyword` requires exactly one closing
+keyword.*
+
+## Writing a pull request
+
+Open with a **plain-English lead** — two or three sentences saying what changed and why, before any
+file name or class name. Someone should be able to tell what happened without reading the diff.
+
+Then **`## Deviations and Decisions`**, always present, `None.` when empty. Include an item only if
+a reviewer knowing it might act differently — object, adjust, or follow up. Exclude what the diff
+already shows, what the conventions already endorse, and routine test structure. A short list is
+the normal outcome.
+
+Then a **`**Docs:**` line** saying what documentation changed, or why none was needed.
+*Enforced: `docs-gate`.*
+
+## Building
+
+**Specification before code.** Write or amend the specification for what you are about to build,
+with a requirement identifier per behaviour. Where something could be built in a way that is
+technically correct but wrong, state an **invariant** — a short imperative sentence constraining
+how it may work — so the bad implementation is excluded before it is written rather than argued
+about afterwards. *Enforced: the spec↔test traceability gate.*
+
+**A failing test before the implementation, and you watch it fail.** If it fails for the wrong
+reason, the test is wrong. If you did not see red, you do not know the test tests anything.
+
+**Reconcile the documentation you affected in the same pull request.** A design contract that lags
+the code by three pull requests is not a contract.
+
+## Judgement
+
+**Ask rather than invent a design decision.** Where the specification is silent about what
+something should do, stop and ask. A plan that quietly decides a question nobody asked is worse
+than no plan, because it looks like an answer and gets approved as one. Offering options is
+helpful; recommending one is deciding.
+
+**Do not weaken a test to make it pass.** If a test is wrong, say that it is wrong and why.
+
+**Do not widen the scope.** The issue is the deliverable. "While I was in there" belongs in another
+issue.
+
+**Do not mark an acceptance check done that you have not verified.**
+
+## Work only a human can do
+
+Repository settings, secrets, external accounts, physical devices, and taste calls are not yours.
+File **one small issue per task**, saying the single action needed and how to verify it, then
+finish everything that does not depend on it and say in the pull request what you left out.
+
+One task per issue. An issue titled "various setup needed" is an issue nobody ever finishes.

--- a/.claude/repo-config.yml
+++ b/.claude/repo-config.yml
@@ -1,0 +1,65 @@
+# What this repository is, for ai-sdlc.
+#
+# Everything else about the pipeline — the skills, the workflows, the specs —
+# is identical in every repository that adopts it. This file is the only place
+# Multiplying Frogs differs from the others.
+#
+# See https://derekwinters.github.io/ai-sdlc/spec/configuration/ for the schema.
+
+# Capabilities arrive one at a time, as each replaces the local tooling doing
+# that job today. This list is what is *live*, not what is intended — `adopt`
+# installs everything a declared capability owns on the next run, so declaring
+# `pipeline` before the old gatekeeper is gone would mean two handlers on one
+# event, racing, both writing.
+#
+# The remaining order, each with its issue:
+#   labels      #342   consistency #343
+#   pipeline    #344 and #346, once the colliding workflows are retired
+#   release     with #342, once release-please is reconciled
+#
+# `substrate` is implied and is not listed.
+capabilities:
+  - hygiene
+
+# Both markers are present — ProjectSettings/ProjectVersion.txt and mkdocs.yml —
+# and detection would find both. Stated explicitly anyway: a repository that has
+# said what it is does not get second-guessed by a marker file appearing or
+# disappearing.
+profiles:
+  - unity
+  - mkdocs
+
+# Who may drive the pipeline with commands. Connor decides plenty about the
+# game, but the pipeline's approvals are Derek's.
+owners:
+  - derekwinters
+
+# The existing dashboard issue, reused rather than replaced. Opening a second
+# one would leave two boards disagreeing.
+dashboard_issue: 163
+
+# v0.5, v0.6, v0.10 — ordered as versions rather than as strings, so v0.10
+# follows v0.9 instead of preceding v0.2. Non-version milestones
+# ("Direct Involvement Needed", "ai-sdlc adoption") are deliberately outside
+# the ordering and are never the focus milestone.
+milestone_ordering: semver
+
+commands:
+  # The Core suite: no editor, no licence, about two seconds.
+  test: dotnet test Tests/Core/Frogs.Core.Tests.csproj
+  # Core has not gained a Unity dependency — rule 2 in CLAUDE.md, enforced.
+  verify: python3 .github/scripts/check_core_isolation.py
+
+# Deliberately absent:
+#
+# `labels:` — frogs' pipeline-state labels already match the canonical
+#   vocabulary exactly (ai-triage, pending-approval, needs-clarification,
+#   ready-for-work, in-progress, parked), so there is nothing to map. Checked
+#   against .github/labels.yml rather than assumed.
+#
+# `bot:` — the default `github-actions` identity, with the watermark read from
+#   `github-actions[bot]`. Revisit under #339, which asks whether `claude[bot]`
+#   should drive commands.
+#
+# `commands.spec_validator` — frogs' docs are prose specs, not AREA-NNN
+#   requirement tables, so there is no validator to name.

--- a/.github/workflows/closing-keyword.yml
+++ b/.github/workflows/closing-keyword.yml
@@ -1,0 +1,25 @@
+# ai-sdlc: derekwinters/ai-sdlc@v0.4.2 hash=6ae3fa4bc47cae9e
+# Managed by `adopt`. Local edits are preserved but stop this file
+# being updated — `adopt verify` will report it.
+name: closing-keyword
+
+# A caller. The logic is in ai-sdlc; this exists because a trigger
+# cannot be centralised — it must be declared in the repository it
+# fires for.
+#
+# Pinned to a commit rather than a tag: a tag can move, and this runs
+# with this repository's token. Upgrade with `adopt apply <version>`,
+# which rewrites both the SHA and the comment.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  closing-keyword:
+    uses: derekwinters/ai-sdlc/.github/workflows/reusable-closing-keyword.yml@b95d6bb30481e24e4b9eb8c6cdfda1a85cdb20d3 # v0.4.2
+    with:
+      ref: b95d6bb30481e24e4b9eb8c6cdfda1a85cdb20d3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,3 +296,5 @@ editor, so it runs in CI
 | Core tests | `Tests/Core/` — plain NUnit, fast, no editor |
 | Unity tests | `Assets/Tests/EditMode/` — needs the editor, runs in CI |
 | The app's version | `/VERSION` — release-please only |
+
+@.claude/ai-sdlc/house-rules.md

--- a/docs/engineering/ai-sdlc.md
+++ b/docs/engineering/ai-sdlc.md
@@ -1,0 +1,70 @@
+# ai-sdlc
+
+Multiplying Frogs used to own every piece of its development tooling: its own gatekeeper, its own
+dashboard renderer, its own label sync, its own reconcile sweep. All of it worked, and all of it
+existed in near-identical form in the other repositories Derek maintains — which meant a fix to any
+of it was a fix in one place and a slow divergence everywhere else.
+
+[ai-sdlc](https://derekwinters.github.io/ai-sdlc/) is that tooling, extracted once, specified, and
+tested. This repository is a consumer of it.
+
+## What lives where now
+
+The logic lives in ai-sdlc. This repository holds only the parts that genuinely differ:
+
+| Here | Why it cannot be centralised |
+| --- | --- |
+| `.claude/repo-config.yml` | What *this* repository is — its capabilities, owners, dashboard, commands |
+| `.claude/ai-sdlc.pin` | The version of ai-sdlc being followed |
+| `.claude/ai-sdlc/house-rules.md` | The shared rules, installed here so agents read them without a network |
+| `.github/workflows/*.yml` callers | A trigger must be declared in the repository it fires for |
+
+A caller is about fifteen lines: a trigger and a `uses:`. Everything it calls is in ai-sdlc, at the
+pinned version.
+
+## Capabilities arrive one at a time
+
+ai-sdlc is six capabilities, ordered so each may depend only on those below it:
+
+    substrate → hygiene → consistency → labels → release → pipeline
+
+A repository takes what it wants. `repo-config.yml` lists what is **live here right now**, not what
+is intended — `adopt` installs everything a declared capability owns on its next run, so declaring
+`pipeline` before the old gatekeeper is gone would put two handlers on one event, racing, both
+writing.
+
+The migration is tracked in the **ai-sdlc adoption** milestone, one issue per capability. It is
+deliberately not a version milestone: this is infrastructure, and a version number belongs to a
+release of the game.
+
+## The pin
+
+`.claude/ai-sdlc.pin` records the version **and** the commit it resolves to:
+
+    v0.4.2 b95d6bb30481e24e4b9eb8c6cdfda1a85cdb20d3
+
+The callers reference that commit, with the version as a trailing comment — the same form as every
+other pin here, and no exception to [the SHA-pinning rule](ci-cd.md). A reusable workflow runs with
+this repository's token, on `issue_comment` and `issues`, so a mutable ref there is the same
+exposure as a mutable action; ai-sdlc being ours says who could move a tag, not that it cannot move.
+
+An upgrade is still a pull request that moves one line, because `adopt apply <version>` resolves the
+version and rewrites both the SHA and the comment. Nobody resolves a SHA by hand, and nobody has to
+read forty characters of hexadecimal to tell how far behind they are.
+
+## Upgrading, and checking for drift
+
+```bash
+python3 .claude/skills/adopt/main.py plan   <pin>   # read-only: what would change
+python3 .claude/skills/adopt/main.py apply  <pin>   # writes, on a branch
+python3 .claude/skills/adopt/main.py verify <pin>   # read-only: are we still current
+```
+
+`apply` is both the install and the upgrade path, so the upgrade cannot rot separately from the
+install.
+
+Every file `adopt` writes carries a provenance header naming the source, the ref, and a content
+hash. That is how it tells a file of its own from one of ours, and a locally-edited managed file
+from a merely outdated one. **An edit is a conflict, not a stale file** — it is reported and left
+alone, never overwritten, because overwriting it would discard the edit silently. If you need to
+change a managed file, change it in ai-sdlc and move the pin.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,5 +123,6 @@ nav:
       - Issue pipeline: engineering/issue-pipeline.md
       - UI design process: engineering/ui-design-process.md
       - Unity serialization: engineering/unity-serialization.md
+      - ai-sdlc: engineering/ai-sdlc.md
   - Tools:
       - tools/index.md


### PR DESCRIPTION
Frogs currently owns its whole development pipeline — a gatekeeper, a dashboard, a label sync, a reconcile sweep — and so do Derek's other repositories, in near-identical form. ai-sdlc is that tooling extracted once, specified and tested. This is the first step of moving frogs onto it, and the first thing that actually starts running is a check frogs has never had: every PR must close its issue with a real keyword.

Nothing is removed yet. The gatekeeper, dashboard and sweep all still run exactly as before.

**The diff is purely additive.** Seven files, all new lines, no existing workflow, script, rule or doc modified.

## Deviations and Decisions

- **Declares only `hygiene`, not all six capabilities.** The issue's checklist listed the full set. `adopt` installs everything a declared capability owns on its *next* run, so declaring `pipeline` while `gatekeeper-comment.yml` still handles `issue_comment` would put two handlers on one event, racing, both writing. Capabilities now arrive with the issues that retire what they replace, and `repo-config.yml` states what is live rather than what is intended. `adopt apply` refuses **globally** on any collision — not per-file — so this is the only ordering that lets anything land at all.
- **The `no-closing-keyword` escape-hatch label does not exist yet.** The check will fail a keywordless PR with no way to override. Left for #341 rather than reaching into the label taxonomy from here, since #342 restructures that file wholesale — but the escape hatch is unavailable until one of them lands. Say the word if you want it sooner.

## What changed since the first version of this PR

The first attempt loosened `check_action_pins.py` to accept a **tag**-pinned caller, because that is what `adopt` used to write and frogs' checker rejected it outright.

That was the wrong half of the trade to give up. Frogs' rule was right: a reusable workflow runs with *this* repository's token, on `issue_comment` and `issues`, so a mutable ref there is the same exposure as a mutable action — ai-sdlc being ours says who could move a tag, not that it cannot move.

So ai-sdlc changed instead (`derekwinters/ai-sdlc#72`, released in **v0.4.2**): callers are now pinned to a commit SHA with the version as a trailing comment, and `VAL-056` — which had exempted reusable workflows — was reversed. This PR now adopts at v0.4.2, and **`check_action_pins.py` and `ci-cd.md` are untouched**:

```yaml
uses: derekwinters/ai-sdlc/.github/workflows/reusable-closing-keyword.yml@b95d6bb3… # v0.4.2
with:
  ref: b95d6bb3…
```

```
$ python3 .github/scripts/check_action_pins.py     # unmodified
All 15 workflows are pinned to full commit SHAs.
```

## Spec invariants

- *A capability may depend only on capabilities below it.* `hygiene` needs only `substrate`, which is implied.
- *`adopt` never overwrites what it did not write.* Every installed file carries a provenance header; `adopt verify v0.4.2` reports the repository as matching its pin.
- *`CLAUDE.md` is never rewritten.* One import line appended at the end; nothing else in a 300-line file changed.
- *Labels are never renamed.* None touched. Frogs' six pipeline-state labels were **checked** against ai-sdlc's canonical vocabulary rather than assumed — they match exactly, so `repo-config.yml` needs no mapping.
- *Every `uses:` is a full commit SHA.* Now true of the adopted caller too, with frogs' rule unmodified.

## Validated

```
CI script tests        223 passed
action pins            all 15 workflows clean (unmodified checker)
core isolation         Core is engine-free
mkdocs build --strict  clean
adopt verify v0.4.2    matches its pin
```

**The Core suite did not run** — `dotnet` is not available in this environment. Nothing here touches C#; the change is configuration, one caller workflow and docs. Worth a glance at CI rather than my word.

## What the next issue sees

`adopt plan v0.4.2` reports three remaining collisions — `dashboard.yml` and `gatekeeper-sweep.yml` on `issues`, `gatekeeper-comment.yml` on `issue_comment`. Those are #344, #345 and #346, and clearing them is what finally lets the pipeline capability land.

Closes #340