### PR TITLE
docs(ui): spread the pond to the full width of the board

### DIFF
--- a/docs/engineering/tech-stack.md
+++ b/docs/engineering/tech-stack.md
@@ -446,15 +446,23 @@ yield return new WaitForSeconds(0.4f);
 
 // Yes.
 const int LaneWinningPosition = 8;
-[SerializeField] float _lanePositionGap = 48f;
+[SerializeField] float _lanePositionGapMin = 48f;
 [SerializeField] float _frogHopDuration = 0.4f;
 ```
 
 None of those three names is invented here. `LaneWinningPosition`,
-`LanePositionGap` and `FrogHopDuration` are what
+`LanePositionGapMin` and `FrogHopDuration` are what
 [the game board spec](../specs/ui/game-board.md) already calls those numbers,
 and a constant in the code keeps the name the spec page gave it so the two can
 be checked against each other.
+
+The example says `LanePositionGapMin` rather than `LanePositionGap` for a
+reason worth noticing: since
+[#325](https://github.com/derekwinters/connor-multiplying-frogs/issues/325) the
+gap itself is **derived from the screen's width** and is not a number anybody
+types. Its floor still is. A derived value does not escape this rule — it gets
+a named function of named constants, not an expression inlined at the one call
+site that needed it.
 
 ### Why this is a rule and not a preference
 

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -68,20 +68,65 @@ height, in this order and with no gaps:
 - `controls` — pinned to the bottom, `BoardControlsHeight` tall, full width.
 
 "Full width" and "the top" mean the screen's, not the reference canvas's, on a
-device that is not 16:10 — a band reaches the edges the way the water does. What
-the bands *contain* is measured in the reference canvas, which is what every
-number below is in. The whole of that rule, and the one control it moves, is
+device that is not 16:10 — a band reaches the edges the way the water does.
+
+What the bands *contain* divides in two, and this is the division
+[#325](https://github.com/derekwinters/connor-multiplying-frogs/issues/325)
+introduced:
+
+- **`header` and `controls` are measured in the reference canvas.** The turn
+  banner, the gear and `Roll` are anchored controls, and a wider screen moves
+  the two that are anchored to an edge without resizing any of them.
+- **The `pond` is measured in the screen.** Its row is a track whose job is to
+  show how far along a lane a frog has got, so it spreads to whatever width it
+  is given — see [across the pond](#anchors) below.
+
+Every number in the tables below is still in reference-canvas units, and every
+one of them still means exactly what it says. `LanePositionGap` is the single
+exception, and it is derived rather than typed.
+
+The whole of that rule, and the one control it moves, is
 [the bands reach the edges too](#the-bands-reach-the-edges-too).
 
 Across the pond, the nine positions occupy the same nine columns in every lane,
-and their total width is fixed by the position count rather than by the space
-available:
+and **the row spans the whole screen** — the chips and the Start log against the
+real left safe margin, the End log against the real right one, and the seven
+lily pads spread evenly in whatever is left between them:
 
-- `chip` — pinned to the **left** safe margin, `LaneGutterWidth` wide.
-- `start-log` — `LaneGutterGap` to the right of the chips.
+- `chip` — pinned to the **left** safe margin, `LaneGutterWidth` wide. It does
+  not stretch; see [why the gutter does not
+  stretch](#why-the-gutter-does-not-stretch).
+- `start-log` — `LaneGutterGap` to the right of the chips. Everything to the
+  left of its right-hand edge is fixed, so the Start log sits at the same x on
+  every screen.
 - `track` — this lane's seven lily pads, `LanePositionGap` from the Start log,
-  from each other, and from the End log.
+  from each other, and from the End log. That gap is **derived from the screen's
+  width**, not typed into the table.
 - `end-log` — pinned to the **right** edge of the safe area.
+
+`LanePositionGap` is the one number on this page that the screen decides:
+
+```text
+LanePositionGap = max( LanePositionGapMin, (screen width − LaneFixedWidth) ÷ LanePositionGapCount )
+```
+
+`LaneFixedWidth` is everything on the row that does not stretch, and
+`LanePositionGapCount` is the number of gaps the slack is divided between —
+one either side of the pads, six among them. Both are in
+[the constants table](#named-constants), and the arithmetic that produces them
+is [worked through there](#the-horizontal-arithmetic).
+
+**At exactly 1920 px the formula gives exactly 48 px**, which was
+`LanePositionGap`'s typed value before this change. That is not a coincidence to
+be grateful for — it is the condition this rule was chosen to satisfy, so that
+the reference canvas keeps being a picture of the game. It is checked rather
+than assumed: [the mockup renders byte-identical](#mockup) at 1920 before and
+after.
+
+The floor is what a *narrower* screen gets. Below 1920 px the formula would
+start closing the pads up, so it stops: the board keeps its reference width and
+is centred, exactly as it always was. **The pond spreads on screens wider than
+16:10 and is unchanged on everything else.**
 
 Both logs are `SharedLogHeight` tall, which is the height of the `pond` band on
 the reference canvas: they fill it, edge to edge with the two hairlines, whether
@@ -168,7 +213,10 @@ The lane:
 | Frog piece diameter | `FrogPieceDiameter` | 88 px |
 | Frog piece outline | `FrogPieceOutline` | 4 px |
 | Lily pad and log outline | `TrackOutline` | 3 px |
-| Gap between positions | `LanePositionGap` | 48 px |
+| Gap between positions | `LanePositionGap` | derived — see [Anchors](#anchors) |
+| Smallest that gap may be | `LanePositionGapMin` | 48 px |
+| Everything on the row that does not stretch | `LaneFixedWidth` | 1536 px |
+| Gaps the leftover width is divided between | `LanePositionGapCount` | 8 |
 | Chip gutter width | `LaneGutterWidth` | 256 px |
 | Gap between chip and track | `LaneGutterGap` | 48 px |
 
@@ -198,12 +246,57 @@ It is written as the band's own arithmetic rather than as the bare 896 because
 the log **is** the band: if `BoardHeaderHeight` or `BoardControlsHeight` ever
 moves, the logs move with it and nobody has to remember them.
 
-That horizontal arithmetic is exact and worth keeping exact, and sharing the
-logs does not disturb it, because a shared log stands in the same column its
-per-lane predecessor did: two logs at 176, seven pads at 112 and eight gaps at
-48 is 1520 px across the pond; plus a 256 px chip gutter, a 48 px gap and two
-48 px margins, that is 1920 px on the nose. If a constant here changes, one of
-the others has to move with it.
+### The horizontal arithmetic
+
+The row used to sum to 1920 px exactly, and the page said so. It still does at
+1920 — but it now sums to the screen's width at every width, because one term in
+it is the term that absorbs the difference.
+
+Split the row into what is fixed and what stretches:
+
+```text
+LaneFixedWidth  =  48 margin + 256 chip gutter + 48 gap
+                     + 176 Start log + 7 × 112 pads + 176 End log
+                     + 48 margin
+                =  1536 px
+
+LanePositionGapCount  =  8      one gap either side of the pads, six among them
+
+LanePositionGap  =  max( 48, (screen width − 1536) ÷ 8 )
+```
+
+Checked at the two widths that are drawn:
+
+| Screen | Slack over `LaneFixedWidth` | `LanePositionGap` | Row sums to |
+| --- | --- | --- | --- |
+| 1920 px — the reference canvas | 384 | **48 px** | 1536 + 8 × 48 = 1920 |
+| 2560 px — the wide drawing | 1024 | **128 px** | 1536 + 8 × 128 = 2560 |
+
+`LaneFixedWidth` is written as its own constant rather than left as a sum
+nobody can name, because it is now load-bearing: it is the term the elastic gap
+is computed against, so a change to `LaneGutterWidth`, `LogWidth`,
+`LilyPadDiameter`, `LaneGutterGap` or `SafeMargin` is a change to it. **If a
+constant here changes, `LaneFixedWidth` moves with it** — and unlike before,
+nothing else has to, because the gap absorbs the difference by construction.
+That is the one genuine simplification in this change: the row used to have to
+be rebalanced by hand.
+
+Sharing the logs did not disturb this arithmetic and neither does spreading it:
+a shared log still stands in the same column its per-lane predecessor did, and
+position 0 is still on the Start log at every width.
+
+### Why the gutter does not stretch
+
+`LaneGutterWidth` is 256 px on every screen. Widening it on a wider tablet was
+considered — frogs have typed names now, so more room for a long one is a real
+benefit — and rejected, because it would make **how much of a name fits depend
+on the device**. A name that shows in full on the tablet and truncates on a
+narrower screen is a bug that only appears on one person's hardware, which is
+the worst kind to be told about.
+
+If 256 px turns out to be too tight for the names Connor types, the fix is to
+make it a bigger fixed number, decided once and drawn — not to make it elastic.
+That is a separate change and it wants its own issue.
 
 Vertically, the pond band is `1200 − BoardHeaderHeight − BoardControlsHeight` =
 896 px, which is `SharedLogHeight` — the logs fill it exactly. Four lanes at
@@ -293,12 +386,20 @@ each of its ends, and two grey bars floating on a pond is a rendering fault
 rather than a design. That is what the tablet was doing until this was written
 down.
 
-**Invariant:** what a band *contains* is still laid out in the reference canvas,
-centred. The lanes are the reference canvas's safe area wide and the two shared
-logs stand in the columns those lanes' tracks start and end in, on every screen,
-so every constant in the table below keeps meaning exactly what it says and
-position 0 is still on the Start log. The band grows; the board inside it does
-not.
+**Invariant:** the `pond`'s row **grows with the band**. The chips and the Start
+log sit against the real left safe margin, the End log against the real right
+one, and `LanePositionGap` takes up the difference. Position 0 is still on the
+Start log and position 8 still on the End log, at every width.
+
+**Invariant:** what `header` and `controls` contain is still laid out in the
+reference canvas. The turn banner, the gear and `Roll` are anchored controls,
+not a track, and there is nothing about them that a wider screen should stretch.
+
+The second of those is what the first used to say about all three bands — see
+[the invariant this page used to carry](#the-invariant-this-page-used-to-carry).
+The two are not in tension: a band's *contents* stretch when they are a track
+whose whole job is to show distance travelled, and do not when they are a
+button.
 
 **A control anchored to a band's edge follows the screen's edge.** The turn chip
 and the settings gear sit `SafeMargin` in from the real left and right edges of
@@ -311,8 +412,40 @@ direction. The two bands keep their heights, because a smaller `Roll` is the
 wrong thing to trade away, and what a taller screen shows more of is water: the
 logs and the lane stack keep their reference size, centred in the band.
 
-At exactly 1920 × 1200 all of this is pixel-identical to the mockups, which is
-why it is a rule stated on this page rather than a new picture to draw.
+At exactly 1920 × 1200 all of this is pixel-identical to the reference mockup —
+verified, not assumed: `game-board.html` renders byte-for-byte the same before
+and after the pond became elastic. What is *not* pixel-identical at any other
+width is now the point, which is why this change comes with
+[a second drawing](#mockup) rather than a rule alone.
+
+### The invariant this page used to carry
+
+Until [#325](https://github.com/derekwinters/connor-multiplying-frogs/issues/325)
+this section carried one invariant covering all three bands, and it ended with a
+sentence that was quoted elsewhere on this page:
+
+> **Invariant:** what a band *contains* is still laid out in the reference
+> canvas, centred. The lanes are the reference canvas's safe area wide and the
+> two shared logs stand in the columns those lanes' tracks start and end in, on
+> every screen, so every constant in the table below keeps meaning exactly what
+> it says and position 0 is still on the Start log. **The band grows; the board
+> inside it does not.**
+
+That is no longer true of the `pond`, and it is exactly what Derek asked to
+change after seeing the built board: the board was a 1920 px picture centred in
+a wider band, so the chips floated some 300 px in from the edge of a screen they
+were supposed to be pinned to.
+
+It remains true of `header` and `controls`, in the invariant above. The old
+wording is kept here rather than deleted, the way
+[`working-out-grid.md` keeps the invariants it used to
+carry](working-out-grid.md#the-invariants-this-page-used-to-carry): a reader who
+remembers the old rule needs to find out that it moved, not to find no trace of
+it and assume they misremembered.
+
+What did **not** change with it: every constant in the table still means exactly
+what it says, and `LanePositionGap` is the single exception — it is the one
+number a screen is now allowed to decide.
 
 ### Keeping the frogs visible
 
@@ -434,11 +567,29 @@ change harder to judge. Whether they now read as a frame or as leftovers is
 
 ## Mockup
 
-[`mockups/game-board.html`](mockups/game-board.html) — and, until Connor has
-picked the water, [`mockups/game-board-paler-water.html`](mockups/game-board-paler-water.html)
-beside it.
+[`mockups/game-board.html`](mockups/game-board.html) — the reference canvas, and
+the one to build against. Beside it,
+[`mockups/game-board-wide.html`](mockups/game-board-wide.html) draws the same
+board at 2560 × 1200, and — until Connor has picked the water —
+[`mockups/game-board-paler-water.html`](mockups/game-board-paler-water.html)
+draws the reference canvas again in the other blue.
 
-The two files differ in **one value**: `PondWater`. `game-board.html` draws the
+**The wide file is deliberately not at the reference canvas**, which every other
+mockup in this project is. It has to be: the whole of
+[the elastic pond](#anchors) is what happens at a width that is not 1920, and a
+drawing at one width cannot show it. 2560 × 1200 is 2.13 : 1, within a hair of
+the roughly 2.17 : 1 the tablet actually reports, and it is the width at which
+the derived gap lands on a whole 128 px that can be checked against the
+constants table by eye.
+
+**At 1920 the two board drawings are the same picture as before this change** —
+byte-for-byte the same rendering, not merely "looks the same". That is the
+check that the reference canvas is still a picture of the game, and it is the
+reason `game-board.html`'s diff in this change is a comment and two CSS
+variables rather than a redraw.
+
+The reference file and the paler-water file differ in **one value**:
+`PondWater`. `game-board.html` draws the
 proposal in the table above, `#9FD8F2`; the second draws `#B5E3F7`, the same
 blue with more light in it. Everything else on the two canvases is identical to
 the pixel. Open both on the tablet, one after the other, and say which is the
