### PR TITLE
docs: rename the Direct Involvement Needed milestone to Human

### DIFF
--- a/.claude/.skills-manifest.json
+++ b/.claude/.skills-manifest.json
@@ -203,7 +203,7 @@
       "vendored_from": "mattpocock/skills",
       "source_path": "skills/engineering/wizard",
       "diverged": false,
-      "notes": "Good fit for the Direct Involvement Needed milestone \u2014 it generates a bash walkthrough for steps only Derek can do."
+      "notes": "Good fit for the Human milestone \u2014 it generates a bash walkthrough for steps only Derek can do."
     },
     {
       "name": "writing-for-agents",

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -150,7 +150,7 @@ different? That is the whole test.
 Include: something the issue didn't ask for, or didn't get; a choice between two
 defensible approaches; something left out or stubbed; an escape hatch used
 (`skip-docs`, a geometry exemption, a skipped test); the issue turning out to be
-wrong; a `Direct Involvement Needed` issue opened.
+wrong; a `Human` issue opened.
 
 **`None.` is a fine entry, and the most common correct one.** Zero to two items
 is the norm. Six means the issues are underspecified or the section is being
@@ -179,7 +179,7 @@ Repo-admin settings, secrets, external accounts, purchases, a physical device, a
 Unity Editor session, or a taste call that is Connor's.
 
 Do **not** guess, stub it silently, or park the whole issue. Open **one small
-issue per task** in the `Direct Involvement Needed` milestone saying exactly
+issue per task** in the `Human` milestone saying exactly
 what the human has to do and what it unblocks. Then finish everything in your
 issue that does not depend on it, and say in the PR what you left out.
 
@@ -206,7 +206,7 @@ When you finish, report:
 2. **The PR link**, and whether CI is green.
 3. **Checklist boxes you could not tick**, and why.
 4. **Anything you opened** — a `type:question`, a `type:wireframe`, a
-   `Direct Involvement Needed` issue.
+   `Human` issue.
 5. **What you did not do** that someone might expect you had.
 
 Do not report the loop you followed; it is the same every time. Report what was

--- a/.claude/repo-config.yml
+++ b/.claude/repo-config.yml
@@ -38,7 +38,7 @@ dashboard_issue: 163
 
 # v0.5, v0.6, v0.10 — ordered as versions rather than as strings, so v0.10
 # follows v0.9 instead of preceding v0.2. Non-version milestones
-# ("Direct Involvement Needed", "ai-sdlc adoption") are deliberately outside
+# ("Human", "ai-sdlc adoption") are deliberately outside
 # the ordering and are never the focus milestone.
 milestone_ordering: semver
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ a Unity Editor session, and any taste call that is Connor's to make.
 
 When you hit one of these, **do not** guess, stub it out silently, or park the
 whole issue. Open **one small issue per task** in the
-`Direct Involvement Needed` milestone, describing exactly what the human has to
+`Human` milestone, describing exactly what the human has to
 do and what unblocks once they've done it. Then finish everything in your
 current issue that doesn't depend on it, and say in the PR what you left out.
 

--- a/docs/engineering/agent-workflow.md
+++ b/docs/engineering/agent-workflow.md
@@ -240,7 +240,7 @@ different. That's the whole test. Concretely:
 - You left something out, or stubbed it.
 - You used an escape hatch — `skip-docs`, a geometry exemption, a skipped test.
 - You found the issue was wrong and worked to your own interpretation.
-- You opened a `Direct Involvement Needed` issue because part of it needed a
+- You opened a `Human` issue because part of it needed a
   human.
 
 ### The norm is zero to two items

--- a/docs/engineering/issue-pipeline.md
+++ b/docs/engineering/issue-pipeline.md
@@ -356,7 +356,7 @@ something is wrong.
 #### Milestone order comes from the title
 
 `vMAJOR.MINOR[.PATCH]` is ordered; anything else is **unordered**. That
-deliberately includes `Direct Involvement Needed` — it never ships, so a blocker
+deliberately includes `Human` — it never ships, so a blocker
 parked there is one nothing will ever build, which is exactly the
 `blocker-unscheduled` case.
 
@@ -1288,7 +1288,7 @@ work that most needs surfacing:
   triage usually has no milestone at all. A focus-scoped Intake is
   structurally near-empty: the section reads "Nothing waiting for triage"
   precisely because the untriaged pile is growing out of sight.
-- **`Direct Involvement Needed` can never be the focus.** It carries no
+- **`Human` can never be the focus.** It carries no
   version and never ships, so a focus-scoped "Waiting for you" hides every
   issue in the one milestone that exists to say *Derek has to do this by
   hand* — which is most of them.

--- a/docs/engineering/unity-serialization.md
+++ b/docs/engineering/unity-serialization.md
@@ -64,7 +64,7 @@ Agent environments have no Unity. So:
 - **Copy the shape from a real file in the repo**, changing only values you can
   see the effect of.
 - **Never invent a key.** If the shape you need isn't in the repo, say so, and
-  open a `Direct Involvement Needed` issue for the editor step rather than
+  open a `Human` issue for the editor step rather than
   guessing at the YAML.
 - **Say what you copied from** in the PR — "modelled on
   `Assets/Prefabs/Frog.prefab`" — so a reviewer can check the source rather than

--- a/docs/intro/conventions.md
+++ b/docs/intro/conventions.md
@@ -95,11 +95,11 @@ the artifact you can check out and build.
 
 Never reopen a shipped milestone to hold follow-up work. Follow-up work is new
 work: it goes in the next open version milestone, or in
-`Direct Involvement Needed` if a human has to do it.
+`Human` if a person has to do it.
 
 ### The non-version milestone
 
-`Direct Involvement Needed` is the one milestone with no version and no ship
+`Human` is the one milestone with no version and no ship
 date. It holds work no agent can finish alone — anything needing repo-admin
 rights, a secret, an external account, a purchase, a device in hand, a Unity
 Editor session, or a taste call that is Connor's to make.
@@ -332,7 +332,7 @@ answer turns out to be small enough to just build. Do not quietly retitle a
 question into a task; the distinction is what makes the question queue
 meaningful.
 
-Questions Connor has to answer get the `Direct Involvement Needed` milestone and
+Questions Connor has to answer get the `Human` milestone and
 no version milestone, because they are not shippable work.
 
 ## Docs versioning


### PR DESCRIPTION
The milestone where work goes when a person has to do it is now called **Human** instead of *Direct Involvement Needed*. The milestone itself is already renamed, along with its description; this updates the thirteen places in the repository that still called it by the old name.

The reason is the rebuilt dashboard: it charts open issues per milestone, and mermaid neither wraps nor rotates x-axis labels, so the long title printed straight through `v0.5` and made both unreadable.

## Deviations and Decisions

- **The milestone was renamed before this PR, not by it.** A milestone title is GitHub data rather than repository content, so there is no way to change it in a commit. The rename is done (`/milestone/3`); this PR only catches the text up. Worth knowing because `main` names the old title until this merges.
- **`Human` rather than `DIN`, which is what was first asked for.** An acronym reads fine in a chart and badly in the milestone picker, where the description is not visible and you are choosing between `DIN`, `v0.5`, `v0.6`. Agreed before making the change.
- **`.claude/.skills-manifest.json` is edited by hand here.** Its own header says it is provenance-only and that nothing reads it at runtime and no workflow syncs against it — checked before editing, since a generated file would have been the wrong thing to touch.
- **`lucas-doggiehood` is deliberately not included**, though it has the same milestone and seven of its own references — including `parse_commands.py`, which is code. It has not adopted ai-sdlc yet, and the agreed order is to prove ai-sdlc here first. Renaming a repository we are not currently testing would widen this change for no benefit.
- **ai-sdlc is deliberately not included either.** Its four occurrences are illustrative examples of a milestone naming no version, and they remain accurate while doggiehood still has one. The right change there is making the examples generic rather than substituting one consumer's milestone name for another's inside a shared tool — filed separately.
- **One line was reworded rather than substituted.** `conventions.md` would have read "`Human` if a human has to do it"; it now says "if a person has to do it".

**Docs:** `docs/intro/conventions.md`, `docs/engineering/issue-pipeline.md`, `docs/engineering/agent-workflow.md`, `docs/engineering/unity-serialization.md` — every reference to the milestone renamed, and the "non-version milestone" section now introduces `Human`. `CLAUDE.md`, `.claude/agents/dev.md` and `.claude/repo-config.yml` updated for the same reason. `mkdocs build --strict` passes.

## Verification

- No occurrence of the old title remains outside `site/` (untracked build output).
- All 31 issues kept their milestone assignment; the milestone URL is keyed on its number, so no link breaks.
- No code depends on the name: ai-sdlc identifies version milestones with `^v(\d+)\.(\d+)`, which rejects both the old and new titles identically, and its only two source occurrences are in comments.

Closes #359

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMeYquCmFH2DZ5J9QeUVvh)_