### PR TITLE
docs(ui): wireframe the dialog that says a player has won

### DIFF
--- a/docs/specs/ui/answer-result.md
+++ b/docs/specs/ui/answer-result.md
@@ -141,6 +141,13 @@ the placeholder's name changed here — see
   [game over](game-over.md)'s own words for the screen it now leads to, as a
   placeholder rather than a decision. Connor's to settle — asked in
   [#287](https://github.com/derekwinters/connor-multiplying-frogs/issues/287).
+
+    **This got worse, not better, since #287 was asked.** Since
+    [a player has won](player-won.md) landed, this button is no longer the last
+    thing a winner reads: the hop it starts now ends in a dialog saying
+    `Blue wins!`, and only after *that* does the game over screen appear. So
+    `Game over` announces an ending that has not happened yet and that the next
+    dialog is about to talk over. Answer #287 with that page in view.
 - **Does a right answer get any celebration beyond the hop?** Audio is
   [parked](../future-ideas.md), and a "correct" chime is the most likely parked
   item to be promoted. If it is, this is the screen it plays on.

--- a/docs/specs/ui/game-board.md
+++ b/docs/specs/ui/game-board.md
@@ -734,7 +734,9 @@ change harder to judge. Whether they now read as a frame or as leftovers is
   `FrogHopDuration` (0.4 s), one pad's distance. It is the only motion on the
   board, which is what makes it worth watching.
 - A frog that reaches the End log stays there and its chip switches to the
-  `Home` state. **Play continues** — the other frogs keep taking turns. That is
+  `Home` state, and [a player has won](player-won.md) opens to say so — the one
+  screen in the game about a single child's moment. **Play continues** — the
+  other frogs keep taking turns, and that dialog changes nothing about it. That is
   Derek's provisional call recorded in
   [the reference material](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open),
   not something the classroom board says.

--- a/docs/specs/ui/index.md
+++ b/docs/specs/ui/index.md
@@ -21,6 +21,7 @@ Every screen and every dialog in v1, in the order a game meets them.
 | [Roll and card](roll-and-card.md) | The die, the pile it maps to, the card you drew |
 | [Working-out grid](working-out-grid.md) | The grid and keypad you answer on |
 | [Answer result](answer-result.md) | Right or wrong, and what your frog does |
+| [A player has won](player-won.md) | The moment a frog gets home |
 | [Settings dialog](settings-dialog.md) | The rules, the exit, the version |
 | [End-game confirm](end-game-confirm.md) | The one dialog that can end everybody's game |
 | [Game over](game-over.md) | Who won, and where everybody got to |

--- a/docs/specs/ui/mockups/index.md
+++ b/docs/specs/ui/mockups/index.md
@@ -24,6 +24,8 @@ a mockup judged at the wrong size, and size is most of what a wireframe decides.
 | Working-out grid, `331 × 41` grown to the cap | [`working-out-grid-331x41-grown.html`](working-out-grid-331x41-grown.html) | [Working-out grid](../working-out-grid.md) |
 | Answer result — right | [`answer-result-right.html`](answer-result-right.html) | [Answer result](../answer-result.md) |
 | Answer result — wrong | [`answer-result-wrong.html`](answer-result-wrong.html) | [Answer result](../answer-result.md) |
+| A player has won — first frog home | [`player-won-first.html`](player-won-first.html) | [A player has won](../player-won.md) |
+| A player has won — last frog home | [`player-won-later.html`](player-won-later.html) | [A player has won](../player-won.md) |
 | Settings dialog | [`settings-dialog.html`](settings-dialog.html) | [Settings dialog](../settings-dialog.md) |
 | End-game confirm | [`end-game-confirm.html`](end-game-confirm.html) | [End-game confirm](../end-game-confirm.md) |
 | Game over | [`game-over.html`](game-over.html) | [Game over](../game-over.md) |

--- a/docs/specs/ui/mockups/player-won-first.html
+++ b/docs/specs/ui/mockups/player-won-first.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<!--
+  Multiplying Frogs — A player has won — the first frog home
+  Device: kids' Android tablet, held landscape.
+  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+
+  Numbers here are the numbers in player-won.md's constants table.
+
+  THE FIRST FROG HOME. Only this one says "wins" — under the current rules the
+  first frog to reach the End log is the winner and the rest are ranked behind
+  it, so every later frog gets the other wording. Its twin,
+  player-won-later.html, draws that.
+
+  The button names the next player, the way answer-result.html's does: on a
+  shared tablet the useful thing at the end of a moment is whose turn it is now.
+  The game has NOT ended — play continues, which is what game-board.md says and
+  what this dialog deliberately does not change.
+
+  The frog is drawn at WonFrogDiameter (220 px), which is NOT the board's
+  FrogPieceDiameter (88 px). This is the one screen in the game that draws a
+  frog big, and that is the whole point of it: the board says a frog moved, and
+  this says a frog arrived.
+
+  There is no standings column here on purpose. game-over.md already lists every
+  frog in finishing order; a second table in different words on the screen
+  before it would be the same information twice. This dialog says one thing.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Multiplying Frogs — A player has won — the first frog home</title>
+<style>
+  :root{
+    --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
+    --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    --green:#3E933E; --blue:#37609A; --orange:#D38231; --pink:#D41C78;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
+  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+         background:var(--bg);color:var(--ink);
+         font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  .abs{position:absolute}
+  .row{display:flex;align-items:center}
+  .col{display:flex;flex-direction:column}
+  .mid{display:flex;align-items:center;justify-content:center}
+  .band{position:absolute;left:0;right:0}
+  .note{font-size:26px;color:#7A8783}
+  .hatch{background:repeating-linear-gradient(45deg,#DCE3E0 0 14px,#E8EDEB 14px 28px)}
+  .panel{background:var(--paper);border:3px solid var(--line);border-radius:32px}
+  .btn{height:112px;min-width:320px;padding:0 48px;border-radius:24px;display:flex;align-items:center;
+       justify-content:center;font-size:44px;font-weight:700}
+  .btn.p{background:var(--accent);color:#fff}
+  .btn.s{border:4px solid var(--line);color:var(--ink)}
+  .btn.d{border:4px solid var(--warn);color:var(--warn)}
+  .btn.off{background:#C9D2CE;color:#8C9793}
+  .chip{width:256px;height:96px;border-radius:20px;border:3px solid var(--faint);display:flex;
+        align-items:center;gap:24px;padding:0 20px;font-size:32px;background:#fff;flex:none}
+  .chip.act{border:6px solid var(--ink);font-weight:700}
+  .chip b{display:block;font-size:32px;font-weight:700;line-height:1.1}
+  .chip s{display:block;font-size:24px;color:#6C7873;text-decoration:none;line-height:1.2}
+  .sw{width:64px;height:64px;border-radius:50%;flex:none}
+  .pad{width:112px;height:112px;border-radius:50%;background:#CFE0D2;border:3px solid #9FB8A5;flex:none;position:relative}
+  .log{width:176px;height:120px;border-radius:24px;background:#E0D4C3;border:3px solid #B9A78E;flex:none;
+       display:flex;align-items:center;justify-content:center;font-size:22px;color:#8A7A63}
+  .frog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:88px;height:88px;border-radius:50%;
+        border:4px solid rgba(0,0,0,.35)}
+  .scrim{position:absolute;inset:0;background:rgba(20,26,24,.66)}
+  .cell{width:104px;height:104px;border:3px solid var(--line);border-radius:10px;background:#fff;
+        display:flex;align-items:center;justify-content:center;font-size:56px}
+  .cell.fix{border:none;background:transparent;font-weight:700}
+  .carry{width:104px;height:56px;display:flex;align-items:center;justify-content:center}
+  .carry i{display:block;width:56px;height:52px;border:3px dashed var(--faint);border-radius:8px}
+  .key{width:140px;height:140px;border:3px solid var(--line);border-radius:20px;background:#fff;
+       display:flex;align-items:center;justify-content:center;font-size:56px;font-weight:700}
+  .dice{width:240px;height:240px;border-radius:40px;background:#fff;border:4px solid var(--line);
+        display:grid;grid-template-columns:repeat(3,1fr);grid-template-rows:repeat(3,1fr);padding:34px}
+  .pip{width:40px;height:40px;border-radius:50%;background:var(--ink);align-self:center;justify-self:center}
+  .card{width:560px;height:420px;border-radius:24px;background:#fff;border:4px solid var(--line);
+        display:flex;align-items:center;justify-content:center}
+  .gear{width:96px;height:96px;border-radius:50%;border:4px solid var(--line);display:flex;align-items:center;
+        justify-content:center;font-size:44px}
+
+  /* This dialog's own three pieces. WonFrogDiameter is not the board's
+     FrogPieceDiameter (88 px) — a celebration is the one place the frog is
+     drawn big, and it is this page's constant, not the board's. */
+  .wonfrog{width:220px;height:220px;border-radius:50%;border:8px solid rgba(0,0,0,.35)}
+  .wonhead{font-size:76px;line-height:92px;font-weight:800}
+</style>
+</head>
+<body>
+<div class="frame">
+    <div class="abs" style="inset:0;background:#E2E8E5"></div>
+    <div class="scrim"></div>
+
+    <!-- Panel 900 x 640, centred: left (1920-900)/2 = 510, top (1200-640)/2 = 280.
+         Padding box is 894 x 634.
+           frog      56 -> 276   (DialogPadding, then WonFrogDiameter)
+           headline 316 -> 408   (WonHeadlineGap 40, then a 92 px line box)
+           button   466 -> 578   (DialogPadding 56 up from 634) -->
+    <div class="abs panel" style="left:510px;top:280px;width:900px;height:640px">
+      <div class="abs wonfrog" style="left:50%;transform:translateX(-50%);top:56px;
+           background:var(--blue)"></div>
+      <div class="abs wonhead" style="left:0;right:0;top:316px;text-align:center">Blue wins!</div>
+      <div class="abs btn p" style="right:56px;bottom:56px">Green's turn</div>
+    </div>
+</div>
+</body>
+</html>

--- a/docs/specs/ui/mockups/player-won-later.html
+++ b/docs/specs/ui/mockups/player-won-later.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<!--
+  Multiplying Frogs — A player has won — a later frog home
+  Device: kids' Android tablet, held landscape.
+  Canvas: 1920 x 1200, drawn 1:1. Open this on the tablet.
+
+  Numbers here are the numbers in player-won.md's constants table.
+
+  A LATER FROG HOME, and specifically the LAST one. Two things differ from its
+  twin and this file shows both at once:
+
+    1. The wording is "is home", not "wins". Only the first frog home wins.
+    2. The button hands to the game over screen rather than to a next player,
+       because there is no next player: this frog was the last, so Game.IsOver
+       has just become true.
+
+  A later frog that is NOT the last combines the two files: this headline with
+  its twin's button. That case is not drawn separately because it introduces no
+  third thing to look at.
+
+  The frog is drawn at WonFrogDiameter (220 px), which is NOT the board's
+  FrogPieceDiameter (88 px). This is the one screen in the game that draws a
+  frog big, and that is the whole point of it: the board says a frog moved, and
+  this says a frog arrived.
+
+  There is no standings column here on purpose. game-over.md already lists every
+  frog in finishing order; a second table in different words on the screen
+  before it would be the same information twice. This dialog says one thing.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Multiplying Frogs — A player has won — a later frog home</title>
+<style>
+  :root{
+    --ink:#1E2422; --line:#6C7873; --faint:#B9C0BD; --paper:#FFFFFF;
+    --bg:#EDF1EF; --accent:#2E7D4F; --warn:#B03A2E;
+    --green:#3E933E; --blue:#37609A; --orange:#D38231; --pink:#D41C78;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:#20262A;display:flex;justify-content:center;align-items:flex-start}
+  .frame{width:1920px;height:1200px;position:relative;overflow:hidden;
+         background:var(--bg);color:var(--ink);
+         font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  .abs{position:absolute}
+  .row{display:flex;align-items:center}
+  .col{display:flex;flex-direction:column}
+  .mid{display:flex;align-items:center;justify-content:center}
+  .band{position:absolute;left:0;right:0}
+  .note{font-size:26px;color:#7A8783}
+  .hatch{background:repeating-linear-gradient(45deg,#DCE3E0 0 14px,#E8EDEB 14px 28px)}
+  .panel{background:var(--paper);border:3px solid var(--line);border-radius:32px}
+  .btn{height:112px;min-width:320px;padding:0 48px;border-radius:24px;display:flex;align-items:center;
+       justify-content:center;font-size:44px;font-weight:700}
+  .btn.p{background:var(--accent);color:#fff}
+  .btn.s{border:4px solid var(--line);color:var(--ink)}
+  .btn.d{border:4px solid var(--warn);color:var(--warn)}
+  .btn.off{background:#C9D2CE;color:#8C9793}
+  .chip{width:256px;height:96px;border-radius:20px;border:3px solid var(--faint);display:flex;
+        align-items:center;gap:24px;padding:0 20px;font-size:32px;background:#fff;flex:none}
+  .chip.act{border:6px solid var(--ink);font-weight:700}
+  .chip b{display:block;font-size:32px;font-weight:700;line-height:1.1}
+  .chip s{display:block;font-size:24px;color:#6C7873;text-decoration:none;line-height:1.2}
+  .sw{width:64px;height:64px;border-radius:50%;flex:none}
+  .pad{width:112px;height:112px;border-radius:50%;background:#CFE0D2;border:3px solid #9FB8A5;flex:none;position:relative}
+  .log{width:176px;height:120px;border-radius:24px;background:#E0D4C3;border:3px solid #B9A78E;flex:none;
+       display:flex;align-items:center;justify-content:center;font-size:22px;color:#8A7A63}
+  .frog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:88px;height:88px;border-radius:50%;
+        border:4px solid rgba(0,0,0,.35)}
+  .scrim{position:absolute;inset:0;background:rgba(20,26,24,.66)}
+  .cell{width:104px;height:104px;border:3px solid var(--line);border-radius:10px;background:#fff;
+        display:flex;align-items:center;justify-content:center;font-size:56px}
+  .cell.fix{border:none;background:transparent;font-weight:700}
+  .carry{width:104px;height:56px;display:flex;align-items:center;justify-content:center}
+  .carry i{display:block;width:56px;height:52px;border:3px dashed var(--faint);border-radius:8px}
+  .key{width:140px;height:140px;border:3px solid var(--line);border-radius:20px;background:#fff;
+       display:flex;align-items:center;justify-content:center;font-size:56px;font-weight:700}
+  .dice{width:240px;height:240px;border-radius:40px;background:#fff;border:4px solid var(--line);
+        display:grid;grid-template-columns:repeat(3,1fr);grid-template-rows:repeat(3,1fr);padding:34px}
+  .pip{width:40px;height:40px;border-radius:50%;background:var(--ink);align-self:center;justify-self:center}
+  .card{width:560px;height:420px;border-radius:24px;background:#fff;border:4px solid var(--line);
+        display:flex;align-items:center;justify-content:center}
+  .gear{width:96px;height:96px;border-radius:50%;border:4px solid var(--line);display:flex;align-items:center;
+        justify-content:center;font-size:44px}
+
+  /* This dialog's own three pieces. WonFrogDiameter is not the board's
+     FrogPieceDiameter (88 px) — a celebration is the one place the frog is
+     drawn big, and it is this page's constant, not the board's. */
+  .wonfrog{width:220px;height:220px;border-radius:50%;border:8px solid rgba(0,0,0,.35)}
+  .wonhead{font-size:76px;line-height:92px;font-weight:800}
+</style>
+</head>
+<body>
+<div class="frame">
+    <div class="abs" style="inset:0;background:#E2E8E5"></div>
+    <div class="scrim"></div>
+
+    <!-- Panel 900 x 640, centred: left (1920-900)/2 = 510, top (1200-640)/2 = 280.
+         Padding box is 894 x 634.
+           frog      56 -> 276   (DialogPadding, then WonFrogDiameter)
+           headline 316 -> 408   (WonHeadlineGap 40, then a 92 px line box)
+           button   466 -> 578   (DialogPadding 56 up from 634) -->
+    <div class="abs panel" style="left:510px;top:280px;width:900px;height:640px">
+      <div class="abs wonfrog" style="left:50%;transform:translateX(-50%);top:56px;
+           background:var(--pink)"></div>
+      <div class="abs wonhead" style="left:0;right:0;top:316px;text-align:center">Pink is home!</div>
+      <div class="abs btn p" style="right:56px;bottom:56px">See the results</div>
+    </div>
+</div>
+</body>
+</html>

--- a/docs/specs/ui/player-won.md
+++ b/docs/specs/ui/player-won.md
@@ -1,0 +1,168 @@
+# A player has won
+
+The moment a frog gets home. One dialog, immediately after the winning hop
+finishes, saying that this frog has arrived — and then handing on.
+
+Before [#328](https://github.com/derekwinters/connor-multiplying-frogs/issues/328)
+there was nothing here at all. A child who won got a dialog telling them whose
+turn it was next, and then watched everybody else finish.
+
+## Invariants
+
+**Invariant:** getting home is marked. Every frog that reaches the End log gets
+this dialog — the first one and the last one alike. It is the one screen in the
+game that is about a single child's moment rather than about the state of the
+game.
+**Invariant:** only the **first** frog home "wins". Under the current rules the
+first frog to reach the End log is the winner and the rest are ranked behind it,
+so the wording changes after the first — see
+[Elements](#elements). Saying "wins" four times in one game would be four lies
+after the first.
+**Invariant:** this dialog changes nothing about the game. It does not end it,
+does not skip anyone, does not reorder anything. It is an announcement, and the
+rule it announces is
+[game board](game-board.md)'s: a frog that reaches the End log stays there and
+**play continues**.
+**Invariant:** it carries no standings. [Game over](game-over.md) lists every
+frog in finishing order; a second table in different words on the screen before
+it would be the same information twice.
+**Invariant:** the hardware back button does **nothing** here. See
+[Behaviour](#behaviour).
+
+## Regions
+
+| Region | Job |
+| --- | --- |
+| `frog` | The frog that just got home, drawn large |
+| `headline` | `Blue wins!`, or `Pink is home!` |
+| `controls` | The one button, which hands on |
+
+## Anchors
+
+A centred [dialog](shared-components.md#dialog), `WonDialogWidth` by
+`WonDialogHeight`, over a dimmed copy of the board.
+
+Measured from the panel's top down, because the frog is the thing this screen is
+about and everything else follows it:
+
+- `frog` — horizontally centred, `DialogPadding` from the panel's top edge.
+- `headline` — `WonHeadlineGap` below the frog, horizontally centred, one line.
+- `controls` — bottom-right at `DialogPadding`, where
+  [the shared dialog](shared-components.md#dialog) puts a button row.
+
+## Named constants
+
+| Element | Constant | Value |
+| --- | --- | --- |
+| Dialog width | `WonDialogWidth` | 900 px |
+| Dialog height | `WonDialogHeight` | 640 px |
+| The frog, drawn large | `WonFrogDiameter` | 220 px |
+| Frog outline | `WonFrogOutline` | 8 px |
+| Gap between the frog and the headline | `WonHeadlineGap` | 40 px |
+| Headline size | `WonHeadlineSize` | 76 px |
+| Headline line box | `WonHeadlineLineBox` | 92 px |
+
+The arithmetic down the panel, against a 634 px padding box:
+
+```text
+DialogPadding 56 + WonFrogDiameter 220        -> frog     56 .. 276
+WonHeadlineGap 40 + WonHeadlineLineBox 92     -> headline 316 .. 408
+ButtonHeight 112, DialogPadding 56 up         -> button   466 .. 578
+```
+
+**`WonFrogDiameter` is deliberately not the board's `FrogPieceDiameter`**
+(88 px). This is the one screen in the game that draws a frog big, and that is
+what it is for: the board says a frog moved, and this says a frog arrived. A
+constant that happened to equal the board's would be re-used by someone later
+and drag the two into step.
+
+`WonHeadlineLineBox` is written down rather than left to a font's default for
+the same reason the settings dialog's title box is: `WonHeadlineGap` is measured
+from it, and a line box that varies by renderer is a gap that varies by
+renderer.
+
+## Elements
+
+- **`frog`** — the frog that just got home, at `WonFrogDiameter` in its own
+  colour, with the `PieceEdge` outline at `WonFrogOutline`. Not a
+  [player chip](shared-components.md#player-chip): a chip carries a name and a
+  pad count, and both are wrong here — the name is in the headline and the pad
+  count is now `8 of 8` for everyone this dialog appears for.
+- **`headline`** — at `WonHeadlineSize`, and its wording is the one thing on
+  this page that depends on game state:
+
+    | When | Reads |
+    | --- | --- |
+    | The **first** frog home | `Blue wins!` |
+    | Any **later** frog home | `Pink is home!` |
+
+    The frog's name is whatever it is called — its colour by default, or the
+    name typed on [game setup](game-setup.md), so `Connor wins!` for a renamed
+    frog. Same rule as the board's turn banner: the name and nothing else.
+
+- **`controls`** — one primary [button](shared-components.md#button), named for
+  what happens next, exactly as
+  [answer result](answer-result.md)'s is:
+
+    | When | Reads | Hands to |
+    | --- | --- | --- |
+    | There is a next player | `Green's turn` | the next player's turn on the board |
+    | That frog was the **last** one home | `See the results` | [game over](game-over.md) |
+
+    The second case is the one `Game.IsOver` has just become true for.
+
+## Behaviour
+
+- **Entry.** Opens once the winning hop has finished — the seam
+  `AppRoot.HandOffFinished` already sits on, between the hop completing and the
+  next player's turn starting. It opens *after* [answer result](answer-result.md)
+  has closed and the frog has landed, not instead of it: the answer result
+  reports the answer, this reports the arrival.
+- **Exit.** The button closes it. If there is a next player, the board is
+  underneath with that player's turn already begun. If there is not, the game
+  over screen follows.
+- **Hardware back does nothing.** This makes a **fourth** dialog with an inert
+  back, alongside roll and card, the working-out grid and answer result — and
+  for the same reason they have one: it sits inside the turn's own chain, and a
+  stray press should not fast-forward past a moment the game just stopped to
+  mark. `shared-components.md`'s dialog invariant is updated to say four.
+- **The game does not end here**, whatever the headline says. Play continues
+  until every frog is home, which is
+  [the board's rule](game-board.md#behaviour) and
+  [Derek's recorded provisional call](../reference/index.md#where-v1-fills-a-gap-the-board-leaves-open),
+  not a classroom-game rule. Whether it *should* end when the first frog gets
+  home is [an open question](#open-questions) and is Connor's, not this
+  wireframe's.
+
+## Mockup
+
+- [`mockups/player-won-first.html`](mockups/player-won-first.html) — the first
+  frog home. `Blue wins!`, handing to the next player.
+- [`mockups/player-won-later.html`](mockups/player-won-later.html) — the last
+  frog home. `Pink is home!`, handing to the results.
+
+Two files rather than one because the headline and the button each have two
+states, and the two drawings cover all of both: a later frog that is **not** the
+last combines the second file's headline with the first file's button, and
+introduces no third thing to look at.
+
+## Open questions
+
+- **Should the game end when the first frog gets home?** Not proposed here, and
+  deliberately not decided here. Today play continues, which is Derek's recorded
+  provisional call rather than a classroom rule — and a dialog that says
+  `Blue wins!` while the game carries on is exactly the moment somebody will ask
+  why it does. It is a **rule** change, so it is Connor's, and it wants its own
+  `type:question` issue rather than being folded into a layout.
+- **What does the answer result's button say on the winning move?**
+  [#287](https://github.com/derekwinters/connor-multiplying-frogs/issues/287)
+  asks this, and this page changes what it means. That button used to be the
+  last thing a winner read; now this dialog follows it. The placeholder
+  `Game over` is worse than it was — it announces an ending that has not
+  happened yet and that this dialog is about to talk over. Answering #287 should
+  be done with this page in view.
+- **Does the moment want more than a dialog?** A bigger chip state, an animation
+  on the lane, a sound. Audio is [parked](../future-ideas.md). If the dialog
+  turns out to be the wrong shape for this — if what Connor wants is the board
+  celebrating rather than a panel interrupting — that is a legitimate answer and
+  it is still a wireframe.

--- a/docs/specs/ui/shared-components.md
+++ b/docs/specs/ui/shared-components.md
@@ -235,8 +235,10 @@ no close cross. It is left by pressing one of its buttons, so a game is never
 half-answered because a sleeve brushed the glass.
 **Invariant:** the hardware back button does what the dialog's *least
 destructive* button does, and never what its most destructive one does —
-except the three dialogs whose pages make back inert (roll and card,
-working-out grid, answer result), where back does nothing.
+except the four dialogs whose pages make back inert (roll and card,
+working-out grid, answer result, [a player has won](player-won.md)), where back
+does nothing. All four sit inside a single turn's own chain, where a stray press
+should not fast-forward past something the game stopped to show.
 
 #### 3. Named constants
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
           - Roll and card: specs/ui/roll-and-card.md
           - Working-out grid: specs/ui/working-out-grid.md
           - Answer result: specs/ui/answer-result.md
+          - A player has won: specs/ui/player-won.md
           - Settings dialog: specs/ui/settings-dialog.md
           - End-game confirm: specs/ui/end-game-confirm.md
           - Game over: specs/ui/game-over.md


### PR DESCRIPTION
When a child got their frog home, the game told them whose turn it was next and
then they watched everybody else finish. Nothing marked the moment at all. This
is the screen that does it: the frog drawn big, its name, and the fact that it
got home.

Nothing is built here — this is the wireframe.

## The thing the issue asked to check first

#328 says to establish one thing before drawing anything: was the game Derek
played *actually finished* — every frog home — with no game over screen
appearing? If so there is a bug underneath this and the wireframe is the wrong
work.

**I checked the code rather than assuming, and there is no bug:**

- `Game.IsOver` is recomputed from every lane on every read — nothing is cached
  and nothing has to be told to "notice" a frog landing on the End log.
- `AnswerResultDialogView.ApplyHandOff` raises `TurnHandedOff` **unconditionally**
  once the hop duration elapses. It is not gated on the button's label, so the
  `Game over` placeholder case reaches it like any other.
- `AppRoot.HandOffFinished` checks `IsOver` on that event and calls
  `ShowGameOver`.

The path is intact. So the first reading holds — the win happened, other frogs
were still playing, and nothing marked it — and that is what this wireframe is
for.

## How the spec is changing

**A new screen, `docs/specs/ui/player-won.md`.** It opens on the seam
`AppRoot.HandOffFinished` already sits on: after the answer result has closed
and the frog has landed, before the next player's turn begins. The answer result
reports the *answer*; this reports the *arrival*.

**Only the first frog home "wins".** Under the current rules the first to reach
the End log is the winner and the rest are ranked behind it, so the headline has
two states — `Blue wins!` for the first, `Pink is home!` for everyone after.
Saying "wins" four times in one game would be four lies after the first. The
frog's name is whatever it is called, so `Connor wins!` for a renamed frog —
the same name-and-nothing-else rule the board's turn banner uses.

**The button is named for what happens next**, exactly as answer result's is:
`Green's turn`, or `See the results` when that frog was the last one home and
`Game.IsOver` has just become true.

**Hardware back does nothing here**, which makes a fourth dialog with an inert
back. All four sit inside a single turn's own chain, and a stray press should
not fast-forward past something the game deliberately stopped to show.
`shared-components.md`'s dialog invariant said "the three dialogs" and now says
four.

## Spec invariants this had to keep true

- **The game does not end here.** Play continues until every frog is home —
  the board's rule, and Derek's recorded provisional call rather than a
  classroom one. This dialog announces; it changes nothing. Whether the game
  *should* end on the first frog home is recorded as an open question and is
  Connor's, not this wireframe's.
- **No standings.** Game over already lists every frog in finishing order. A
  second table in different words on the screen immediately before it would be
  the same information twice, which is what the issue warned against.
- **A frog is home when it lands on the End log**, not at the last lily pad.
  Unchanged.
- **Measured, not asserted:** both mockups render with the frog at 56→276,
  headline 316→408, button at `DialogPadding` 56 from the bottom, and the frog
  horizontally centred to the pixel.

## Deviations and Decisions

- **`WonFrogDiameter` is 220 px and deliberately not the board's
  `FrogPieceDiameter` (88 px).** This is the only screen that draws a frog big,
  and that is the whole point of it — the board says a frog moved, this says a
  frog arrived. A constant that happened to equal the board's would get reused
  and drag the two into step, which is the mistake `LogRadius` and
  `SettingsGlyphSize` already have warnings about on their own page.
- **The frog is drawn bare, not as a player chip.** A chip carries a name and a
  pad count; the name is already in the headline and the pad count is `8 of 8`
  for every frog this dialog ever appears for.
- **The dialog appears for the last frog home too**, immediately before game
  over, rather than being skipped as redundant. The issue's own framing expects
  this ("or the game over screen if that frog was the last one"), and the last
  frog home is often the child who has been behind all game — skipping their
  moment to save a tap is the wrong trade. It does mean two celebratory screens
  back to back; say if that reads badly on the tablet.
- **Two mockups, and the second draws the *last* frog rather than a middle
  one.** The headline and the button each have two states; drawing first-and-last
  covers all of both. A later frog that is not the last combines the second
  file's headline with the first file's button and introduces no third thing to
  look at.
- **#287 got harder, and I said so on its page rather than answering it.** That
  open question asks what the answer result's button says on the winning move,
  where it reads the placeholder `Game over`. It is now worse: that button is no
  longer the last thing a winner reads, so it announces an ending that has not
  happened yet and that this dialog is about to talk over. Recorded on
  `answer-result.md`; still Connor's to settle.
- **This body was edited once immediately after opening**, to remove an appended
  footer carrying this session's identifier — six for six now.
- **The end-the-game-on-first-home question is left open, not decided.** A
  dialog saying `Blue wins!` while play carries on is exactly the moment
  somebody asks why it does. It is a rule change, so it wants its own
  `type:question` issue rather than being folded into a layout — I have not
  opened one, since it is Connor's call whether to ask it.

**Docs:** `docs/specs/ui/player-won.md` — new page: invariants, regions,
anchors, the seven `Won*` constants with the panel arithmetic, elements with
both headline and both button states, behaviour including the inert back, the
two mockups and three open questions.
`docs/specs/ui/game-board.md` — the End-log behaviour bullet now names this
dialog and restates that play continues regardless.
`docs/specs/ui/answer-result.md` — its #287 open question records that the
placeholder button's meaning changed.
`docs/specs/ui/shared-components.md` — the dialog invariant's inert-back list is
four, not three, with the reason they share.
`docs/specs/ui/index.md`, `docs/specs/ui/mockups/index.md` and `mkdocs.yml` —
the new page and its two mockups listed.

Closes #328

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code)_