### PR TITLE
docs(ai-sdlc): document the two escape-hatch labels

### DIFF
--- a/docs/engineering/ai-sdlc.md
+++ b/docs/engineering/ai-sdlc.md
@@ -52,6 +52,24 @@ An upgrade is still a pull request that moves one line, because `adopt apply <ve
 version and rewrites both the SHA and the comment. Nobody resolves a SHA by hand, and nobody has to
 read forty characters of hexadecimal to tell how far behind they are.
 
+## The two escape hatches
+
+Both adopted checks can be overridden, and both do it the same way — with a **label that makes the
+check pass**, never one that skips it. That distinction is the whole design: a skipped required
+check stays pending forever and blocks the merge it was meant to permit, so an `if:` would turn an
+escape hatch into a trap.
+
+| Label | Overrides | Use it when |
+| --- | --- | --- |
+| `no-closing-keyword` | `closing-keyword` | the pull request deliberately closes no issue |
+| `skip-docs` | `docs-gate` | the change genuinely needs no documentation |
+
+Adding either label re-runs its check, because `labeled` is among the caller's triggers. Nothing
+needs pushing. Using one is a decision, so it belongs in `## Deviations and Decisions`.
+
+Verified end to end when the closing-keyword check was adopted: a pull request with no closing
+keyword failed, the label made it pass on a fresh run, and removing the label failed it again.
+
 ## What the docs gate does, and does not, replace
 
 The reconciliation gate — *a pull request that changes code must change documentation, or carry


### PR DESCRIPTION
Documents the two labels that override the adopted checks, and how they work — and this pull request was itself the live test of the closing-keyword check that #340 turned on.

## The verification

Opened deliberately **without** a closing keyword, then driven through the full cycle. Each line is a separate run, not a re-evaluation:

| Time | State | Result |
| --- | --- | --- |
| 16:17:38 | no keyword, no label | **failure** |
| 16:18:07 | `no-closing-keyword` added | **success** |
| 16:18:38 | label removed again | **failure** |

That is the property that matters: the label makes the check **pass on a fresh run**, it does not skip it. A skipped required check stays pending forever and blocks the merge it was meant to permit — an `if:` here would turn the escape hatch into a trap.

The `no-closing-keyword` label exists because #342 installed it in `labels.core.yml`, which is why that issue had to run before this one.

## Deviations and Decisions

- **The issue's checklist has moved on since it was written.** #341 originally said "add the caller workflow" and "confirm the label exists". The caller landed in #340 and the label in #342, so what was actually left was the verification — which is the half of the issue that was always the point, and is now done against the live repository rather than asserted.
- **The keyword was added after the test, not before.** The body carried none for the first three runs on purpose. It closes #341 now.

**Docs:** `docs/engineering/ai-sdlc.md` — a new section on the two escape hatches, why they make a check pass rather than skip it, that adding one re-runs the check with nothing to push, and that using one belongs in `## Deviations and Decisions`. The table of verified results above is recorded there in one sentence.

## Spec invariants

- *An escape hatch makes a check pass, never absent.* Demonstrated by three real runs rather than by reading the workflow.
- *Every event that can change a check's verdict re-runs it.* `labeled` and `unlabeled` are both in the caller's triggers — the removal at 16:18:38 proves `unlabeled` works too, which nothing had tested.

Closes #341