@@ -476,6 +627,25 @@ decided against; keeping a mockup of a layout nobody is building is how a
   bar before it lands. The same is true of `LogBrown` and `LilyPadGreen`, which
   are drawn once each rather than twice — say if either is wrong and it gets
   the same treatment.
+- **Does the gap look right when it is wider than the lily pad?** At the
+  reference canvas `LanePositionGap` is 48 px against a 112 px
+  `LilyPadDiameter`, and the pads plainly read as a track. On the wide drawing
+  the gap is **128 px — wider than the pad itself**, and seven pads further
+  apart than they are big could read as scattered stepping stones rather than as
+  something to hop along. [The wide mockup](mockups/game-board-wide.html) exists
+  to answer this, and it is a look-at-it call on the tablet, not an argument.
+
+    If it does read wrong, the fix is a **cap** — a `LanePositionGapMax` beside
+    the existing floor, with the leftover width going to water at the pond's
+    right-hand end rather than into the gaps — and *not* a return to the centred
+    board, which is the thing being fixed. No cap is proposed here, because
+    proposing a number for a problem nobody has seen yet is how a constants
+    table fills up with values nobody can justify.
+
+    The neighbouring option, growing the pads to fill the space, is a different
+    and much bigger change: `LilyPadDiameter` is 112 px because
+    [that is what decided lanes-across over lanes-up](#why-the-lanes-run-across),
+    and moving it reopens that decision. It wants its own issue if it is wanted.
 - **Do the header and controls bands change?** They are `BandFill`, the pale
   grey-green chosen to sit against a pale board, and this change
   [deliberately left them alone](#the-bands-are-unchanged-deliberately). Against

--- a/docs/specs/ui/index.md
+++ b/docs/specs/ui/index.md
@@ -90,7 +90,7 @@ radius, and duration on the screen, named and valued.
 | Element | Constant | Value |
 | --- | --- | --- |
 | `Roll` button width | `RollButtonWidth` | 480 px |
-| Gap between positions in a lane | `LanePositionGap` | 48 px |
+| Smallest gap between positions in a lane | `LanePositionGapMin` | 48 px |
 
 Same names in the code. See
 [named constants are the origin](../../engineering/ui-design-process.md#the-named-constants-are-the-origin-not-an-afterthought).

--- a/docs/specs/ui/mockups/game-board-paler-water.html
+++ b/docs/specs/ui/mockups/game-board-paler-water.html
@@ -61,12 +61,31 @@
     --pad:#CCEAAF; --pad-edge:#7FAE5E;
     --log:#E2C79C; --log-edge:#A97F4F;
     --band:#E2E8E5;
+
+    /* THE TWO NUMBERS THAT MAKE THE POND ELASTIC.
+
+       --canvas is the width of the screen this file is a picture of.
+       --lane-gap is LanePositionGap, and it is DERIVED from that width:
+
+           LanePositionGap = (canvas - 1536) / 8,  floored at 48
+
+       1536 px is everything on the row that does not stretch — two safe
+       margins, the chip gutter, its gap, and the two logs and seven lily pads
+       at their own fixed sizes. 8 is the number of gaps between them. At
+       canvas 1920 the formula gives exactly 48, which is why this drawing is
+       pixel-identical to the one before the pond became elastic.
+
+       The floor is what stops a narrower-than-16:10 screen from squeezing the
+       pads together: below 1920 the board stops spreading and is centred,
+       which is what it has always done. */
+    --canvas:1920px;
+    --lane-gap:48px;
   }
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
   /* PondWater is the whole screen, not a band inside it — the header and the
      controls are drawn on top of the water. */
-  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+  .frame{width:var(--canvas);height:1200px;position:relative;overflow:hidden;
          background:var(--water);color:var(--ink);
          font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
   .abs{position:absolute}
@@ -131,7 +150,7 @@
     <!-- THE SHARED END LOG — one for the whole pond, position 8 of all four
          lanes and the winning space. Blue is home on it, on lane 2's centre
          line (y=484, i.e. 356 down the log). -->
-    <div class="log" style="left:1696px;top:128px;height:896px">End<span class="frog"
+    <div class="log" style="right:48px;top:128px;height:896px">End<span class="frog"
          style="background:var(--blue);top:356px"></span></div>
 
     <!-- The lanes. A lane is now its chip and its own seven lily pads; both
@@ -140,7 +159,7 @@
       <!-- lane 1 green, on its third lily pad -->
       <div class="row" style="height:184px;gap:0">
         <div style="width:48px"></div><div class="chip act"><span class="sw" style="background:var(--green)"></span><span><b>Green</b><s>3 of 8</s></span></div>
-        <div class="row" style="margin-left:272px;gap:48px">
+        <div class="row" style="margin-left:calc(224px + var(--lane-gap));gap:var(--lane-gap)">
           <div class="pad"></div><div class="pad"></div>
           <div class="pad"><span class="frog" style="background:var(--green)"></span></div>
           <div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div>
@@ -149,21 +168,21 @@
       <!-- lane 2 blue, home on the shared End log -->
       <div class="row" style="height:184px;gap:0">
         <div style="width:48px"></div><div class="chip"><span class="sw" style="background:var(--blue)"></span><span><b>Blue</b><s>Home!</s></span></div>
-        <div class="row" style="margin-left:272px;gap:48px">
+        <div class="row" style="margin-left:calc(224px + var(--lane-gap));gap:var(--lane-gap)">
           <div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div>
         </div>
       </div>
       <!-- lane 3 orange, still on the shared Start log -->
       <div class="row" style="height:184px;gap:0">
         <div style="width:48px"></div><div class="chip"><span class="sw" style="background:var(--orange)"></span><span><b>Orange</b><s>0 of 8</s></span></div>
-        <div class="row" style="margin-left:272px;gap:48px">
+        <div class="row" style="margin-left:calc(224px + var(--lane-gap));gap:var(--lane-gap)">
           <div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div>
         </div>
       </div>
       <!-- lane 4 pink, on its sixth lily pad -->
       <div class="row" style="height:184px;gap:0">
         <div style="width:48px"></div><div class="chip"><span class="sw" style="background:var(--pink)"></span><span><b>Pink</b><s>6 of 8</s></span></div>
-        <div class="row" style="margin-left:272px;gap:48px">
+        <div class="row" style="margin-left:calc(224px + var(--lane-gap));gap:var(--lane-gap)">
           <div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div><div class="pad"></div>
           <div class="pad"><span class="frog" style="background:var(--pink)"></span></div>
           <div class="pad"></div>

--- a/docs/specs/ui/mockups/game-board-wide.html
+++ b/docs/specs/ui/mockups/game-board-wide.html
@@ -1,54 +1,58 @@
 <!doctype html>
 <!--
-  Multiplying Frogs — Game board
+  Multiplying Frogs — Game board, on a wider screen
   Device: kids' Android tablet, held landscape.
-  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+  Canvas: 2560 x 1200 — DELIBERATELY NOT the 1920 x 1200 reference canvas.
 
-  Numbers here are the numbers in the spec page's constants table, and so are
-  the colours: game-board.md now has a Colours table, and --water, --pad,
-  --pad-edge, --log and --log-edge below are its rows.
+  WHY THIS FILE BREAKS THE ONE-CANVAS RULE. Every other mockup in this
+  directory is drawn at 1920 x 1200, because a mockup at some other size is a
+  mockup of a screen nobody has. This one is the exception, and issue #325 asks
+  for it by name: the whole point of the elastic pond is what happens at a width
+  that is NOT the reference canvas, and a drawing at one width cannot show that.
+  Its twin, game-board.html, is the reference canvas and is the one to build
+  against.
 
-  THE POND IS WATER. Blue water, brown logs, green lily pads — Derek's call on
-  issue #291. Blue is settled; WHICH blue is Connor's, and there are two files:
-  this one draws PondWater #9FD8F2, and game-board-paler-water.html draws
-  #B5E3F7. They differ in that one value and in nothing else. Open both.
+  WHAT 2560 STANDS FOR. The tablet reports roughly 2000 x 920 of usable
+  viewport, which is about 2.17 : 1 against the reference canvas's 1.6 : 1.
+  Because the canvas scales to height, that is the same shape as 2609 x 1200 in
+  reference units. This file rounds that to 2560 x 1200 — 2.13 : 1, within a
+  hair of the device — because it makes the derived gap land on a whole number
+  that can be checked against the constants table by eye:
 
-  Every frog is drawn on something it has to be legible against — Green and
-  Pink on lily pads, Orange on the Start log, Blue home on the End log — so the
-  contrast question is in the picture. Every frog/surface pair clears the bar
-  the spec page sets; the two tightest are Green on a lily pad and Orange on a
-  log, which are the two to look at hardest.
+      LanePositionGap = (2560 - 1536) / 8 = 128 px
 
-  The four frog colours are untouched by this drawing. They are placeholders
-  for the real palette, which is an area:art decision, and a frog that is hard
-  to see is a reason to move the surface under it, not the frog.
+  WHAT TO LOOK AT. Compare this against game-board.html and the difference is
+  the whole of issue #325:
 
-  ONE Start log and ONE End log for the whole pond, spanning every lane in
-  play — not one pair per lane. Count them: there are two logs on this canvas,
-  whatever the lane count.
+    - The chips and the Start log are hard against the left safe margin, not
+      floating ~300 px in from it. They did not move relative to the board; the
+      board stopped being a 1920 px picture centred in a wider band.
+    - The End log is hard against the right safe margin.
+    - The seven lily pads are 128 px apart instead of 48, spread evenly in what
+      is left between the two logs.
 
-  The three questions #289 left open about the logs are settled, by Derek on
-  issue #296, and this draws the answers:
-    1. The logs span the FULL POND (SharedLogHeight = 896 px), not the lanes in
-       play. Same height at two frogs as at four. This drawing used to show the
-       736 px lanes-in-play proposal; #296 chose the other one.
-    2. Each frog sits on its own lane's centre line, so the log is shared and
-       the positions plainly are not.
-    3. LogRadius (24 px) and TrackOutline (3 px) are unchanged from the old
-       176 x 120 log.
+  AND THE THING TO LOOK AT HARDEST. At this width the gap (128 px) is wider
+  than the lily pad (112 px). Seven pads further apart than they are big may
+  read as scattered stepping stones rather than as a track to hop along, and
+  this is the drawing that can answer that. If it does read wrong, the fix is a
+  cap on the gap, not a return to the centred board — see the spec page's open
+  question. Nothing about the pads themselves changed: LilyPadDiameter is still
+  112 px, because growing the pads is a different and much bigger change.
 
-  Horizontal arithmetic, unchanged by the sharing:
+  Everything else on this canvas is identical to game-board.html — same
+  colours, same logs, same lane stack, same frogs on the same surfaces.
+
+  Horizontal arithmetic at this width:
     48 margin + 256 chip + 48 gap
-      + 176 log + 48 + (7 x 112 + 6 x 48) + 48 + 176 log
-      + 48 margin = 1920.
-  Vertical: pond is 1200 - 128 - 176 = 896, and both logs fill it, y=128 to
-  y=1024. Four lanes at 184 = 736, centred in that band, so the lane stack runs
-  from y=208 to y=944 with the logs standing 80 px proud at each end.
+      + 176 log + 128 + (7 x 112 + 6 x 128) + 128 + 176 log
+      + 48 margin = 2560.
+  Vertical is unchanged and does not stretch: pond is 1200 - 128 - 176 = 896,
+  both logs fill it, four lanes at 184 = 736 centred in that band.
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Multiplying Frogs — Game board</title>
+<title>Multiplying Frogs — Game board, on a wider screen</title>
 <style>
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
@@ -77,8 +81,8 @@
        The floor is what stops a narrower-than-16:10 screen from squeezing the
        pads together: below 1920 the board stops spreading and is centred,
        which is what it has always done. */
-    --canvas:1920px;
-    --lane-gap:48px;
+    --canvas:2560px;
+    --lane-gap:128px;
   }
   *{box-sizing:border-box;margin:0;padding:0}
   body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -18,6 +18,7 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Game setup, before names | [`game-setup.html`](game-setup.html) | [Game setup](../game-setup.md) |
 | Game board | [`game-board.html`](game-board.html) | [Game board](../game-board.md) |
 | Game board, paler water | [`game-board-paler-water.html`](game-board-paler-water.html) | [Game board](../game-board.md) |
+| Game board, on a wider screen | [`game-board-wide.html`](game-board-wide.html) | [Game board](../game-board.md) |
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
 | Working-out grid, `331 × 41` | [`working-out-grid-331x41.html`](working-out-grid-331x41.html) | [Working-out grid](../working-out-grid.md) |
 | Working-out grid, `68 × 5` | [`working-out-grid-68x5.html`](working-out-grid-68x5.html) | [Working-out grid](../working-out-grid.md) |
@@ -60,12 +61,23 @@ exactly the same panel height as its rival — so the question the pair was open
 to ask, which placement is cheaper, turned out to have no answer, and the choice
 was decided on what the block should read as instead.
 
-The game board's pair is the other live one, and it is the second kind: a real
-choice, drawn twice. `game-board.html` and `game-board-paler-water.html` are
-the same canvas differing in exactly one value — the water's blue. Connor picks
-one on the tablet, the spec page takes the answer, and the losing file is
+The game board's water pair is the other live one, and it is the second kind: a
+real choice, drawn twice. `game-board.html` and `game-board-paler-water.html`
+are the same canvas differing in exactly one value — the water's blue. Connor
+picks one on the tablet, the spec page takes the answer, and the losing file is
 deleted. Until then, an edit to the board's layout has to be made in **both**
 files, which is the cost of the pair and the reason it does not stay open long.
+
+The board's **third** file, `game-board-wide.html`, is a fifth kind that no
+other screen has: the same layout drawn at a second width. It is not a choice
+and there is nothing to pick between — it is the only way to see a rule that
+only exists between two widths. Since
+[#325](https://github.com/derekwinters/connor-multiplying-frogs/issues/325) the
+pond spreads to fill whatever screen it is on, so at 1920 the board is what it
+always was and at 2560 the lily pads sit 128 px apart instead of 48. Both
+drawings are generated from the same two CSS variables — the canvas width and
+the derived gap — which is why keeping them in step costs almost nothing
+despite there now being three board files.
 
 Game setup has **four** files, which is three more than a screen should need,
 and each has a different job. `game-setup-names-set.html` is the screen at
@@ -124,6 +136,12 @@ entire point.
 - **Sized to the target viewport** with a fixed-size container, so it renders at
   1:1 rather than filling whatever window it opens in. State the device and
   dimensions in a comment at the top of the file.
+- **One canvas: 1920 × 1200.** There is exactly one exception in this folder and
+  it is [`game-board-wide.html`](game-board-wide.html), at 2560 × 1200. It earns
+  it: the pond's layout is elastic, so its whole subject is what happens at a
+  width that is not the reference canvas, and no drawing at 1920 can show that.
+  A file that wants this exception has to be about a rule that only exists
+  between two widths — not merely inconvenient to draw at 1920.
 - **Real proportions, real units.** The numbers in the mockup are the numbers in
   the spec page's constants table. If they disagree, one of them is a bug.
 - **Placeholder content is honest** — the longest plausible score, not `0`; a


### PR DESCRIPTION
The pond now fills the whole screen instead of sitting as a fixed-size picture
in the middle of it. The frog names and the Start log go hard against the left
edge, the End log against the right edge, and the seven lily pads spread out
evenly in the space between. On the tablet that means a board that uses the
screen it is on, rather than one with 300 px of empty water past each end.

Nothing is built here — this is the wireframe.

## How the spec is changing

**The old rule was one sentence, and it is the sentence being reversed:**

> The band grows; the board inside it does not.

That is why the built board looked the way it did. The three bands already
reached the screen's edges, but what they *contained* was laid out in the
1920 px reference canvas and centred — so on a 2.17 : 1 tablet the chips floated
some 300 px in from an edge they were supposed to be pinned to.

**The new rule splits that in two, because it was doing two jobs.** It stays
true of `header` and `controls`, whose contents are anchored controls — a turn
banner, a gear, a `Roll` button — and there is nothing about a button that a
wider screen should stretch. It stops being true of `pond`, whose row is a track
whose entire job is showing how far along a lane a frog has got. Both are now
stated as invariants, and the old wording is kept verbatim on the page in the
style `working-out-grid.md` uses, so a reader who remembers the old rule finds
out that it moved rather than finding no trace of it.

**`LanePositionGap` stops being typed and becomes derived** — the only number on
the page a screen is allowed to decide:

```text
LanePositionGap = max( LanePositionGapMin, (screen width − LaneFixedWidth) ÷ LanePositionGapCount )
```

`LaneFixedWidth` (1536 px) is everything on the row that does not stretch, and
it is named because it is now load-bearing: a change to `LaneGutterWidth`,
`LogWidth`, `LilyPadDiameter`, `LaneGutterGap` or `SafeMargin` is a change to
it. That is also the one genuine simplification here — the row used to have to
be rebalanced by hand to keep summing to 1920, and now the gap absorbs the
difference by construction.

## Spec invariants this had to keep true

- **At 1920 × 1200 the board is unchanged.** Not "looks unchanged" — I rendered
  `game-board.html` at the merged commit and at this one and compared the PNG
  buffers: **byte-for-byte identical**. That is the condition the formula was
  chosen to satisfy, since it is what keeps the reference canvas a picture of
  the game, and it falls out because `(1920 − 1536) ÷ 8` is exactly 48.
- **Position 0 is still on the Start log and position 8 still on the End log**,
  at every width. `LanePositionCount` is still 9 and the chips still read
  `of 8`.
- **The lily pad is still 112 px.** It is the number that
  [decided lanes-across over lanes-up](https://github.com/derekwinters/connor-multiplying-frogs/blob/main/docs/specs/ui/game-board.md#why-the-lanes-run-across),
  so growing the pads would reopen that decision. Fixed pads, elastic gaps —
  the issue's own recommendation.
- **Nothing vertical moved.** `SharedLogHeight` is still the pond band's own
  height, the lane stack still centres in it, and the two bands still keep their
  heights on a shorter screen.

Measured in the rendered mockups rather than asserted: at 1920 the gaps are
48/48/48 and the End log's right margin is `SafeMargin`; at 2560 they are
128/128/128 and the right margin is still `SafeMargin`.

## Deviations and Decisions

- **A mockup that is deliberately not 1920 × 1200.** `game-board-wide.html` is
  2560 × 1200 — the only file in `mockups/` not at the reference canvas, which
  `CLAUDE.md` rule 8 otherwise requires. #325 asks for it by name, and it is
  unavoidable: the whole subject of an elastic layout is what happens at a width
  that is not the reference canvas. I've written the exception into the mockups
  conventions with a test for when it may be used again, so it does not become a
  precedent for drawing at whatever size is convenient.
- **2560 rather than the tablet's actual 2000 × 920.** Because the canvas scales
  to height, the device is equivalent to 2609 × 1200 in reference units, which
  makes the derived gap 134.125 px. 2560 is 2.13 : 1 against the device's
  2.17 : 1 and puts the gap on a whole 128 px that can be checked against the
  constants table by eye.
- **The gap is now wider than the lily pad, and I have not proposed a fix.** At
  2560 the gap is 128 px against a 112 px pad, and seven pads further apart than
  they are big may read as scattered stepping stones rather than a track. It is
  recorded as an open question for the tablet to answer, with the shape of the
  fix if it reads wrong (a `LanePositionGapMax`, with the leftover going to
  water — not a return to the centred board). I have not picked a cap value,
  because proposing a number for a problem nobody has seen is how a constants
  table fills with values nobody can justify.
- **The chip gutter does not stretch — question 3, answered no.** Widening it on
  a wider tablet would give typed names more room, but it would make *how much
  of a name fits depend on the device*, which is a bug that only shows on one
  person's hardware. If 256 px is too tight for the names Connor types, the fix
  is a bigger fixed number in its own issue.
- **Two files outside the issue's list are reconciled.**
  `docs/engineering/tech-stack.md` used `LanePositionGap = 48f` as its worked
  example of a named value, and `docs/specs/ui/index.md` used it in the
  template's constants table. Both became false with this change; both now say
  `LanePositionGapMin`. The tech-stack example gains a note that a derived value
  still gets a named function of named constants rather than an expression
  inlined at its one call site.
- **`game-board.html`'s diff is a comment and two CSS variables, not a redraw.**
  All three board mockups are now driven by `--canvas` and `--lane-gap`, so the
  elastic rule is legible in the file and the wide drawing differs from the
  reference one in exactly those two declarations. It also means the paler-water
  twin stays in step for free.
- **The paler-water twin is updated in lockstep**, as its spec page requires
  while the water question is open. It remains pixel-identical to
  `game-board.html` but for `--water`.
- **No implementation issue opened**, per the loop — it is opened against what
  this settles. Note that #326 is blocked by this one and redraws the same
  files.
- **The attribution footer carries no link, and this body has been edited once
  since it was opened.** On creation the tooling appended its own footer
  carrying this session's identifier, underneath the plain-text one written
  here — the same rewrite that hit #393, and confirmation that writing the
  footer as plain text does not prevent it, because it is appended after the
  author has finished. This repository is public, so that is a private link
  published; it has been edited out. Anyone comparing this body against the
  original notification email will see the difference, which is why it is
  recorded here rather than quietly fixed.

**Docs:** `docs/specs/ui/game-board.md` — Anchors rewritten to derive
`LanePositionGap` from the screen width; `LanePositionGapMin`, `LaneFixedWidth`
and `LanePositionGapCount` added to the constants table; a new
*The horizontal arithmetic* section replacing the old sums-to-1920 paragraph; a
new *Why the gutter does not stretch* section; the single band-contents
invariant split into two and the old wording preserved under *The invariant this
page used to carry*; the Mockup section and a new open question about the gap
reading wider than the pad.
`docs/specs/ui/mockups/game-board.html` and `game-board-paler-water.html` —
elastic layout via two CSS variables, rendering unchanged at 1920.
`docs/specs/ui/mockups/game-board-wide.html` — new, 2560 × 1200.
`docs/specs/ui/mockups/index.md` — the new row, the one-canvas exception, and
the record of what the third board file is for.
`docs/engineering/tech-stack.md` and `docs/specs/ui/index.md` — both cited
`LanePositionGap` as a typed constant, which it no longer is.

Closes #325

---
_Generated by Claude Code_