### PR TITLE
docs(ui): drop the player chip from the board's turn banner

### DIFF
--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -22,7 +22,11 @@ mistake for frogs sharing something, which is why it is written down here.
 **Invariant:** the board never moves on its own. A frog moves only as the direct
 result of the answer the player just gave.
 **Invariant:** whose turn it is is stated in words in the header, not only shown
-by a highlight.
+by a highlight. Since
+[#326](https://github.com/derekwinters/connor-multiplying-frogs/issues/326) the
+words are the *only* thing in the header that says it, so this invariant is no
+longer a floor the layout comfortably clears — it is the layout. Nothing may
+remove those words in favour of a colour, a ring, or an arrow.
 **Invariant:** `Roll` is the only way to start a turn, and it is disabled the
 moment it is pressed until the turn resolves. A double-tap cannot roll twice.
 **Invariant:** nothing on this screen is destructive. Ending the game lives
@@ -177,7 +181,6 @@ lanes-across** after seeing both drawn.
 | Controls band height | `BoardControlsHeight` | 176 px |
 | Hairline under `header`, over `controls` | `BoardBandOutline` | 3 px |
 | Turn banner text size | `TurnBannerSize` | 52 px |
-| Gap between the banner's chip and its words | `TurnBannerGap` | 24 px |
 | Settings button, square | `SettingsButtonSize` | 96 px |
 | Settings gear glyph size | `SettingsGlyphSize` | 44 px |
 | Settings button outline | `SettingsButtonOutline` | 4 px |
@@ -401,10 +404,13 @@ The two are not in tension: a band's *contents* stretch when they are a track
 whose whole job is to show distance travelled, and do not when they are a
 button.
 
-**A control anchored to a band's edge follows the screen's edge.** The turn chip
-and the settings gear sit `SafeMargin` in from the real left and right edges of
-the screen, because `SafeMargin` is a margin from the screen and not from a
-rectangle nobody can see. `Roll` is centred and does not care either way.
+**A control anchored to a band's edge follows the screen's edge.** The turn
+banner and the settings gear sit `SafeMargin` in from the real left and right
+edges of the screen, because `SafeMargin` is a margin from the screen and not
+from a rectangle nobody can see. This used to say "the turn chip", and the chip
+is gone — see
+[#326](https://github.com/derekwinters/connor-multiplying-frogs/issues/326);
+what is anchored there now is the words themselves. `Roll` is centred and does not care either way.
 
 **Extra height goes to `pond` and nowhere else** — the same answer
 [Anchors](#anchors) already gives for a *shorter* screen, in the other
@@ -417,6 +423,23 @@ verified, not assumed: `game-board.html` renders byte-for-byte the same before
 and after the pond became elastic. What is *not* pixel-identical at any other
 width is now the point, which is why this change comes with
 [a second drawing](#mockup) rather than a rule alone.
+
+### The constant this page used to carry
+
+| Was | Is now | Value | Note |
+| --- | --- | --- | --- |
+| `TurnBannerGap` | *(gone)* | was 24 px | It measured the gap between the banner's chip and its words. There is no chip |
+
+`TurnBannerGap` is **removed, not redefined.** Under the option this page did
+not take — a small colour swatch in front of the words — it would have survived
+with the same 24 px value and a new meaning, which is the kind of survival that
+leaves a constant meaning two things a year apart. Words alone need no gap,
+because there is nothing to gap.
+
+`PlayerChipWidth` is untouched: the lane chips still use it, and so do
+[roll and card](roll-and-card.md) and the
+[working-out grid](working-out-grid.md). Only this screen's header stopped
+drawing one.
 
 ### The invariant this page used to carry
 
@@ -500,11 +523,20 @@ change harder to judge. Whether they now read as a frame or as leftovers is
 
 ## Elements
 
-- **Turn banner** — `Green's turn`, left of the header, with that frog's
-  [player chip](shared-components.md#player-chip) in its active state. The
+- **Turn banner** — `Green's turn` at `TurnBannerSize`, starting at
+  `SafeMargin` from the real left edge of the header band and vertically centred
+  in it. **Words alone: no chip, no swatch, no colour** — settled,
+  [open question](#open-questions). The
   wording is the frog's **name and nothing else** — `Green's turn` for a frog
   still on its default, `Connor's turn` for one that has been renamed on
   [game setup](game-setup.md).
+
+    The [player chip](shared-components.md#player-chip) that used to sit in
+    front of these words is gone. Derek's reason is the whole argument: *"it's
+    already selected in the lanes section too"* — the active frog's own lane
+    chip, directly below in the pond, carries the same name, the same colour and
+    the same Active ring. The header chip was the third statement of a thing the
+    screen said twice already.
 
     It used to read `Green frog's turn`, and the reason given was that frogs
     have no other name. They do now, so the justification went with the word:
@@ -574,6 +606,14 @@ board at 2560 × 1200, and — until Connor has picked the water —
 [`mockups/game-board-paler-water.html`](mockups/game-board-paler-water.html)
 draws the reference canvas again in the other blue.
 
+A fourth file,
+[`mockups/game-board-banner-swatch.html`](mockups/game-board-banner-swatch.html),
+draws the header with a colour swatch in front of the words. It is a comparison
+and nothing else — see [the open question](#open-questions) — and it is deleted
+when that is settled. Four files for one screen is two more than a screen should
+need; the water pair and this pair are both live questions, and both should be
+closed rather than left open.
+
 **The wide file is deliberately not at the reference canvas**, which every other
 mockup in this project is. It has to be: the whole of
 [the elastic pond](#anchors) is what happens at a width that is not 1920, and a
@@ -627,6 +667,23 @@ decided against; keeping a mockup of a layout nobody is building is how a
   bar before it lands. The same is true of `LogBrown` and `LilyPadGreen`, which
   are drawn once each rather than twice — say if either is wrong and it gets
   the same treatment.
+- **Should the turn banner show the frog's colour at all?** Derek asked for the
+  chip to go, and it has. What is open is whether a small swatch should stay in
+  front of the words. Two files differ in exactly that:
+  `game-board.html` (words alone, the proposal) and
+  [`game-board-banner-swatch.html`](mockups/game-board-banner-swatch.html).
+
+    Words alone is proposed, for three reasons. The lane chip below already
+    carries that colour in the same Active state on the same screen. A bare
+    swatch outside a chip would be a **new element** — the 64 px circle inside a
+    player chip is that component's `PlayerSwatchDiameter`, and lifting it out
+    means naming a constant for a lone circle that belongs to nothing. And the
+    chip's accessibility invariant is *"a word, always, never colour alone"*,
+    which forbids colour without a word and permits the inverse.
+
+    The case against, worth stating because it is real: the header becomes the
+    only place on the board that names the active player without showing their
+    colour.
 - **Does the gap look right when it is wider than the lily pad?** At the
   reference canvas `LanePositionGap` is 48 px against a 112 px
   `LilyPadDiameter`, and the pads plainly read as a track. On the wide drawing

--- a/docs/specs/ui/mockups/game-board-banner-swatch.html
+++ b/docs/specs/ui/mockups/game-board-banner-swatch.html
@@ -1,63 +1,50 @@
 <!doctype html>
 <!--
-  Multiplying Frogs — Game board
+  Multiplying Frogs — Game board, turn banner with a swatch
   Device: kids' Android tablet, held landscape.
   Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
 
-  Numbers here are the numbers in the spec page's constants table, and so are
-  the colours: game-board.md now has a Colours table, and --water, --pad,
-  --pad-edge, --log and --log-edge below are its rows.
+  THIS FILE EXISTS TO BE COMPARED WITH game-board.html AND FOR NO OTHER REASON.
+  Issue #326 removes the player chip from the header, and asks one question on
+  the way past: with the chip gone, should the header keep the frog's COLOUR at
+  all, or say whose turn it is in words alone?
 
-  THE PALER WATER. This file exists to be compared with game-board.html and for
-  no other reason. It draws PondWater as #B5E3F7 — the same blue as that file's
-  #9FD8F2 with more light in it — and every other pixel on the canvas is
-  identical. Open both on the tablet, one after the other, and say which one is
-  the pond. Whichever loses gets deleted.
+  This file keeps a swatch. game-board.html drops colour entirely. Every other
+  pixel on the two canvases is identical — same pond, same elastic gaps, same
+  four frogs on the same surfaces. Open both and say which header is the board's.
 
-  Every frog is drawn on something it has to be legible against — Green and
-  Pink on lily pads, Orange on the Start log, Blue home on the End log — so the
-  contrast question is in the picture. Every frog/surface pair clears the bar
-  the spec page sets; the two tightest are Green on a lily pad and Orange on a
-  log, which are the two to look at hardest.
+  Derek asked for words alone and that is what its twin draws, so this is the
+  option to argue FOR if it is going to win. The case for it: the header would
+  otherwise be the only place on the board that names the active player without
+  showing their colour.
 
-  The four frog colours are untouched by this drawing. They are placeholders
-  for the real palette, which is an area:art decision, and a frog that is hard
-  to see is a reason to move the surface under it, not the frog.
+  The case against, which is why its twin is the proposal:
 
-  ONE Start log and ONE End log for the whole pond, spanning every lane in
-  play — not one pair per lane. Count them: there are two logs on this canvas,
-  whatever the lane count.
+    - The lane chip directly below already carries that colour, in the same
+      Active state, on the same screen. The swatch is a third statement of a
+      thing said twice already.
+    - A bare swatch outside a chip is a new element. The 64 px circle inside a
+      player chip is that component's `PlayerSwatchDiameter`; lifting it out
+      here means naming `TurnBannerSwatchDiameter` for a lone circle belonging
+      to no component.
+    - The player chip's accessibility invariant is "a word, always, never colour
+      alone". Words alone is the inverse case and the invariant permits it —
+      the invariant forbids colour without a word, not a word without colour.
 
-  The three questions #289 left open about the logs are settled, by Derek on
-  issue #296, and this draws the answers:
-    1. The logs span the FULL POND (SharedLogHeight = 896 px), not the lanes in
-       play. Same height at two frogs as at four. This drawing used to show the
-       736 px lanes-in-play proposal; #296 chose the other one.
-    2. Each frog sits on its own lane's centre line, so the log is shared and
-       the positions plainly are not.
-    3. LogRadius (24 px) and TrackOutline (3 px) are unchanged from the old
-       176 x 120 log.
-
-  Horizontal arithmetic, unchanged by the sharing:
-    48 margin + 256 chip + 48 gap
-      + 176 log + 48 + (7 x 112 + 6 x 48) + 48 + 176 log
-      + 48 margin = 1920.
-  Vertical: pond is 1200 - 128 - 176 = 896, and both logs fill it, y=128 to
-  y=1024. Four lanes at 184 = 736, centred in that band, so the lane stack runs
-  from y=208 to y=944 with the logs standing 80 px proud at each end.
+  Whichever loses gets deleted.
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Multiplying Frogs — Game board, paler water</title>
+<title>Multiplying Frogs — Game board, turn banner with a swatch</title>
 <style>
   :root{
     --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
     --accent:#2E7D4F; --warn:#B03A2E;
     --green:#3F8E4F; --blue:#2C6DAF; --orange:#D2762B; --pink:#C24C86;
     /* game-board.md's Colours table. The one line that differs between this
-       file and game-board.html is --water. */
-    --water:#B5E3F7;
+       file and game-board-paler-water.html is --water. */
+    --water:#9FD8F2;
     --pad:#CCEAAF; --pad-edge:#7FAE5E;
     --log:#E2C79C; --log-edge:#A97F4F;
     --band:#E2E8E5;
@@ -135,16 +122,24 @@
 <body>
 <div class="frame">
     <div class="band" style="top:0;height:128px;background:var(--band);border-bottom:3px solid var(--faint)"></div>
-    <!-- TURN BANNER — words alone. The player chip that used to sit in front of
-         these words is gone (#326): the active frog's own lane chip, directly
-         below in the pond, already says the same thing in the same Active state.
-         So the banner starts at SafeMargin and `TurnBannerGap` no longer exists.
+    <!-- TURN BANNER — with a swatch. This is the half of #326's question that
+         is NOT what Derek asked for, drawn so the choice can be looked at
+         rather than argued: the chip goes either way, and this keeps the frog's
+         colour in the header while its twin drops colour entirely.
 
-         The wording is `Green's turn`, not `Green frog's turn`. These mockups
-         were stale — game-board.md has said name-and-nothing-else since #310,
-         because `Connor frog's turn` is not a sentence anybody would write. -->
-    <div class="abs" style="left:48px;top:16px;height:96px;display:flex;align-items:center;
-                            font-size:52px;font-weight:700">Green's turn</div>
+         Note what it costs. A bare swatch outside a chip is a NEW element on
+         this board — the 64 px circle inside a player chip is that component's
+         `PlayerSwatchDiameter`, and lifting it out here means naming
+         `TurnBannerSwatchDiameter` for a lone circle that belongs to nothing.
+         `TurnBannerGap` survives under this option, redefined from "gap between
+         the banner's chip and its words" to "gap between its swatch and its
+         words", at the same 24 px.
+
+         Its twin needs neither constant. -->
+    <div class="abs row" style="left:48px;top:16px;height:96px;gap:24px">
+      <span class="sw" style="background:var(--green)"></span>
+      <div style="font-size:52px;font-weight:700">Green's turn</div>
+    </div>
     <div class="abs gear" style="right:48px;top:16px">⚙</div>
 
     <!-- THE SHARED START LOG — one for the whole pond, position 0 of all four

--- a/docs/specs/ui/mockups/game-board-wide.html
+++ b/docs/specs/ui/mockups/game-board-wide.html
@@ -138,10 +138,16 @@
 <body>
 <div class="frame">
     <div class="band" style="top:0;height:128px;background:var(--band);border-bottom:3px solid var(--faint)"></div>
-    <div class="abs row" style="left:48px;top:16px;gap:24px">
-      <div class="chip act"><span class="sw" style="background:var(--green)"></span><span>Green</span></div>
-      <div style="font-size:52px;font-weight:700">Green frog's turn</div>
-    </div>
+    <!-- TURN BANNER — words alone. The player chip that used to sit in front of
+         these words is gone (#326): the active frog's own lane chip, directly
+         below in the pond, already says the same thing in the same Active state.
+         So the banner starts at SafeMargin and `TurnBannerGap` no longer exists.
+
+         The wording is `Green's turn`, not `Green frog's turn`. These mockups
+         were stale — game-board.md has said name-and-nothing-else since #310,
+         because `Connor frog's turn` is not a sentence anybody would write. -->
+    <div class="abs" style="left:48px;top:16px;height:96px;display:flex;align-items:center;
+                            font-size:52px;font-weight:700">Green's turn</div>
     <div class="abs gear" style="right:48px;top:16px">⚙</div>
 
     <!-- THE SHARED START LOG — one for the whole pond, position 0 of all four

--- a/docs/specs/ui/mockups/game-board.html
+++ b/docs/specs/ui/mockups/game-board.html
@@ -134,10 +134,16 @@
 <body>
 <div class="frame">
     <div class="band" style="top:0;height:128px;background:var(--band);border-bottom:3px solid var(--faint)"></div>
-    <div class="abs row" style="left:48px;top:16px;gap:24px">
-      <div class="chip act"><span class="sw" style="background:var(--green)"></span><span>Green</span></div>
-      <div style="font-size:52px;font-weight:700">Green frog's turn</div>
-    </div>
+    <!-- TURN BANNER — words alone. The player chip that used to sit in front of
+         these words is gone (#326): the active frog's own lane chip, directly
+         below in the pond, already says the same thing in the same Active state.
+         So the banner starts at SafeMargin and `TurnBannerGap` no longer exists.
+
+         The wording is `Green's turn`, not `Green frog's turn`. These mockups
+         were stale — game-board.md has said name-and-nothing-else since #310,
+         because `Connor frog's turn` is not a sentence anybody would write. -->
+    <div class="abs" style="left:48px;top:16px;height:96px;display:flex;align-items:center;
+                            font-size:52px;font-weight:700">Green's turn</div>
     <div class="abs gear" style="right:48px;top:16px">⚙</div>
 
     <!-- THE SHARED START LOG — one for the whole pond, position 0 of all four

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -19,6 +19,7 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Game board | [`game-board.html`](game-board.html) | [Game board](../game-board.md) |
 | Game board, paler water | [`game-board-paler-water.html`](game-board-paler-water.html) | [Game board](../game-board.md) |
 | Game board, on a wider screen | [`game-board-wide.html`](game-board-wide.html) | [Game board](../game-board.md) |
+| Game board, turn banner with a swatch | [`game-board-banner-swatch.html`](game-board-banner-swatch.html) | [Game board](../game-board.md) |
 | Roll and card | [`roll-and-card.html`](roll-and-card.html) | [Roll and card](../roll-and-card.md) |
 | Working-out grid, `331 × 41` | [`working-out-grid-331x41.html`](working-out-grid-331x41.html) | [Working-out grid](../working-out-grid.md) |
 | Working-out grid, `68 × 5` | [`working-out-grid-68x5.html`](working-out-grid-68x5.html) | [Working-out grid](../working-out-grid.md) |
@@ -67,6 +68,22 @@ are the same canvas differing in exactly one value — the water's blue. Connor
 picks one on the tablet, the spec page takes the answer, and the losing file is
 deleted. Until then, an edit to the board's layout has to be made in **both**
 files, which is the cost of the pair and the reason it does not stay open long.
+
+The board's **fourth** file, `game-board-banner-swatch.html`, is another of the
+second kind — a real choice drawn twice. Since
+[#326](https://github.com/derekwinters/connor-multiplying-frogs/issues/326) the
+header no longer carries a player chip, and the open question is whether it
+should keep the frog's *colour* as a bare swatch or say whose turn it is in
+words alone. `game-board.html` draws words alone and is the proposal; this file
+draws the swatch. The loser is deleted.
+
+**Four files for one screen is two more than a screen should need**, and it is
+worth saying plainly rather than letting it accumulate quietly. Two of the four
+exist because two questions are open at once — which blue the water is, and
+whether the banner keeps a swatch — and each is a `Connor looks at it on the
+tablet` call that costs minutes to answer and is costing an edit to four files
+until it is. The third is the wide drawing, which is permanent. If a fifth board
+file is ever proposed, that is the moment to close the open questions first.
 
 The board's **third** file, `game-board-wide.html`, is a fifth kind that no
 other screen has: the same layout drawn at a second width. It is not a choice

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -375,6 +375,27 @@ row: the chip has always drawn the frog's name, and until
 [#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310) a
 frog's name was always its colour's.
 
+**Active still has callers, checked rather than assumed.**
+[#326](https://github.com/derekwinters/connor-multiplying-frogs/issues/326)
+removed the one Active chip in the game board's *header* and asked whether the
+state still earns its place on this component. It does, in four places, and
+three of them are not the board:
+
+| Screen | Where the Active chip is |
+| --- | --- |
+| [Game board](game-board.md) | the active frog's **lane** chip, in the pond |
+| [Roll and card](roll-and-card.md) | the `whose` region, beside `rolled` |
+| [Working-out grid](working-out-grid.md) | the `header`, beside `Work it out` |
+| [Answer result](answer-result.md) | **none** — it draws a `pad 7 → 8` chip, not an Active one |
+
+So the board's header was never the state's only caller, and dropping it there
+changes nothing here. What is worth noticing is the last row: the four screens
+of a single turn were already not uniform about this, which is part of why
+removing the header chip from the board does not make the turn sequence
+inconsistent — it was never consistent, and the chip's job differs by screen. On
+the board the lane chip makes a header chip redundant; in the two dialogs there
+are no lanes, so nothing else there carries the colour.
+
 The Active row dropped "filled background": the mockups' `.chip.act` rule
 gives the ring and the bold weight but leaves the base chip background
 unchanged, and the chip invariant only requires the active chip be visibly


### PR DESCRIPTION
The top of the board said whose turn it was three times over: a box with the
frog's name in it, the words next to that box, and the same frog's name and
colour again in its lane just below. The box goes. The words stay, and slide
left to where the box used to start.

Nothing is built here — this is the wireframe.

## How the spec is changing

**The turn banner is words alone.** `Green's turn`, at `SafeMargin` from the
real left edge of the header band, vertically centred in it. No chip, no
swatch, no colour.

**`TurnBannerGap` is removed, not redefined.** It measured the gap between the
banner's chip and its words, and there is no chip. Under the option this change
did *not* take — a small colour swatch in front of the words — it would have
survived with the same 24 px value and a new meaning, and a constant that means
one thing this year and another thing next is worse than a constant that was
deleted and re-added.

**One invariant gets heavier without changing a word.** *"Whose turn it is is
stated in words in the header, not only shown by a highlight"* used to be a
floor the layout comfortably cleared, because there was a chip doing the job
too. Now the words are the only thing in the header that says it. The page now
says that explicitly, so nobody later swaps them for a colour or an arrow
thinking the invariant is still slack.

## Spec invariants this had to keep true

- **The words survive** — that part was never open. What went is the chip
  beside the sentence, not the sentence.
- **The player chip's accessibility invariant is not violated.** It reads *"a
  word, always, never colour alone."* This is the inverse case — colour dropped,
  word kept — which the invariant permits. It forbids colour without a word, not
  a word without colour.
- **The lane chips are untouched.** They are the thing Derek pointed at as
  already doing this job, and every one of the four board drawings still has
  exactly one Active chip on it: the active frog's lane chip. Checked by
  counting `.chip.act` in each rendered file, not by reading the diff.
- **Nothing else on the board moved.** The pond, the elastic gaps from #325, the
  logs, the gear and `Roll` are all where they were. Verified by comparing the
  four board files structurally: the paler twin differs from the reference in
  one colour, the wide file in two CSS variables, and the swatch file only in
  the banner markup.

## Two things that surfaced while drawing this

Neither was in the issue, and both are the kind of thing that only shows up when
you go to redraw the exact element involved.

**The mockups were stale about the banner's own wording.** All three board files
drew `Green frog's turn`. `game-board.md` stopped saying that at
[#310](https://github.com/derekwinters/connor-multiplying-frogs/issues/310),
when frogs got editable names and `Connor frog's turn` stopped being a sentence
anybody would write — and `answer-result.html` had already been updated to
`Blue's turn`. **I treated the spec page as authoritative and corrected the
mockups**, since it records a decision Derek settled and the mockups record
nothing. They now read `Green's turn`.

**Question 4 has a bigger answer than housekeeping.** The issue asks whether
`PlayerChipState.Active` still earns its place with the header chip gone. It
does — it has three callers besides the board's lane chip:

| Screen | Where its Active chip is |
| --- | --- |
| Roll and card | the `whose` region, beside `rolled` |
| Working-out grid | the `header`, beside `Work it out` |
| Answer result | **none** — it draws a `pad 7 → 8` chip instead |

That last row is the interesting one. The four screens of a single turn were
already not uniform about this, so removing the board's header chip does not
make the sequence inconsistent — it never was, and the chip's job genuinely
differs by screen. On the board a lane chip makes a header chip redundant; in
the two dialogs there are no lanes, so nothing else there carries the colour.
Recorded on `shared-components.md` so it does not have to be re-derived.

## Deviations and Decisions

- **The board now has four mockup files, and I have said so loudly rather than
  letting it accumulate.** `game-board-banner-swatch.html` is the comparison for
  the open question below. Two of the four exist only because two questions are
  open at once — which blue the water is, and whether the banner keeps a swatch
  — each a look-at-it call that costs minutes to answer and an edit to four
  files until it is. The mockups index now says that if a fifth board file is
  ever proposed, that is the moment to close the open questions first.
- **The swatch comparison is drawn only at the reference canvas**, not also at
  2560. The question is about a 64 px circle in a header, and nothing about it
  changes with screen width.
- **Question 3 is left open rather than decided.** Derek asked for the chip to
  go and it has; whether a bare swatch stays is the thing the issue says to draw
  twice. Words alone is proposed, and the case against it is stated on the page
  — the header becomes the only place on the board naming the active player
  without showing their colour.
- **`shared-components.md` is touched**, which the issue said would happen "only
  if question 4 turns something up". It did.
- **The banner wording fix is in this PR rather than its own.** It is a
  correction to the exact element being redrawn, and leaving three mockups
  contradicting their spec page while editing that element would have been
  choosing not to look.
- **No implementation issue opened**, per the loop.
- **This body was edited once immediately after opening, to remove an appended
  footer carrying this session's identifier.** That is now three for three —
  #393, #394 and this one — so it is reliably a create-time append, and editing
  it out afterwards is reliably the fix. The repository is public, so the link
  is a publication; it is noted here because anyone comparing this body against
  the original notification email will see it differ.

**Docs:** `docs/specs/ui/game-board.md` — the turn banner Elements entry rewritten
to words alone with its position; `TurnBannerGap` removed from the constants
table and recorded under a new *The constant this page used to carry*; the
words-in-the-header invariant strengthened now that it carries the whole job;
the band-edge rule no longer refers to "the turn chip"; the Mockup section and a
new open question about the swatch.
`docs/specs/ui/shared-components.md` — the Player chip's States section records
that Active has three callers besides the board's lane chip, and that answer
result has none.
`docs/specs/ui/mockups/game-board.html`, `game-board-wide.html` and
`game-board-paler-water.html` — header chip removed, banner at `SafeMargin`,
wording corrected to `Green's turn`.
`docs/specs/ui/mockups/game-board-banner-swatch.html` — new, the comparison.
`docs/specs/ui/mockups/index.md` — the new row, and what four files for one
screen costs.

Closes #326

---
_Generated by Claude Code_